### PR TITLE
feat: add wyrelog library skeleton with error codes and logging

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -36,6 +36,9 @@ libchronoid_dep = declare_dependency(
   include_directories : libchronoid_proj.get_variable('inc'),
 )
 
+subdir('wyrelog')
+subdir('tests')
+
 install_data(
   'templates/access/bootstrap.dl',
   install_dir : join_paths(get_option('datadir'), 'wyrelog', 'access'),

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,0 +1,6 @@
+test_smoke = executable('test-smoke',
+  'test-smoke.c',
+  dependencies : [wyrelog_dep],
+)
+
+test('smoke', test_smoke)

--- a/tests/test-smoke.c
+++ b/tests/test-smoke.c
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <stddef.h>
+
+#include "wyrelog/error.h"
+
+int
+main (void)
+{
+  const char *msg = wyrelog_error_string (WYRELOG_E_OK);
+
+  if (msg == NULL || msg[0] == '\0')
+    return 1;
+
+  return 0;
+}

--- a/wyrelog/error.h
+++ b/wyrelog/error.h
@@ -1,0 +1,25 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+  typedef enum wyrelog_error_t
+  {
+    WYRELOG_E_OK = 0,
+    WYRELOG_E_INVALID = -1,
+    WYRELOG_E_NOMEM = -2,
+    WYRELOG_E_IO = -3,
+    WYRELOG_E_CRYPTO = -4,
+    WYRELOG_E_POLICY = -5,
+    WYRELOG_E_AUTH = -6,
+    WYRELOG_E_INTERNAL = -7,
+  } wyrelog_error_t;
+
+  const char *wyrelog_error_string (wyrelog_error_t err);
+
+#ifdef __cplusplus
+}
+#endif

--- a/wyrelog/meson.build
+++ b/wyrelog/meson.build
@@ -1,0 +1,24 @@
+wyrelog_inc = include_directories('..')
+
+wyrelog_public_headers = files(
+  'error.h',
+)
+
+wyrelog_sources = files(
+  'wyl-error.c',
+)
+
+libwyrelog = library('wyrelog',
+  wyrelog_sources,
+  include_directories : wyrelog_inc,
+  dependencies : [glib_dep],
+  install : true,
+  soversion : '0',
+)
+
+install_headers(wyrelog_public_headers, subdir : 'wyrelog')
+
+wyrelog_dep = declare_dependency(
+  link_with : libwyrelog,
+  include_directories : wyrelog_inc,
+)

--- a/wyrelog/wyl-common-private.h
+++ b/wyrelog/wyl-common-private.h
@@ -1,0 +1,7 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+
+#include <glib.h>
+
+#include "wyrelog/error.h"
+#include "wyl-log-private.h"

--- a/wyrelog/wyl-error.c
+++ b/wyrelog/wyl-error.c
@@ -1,0 +1,26 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "wyrelog/error.h"
+
+const char *
+wyrelog_error_string (wyrelog_error_t err)
+{
+  switch (err) {
+    case WYRELOG_E_OK:
+      return "success";
+    case WYRELOG_E_INVALID:
+      return "invalid argument";
+    case WYRELOG_E_NOMEM:
+      return "out of memory";
+    case WYRELOG_E_IO:
+      return "i/o error";
+    case WYRELOG_E_CRYPTO:
+      return "cryptographic operation failed";
+    case WYRELOG_E_POLICY:
+      return "policy evaluation failed";
+    case WYRELOG_E_AUTH:
+      return "authentication or authorization failure";
+    case WYRELOG_E_INTERNAL:
+      return "internal invariant violated";
+  }
+  return "unknown error";
+}

--- a/wyrelog/wyl-log-private.h
+++ b/wyrelog/wyl-log-private.h
@@ -1,0 +1,37 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+
+#include <glib.h>
+
+#ifndef WYL_LOG_DOMAIN
+#define WYL_LOG_DOMAIN "wyrelog"
+#endif
+
+/*
+ * Severity macros mapped onto GLib log levels:
+ *
+ *   WYL_LOG_DEBUG    -> G_LOG_LEVEL_DEBUG     (verbose)
+ *   WYL_LOG_INFO     -> G_LOG_LEVEL_INFO      (informational)
+ *   WYL_LOG_WARN     -> G_LOG_LEVEL_WARNING   (recoverable warning)
+ *   WYL_LOG_ERROR    -> G_LOG_LEVEL_CRITICAL  (recoverable error;
+ *                                              program continues)
+ *   WYL_LOG_CRITICAL -> G_LOG_LEVEL_ERROR     (invariant violation;
+ *                                              terminates the program)
+ *
+ * The mapping for ERROR/CRITICAL is intentionally inverted relative to
+ * the GLib level names because GLib treats G_LOG_LEVEL_ERROR as
+ * always-fatal (it calls abort()) and G_LOG_LEVEL_CRITICAL as
+ * non-fatal. Library code reaches for WYL_LOG_ERROR to record handled
+ * but bad events; only WYL_LOG_CRITICAL is intended to terminate.
+ */
+
+#define WYL_LOG_DEBUG(...) \
+  g_log (WYL_LOG_DOMAIN, G_LOG_LEVEL_DEBUG, __VA_ARGS__)
+#define WYL_LOG_INFO(...) \
+  g_log (WYL_LOG_DOMAIN, G_LOG_LEVEL_INFO, __VA_ARGS__)
+#define WYL_LOG_WARN(...) \
+  g_log (WYL_LOG_DOMAIN, G_LOG_LEVEL_WARNING, __VA_ARGS__)
+#define WYL_LOG_ERROR(...) \
+  g_log (WYL_LOG_DOMAIN, G_LOG_LEVEL_CRITICAL, __VA_ARGS__)
+#define WYL_LOG_CRITICAL(...) \
+  g_log (WYL_LOG_DOMAIN, G_LOG_LEVEL_ERROR, __VA_ARGS__)


### PR DESCRIPTION
## Summary

Introduces the initial source layout for `libwyrelog`:

- **`wyrelog/error.h`** (public): `wyrelog_error_t` enum (8 variants — `WYRELOG_E_OK = 0` plus 7 negative error codes covering invalid argument, OOM, I/O, crypto, policy, auth, and internal-invariant cases) plus the `wyrelog_error_string()` declaration.
- **`wyrelog/wyl-common-private.h`** (internal): prelude that pulls in `<glib.h>`, the public `error.h`, and the log macros.
- **`wyrelog/wyl-log-private.h`** (internal): `WYL_LOG_DEBUG/INFO/WARN/ERROR/CRITICAL` macros built on `g_log()`. The mapping for `ERROR`/`CRITICAL` is intentionally inverted relative to GLib's level names — `WYL_LOG_ERROR` → `G_LOG_LEVEL_CRITICAL` (non-fatal, program continues) and `WYL_LOG_CRITICAL` → `G_LOG_LEVEL_ERROR` (fatal, aborts) — because GLib treats `G_LOG_LEVEL_ERROR` as always-fatal. The header carries a comment block explaining this matrix.
- **`wyrelog/wyl-error.c`**: `wyrelog_error_string` implementation (switch over the enum + `"unknown error"` fallback).
- **`wyrelog/meson.build`**: builds `libwyrelog` as a shared library (`soversion = '0'`) linking against `glib-2.0`, installs `error.h` under `${includedir}/wyrelog/`, and exposes `wyrelog_dep`.
- **`tests/test-smoke.c`** + **`tests/meson.build`**: a minimal smoke test that calls `wyrelog_error_string(WYRELOG_E_OK)` and asserts the returned string is non-NULL and non-empty. Registered as `meson test smoke`.
- **Top-level `meson.build`**: pulls in the new `wyrelog/` and `tests/` subdirectories.

All new C/C++ files start with `/* SPDX-License-Identifier: GPL-3.0-or-later */`. Headers use `#pragma once`. Source is gst-indent idempotent.

## Test plan

- [x] `rm -rf builddir && meson setup builddir` returns 0.
- [x] `ninja -C builddir tests/test-smoke wyrelog/libwyrelog.so.0` produces `libwyrelog.so.0` and `tests/test-smoke`.
- [x] `meson test -C builddir smoke` reports `1/1 wyrelog:smoke OK`.
- [x] `nm -D --defined-only builddir/wyrelog/libwyrelog.so.0` exports `T wyrelog_error_string`.
- [x] `./tools/gst-indent <file>` is idempotent on every new C/H file (zero diff after the first pass).