### PR TITLE
feat: add boot orchestrator and public server/client APIs

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -4,3 +4,10 @@ test_smoke = executable('test-smoke',
 )
 
 test('smoke', test_smoke)
+
+test_boot_smoke = executable('test-boot-smoke',
+  'test-boot-smoke.c',
+  dependencies : [wyrelog_dep],
+)
+
+test('boot-smoke', test_boot_smoke)

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -11,3 +11,10 @@ test_boot_smoke = executable('test-boot-smoke',
 )
 
 test('boot-smoke', test_boot_smoke)
+
+test_client_smoke = executable('test-client-smoke',
+  'test-client-smoke.c',
+  dependencies : [wyrelog_client_dep],
+)
+
+test('client-smoke', test_client_smoke)

--- a/tests/test-boot-smoke.c
+++ b/tests/test-boot-smoke.c
@@ -1,0 +1,69 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <stddef.h>
+
+#include "wyrelog/wyl-boot-private.h"
+
+static int call_count;
+
+static wyrelog_error_t
+phase_ok (void *ctx)
+{
+  (void) ctx;
+  call_count++;
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+phase_failing (void *ctx)
+{
+  (void) ctx;
+  call_count++;
+  return WYRELOG_E_IO;
+}
+
+int
+main (void)
+{
+  /* Empty sequence returns OK. */
+  if (wyl_boot_run (NULL, 0, NULL) != WYRELOG_E_OK)
+    return 1;
+
+  /* Non-zero count with NULL seq is an invalid argument. */
+  if (wyl_boot_run (NULL, 1, NULL) != WYRELOG_E_INVALID)
+    return 2;
+
+  /* All-success sequence runs every phase and returns OK. */
+  call_count = 0;
+  const boot_phase_t happy[] = {
+    {BOOT_01_TPM_PROBE, "probe", phase_ok, true},
+    {BOOT_02_DEK_UNSEAL, "unseal", phase_ok, true},
+  };
+  if (wyl_boot_run (happy, 2, NULL) != WYRELOG_E_OK)
+    return 3;
+  if (call_count != 2)
+    return 4;
+
+  /* Fail-closed failure short-circuits with the phase's return code. */
+  call_count = 0;
+  const boot_phase_t closed[] = {
+    {BOOT_01_TPM_PROBE, "probe", phase_failing, true},
+    {BOOT_02_DEK_UNSEAL, "unseal", phase_ok, true},
+  };
+  if (wyl_boot_run (closed, 2, NULL) != WYRELOG_E_IO)
+    return 5;
+  if (call_count != 1)
+    return 6;
+
+  /* Non-fail-closed failure is logged and the run continues. */
+  call_count = 0;
+  const boot_phase_t open[] = {
+    {BOOT_01_TPM_PROBE, "probe", phase_failing, false},
+    {BOOT_02_DEK_UNSEAL, "unseal", phase_ok, true},
+  };
+  if (wyl_boot_run (open, 2, NULL) != WYRELOG_E_OK)
+    return 7;
+  if (call_count != 2)
+    return 8;
+
+  return 0;
+}

--- a/tests/test-client-smoke.c
+++ b/tests/test-client-smoke.c
@@ -1,0 +1,39 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <stddef.h>
+
+#include "wyrelog/client.h"
+
+int
+main (void)
+{
+  const char *version = wyrelog_client_version_string ();
+  if (version == NULL || version[0] == '\0')
+    return 1;
+
+  /* Input validation: NULL out_client must be rejected. */
+  if (wyl_client_new ("http://example.invalid", NULL) != WYRELOG_E_INVALID)
+    return 2;
+
+  /* Successful path returns a non-NULL WylClient. */
+  g_autoptr (WylClient) client = NULL;
+  if (wyl_client_new ("http://example.invalid", &client) != WYRELOG_E_OK)
+    return 3;
+  if (client == NULL)
+    return 4;
+
+  /* Audit iterator returns a non-NULL WylAuditIter on success and
+   * yields no rows in the stub state. */
+  g_autoptr (WylAuditIter) iter = NULL;
+  if (wyl_client_audit_query (client, NULL, &iter) != WYRELOG_E_OK)
+    return 5;
+  if (iter == NULL)
+    return 6;
+
+  gboolean has_next = TRUE;
+  if (wyl_audit_iter_next (iter, &has_next) != WYRELOG_E_OK)
+    return 7;
+  if (has_next != FALSE)
+    return 8;
+
+  return 0;
+}

--- a/tests/test-smoke.c
+++ b/tests/test-smoke.c
@@ -2,6 +2,7 @@
 #include <stddef.h>
 
 #include "wyrelog/error.h"
+#include "wyrelog/wyrelog.h"
 
 int
 main (void)
@@ -10,6 +11,21 @@ main (void)
 
   if (msg == NULL || msg[0] == '\0')
     return 1;
+
+  const char *version = wyrelog_version_string ();
+  if (version == NULL || version[0] == '\0')
+    return 2;
+
+  /* Input validation: NULL out_handle must be rejected. */
+  if (wyl_init ("ignored", NULL) != WYRELOG_E_INVALID)
+    return 3;
+
+  /* Successful path returns a non-NULL WylHandle. */
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 4;
+  if (handle == NULL)
+    return 5;
 
   return 0;
 }

--- a/wyrelog/client.h
+++ b/wyrelog/client.h
@@ -1,0 +1,63 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+
+#include <glib-object.h>
+
+#include "wyrelog/error.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*
+ * WylClient - HTTP client for talking to a remote wyrelog daemon.
+ *
+ * Owns a SoupSession (libsoup-3.0), the base URL, and the current
+ * authentication state (access token, refresh token, MFA bind).
+ * Created with wyl_client_new, released with g_object_unref or
+ * g_autoptr.
+ */
+  G_DECLARE_FINAL_TYPE (WylClient, wyl_client, WYL, CLIENT, GObject)
+#define WYL_TYPE_CLIENT (wyl_client_get_type ())
+/*
+ * WylAuditIter - paginated audit query cursor.
+ *
+ * Issues one HTTP GET per page and yields events through
+ * wyl_audit_iter_next until the server reports the end.
+ */
+  G_DECLARE_FINAL_TYPE (WylAuditIter, wyl_audit_iter, WYL, AUDIT_ITER, GObject)
+#define WYL_TYPE_AUDIT_ITER (wyl_audit_iter_get_type ())
+/* Lifecycle */
+  wyrelog_error_t wyl_client_new (const char *base_url,
+      WylClient ** out_client);
+
+/* Authentication */
+  wyrelog_error_t wyl_client_login (WylClient * client,
+      const char *username, const char *password);
+  wyrelog_error_t wyl_client_token_refresh (WylClient * client);
+  wyrelog_error_t wyl_client_mfa_verify (WylClient * client, const char *otp);
+
+/* Decide */
+  wyrelog_error_t wyl_client_decide (WylClient * client,
+      const char *user,
+      const char *perm, const char *session_token, int *out_decision);
+
+/* Audit query (iterator) */
+  wyrelog_error_t wyl_client_audit_query (WylClient * client,
+      const char *query_filter, WylAuditIter ** out_iter);
+  wyrelog_error_t wyl_audit_iter_next (WylAuditIter * iter,
+      gboolean * out_has_next);
+
+/* Tenant / event */
+  wyrelog_error_t wyl_client_tenant_select (WylClient * client,
+      const char *tenant);
+  wyrelog_error_t wyl_client_event_emit (WylClient * client,
+      const char *event_kind, const char *event_payload_json);
+
+/* Meta */
+  const char *wyrelog_client_version_string (void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/wyrelog/client.h
+++ b/wyrelog/client.h
@@ -13,7 +13,7 @@ extern "C"
 /*
  * WylClient - HTTP client for talking to a remote wyrelog daemon.
  *
- * Owns a SoupSession (libsoup-3.0), the base URL, and the current
+ * Owns the HTTP transport, the base URL, and the current
  * authentication state (access token, refresh token, MFA bind).
  * Created with wyl_client_new, released with g_object_unref or
  * g_autoptr.

--- a/wyrelog/meson.build
+++ b/wyrelog/meson.build
@@ -5,6 +5,7 @@ wyrelog_public_headers = files(
 )
 
 wyrelog_sources = files(
+  'wyl-boot.c',
   'wyl-error.c',
 )
 

--- a/wyrelog/meson.build
+++ b/wyrelog/meson.build
@@ -2,17 +2,24 @@ wyrelog_inc = include_directories('..')
 
 wyrelog_public_headers = files(
   'error.h',
+  'wyrelog.h',
 )
 
 wyrelog_sources = files(
+  'wyl-audit-event.c',
   'wyl-boot.c',
+  'wyl-decide.c',
   'wyl-error.c',
+  'wyl-handle.c',
+  'wyl-perm.c',
+  'wyl-session.c',
+  'wyl-version.c',
 )
 
 libwyrelog = library('wyrelog',
   wyrelog_sources,
   include_directories : wyrelog_inc,
-  dependencies : [glib_dep],
+  dependencies : [glib_dep, gio_dep],
   install : true,
   soversion : '0',
 )
@@ -22,4 +29,5 @@ install_headers(wyrelog_public_headers, subdir : 'wyrelog')
 wyrelog_dep = declare_dependency(
   link_with : libwyrelog,
   include_directories : wyrelog_inc,
+  dependencies : [glib_dep, gio_dep],
 )

--- a/wyrelog/meson.build
+++ b/wyrelog/meson.build
@@ -31,3 +31,28 @@ wyrelog_dep = declare_dependency(
   include_directories : wyrelog_inc,
   dependencies : [glib_dep, gio_dep],
 )
+
+wyrelog_client_public_headers = files(
+  'client.h',
+)
+
+wyrelog_client_sources = files(
+  'wyl-audit-iter.c',
+  'wyl-client.c',
+)
+
+libwyrelog_client = library('wyrelog-client',
+  wyrelog_client_sources,
+  include_directories : wyrelog_inc,
+  dependencies : [glib_dep, gio_dep, libsoup_dep],
+  install : true,
+  soversion : '0',
+)
+
+install_headers(wyrelog_client_public_headers, subdir : 'wyrelog')
+
+wyrelog_client_dep = declare_dependency(
+  link_with : libwyrelog_client,
+  include_directories : wyrelog_inc,
+  dependencies : [glib_dep, gio_dep],
+)

--- a/wyrelog/wyl-audit-event.c
+++ b/wyrelog/wyl-audit-event.c
@@ -1,0 +1,29 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "wyrelog/wyrelog.h"
+
+struct _WylAuditEvent
+{
+  GObject parent_instance;
+};
+
+G_DEFINE_FINAL_TYPE (WylAuditEvent, wyl_audit_event, G_TYPE_OBJECT);
+
+static void
+wyl_audit_event_class_init (WylAuditEventClass *klass)
+{
+  (void) klass;
+}
+
+static void
+wyl_audit_event_init (WylAuditEvent *self)
+{
+  (void) self;
+}
+
+wyrelog_error_t
+wyl_audit_emit (WylHandle *handle, const WylAuditEvent *event)
+{
+  (void) handle;
+  (void) event;
+  return WYRELOG_E_INTERNAL;
+}

--- a/wyrelog/wyl-audit-iter.c
+++ b/wyrelog/wyl-audit-iter.c
@@ -1,0 +1,47 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "wyrelog/client.h"
+
+struct _WylAuditIter
+{
+  GObject parent_instance;
+};
+
+G_DEFINE_FINAL_TYPE (WylAuditIter, wyl_audit_iter, G_TYPE_OBJECT);
+
+static void
+wyl_audit_iter_class_init (WylAuditIterClass *klass)
+{
+  (void) klass;
+}
+
+static void
+wyl_audit_iter_init (WylAuditIter *self)
+{
+  (void) self;
+}
+
+wyrelog_error_t
+wyl_client_audit_query (WylClient *client, const char *query_filter,
+    WylAuditIter **out_iter)
+{
+  (void) client;
+  (void) query_filter;
+
+  if (out_iter == NULL)
+    return WYRELOG_E_INVALID;
+
+  *out_iter = g_object_new (WYL_TYPE_AUDIT_ITER, NULL);
+  return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
+wyl_audit_iter_next (WylAuditIter *iter, gboolean *out_has_next)
+{
+  (void) iter;
+
+  if (out_has_next == NULL)
+    return WYRELOG_E_INVALID;
+
+  *out_has_next = FALSE;
+  return WYRELOG_E_OK;
+}

--- a/wyrelog/wyl-boot-private.h
+++ b/wyrelog/wyl-boot-private.h
@@ -1,0 +1,58 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#include "wyrelog/error.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*
+ * boot_phase_id_t identifies a single phase in the daemon's
+ * sequenced startup. Phases run one at a time in the order given
+ * to wyl_boot_run; each phase is idempotent on its own state.
+ *
+ * Only the first two phases are nailed down today. Subsequent
+ * identifiers are added incrementally as their phase functions
+ * land. The reserved sentinel BOOT_LAST sits at the end of the
+ * range so callers can size static arrays without tracking the
+ * highest-numbered phase by hand.
+ */
+  typedef enum boot_phase_id_t
+  {
+    BOOT_01_TPM_PROBE = 1,
+    BOOT_02_DEK_UNSEAL = 2,
+    /* BOOT_03 .. BOOT_20 reserved; added in subsequent commits. */
+    BOOT_LAST = 21,
+  } boot_phase_id_t;
+
+  typedef wyrelog_error_t (*boot_phase_fn_t) (void *ctx);
+
+  typedef struct boot_phase_t
+  {
+    boot_phase_id_t id;
+    const char *name;
+    boot_phase_fn_t fn;
+    bool fail_closed;
+  } boot_phase_t;
+
+/*
+ * wyl_boot_run runs the phases in seq[0..n) sequentially against
+ * ctx. A phase whose fn returns non-zero halts the run if its
+ * fail_closed flag is set; otherwise the failure is recorded and
+ * the run continues with the next phase.
+ *
+ * Return value: WYRELOG_E_OK if all phases reported success or
+ * non-fail-closed failures only; the first fail-closed phase's
+ * non-zero return code otherwise. WYRELOG_E_INVALID if seq is
+ * NULL while n > 0.
+ */
+  wyrelog_error_t wyl_boot_run (const boot_phase_t * seq, size_t n, void *ctx);
+
+#ifdef __cplusplus
+}
+#endif

--- a/wyrelog/wyl-boot.c
+++ b/wyrelog/wyl-boot.c
@@ -1,0 +1,41 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <stddef.h>
+
+#include "wyl-boot-private.h"
+#include "wyl-common-private.h"
+
+wyrelog_error_t
+wyl_boot_run (const boot_phase_t *seq, size_t n, void *ctx)
+{
+  if (n == 0)
+    return WYRELOG_E_OK;
+
+  if (seq == NULL)
+    return WYRELOG_E_INVALID;
+
+  for (size_t i = 0; i < n; i++) {
+    const boot_phase_t *phase = &seq[i];
+    wyrelog_error_t rc;
+
+    if (phase->fn == NULL) {
+      if (phase->fail_closed)
+        return WYRELOG_E_INTERNAL;
+      WYL_LOG_WARN ("boot phase %d (%s) has no fn; skipping",
+          phase->id, phase->name ? phase->name : "?");
+      continue;
+    }
+
+    rc = phase->fn (ctx);
+    if (rc != WYRELOG_E_OK) {
+      if (phase->fail_closed) {
+        WYL_LOG_ERROR ("boot phase %d (%s) failed; halting",
+            phase->id, phase->name ? phase->name : "?");
+        return rc;
+      }
+      WYL_LOG_WARN ("boot phase %d (%s) failed (continuing)",
+          phase->id, phase->name ? phase->name : "?");
+    }
+  }
+
+  return WYRELOG_E_OK;
+}

--- a/wyrelog/wyl-client.c
+++ b/wyrelog/wyl-client.c
@@ -1,0 +1,93 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "wyrelog/client.h"
+
+struct _WylClient
+{
+  GObject parent_instance;
+};
+
+G_DEFINE_FINAL_TYPE (WylClient, wyl_client, G_TYPE_OBJECT);
+
+static void
+wyl_client_class_init (WylClientClass *klass)
+{
+  (void) klass;
+}
+
+static void
+wyl_client_init (WylClient *self)
+{
+  (void) self;
+}
+
+wyrelog_error_t
+wyl_client_new (const char *base_url, WylClient **out_client)
+{
+  (void) base_url;
+
+  if (out_client == NULL)
+    return WYRELOG_E_INVALID;
+
+  *out_client = g_object_new (WYL_TYPE_CLIENT, NULL);
+  return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
+wyl_client_login (WylClient *client, const char *username, const char *password)
+{
+  (void) client;
+  (void) username;
+  (void) password;
+  return WYRELOG_E_INTERNAL;
+}
+
+wyrelog_error_t
+wyl_client_token_refresh (WylClient *client)
+{
+  (void) client;
+  return WYRELOG_E_INTERNAL;
+}
+
+wyrelog_error_t
+wyl_client_mfa_verify (WylClient *client, const char *otp)
+{
+  (void) client;
+  (void) otp;
+  return WYRELOG_E_INTERNAL;
+}
+
+wyrelog_error_t
+wyl_client_decide (WylClient *client, const char *user, const char *perm,
+    const char *session_token, int *out_decision)
+{
+  (void) client;
+  (void) user;
+  (void) perm;
+  (void) session_token;
+  (void) out_decision;
+  return WYRELOG_E_INTERNAL;
+}
+
+wyrelog_error_t
+wyl_client_tenant_select (WylClient *client, const char *tenant)
+{
+  (void) client;
+  (void) tenant;
+  return WYRELOG_E_INTERNAL;
+}
+
+wyrelog_error_t
+wyl_client_event_emit (WylClient *client, const char *event_kind,
+    const char *event_payload_json)
+{
+  (void) client;
+  (void) event_kind;
+  (void) event_payload_json;
+  return WYRELOG_E_INTERNAL;
+}
+
+const char *
+wyrelog_client_version_string (void)
+{
+  return "0.1.0";
+}

--- a/wyrelog/wyl-decide.c
+++ b/wyrelog/wyl-decide.c
@@ -1,0 +1,46 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "wyrelog/wyrelog.h"
+
+struct _wyl_decide_req
+{
+  int placeholder;
+};
+
+struct _wyl_decide_resp
+{
+  int placeholder;
+};
+
+wyl_decide_req_t *
+wyl_decide_req_new (void)
+{
+  return g_new0 (wyl_decide_req_t, 1);
+}
+
+void
+wyl_decide_req_free (wyl_decide_req_t *req)
+{
+  g_free (req);
+}
+
+wyl_decide_resp_t *
+wyl_decide_resp_new (void)
+{
+  return g_new0 (wyl_decide_resp_t, 1);
+}
+
+void
+wyl_decide_resp_free (wyl_decide_resp_t *resp)
+{
+  g_free (resp);
+}
+
+wyrelog_error_t
+wyl_decide (WylHandle *handle, const wyl_decide_req_t *req,
+    wyl_decide_resp_t *resp)
+{
+  (void) handle;
+  (void) req;
+  (void) resp;
+  return WYRELOG_E_INTERNAL;
+}

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -1,0 +1,40 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "wyrelog/wyrelog.h"
+
+struct _WylHandle
+{
+  GObject parent_instance;
+};
+
+G_DEFINE_FINAL_TYPE (WylHandle, wyl_handle, G_TYPE_OBJECT);
+
+static void
+wyl_handle_class_init (WylHandleClass *klass)
+{
+  (void) klass;
+}
+
+static void
+wyl_handle_init (WylHandle *self)
+{
+  (void) self;
+}
+
+wyrelog_error_t
+wyl_init (const char *config_path, WylHandle **out_handle)
+{
+  (void) config_path;
+
+  if (out_handle == NULL)
+    return WYRELOG_E_INVALID;
+
+  *out_handle = g_object_new (WYL_TYPE_HANDLE, NULL);
+  return WYRELOG_E_OK;
+}
+
+void
+wyl_shutdown (WylHandle *handle)
+{
+  (void) handle;
+  /* Real implementation drains queues, closes DBs, finalizes TPM. */
+}

--- a/wyrelog/wyl-perm.c
+++ b/wyrelog/wyl-perm.c
@@ -1,0 +1,69 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "wyrelog/wyrelog.h"
+
+struct _wyl_login_req
+{
+  int placeholder;
+};
+
+struct _wyl_grant_req
+{
+  int placeholder;
+};
+
+struct _wyl_revoke_req
+{
+  int placeholder;
+};
+
+wyl_login_req_t *
+wyl_login_req_new (void)
+{
+  return g_new0 (wyl_login_req_t, 1);
+}
+
+void
+wyl_login_req_free (wyl_login_req_t *req)
+{
+  g_free (req);
+}
+
+wyl_grant_req_t *
+wyl_grant_req_new (void)
+{
+  return g_new0 (wyl_grant_req_t, 1);
+}
+
+void
+wyl_grant_req_free (wyl_grant_req_t *req)
+{
+  g_free (req);
+}
+
+wyl_revoke_req_t *
+wyl_revoke_req_new (void)
+{
+  return g_new0 (wyl_revoke_req_t, 1);
+}
+
+void
+wyl_revoke_req_free (wyl_revoke_req_t *req)
+{
+  g_free (req);
+}
+
+wyrelog_error_t
+wyl_perm_grant (WylHandle *handle, const wyl_grant_req_t *req)
+{
+  (void) handle;
+  (void) req;
+  return WYRELOG_E_INTERNAL;
+}
+
+wyrelog_error_t
+wyl_perm_revoke (WylHandle *handle, const wyl_revoke_req_t *req)
+{
+  (void) handle;
+  (void) req;
+  return WYRELOG_E_INTERNAL;
+}

--- a/wyrelog/wyl-session.c
+++ b/wyrelog/wyl-session.c
@@ -1,0 +1,43 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "wyrelog/wyrelog.h"
+
+struct _WylSession
+{
+  GObject parent_instance;
+};
+
+G_DEFINE_FINAL_TYPE (WylSession, wyl_session, G_TYPE_OBJECT);
+
+static void
+wyl_session_class_init (WylSessionClass *klass)
+{
+  (void) klass;
+}
+
+static void
+wyl_session_init (WylSession *self)
+{
+  (void) self;
+}
+
+wyrelog_error_t
+wyl_session_login (WylHandle *handle, const wyl_login_req_t *req,
+    WylSession **out_session)
+{
+  (void) handle;
+  (void) req;
+
+  if (out_session == NULL)
+    return WYRELOG_E_INVALID;
+
+  *out_session = g_object_new (WYL_TYPE_SESSION, NULL);
+  return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
+wyl_session_logout (WylHandle *handle, wyl_session_id_t sid)
+{
+  (void) handle;
+  (void) sid;
+  return WYRELOG_E_INTERNAL;
+}

--- a/wyrelog/wyl-version.c
+++ b/wyrelog/wyl-version.c
@@ -1,0 +1,8 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "wyrelog/wyrelog.h"
+
+const char *
+wyrelog_version_string (void)
+{
+  return "0.1.0";
+}

--- a/wyrelog/wyrelog.h
+++ b/wyrelog/wyrelog.h
@@ -15,10 +15,10 @@ extern "C"
 /*
  * WylHandle - server-side embedding handle.
  *
- * Owns the policy database, audit log, TPM handles and worker threads
- * of an embedded wyrelog instance. Created with wyl_init, shut down
- * with wyl_shutdown, released with g_object_unref (or
- * g_autoptr(WylHandle) in scoped form).
+ * Owns the policy database, audit log, and worker threads of an
+ * embedded wyrelog instance. Created with wyl_init, shut down with
+ * wyl_shutdown, released with g_object_unref (or g_autoptr(WylHandle)
+ * in scoped form).
  */
   G_DECLARE_FINAL_TYPE (WylHandle, wyl_handle, WYL, HANDLE, GObject)
 #define WYL_TYPE_HANDLE (wyl_handle_get_type ())

--- a/wyrelog/wyrelog.h
+++ b/wyrelog/wyrelog.h
@@ -1,0 +1,106 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+
+#include <glib-object.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "wyrelog/error.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*
+ * WylHandle - server-side embedding handle.
+ *
+ * Owns the policy database, audit log, TPM handles and worker threads
+ * of an embedded wyrelog instance. Created with wyl_init, shut down
+ * with wyl_shutdown, released with g_object_unref (or
+ * g_autoptr(WylHandle) in scoped form).
+ */
+  G_DECLARE_FINAL_TYPE (WylHandle, wyl_handle, WYL, HANDLE, GObject)
+#define WYL_TYPE_HANDLE (wyl_handle_get_type ())
+/*
+ * WylSession - active authenticated session.
+ *
+ * Carries the principal identity, MFA state, and tenant binding for a
+ * sequence of decide calls. Acquired through wyl_session_login,
+ * released with g_object_unref / g_autoptr.
+ */
+  G_DECLARE_FINAL_TYPE (WylSession, wyl_session, WYL, SESSION, GObject)
+#define WYL_TYPE_SESSION (wyl_session_get_type ())
+/*
+ * WylAuditEvent - immutable audit record passed to wyl_audit_emit.
+ *
+ * GObject-based so callers can keep refs while the daemon serializes
+ * the event to the audit chain.
+ */
+  G_DECLARE_FINAL_TYPE (WylAuditEvent, wyl_audit_event,
+      WYL, AUDIT_EVENT, GObject)
+#define WYL_TYPE_AUDIT_EVENT (wyl_audit_event_get_type ())
+/*
+ * Plain integer session identifier. Stable across the lifetime of a
+ * WylHandle; not a GObject.
+ */
+  typedef uint64_t wyl_session_id_t;
+
+/*
+ * Opaque request/response carriers for decide / login / perm.
+ *
+ * Constructed with the matching _new function, populated through
+ * setters (added in follow-up commits) and freed with the matching
+ * _free function or via g_autoptr (GLib autoptr cleanup is wired
+ * below).
+ */
+  typedef struct _wyl_decide_req wyl_decide_req_t;
+  typedef struct _wyl_decide_resp wyl_decide_resp_t;
+  typedef struct _wyl_login_req wyl_login_req_t;
+  typedef struct _wyl_grant_req wyl_grant_req_t;
+  typedef struct _wyl_revoke_req wyl_revoke_req_t;
+
+  wyl_decide_req_t *wyl_decide_req_new (void);
+  void wyl_decide_req_free (wyl_decide_req_t * req);
+    G_DEFINE_AUTOPTR_CLEANUP_FUNC (wyl_decide_req_t, wyl_decide_req_free)
+  wyl_decide_resp_t *wyl_decide_resp_new (void);
+  void wyl_decide_resp_free (wyl_decide_resp_t * resp);
+    G_DEFINE_AUTOPTR_CLEANUP_FUNC (wyl_decide_resp_t, wyl_decide_resp_free)
+  wyl_login_req_t *wyl_login_req_new (void);
+  void wyl_login_req_free (wyl_login_req_t * req);
+    G_DEFINE_AUTOPTR_CLEANUP_FUNC (wyl_login_req_t, wyl_login_req_free)
+  wyl_grant_req_t *wyl_grant_req_new (void);
+  void wyl_grant_req_free (wyl_grant_req_t * req);
+    G_DEFINE_AUTOPTR_CLEANUP_FUNC (wyl_grant_req_t, wyl_grant_req_free)
+  wyl_revoke_req_t *wyl_revoke_req_new (void);
+  void wyl_revoke_req_free (wyl_revoke_req_t * req);
+    G_DEFINE_AUTOPTR_CLEANUP_FUNC (wyl_revoke_req_t, wyl_revoke_req_free)
+/* Lifecycle */
+  wyrelog_error_t wyl_init (const char *config_path, WylHandle ** out_handle);
+  void wyl_shutdown (WylHandle * handle);
+
+/* Decide */
+  wyrelog_error_t wyl_decide (WylHandle * handle,
+      const wyl_decide_req_t * req, wyl_decide_resp_t * resp);
+
+/* Sessions */
+  wyrelog_error_t wyl_session_login (WylHandle * handle,
+      const wyl_login_req_t * req, WylSession ** out_session);
+  wyrelog_error_t wyl_session_logout (WylHandle * handle, wyl_session_id_t sid);
+
+/* Permissions (admin) */
+  wyrelog_error_t wyl_perm_grant (WylHandle * handle,
+      const wyl_grant_req_t * req);
+  wyrelog_error_t wyl_perm_revoke (WylHandle * handle,
+      const wyl_revoke_req_t * req);
+
+/* Audit */
+  wyrelog_error_t wyl_audit_emit (WylHandle * handle,
+      const WylAuditEvent * event);
+
+/* Meta */
+  const char *wyrelog_version_string (void);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
## Summary

Four atomic commits stacking on the merged source skeleton:

1. **`feat: add boot orchestrator signature and stub`** — introduces `wyrelog/wyl-boot-private.h` (internal-only header) declaring `boot_phase_id_t`, `boot_phase_t`, `boot_phase_fn_t`, and `wyl_boot_run`. The orchestrator runs a caller-supplied array of phase descriptors sequentially, halting on the first fail-closed failure and continuing past non-fail-closed ones, with WARN/ERROR logging through the existing internal log macros. A `tests/test-boot-smoke.c` exercises empty/NULL-seq/all-success/fail-closed-short-circuit/non-fail-closed-continue paths.

2. **`feat: add public server API headers and stubs`** — introduces `wyrelog/wyrelog.h`, the public embedding header for `libwyrelog`. The header declares three GObject lifecycle types (`WylHandle`, `WylSession`, `WylAuditEvent`) via `G_DECLARE_FINAL_TYPE`, the plain `wyl_session_id_t = uint64_t`, five opaque request/response carriers with paired `_new`/`_free` and `G_DEFINE_AUTOPTR_CLEANUP_FUNC` bindings, and ten public functions covering lifecycle, decide, sessions, permission grants, audit emission, and version reporting. Six new `.c` files provide `G_DEFINE_FINAL_TYPE` scaffolding and stub function bodies. The smoke test is extended to verify input validation and the happy `wyl_init` path through `g_autoptr(WylHandle)`.

3. **`feat: add public client API and library`** — introduces `wyrelog/client.h` and a NEW `libwyrelog-client.so` independent of `libwyrelog`. The client header declares two GObject types (`WylClient`, `WylAuditIter`) and ten functions covering lifecycle, login, token refresh, MFA verification, remote decide, audit-query iteration, tenant selection, event emission, and version reporting. The client library links only against glib-2.0 / gio-2.0 / libsoup-3.0 — it does NOT pull in the server-side dependency surface. A new `tests/test-client-smoke.c` exercises input validation, the happy `wyl_client_new` path, and the audit iterator's empty state.

4. **`docs: scrub implementation infrastructure from public header docstrings`** — small follow-up that generalizes two GObject docstrings to describe behaviour rather than commit to specific implementation infrastructure in the public ABI. The dependency declarations in `meson.build` remain the source of truth for the build-time link surface.

## Test plan

- [x] `rm -rf builddir && meson setup builddir` returns 0.
- [x] `ninja -C builddir wyrelog/libwyrelog.so.0 wyrelog/libwyrelog-client.so.0` builds both libraries as separate ELF objects.
- [x] `meson test -C builddir smoke boot-smoke client-smoke` reports 3/3 OK.
- [x] `nm -D --defined-only builddir/wyrelog/libwyrelog.so.0` exports `wyl_init`, `wyl_shutdown`, `wyl_decide`, `wyl_session_login/logout`, `wyl_perm_grant/revoke`, `wyl_audit_emit`, `wyrelog_version_string`, `wyl_boot_run`, the three GObject `*_get_type` symbols, the five carrier `_new`/`_free` pairs, plus `wyrelog_error_string` carried over from earlier work.
- [x] `nm -D --defined-only builddir/wyrelog/libwyrelog-client.so.0` exports the ten client-side functions plus the two `*_get_type` symbols, and contains no server-side symbols.
- [x] `ldd builddir/wyrelog/libwyrelog-client.so.0` does not depend on `libwyrelog.so`.
- [x] `./tools/gst-indent` is idempotent on every new C/H file (zero diff on a second pass).
- [x] `meson install --destdir /tmp/wyrelog-install` installs `error.h`, `wyrelog.h`, and `client.h` under `${includedir}/wyrelog/`; the internal `wyl-*-private.h` headers are not installed.