### PR TITLE
build: add wirelog as a meson subproject

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -13,6 +13,18 @@ gio_dep = dependency('gio-2.0', required : true)
 libsoup_dep = dependency('libsoup-3.0', version : '>= 3.0', required : true)
 duckdb_dep = dependency('duckdb', fallback : ['duckdb', 'duckdb_dep'])
 
+wirelog_proj = subproject(
+  'wirelog',
+  default_options : ['tests=false', 'documentation=false'],
+)
+wirelog_dep = declare_dependency(
+  link_with : wirelog_proj.get_variable('wirelog_lib'),
+  include_directories : [
+    wirelog_proj.get_variable('wirelog_inc'),
+    wirelog_proj.get_variable('wirelog_src_inc'),
+  ],
+)
+
 install_data(
   'templates/access/bootstrap.dl',
   install_dir : join_paths(get_option('datadir'), 'wyrelog', 'access'),

--- a/subprojects/.gitignore
+++ b/subprojects/.gitignore
@@ -1,0 +1,6 @@
+*
+!.gitignore
+!duckdb.wrap
+!wirelog.wrap
+!packagefiles
+!packagefiles/**

--- a/subprojects/wirelog.wrap
+++ b/subprojects/wirelog.wrap
@@ -1,0 +1,4 @@
+[wrap-git]
+url = https://github.com/semantic-reasoning/wirelog.git
+revision = main
+depth = 1


### PR DESCRIPTION
## Summary

- Add `subprojects/wirelog.wrap` (`[wrap-git]`, public github URL, `revision = main`, `depth = 1`) so that wirelog is fetched and configured as a meson subproject.
- In top-level `meson.build`, instantiate the subproject with `tests=false, documentation=false` and declare `wirelog_dep` via `declare_dependency(...)`, linking the upstream `wirelog_lib` target with the upstream `wirelog_inc` and `wirelog_src_inc` include directories. Downstream targets can take a dependency on `wirelog_dep`.
- Add `subprojects/.gitignore` (allow-list the manually maintained `duckdb.wrap` and `wirelog.wrap` plus `packagefiles/`; exclude cloned subproject directories, auto-generated wrap redirects, and meson lock files).

The `declare_dependency` form is used because the upstream wirelog `meson.build` exports `wirelog_lib` / `wirelog_inc` / `wirelog_src_inc` but does not call `meson.override_dependency('wirelog', ...)`, so a plain `dependency('wirelog', fallback: ...)` would not resolve.

## Test plan

- [x] `rm -rf builddir && meson setup builddir` returns 0; `Subprojects` block reports `wirelog: YES` (with 4 unrelated upstream meson-style warnings) and the transitive `nanoarrow`, `xxhash`, and `duckdb` subprojects all `YES`.
- [x] `wirelog_dep` is a top-level binding in `meson.build` and is usable as a dependency in future `library()` / `executable()` calls.
- [x] No public C/C++ source, headers, or stub libraries are introduced; commit is build-wiring only.