### PR TITLE
build: expand build dependencies (libchronoid, libsodium, tss2-esys)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -11,6 +11,7 @@ project('wyrelog', 'c',
 glib_dep = dependency('glib-2.0', required : true)
 gio_dep = dependency('gio-2.0', required : true)
 libsoup_dep = dependency('libsoup-3.0', version : '>= 3.0', required : true)
+tss2_esys_dep = dependency('tss2-esys', required : true)
 duckdb_dep = dependency('duckdb', fallback : ['duckdb', 'duckdb_dep'])
 
 wirelog_proj = subproject(

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('wyrelog', 'c',
   version : '0.1.0',
   license : 'GPL-3.0-or-later',
-  meson_version : '>= 0.62.0',
+  meson_version : '>= 1.1.0',
   default_options : [
     'c_std=c17',
     'warning_level=2',
@@ -23,6 +23,15 @@ wirelog_dep = declare_dependency(
     wirelog_proj.get_variable('wirelog_inc'),
     wirelog_proj.get_variable('wirelog_src_inc'),
   ],
+)
+
+libchronoid_proj = subproject(
+  'libchronoid',
+  default_options : ['tests=false', 'cli=false'],
+)
+libchronoid_dep = declare_dependency(
+  link_with : libchronoid_proj.get_variable('chronoid_lib'),
+  include_directories : libchronoid_proj.get_variable('inc'),
 )
 
 install_data(

--- a/meson.build
+++ b/meson.build
@@ -11,6 +11,7 @@ project('wyrelog', 'c',
 glib_dep = dependency('glib-2.0', required : true)
 gio_dep = dependency('gio-2.0', required : true)
 libsoup_dep = dependency('libsoup-3.0', version : '>= 3.0', required : true)
+sodium_dep = dependency('libsodium', required : true)
 tss2_esys_dep = dependency('tss2-esys', required : true)
 duckdb_dep = dependency('duckdb', fallback : ['duckdb', 'duckdb_dep'])
 

--- a/subprojects/.gitignore
+++ b/subprojects/.gitignore
@@ -1,6 +1,7 @@
 *
 !.gitignore
 !duckdb.wrap
+!libchronoid.wrap
 !wirelog.wrap
 !packagefiles
 !packagefiles/**

--- a/subprojects/libchronoid.wrap
+++ b/subprojects/libchronoid.wrap
@@ -1,0 +1,4 @@
+[wrap-git]
+url = https://github.com/semantic-reasoning/libchronoid.git
+revision = main
+depth = 1


### PR DESCRIPTION
## Summary

Three atomic commits expanding the wyrelog build dependency surface:

1. **`build: add libchronoid as a meson subproject`** — registers libchronoid (https://github.com/semantic-reasoning/libchronoid) via `[wrap-git]` (revision = main, depth = 1) and exposes `libchronoid_dep` linking against the upstream `chronoid_lib` with the upstream `inc` include directory. Disables libchronoid tests + CLI in the subproject. Bumps the project's `meson_version` requirement to `>= 1.1.0` to match libchronoid's minimum, and adds `libchronoid.wrap` to the `subprojects/.gitignore` allow-list.

2. **`build: add tss2-esys as a system dependency`** — adds `tss2_esys_dep = dependency('tss2-esys', required : true)` for the TPM 2.0 ESAPI from the `tpm2-tss` system package. No subproject fallback.

3. **`build: add libsodium as a system dependency`** — adds `sodium_dep = dependency('libsodium', required : true)` for libsodium's cryptographic primitives. No subproject fallback.

Final dependency block ordering (after this series): `glib_dep`, `gio_dep`, `libsoup_dep`, `sodium_dep`, `tss2_esys_dep`, `duckdb_dep`, plus subproject-derived `wirelog_dep` and `libchronoid_dep`.

## Test plan

- [x] `rm -rf builddir && meson setup builddir` returns 0 at HEAD.
- [x] `Subprojects` block reports `libchronoid: YES` (alongside the previously wired `wirelog: YES`, transitive `nanoarrow`, `xxhash`, and `duckdb`).
- [x] `Run-time dependency libsodium found: YES 1.0.22` and `Run-time dependency tss2-esys found: YES 4.1.3` in setup output.
- [x] Each commit individually configures clean (verified via per-commit checkout): bisect-friendly.
- [x] No public C/C++ source, headers, or stub libraries are introduced; series is build-wiring only.

## Required system packages

To build, the following pkg-config dependencies must be available on the host:

- `libsodium` (e.g., Arch `libsodium`)
- `tss2-esys` (e.g., Arch `tpm2-tss`)
- `libsoup-3.0` (e.g., Arch `libsoup3`) — pre-existing
- `glib-2.0`, `gio-2.0` — pre-existing