### PR TITLE
feat: add Datalog stratification static checker

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -25,3 +25,10 @@ test_traits_compile = executable('test-traits-compile',
 )
 
 test('traits-compile', test_traits_compile)
+
+test_dl_static = executable('test-dl-static',
+  'test-dl-static.c',
+  dependencies : [wyrelog_dep],
+)
+
+test('dl-static', test_dl_static)

--- a/tests/test-dl-static.c
+++ b/tests/test-dl-static.c
@@ -1,0 +1,166 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <stddef.h>
+
+#include "wyrelog/wyl-dl-static-private.h"
+
+static int
+check (const wyl_dl_rule_t *rules, size_t n)
+{
+  return (int) wyl_dl_static_check (rules, n);
+}
+
+int
+main (void)
+{
+  /* Case 1: empty input -> OK. */
+  if (check (NULL, 0) != WYRELOG_E_OK)
+    return 1;
+
+  /* Case 2: NULL rules with n > 0 -> INVALID. */
+  if (check (NULL, 1) != WYRELOG_E_INVALID)
+    return 2;
+
+  /* Case 3: NULL head -> INVALID. */
+  {
+    wyl_dl_rule_t rules[] = { {NULL, NULL, 0}
+    };
+    if (check (rules, 1) != WYRELOG_E_INVALID)
+      return 3;
+  }
+
+  /* Case 4: NULL body predicate -> INVALID. */
+  {
+    wyl_dl_body_atom_t body[] = { {NULL, false}
+    };
+    wyl_dl_rule_t rules[] = { {"p", body, 1}
+    };
+    if (check (rules, 1) != WYRELOG_E_INVALID)
+      return 4;
+  }
+
+  /* Case 5: single fact, no body (p.) -> OK. */
+  {
+    wyl_dl_rule_t rules[] = { {"p", NULL, 0}
+    };
+    if (check (rules, 1) != WYRELOG_E_OK)
+      return 5;
+  }
+
+  /* Case 6: linear chain r :- q. q :- p. -> OK. */
+  {
+    wyl_dl_body_atom_t body_r[] = { {"q", false}
+    };
+    wyl_dl_body_atom_t body_q[] = { {"p", false}
+    };
+    wyl_dl_rule_t rules[] = {
+      {"r", body_r, 1},
+      {"q", body_q, 1},
+    };
+    if (check (rules, 2) != WYRELOG_E_OK)
+      return 6;
+  }
+
+  /* Case 7: self-loop without negation p :- p. -> OK. */
+  {
+    wyl_dl_body_atom_t body[] = { {"p", false}
+    };
+    wyl_dl_rule_t rules[] = { {"p", body, 1}
+    };
+    if (check (rules, 1) != WYRELOG_E_OK)
+      return 7;
+  }
+
+  /* Case 8: self-loop with negation p :- \+ p. -> POLICY. */
+  {
+    wyl_dl_body_atom_t body[] = { {"p", true}
+    };
+    wyl_dl_rule_t rules[] = { {"p", body, 1}
+    };
+    if (check (rules, 1) != WYRELOG_E_POLICY)
+      return 8;
+  }
+
+  /* Case 9: mutual recursion without negation
+   *   p :- q.  q :- p.  -> OK. */
+  {
+    wyl_dl_body_atom_t body_p[] = { {"q", false}
+    };
+    wyl_dl_body_atom_t body_q[] = { {"p", false}
+    };
+    wyl_dl_rule_t rules[] = {
+      {"p", body_p, 1},
+      {"q", body_q, 1},
+    };
+    if (check (rules, 2) != WYRELOG_E_OK)
+      return 9;
+  }
+
+  /* Case 10: mutual recursion with negation in cycle
+   *   p :- \+ q.  q :- p.  -> POLICY. */
+  {
+    wyl_dl_body_atom_t body_p[] = { {"q", true}
+    };
+    wyl_dl_body_atom_t body_q[] = { {"p", false}
+    };
+    wyl_dl_rule_t rules[] = {
+      {"p", body_p, 1},
+      {"q", body_q, 1},
+    };
+    if (check (rules, 2) != WYRELOG_E_POLICY)
+      return 10;
+  }
+
+  /* Case 11: cross-stratum negation (no cycle through negation)
+   *   p :- q.  r :- \+ p.   -> OK. */
+  {
+    wyl_dl_body_atom_t body_p[] = { {"q", false}
+    };
+    wyl_dl_body_atom_t body_r[] = { {"p", true}
+    };
+    wyl_dl_rule_t rules[] = {
+      {"p", body_p, 1},
+      {"r", body_r, 1},
+    };
+    if (check (rules, 2) != WYRELOG_E_OK)
+      return 11;
+  }
+
+  /* Case 12: two SCCs connected by a negation edge that is NOT
+   * inside either SCC.
+   *   p :- p.            (singleton SCC {p})
+   *   q :- q.            (singleton SCC {q})
+   *   q :- \+ p.         (negation crosses SCC boundary)
+   *  -> OK. */
+  {
+    wyl_dl_body_atom_t body_p_self[] = { {"p", false}
+    };
+    wyl_dl_body_atom_t body_q_self[] = { {"q", false}
+    };
+    wyl_dl_body_atom_t body_q_not_p[] = { {"p", true}
+    };
+    wyl_dl_rule_t rules[] = {
+      {"p", body_p_self, 1},
+      {"q", body_q_self, 1},
+      {"q", body_q_not_p, 1},
+    };
+    if (check (rules, 3) != WYRELOG_E_OK)
+      return 12;
+  }
+
+  /* Case 13: multi-rule same head (no cycle)
+   *   p :- q.  p :- r.  -> OK. */
+  {
+    wyl_dl_body_atom_t body_a[] = { {"q", false}
+    };
+    wyl_dl_body_atom_t body_b[] = { {"r", false}
+    };
+    wyl_dl_rule_t rules[] = {
+      {"p", body_a, 1},
+      {"p", body_b, 1},
+    };
+    if (check (rules, 2) != WYRELOG_E_OK)
+      return 13;
+  }
+
+  return 0;
+}

--- a/wyrelog/meson.build
+++ b/wyrelog/meson.build
@@ -9,6 +9,7 @@ wyrelog_sources = files(
   'wyl-audit-event.c',
   'wyl-boot.c',
   'wyl-decide.c',
+  'wyl-dl-static.c',
   'wyl-error.c',
   'wyl-handle.c',
   'wyl-perm.c',

--- a/wyrelog/wyl-dl-static-private.h
+++ b/wyrelog/wyl-dl-static-private.h
@@ -1,0 +1,70 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#include "wyrelog/error.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*
+ * Static stratification check for Datalog rule sets.
+ *
+ * A Datalog program is stratified iff its predicate dependency graph
+ * contains no cycle whose edges include a negation. Stratification is
+ * a sufficient condition for the program to have a unique well-founded
+ * model under negation as failure. wyrelog rejects non-stratified
+ * inputs at load time so evaluation never observes a value that
+ * depends on its own absence.
+ *
+ * The checker operates on a caller-owned array of rules. Each rule
+ * names one head predicate and zero or more body atoms; each body
+ * atom carries a flag marking whether it appears under negation
+ * ("\+" in the source program). Strings are inspected only -- the
+ * checker neither copies nor frees them, and the caller must keep
+ * them alive across the call. Predicate names are matched
+ * byte-for-byte (case-sensitive); arity is not part of the identity
+ * in v0, so callers that need arity disambiguation encode it into
+ * the name (for example "foo/2").
+ *
+ * Implementation note: the underlying SCC pass uses recursive DFS,
+ * so callers must keep the predicate count below roughly ten
+ * thousand to avoid stack overflow on default thread stacks. v0
+ * policies are well below that bound; an iterative rewrite is left
+ * to a future hardening commit.
+ *
+ * Return codes:
+ *   WYRELOG_E_OK        program is stratified (or trivially empty).
+ *   WYRELOG_E_POLICY    a negation edge participates in a cycle;
+ *                       the program is rejected.
+ *   WYRELOG_E_INVALID   rules == NULL with n > 0, or any rule's head
+ *                       is NULL, or any body atom has a NULL
+ *                       predicate, or body == NULL while body_len > 0.
+ *
+ * The checker does not return WYRELOG_E_NOMEM because all of its
+ * allocations go through GLib, and GLib aborts the process on
+ * allocation failure by design.
+ */
+
+  typedef struct wyl_dl_body_atom_t
+  {
+    const char *predicate;
+    bool negated;
+  } wyl_dl_body_atom_t;
+
+  typedef struct wyl_dl_rule_t
+  {
+    const char *head;
+    const wyl_dl_body_atom_t *body;
+    size_t body_len;
+  } wyl_dl_rule_t;
+
+  wyrelog_error_t wyl_dl_static_check (const wyl_dl_rule_t * rules, size_t n);
+
+#ifdef __cplusplus
+}
+#endif

--- a/wyrelog/wyl-dl-static.c
+++ b/wyrelog/wyl-dl-static.c
@@ -1,0 +1,210 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "wyl-dl-static-private.h"
+#include "wyl-common-private.h"
+
+#include <glib.h>
+#include <stdint.h>
+
+/*
+ * Implementation overview.
+ *
+ * 1. Walk the rules once and intern every distinct predicate name in
+ *    a GHashTable that maps name -> small integer index. The number
+ *    of distinct predicates V bounds every subsequent array.
+ *
+ * 2. Walk the rules a second time and emit one edge per body atom:
+ *    edge from body-predicate-index to head-predicate-index, with
+ *    the body atom's negation flag carried alongside. Edges are
+ *    stored in per-source adjacency lists.
+ *
+ * 3. Run Tarjan's SCC on the graph. After SCC computation, walk
+ *    every edge once: if both endpoints share a component AND the
+ *    edge is marked negated, the program is rejected.
+ *
+ * The algorithm is O(V + E). Allocations are released through
+ * g_autoptr / g_autofree on both success and failure paths; the
+ * out_edges array of GArray pointers is freed by an explicit helper
+ * because g_autoptr does not compose with arrays of owned pointers.
+ */
+
+typedef struct edge_t
+{
+  int to;
+  bool negated;
+} edge_t;
+
+typedef struct scc_state_t
+{
+  int n_predicates;
+
+  /* Per-predicate adjacency: out_edges[i] -> array of edge_t. */
+  GArray **out_edges;
+
+  /* Tarjan bookkeeping. */
+  int *index;
+  int *lowlink;
+  bool *on_stack;
+  int next_index;
+
+  GArray *stack;
+  int *comp_id;
+  int next_comp_id;
+} scc_state_t;
+
+
+static int
+intern_predicate (GHashTable *names, const char *p, int *next_id)
+{
+  gpointer slot = g_hash_table_lookup (names, p);
+  if (slot != NULL)
+    return GPOINTER_TO_INT (slot) - 1;
+
+  int id = (*next_id)++;
+  g_hash_table_insert (names, (gpointer) p, GINT_TO_POINTER (id + 1));
+  return id;
+}
+
+static void
+strongconnect (scc_state_t *s, int v)
+{
+  s->index[v] = s->next_index;
+  s->lowlink[v] = s->next_index;
+  s->next_index++;
+  g_array_append_val (s->stack, v);
+  s->on_stack[v] = true;
+
+  GArray *out = s->out_edges[v];
+  for (guint i = 0; i < out->len; i++) {
+    edge_t e = g_array_index (out, edge_t, i);
+    int w = e.to;
+    if (s->index[w] == -1) {
+      strongconnect (s, w);
+      if (s->lowlink[w] < s->lowlink[v])
+        s->lowlink[v] = s->lowlink[w];
+    } else if (s->on_stack[w]) {
+      if (s->index[w] < s->lowlink[v])
+        s->lowlink[v] = s->index[w];
+    }
+  }
+
+  if (s->lowlink[v] == s->index[v]) {
+    int comp = s->next_comp_id++;
+    int w;
+    do {
+      w = g_array_index (s->stack, int, s->stack->len - 1);
+      g_array_set_size (s->stack, s->stack->len - 1);
+      s->on_stack[w] = false;
+      s->comp_id[w] = comp;
+    } while (w != v);
+  }
+}
+
+static void
+free_out_edges (GArray **out_edges, int n)
+{
+  if (out_edges == NULL)
+    return;
+  for (int i = 0; i < n; i++) {
+    if (out_edges[i] != NULL)
+      g_array_unref (out_edges[i]);
+  }
+  g_free (out_edges);
+}
+
+wyrelog_error_t
+wyl_dl_static_check (const wyl_dl_rule_t *rules, size_t n)
+{
+  if (n == 0)
+    return WYRELOG_E_OK;
+  if (rules == NULL)
+    return WYRELOG_E_INVALID;
+
+  /* Validate input shape before allocating anything. */
+  for (size_t i = 0; i < n; i++) {
+    if (rules[i].head == NULL)
+      return WYRELOG_E_INVALID;
+    if (rules[i].body_len > 0 && rules[i].body == NULL)
+      return WYRELOG_E_INVALID;
+    for (size_t j = 0; j < rules[i].body_len; j++) {
+      if (rules[i].body[j].predicate == NULL)
+        return WYRELOG_E_INVALID;
+    }
+  }
+
+  /* Pass 1: intern every distinct predicate name. The hash table
+   * does not own the strings; the caller does. */
+  g_autoptr (GHashTable) names = g_hash_table_new (g_str_hash, g_str_equal);
+  int next_id = 0;
+  for (size_t i = 0; i < n; i++) {
+    intern_predicate (names, rules[i].head, &next_id);
+    for (size_t j = 0; j < rules[i].body_len; j++)
+      intern_predicate (names, rules[i].body[j].predicate, &next_id);
+  }
+
+  int V = next_id;
+  if (V == 0)
+    return WYRELOG_E_OK;
+
+  scc_state_t s = { 0 };
+  s.n_predicates = V;
+  s.out_edges = g_new0 (GArray *, V);
+  for (int i = 0; i < V; i++)
+    s.out_edges[i] = g_array_new (FALSE, FALSE, sizeof (edge_t));
+
+  /* Pass 2: emit edges. */
+  for (size_t i = 0; i < n; i++) {
+    int head_id =
+        GPOINTER_TO_INT (g_hash_table_lookup (names, rules[i].head)) - 1;
+    for (size_t j = 0; j < rules[i].body_len; j++) {
+      int body_id = GPOINTER_TO_INT (g_hash_table_lookup (names,
+              rules[i].body[j].predicate)) - 1;
+      edge_t e = {.to = head_id,
+        .negated = rules[i].body[j].negated
+      };
+      g_array_append_val (s.out_edges[body_id], e);
+    }
+  }
+
+  /* Tarjan bookkeeping. */
+  g_autofree int *index = g_new (int, V);
+  g_autofree int *lowlink = g_new (int, V);
+  g_autofree bool *on_stack = g_new0 (bool, V);
+  g_autofree int *comp_id = g_new (int, V);
+  for (int i = 0; i < V; i++) {
+    index[i] = -1;
+    lowlink[i] = 0;
+    comp_id[i] = -1;
+  }
+  g_autoptr (GArray) stack = g_array_new (FALSE, FALSE, sizeof (int));
+
+  s.index = index;
+  s.lowlink = lowlink;
+  s.on_stack = on_stack;
+  s.comp_id = comp_id;
+  s.stack = stack;
+  s.next_index = 0;
+  s.next_comp_id = 0;
+
+  for (int i = 0; i < V; i++) {
+    if (index[i] == -1)
+      strongconnect (&s, i);
+  }
+
+  /* Reject when any negated edge has both endpoints in the same
+   * SCC. Self-loops (singleton SCC with a negated self-edge) are
+   * caught by the same rule. */
+  wyrelog_error_t rc = WYRELOG_E_OK;
+  for (int v = 0; v < V && rc == WYRELOG_E_OK; v++) {
+    GArray *out = s.out_edges[v];
+    for (guint i = 0; i < out->len; i++) {
+      edge_t e = g_array_index (out, edge_t, i);
+      if (e.negated && comp_id[v] == comp_id[e.to]) {
+        rc = WYRELOG_E_POLICY;
+        break;
+      }
+    }
+  }
+
+  free_out_edges (s.out_edges, V);
+  return rc;
+}


### PR DESCRIPTION
## Summary

Introduces an internal-only Datalog stratification check for libwyrelog so non-stratified rule sets are rejected fail-closed at load time, before evaluation begins.

A Datalog program is *stratified* iff its predicate dependency graph contains no cycle whose edges include a negation. Stratification is a sufficient condition for the program to have a unique well-founded model under negation as failure; rule sets that violate it cannot be evaluated soundly.

### `wyrelog/wyl-dl-static-private.h` (NEW, internal-only)

Declares an in-memory rule IR and the single entry point:

```c
typedef struct wyl_dl_body_atom_t { const char *predicate; bool negated; } wyl_dl_body_atom_t;
typedef struct wyl_dl_rule_t { const char *head; const wyl_dl_body_atom_t *body; size_t body_len; } wyl_dl_rule_t;

wyrelog_error_t wyl_dl_static_check (const wyl_dl_rule_t *rules, size_t n);
```

Return contract: `WYRELOG_E_OK` (stratified or empty), `WYRELOG_E_POLICY` (negation cycle detected), `WYRELOG_E_INVALID` (NULL or malformed input). The function does NOT return `WYRELOG_E_NOMEM` because all of its allocations go through GLib, which aborts on allocation failure by design.

### `wyrelog/wyl-dl-static.c` (NEW, joins libwyrelog)

Two-pass implementation:

1. **Intern**: walk every rule, map each distinct predicate name to a small integer index using a `GHashTable` (caller owns the strings; the table only borrows them).
2. **Build + classify**: emit one edge per body atom (carrying the negation flag), run Tarjan's SCC, then walk every edge once. Reject if `comp_id[from] == comp_id[to] && edge.negated`. Self-loops with negation are caught by the same rule.

Algorithm is O(V + E). All allocations are released via `g_autoptr` / `g_autofree` on success and failure paths; the `out_edges` array of `GArray *` is freed by an explicit helper because `g_autoptr` does not compose with arrays of owned pointers.

### `tests/test-dl-static.c` (NEW)

Thirteen cases, vanilla `if/return <code>` style:

1. Empty input → OK
2. NULL rules with `n>0` → INVALID
3. NULL head → INVALID
4. NULL body predicate → INVALID
5. Single fact (no body) → OK
6. Linear chain `r :- q. q :- p.` → OK (EDB-only `p`)
7. Self-loop `p :- p.` → OK
8. Self-loop `p :- \+ p.` → POLICY
9. Mutual recursion without negation → OK
10. Mutual recursion with negation in cycle → POLICY
11. Cross-stratum negation (no cycle) → OK
12. Two SCCs connected by a negation edge that is NOT inside either SCC → OK
13. Multi-rule same head → OK

## Test plan

- [x] `meson test -C builddir smoke boot-smoke client-smoke traits-compile dl-static` reports 5/5 OK on the Linux dev host.
- [x] `wyrelog/meson.build` install_headers list still contains only `error.h`, `wyrelog.h`, `client.h`; `wyl-dl-static-private.h` is not installed.
- [x] `./tools/gst-indent` is idempotent on every new C/H file (zero diff after one pass).
- [ ] CI build gate validates Linux/macOS/Windows on the PR.