### PR TITLE
refactor: replace extern "C" blocks with G_BEGIN_DECLS / G_END_DECLS

### DIFF
--- a/wyrelog/client.h
+++ b/wyrelog/client.h
@@ -5,10 +5,7 @@
 
 #include "wyrelog/error.h"
 
-#ifdef __cplusplus
-extern "C"
-{
-#endif
+G_BEGIN_DECLS;
 
 /*
  * WylClient - HTTP client for talking to a remote wyrelog daemon.
@@ -18,46 +15,45 @@ extern "C"
  * Created with wyl_client_new, released with g_object_unref or
  * g_autoptr.
  */
-  G_DECLARE_FINAL_TYPE (WylClient, wyl_client, WYL, CLIENT, GObject)
+G_DECLARE_FINAL_TYPE (WylClient, wyl_client, WYL, CLIENT, GObject);
 #define WYL_TYPE_CLIENT (wyl_client_get_type ())
+
 /*
  * WylAuditIter - paginated audit query cursor.
  *
  * Issues one HTTP GET per page and yields events through
  * wyl_audit_iter_next until the server reports the end.
  */
-  G_DECLARE_FINAL_TYPE (WylAuditIter, wyl_audit_iter, WYL, AUDIT_ITER, GObject)
+G_DECLARE_FINAL_TYPE (WylAuditIter, wyl_audit_iter, WYL, AUDIT_ITER, GObject);
 #define WYL_TYPE_AUDIT_ITER (wyl_audit_iter_get_type ())
+
 /* Lifecycle */
-  wyrelog_error_t wyl_client_new (const char *base_url,
-      WylClient ** out_client);
+wyrelog_error_t wyl_client_new (const char *base_url, WylClient ** out_client);
 
 /* Authentication */
-  wyrelog_error_t wyl_client_login (WylClient * client,
-      const char *username, const char *password);
-  wyrelog_error_t wyl_client_token_refresh (WylClient * client);
-  wyrelog_error_t wyl_client_mfa_verify (WylClient * client, const char *otp);
+wyrelog_error_t wyl_client_login (WylClient * client,
+    const char *username, const char *password);
+wyrelog_error_t wyl_client_token_refresh (WylClient * client);
+wyrelog_error_t wyl_client_mfa_verify (WylClient * client, const char *otp);
 
 /* Decide */
-  wyrelog_error_t wyl_client_decide (WylClient * client,
-      const char *user,
-      const char *perm, const char *session_token, int *out_decision);
+wyrelog_error_t wyl_client_decide (WylClient * client,
+    const char *user,
+    const char *perm, const char *session_token, int *out_decision);
 
 /* Audit query (iterator) */
-  wyrelog_error_t wyl_client_audit_query (WylClient * client,
-      const char *query_filter, WylAuditIter ** out_iter);
-  wyrelog_error_t wyl_audit_iter_next (WylAuditIter * iter,
-      gboolean * out_has_next);
+wyrelog_error_t wyl_client_audit_query (WylClient * client,
+    const char *query_filter, WylAuditIter ** out_iter);
+wyrelog_error_t wyl_audit_iter_next (WylAuditIter * iter,
+    gboolean * out_has_next);
 
 /* Tenant / event */
-  wyrelog_error_t wyl_client_tenant_select (WylClient * client,
-      const char *tenant);
-  wyrelog_error_t wyl_client_event_emit (WylClient * client,
-      const char *event_kind, const char *event_payload_json);
+wyrelog_error_t wyl_client_tenant_select (WylClient * client,
+    const char *tenant);
+wyrelog_error_t wyl_client_event_emit (WylClient * client,
+    const char *event_kind, const char *event_payload_json);
 
 /* Meta */
-  const char *wyrelog_client_version_string (void);
+const char *wyrelog_client_version_string (void);
 
-#ifdef __cplusplus
-}
-#endif
+G_END_DECLS;

--- a/wyrelog/error.h
+++ b/wyrelog/error.h
@@ -1,25 +1,22 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #pragma once
 
-#ifdef __cplusplus
-extern "C"
+#include <glib.h>
+
+G_BEGIN_DECLS;
+
+typedef enum wyrelog_error_t
 {
-#endif
+  WYRELOG_E_OK = 0,
+  WYRELOG_E_INVALID = -1,
+  WYRELOG_E_NOMEM = -2,
+  WYRELOG_E_IO = -3,
+  WYRELOG_E_CRYPTO = -4,
+  WYRELOG_E_POLICY = -5,
+  WYRELOG_E_AUTH = -6,
+  WYRELOG_E_INTERNAL = -7,
+} wyrelog_error_t;
 
-  typedef enum wyrelog_error_t
-  {
-    WYRELOG_E_OK = 0,
-    WYRELOG_E_INVALID = -1,
-    WYRELOG_E_NOMEM = -2,
-    WYRELOG_E_IO = -3,
-    WYRELOG_E_CRYPTO = -4,
-    WYRELOG_E_POLICY = -5,
-    WYRELOG_E_AUTH = -6,
-    WYRELOG_E_INTERNAL = -7,
-  } wyrelog_error_t;
+const char *wyrelog_error_string (wyrelog_error_t err);
 
-  const char *wyrelog_error_string (wyrelog_error_t err);
-
-#ifdef __cplusplus
-}
-#endif
+G_END_DECLS;

--- a/wyrelog/wyl-boot-private.h
+++ b/wyrelog/wyl-boot-private.h
@@ -6,10 +6,7 @@
 
 #include "wyrelog/error.h"
 
-#ifdef __cplusplus
-extern "C"
-{
-#endif
+G_BEGIN_DECLS;
 
 /*
  * boot_phase_id_t identifies a single phase in the daemon's
@@ -22,23 +19,23 @@ extern "C"
  * range so callers can size static arrays without tracking the
  * highest-numbered phase by hand.
  */
-  typedef enum boot_phase_id_t
-  {
-    BOOT_01_TPM_PROBE = 1,
-    BOOT_02_DEK_UNSEAL = 2,
-    /* BOOT_03 .. BOOT_20 reserved; added in subsequent commits. */
-    BOOT_LAST = 21,
-  } boot_phase_id_t;
+typedef enum boot_phase_id_t
+{
+  BOOT_01_TPM_PROBE = 1,
+  BOOT_02_DEK_UNSEAL = 2,
+  /* BOOT_03 .. BOOT_20 reserved; added in subsequent commits. */
+  BOOT_LAST = 21,
+} boot_phase_id_t;
 
-  typedef wyrelog_error_t (*boot_phase_fn_t) (void *ctx);
+typedef wyrelog_error_t (*boot_phase_fn_t) (void *ctx);
 
-  typedef struct boot_phase_t
-  {
-    boot_phase_id_t id;
-    const char *name;
-    boot_phase_fn_t fn;
-    bool fail_closed;
-  } boot_phase_t;
+typedef struct boot_phase_t
+{
+  boot_phase_id_t id;
+  const char *name;
+  boot_phase_fn_t fn;
+  bool fail_closed;
+} boot_phase_t;
 
 /*
  * wyl_boot_run runs the phases in seq[0..n) sequentially against
@@ -51,8 +48,6 @@ extern "C"
  * non-zero return code otherwise. WYRELOG_E_INVALID if seq is
  * NULL while n > 0.
  */
-  wyrelog_error_t wyl_boot_run (const boot_phase_t * seq, size_t n, void *ctx);
+wyrelog_error_t wyl_boot_run (const boot_phase_t * seq, size_t n, void *ctx);
 
-#ifdef __cplusplus
-}
-#endif
+G_END_DECLS;

--- a/wyrelog/wyl-dl-static-private.h
+++ b/wyrelog/wyl-dl-static-private.h
@@ -6,10 +6,7 @@
 
 #include "wyrelog/error.h"
 
-#ifdef __cplusplus
-extern "C"
-{
-#endif
+G_BEGIN_DECLS;
 
 /*
  * Static stratification check for Datalog rule sets.
@@ -50,21 +47,19 @@ extern "C"
  * allocation failure by design.
  */
 
-  typedef struct wyl_dl_body_atom_t
-  {
-    const char *predicate;
-    bool negated;
-  } wyl_dl_body_atom_t;
+typedef struct wyl_dl_body_atom_t
+{
+  const char *predicate;
+  bool negated;
+} wyl_dl_body_atom_t;
 
-  typedef struct wyl_dl_rule_t
-  {
-    const char *head;
-    const wyl_dl_body_atom_t *body;
-    size_t body_len;
-  } wyl_dl_rule_t;
+typedef struct wyl_dl_rule_t
+{
+  const char *head;
+  const wyl_dl_body_atom_t *body;
+  size_t body_len;
+} wyl_dl_rule_t;
 
-  wyrelog_error_t wyl_dl_static_check (const wyl_dl_rule_t * rules, size_t n);
+wyrelog_error_t wyl_dl_static_check (const wyl_dl_rule_t * rules, size_t n);
 
-#ifdef __cplusplus
-}
-#endif
+G_END_DECLS;

--- a/wyrelog/wyl-traits-private.h
+++ b/wyrelog/wyl-traits-private.h
@@ -7,10 +7,7 @@
 
 #include "wyrelog/error.h"
 
-#ifdef __cplusplus
-extern "C"
-{
-#endif
+G_BEGIN_DECLS;
 
 /*
  * Internal trait vtables.
@@ -53,41 +50,41 @@ extern "C"
  * The engine sees only the bytes pointer + length and never inspects
  * the format.
  */
-  typedef struct wyl_sealed_blob_t
-  {
-    uint8_t *bytes;
-    size_t len;
-  } wyl_sealed_blob_t;
+typedef struct wyl_sealed_blob_t
+{
+  uint8_t *bytes;
+  size_t len;
+} wyl_sealed_blob_t;
 
-  typedef struct wyl_keyprovider_vtable_t
-  {
-    /* Verify that the backing key material is reachable and the
-     * implementation is healthy enough to satisfy unseal calls. */
-    wyrelog_error_t (*probe) (void *self);
+typedef struct wyl_keyprovider_vtable_t
+{
+  /* Verify that the backing key material is reachable and the
+   * implementation is healthy enough to satisfy unseal calls. */
+  wyrelog_error_t (*probe) (void *self);
 
-    /* Seal a plaintext key into an opaque blob suitable for at-rest
-     * storage. Output blob ownership transfers to the caller. */
-    wyrelog_error_t (*seal) (void *self,
-        const uint8_t * plaintext, size_t plaintext_len,
-        wyl_sealed_blob_t * out_blob);
+  /* Seal a plaintext key into an opaque blob suitable for at-rest
+   * storage. Output blob ownership transfers to the caller. */
+  wyrelog_error_t (*seal) (void *self,
+      const uint8_t * plaintext,
+      size_t plaintext_len, wyl_sealed_blob_t * out_blob);
 
-    /* Reverse of seal: returns the plaintext into a caller-owned
-     * buffer. */
-    wyrelog_error_t (*unseal) (void *self,
-        const wyl_sealed_blob_t * blob,
-        uint8_t * out_plaintext, size_t out_capacity, size_t *out_written);
+  /* Reverse of seal: returns the plaintext into a caller-owned
+   * buffer. */
+  wyrelog_error_t (*unseal) (void *self,
+      const wyl_sealed_blob_t * blob,
+      uint8_t * out_plaintext, size_t out_capacity, size_t *out_written);
 
-    /* Derive a sub-key from an unsealed root through HKDF (or an
-     * equivalent KDF the implementation chooses). The label scopes
-     * the derivation so the same root yields independent sub-keys
-     * for distinct uses. */
-    wyrelog_error_t (*derive) (void *self,
-        const char *label, uint8_t * out_key, size_t out_len);
+  /* Derive a sub-key from an unsealed root through HKDF (or an
+   * equivalent KDF the implementation chooses). The label scopes
+   * the derivation so the same root yields independent sub-keys
+   * for distinct uses. */
+  wyrelog_error_t (*derive) (void *self,
+      const char *label, uint8_t * out_key, size_t out_len);
 
-    /* Zero out any in-memory copies the implementation holds. Called
-     * during shutdown and on error paths. */
-    void (*wipe) (void *self);
-  } wyl_keyprovider_vtable_t;
+  /* Zero out any in-memory copies the implementation holds. Called
+   * during shutdown and on error paths. */
+  void (*wipe) (void *self);
+} wyl_keyprovider_vtable_t;
 
 
 /* --- AuditSink ---------------------------------------------------- */
@@ -98,24 +95,24 @@ extern "C"
  * The full record type is defined in a private header local to the
  * audit module; the trait only sees an opaque pointer.
  */
-  typedef struct wyl_audit_record_t wyl_audit_record_t;
+typedef struct wyl_audit_record_t wyl_audit_record_t;
 
-  typedef struct wyl_auditsink_vtable_t
-  {
-    /* Open the underlying store and prepare it for appends. */
-    wyrelog_error_t (*open) (void *self);
+typedef struct wyl_auditsink_vtable_t
+{
+  /* Open the underlying store and prepare it for appends. */
+  wyrelog_error_t (*open) (void *self);
 
-    /* Append a single record. The sink may buffer; durability is
-     * promised only after a subsequent flush. */
-    wyrelog_error_t (*append) (void *self, const wyl_audit_record_t * record);
+  /* Append a single record. The sink may buffer; durability is
+   * promised only after a subsequent flush. */
+  wyrelog_error_t (*append) (void *self, const wyl_audit_record_t * record);
 
-    /* Force any buffered records to durable storage. */
-    wyrelog_error_t (*flush) (void *self);
+  /* Force any buffered records to durable storage. */
+  wyrelog_error_t (*flush) (void *self);
 
-    /* Close the store cleanly. After close, append is invalid until a
-     * subsequent open. */
-    wyrelog_error_t (*close) (void *self);
-  } wyl_auditsink_vtable_t;
+  /* Close the store cleanly. After close, append is invalid until a
+   * subsequent open. */
+  wyrelog_error_t (*close) (void *self);
+} wyl_auditsink_vtable_t;
 
 
 /* --- IngressSource ------------------------------------------------ */
@@ -126,30 +123,30 @@ extern "C"
  * Concrete event payloads are defined elsewhere; this trait only
  * shuttles them from source to engine.
  */
-  typedef struct wyl_ingress_event_t wyl_ingress_event_t;
+typedef struct wyl_ingress_event_t wyl_ingress_event_t;
 
 /*
  * Callback signature for subscribers. The source invokes this for
  * each event it produces; the callback returns OK to acknowledge,
  * non-OK to reject (the source may choose to retry or drop).
  */
-  typedef wyrelog_error_t (*wyl_ingress_handler_fn) (void *user_data,
-      const wyl_ingress_event_t * event);
+typedef wyrelog_error_t (*wyl_ingress_handler_fn) (void *user_data,
+    const wyl_ingress_event_t * event);
 
-  typedef struct wyl_ingress_vtable_t
-  {
-    /* Register a handler. Subsequent poll calls dispatch events to it. */
-    wyrelog_error_t (*subscribe) (void *self,
-        wyl_ingress_handler_fn handler, void *user_data);
+typedef struct wyl_ingress_vtable_t
+{
+  /* Register a handler. Subsequent poll calls dispatch events to it. */
+  wyrelog_error_t (*subscribe) (void *self,
+      wyl_ingress_handler_fn handler, void *user_data);
 
-    /* Drive a single iteration of the event loop. Implementations
-     * decide whether this blocks, returns immediately on empty, or
-     * yields after a fixed quantum. */
-    wyrelog_error_t (*poll) (void *self);
+  /* Drive a single iteration of the event loop. Implementations
+   * decide whether this blocks, returns immediately on empty, or
+   * yields after a fixed quantum. */
+  wyrelog_error_t (*poll) (void *self);
 
-    /* Stop accepting new events and release source-side resources. */
-    void (*close) (void *self);
-  } wyl_ingress_vtable_t;
+  /* Stop accepting new events and release source-side resources. */
+  void (*close) (void *self);
+} wyl_ingress_vtable_t;
 
 
 /* --- ContextProvider --------------------------------------------- */
@@ -162,36 +159,34 @@ extern "C"
  * principals and sessions through it; the engine releases it when
  * the call ends.
  */
-  typedef struct wyl_ctx_snapshot_t wyl_ctx_snapshot_t;
+typedef struct wyl_ctx_snapshot_t wyl_ctx_snapshot_t;
 
 /*
  * Opaque principal and session handles produced by the snapshot.
  */
-  typedef struct wyl_ctx_principal_t wyl_ctx_principal_t;
-  typedef struct wyl_ctx_session_t wyl_ctx_session_t;
+typedef struct wyl_ctx_principal_t wyl_ctx_principal_t;
+typedef struct wyl_ctx_session_t wyl_ctx_session_t;
 
-  typedef struct wyl_ctxprovider_vtable_t
-  {
-    /* Take a consistent snapshot of current state. The handle must
-     * remain valid until release is called against it. */
-    wyrelog_error_t (*snapshot) (void *self, wyl_ctx_snapshot_t ** out_snap);
+typedef struct wyl_ctxprovider_vtable_t
+{
+  /* Take a consistent snapshot of current state. The handle must
+   * remain valid until release is called against it. */
+  wyrelog_error_t (*snapshot) (void *self, wyl_ctx_snapshot_t ** out_snap);
 
-    /* Resolve a principal identifier inside a snapshot. Returns
-     * WYRELOG_E_INVALID if the id has no entry in the snapshot. */
-    wyrelog_error_t (*get_principal) (void *self,
-        wyl_ctx_snapshot_t * snap,
-        const char *principal_id, const wyl_ctx_principal_t ** out_principal);
+  /* Resolve a principal identifier inside a snapshot. Returns
+   * WYRELOG_E_INVALID if the id has no entry in the snapshot. */
+  wyrelog_error_t (*get_principal) (void *self,
+      wyl_ctx_snapshot_t * snap,
+      const char *principal_id, const wyl_ctx_principal_t ** out_principal);
 
-    /* Resolve a session identifier inside a snapshot. */
-    wyrelog_error_t (*get_session) (void *self,
-        wyl_ctx_snapshot_t * snap,
-        uint64_t session_id, const wyl_ctx_session_t ** out_session);
+  /* Resolve a session identifier inside a snapshot. */
+  wyrelog_error_t (*get_session) (void *self,
+      wyl_ctx_snapshot_t * snap,
+      uint64_t session_id, const wyl_ctx_session_t ** out_session);
 
-    /* Release the snapshot and any handles derived from it. */
-    void (*release) (void *self, wyl_ctx_snapshot_t * snap);
-  } wyl_ctxprovider_vtable_t;
+  /* Release the snapshot and any handles derived from it. */
+  void (*release) (void *self, wyl_ctx_snapshot_t * snap);
+} wyl_ctxprovider_vtable_t;
 
 
-#ifdef __cplusplus
-}
-#endif
+G_END_DECLS;

--- a/wyrelog/wyrelog.h
+++ b/wyrelog/wyrelog.h
@@ -7,10 +7,7 @@
 
 #include "wyrelog/error.h"
 
-#ifdef __cplusplus
-extern "C"
-{
-#endif
+G_BEGIN_DECLS;
 
 /*
  * WylHandle - server-side embedding handle.
@@ -20,8 +17,9 @@ extern "C"
  * wyl_shutdown, released with g_object_unref (or g_autoptr(WylHandle)
  * in scoped form).
  */
-  G_DECLARE_FINAL_TYPE (WylHandle, wyl_handle, WYL, HANDLE, GObject)
+G_DECLARE_FINAL_TYPE (WylHandle, wyl_handle, WYL, HANDLE, GObject);
 #define WYL_TYPE_HANDLE (wyl_handle_get_type ())
+
 /*
  * WylSession - active authenticated session.
  *
@@ -29,22 +27,24 @@ extern "C"
  * sequence of decide calls. Acquired through wyl_session_login,
  * released with g_object_unref / g_autoptr.
  */
-  G_DECLARE_FINAL_TYPE (WylSession, wyl_session, WYL, SESSION, GObject)
+G_DECLARE_FINAL_TYPE (WylSession, wyl_session, WYL, SESSION, GObject);
 #define WYL_TYPE_SESSION (wyl_session_get_type ())
+
 /*
  * WylAuditEvent - immutable audit record passed to wyl_audit_emit.
  *
  * GObject-based so callers can keep refs while the daemon serializes
  * the event to the audit chain.
  */
-  G_DECLARE_FINAL_TYPE (WylAuditEvent, wyl_audit_event,
-      WYL, AUDIT_EVENT, GObject)
+G_DECLARE_FINAL_TYPE (WylAuditEvent, wyl_audit_event,
+    WYL, AUDIT_EVENT, GObject);
 #define WYL_TYPE_AUDIT_EVENT (wyl_audit_event_get_type ())
+
 /*
  * Plain integer session identifier. Stable across the lifetime of a
  * WylHandle; not a GObject.
  */
-  typedef uint64_t wyl_session_id_t;
+typedef uint64_t wyl_session_id_t;
 
 /*
  * Opaque request/response carriers for decide / login / perm.
@@ -54,53 +54,56 @@ extern "C"
  * _free function or via g_autoptr (GLib autoptr cleanup is wired
  * below).
  */
-  typedef struct _wyl_decide_req wyl_decide_req_t;
-  typedef struct _wyl_decide_resp wyl_decide_resp_t;
-  typedef struct _wyl_login_req wyl_login_req_t;
-  typedef struct _wyl_grant_req wyl_grant_req_t;
-  typedef struct _wyl_revoke_req wyl_revoke_req_t;
+typedef struct _wyl_decide_req wyl_decide_req_t;
+typedef struct _wyl_decide_resp wyl_decide_resp_t;
+typedef struct _wyl_login_req wyl_login_req_t;
+typedef struct _wyl_grant_req wyl_grant_req_t;
+typedef struct _wyl_revoke_req wyl_revoke_req_t;
 
-  wyl_decide_req_t *wyl_decide_req_new (void);
-  void wyl_decide_req_free (wyl_decide_req_t * req);
-    G_DEFINE_AUTOPTR_CLEANUP_FUNC (wyl_decide_req_t, wyl_decide_req_free)
-  wyl_decide_resp_t *wyl_decide_resp_new (void);
-  void wyl_decide_resp_free (wyl_decide_resp_t * resp);
-    G_DEFINE_AUTOPTR_CLEANUP_FUNC (wyl_decide_resp_t, wyl_decide_resp_free)
-  wyl_login_req_t *wyl_login_req_new (void);
-  void wyl_login_req_free (wyl_login_req_t * req);
-    G_DEFINE_AUTOPTR_CLEANUP_FUNC (wyl_login_req_t, wyl_login_req_free)
-  wyl_grant_req_t *wyl_grant_req_new (void);
-  void wyl_grant_req_free (wyl_grant_req_t * req);
-    G_DEFINE_AUTOPTR_CLEANUP_FUNC (wyl_grant_req_t, wyl_grant_req_free)
-  wyl_revoke_req_t *wyl_revoke_req_new (void);
-  void wyl_revoke_req_free (wyl_revoke_req_t * req);
-    G_DEFINE_AUTOPTR_CLEANUP_FUNC (wyl_revoke_req_t, wyl_revoke_req_free)
+wyl_decide_req_t *wyl_decide_req_new (void);
+void wyl_decide_req_free (wyl_decide_req_t * req);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (wyl_decide_req_t, wyl_decide_req_free);
+
+wyl_decide_resp_t *wyl_decide_resp_new (void);
+void wyl_decide_resp_free (wyl_decide_resp_t * resp);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (wyl_decide_resp_t, wyl_decide_resp_free);
+
+wyl_login_req_t *wyl_login_req_new (void);
+void wyl_login_req_free (wyl_login_req_t * req);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (wyl_login_req_t, wyl_login_req_free);
+
+wyl_grant_req_t *wyl_grant_req_new (void);
+void wyl_grant_req_free (wyl_grant_req_t * req);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (wyl_grant_req_t, wyl_grant_req_free);
+
+wyl_revoke_req_t *wyl_revoke_req_new (void);
+void wyl_revoke_req_free (wyl_revoke_req_t * req);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (wyl_revoke_req_t, wyl_revoke_req_free);
+
 /* Lifecycle */
-  wyrelog_error_t wyl_init (const char *config_path, WylHandle ** out_handle);
-  void wyl_shutdown (WylHandle * handle);
+wyrelog_error_t wyl_init (const char *config_path, WylHandle ** out_handle);
+void wyl_shutdown (WylHandle * handle);
 
 /* Decide */
-  wyrelog_error_t wyl_decide (WylHandle * handle,
-      const wyl_decide_req_t * req, wyl_decide_resp_t * resp);
+wyrelog_error_t wyl_decide (WylHandle * handle,
+    const wyl_decide_req_t * req, wyl_decide_resp_t * resp);
 
 /* Sessions */
-  wyrelog_error_t wyl_session_login (WylHandle * handle,
-      const wyl_login_req_t * req, WylSession ** out_session);
-  wyrelog_error_t wyl_session_logout (WylHandle * handle, wyl_session_id_t sid);
+wyrelog_error_t wyl_session_login (WylHandle * handle,
+    const wyl_login_req_t * req, WylSession ** out_session);
+wyrelog_error_t wyl_session_logout (WylHandle * handle, wyl_session_id_t sid);
 
 /* Permissions (admin) */
-  wyrelog_error_t wyl_perm_grant (WylHandle * handle,
-      const wyl_grant_req_t * req);
-  wyrelog_error_t wyl_perm_revoke (WylHandle * handle,
-      const wyl_revoke_req_t * req);
+wyrelog_error_t wyl_perm_grant (WylHandle * handle,
+    const wyl_grant_req_t * req);
+wyrelog_error_t wyl_perm_revoke (WylHandle * handle,
+    const wyl_revoke_req_t * req);
 
 /* Audit */
-  wyrelog_error_t wyl_audit_emit (WylHandle * handle,
-      const WylAuditEvent * event);
+wyrelog_error_t wyl_audit_emit (WylHandle * handle,
+    const WylAuditEvent * event);
 
 /* Meta */
-  const char *wyrelog_version_string (void);
+const char *wyrelog_version_string (void);
 
-#ifdef __cplusplus
-}
-#endif
+G_END_DECLS;


### PR DESCRIPTION
## Summary

Replaces the bare `extern "C" { ... }` guard at the top and bottom of every header with GLib's `G_BEGIN_DECLS;` / `G_END_DECLS;` macros (with trailing semicolons) so that `./tools/gst-indent` no longer shifts every declaration two columns to the right under the brace block.

The trailing semicolon was the key. A bare `G_BEGIN_DECLS` followed by a typedef on the next line gets glued by gst-indent into `G_BEGIN_DECLS typedef ...`. The semicolon-terminated form `G_BEGIN_DECLS;` is treated as a complete statement and leaves the following declaration untouched at column zero. Verified locally that every touched header is gst-indent idempotent on the second pass and that declarations now appear flush left.

The same trailing-semicolon idiom is applied to `G_DECLARE_FINAL_TYPE(...)` and `G_DEFINE_AUTOPTR_CLEANUP_FUNC(...)` invocations to prevent gst-indent from glueing the next typedef to the macro line.

### Headers touched

| Header | extra change |
|---|---|
| `wyrelog/error.h` | adds `#include <glib.h>` (the only include in the file) |
| `wyrelog/wyrelog.h` | already pulled `<glib-object.h>`; semicolons on 3 `G_DECLARE_FINAL_TYPE` + 5 `G_DEFINE_AUTOPTR_CLEANUP_FUNC` lines |
| `wyrelog/client.h` | already pulled `<glib-object.h>`; semicolons on 2 `G_DECLARE_FINAL_TYPE` lines |
| `wyrelog/wyl-boot-private.h` | inherits glib via `wyrelog/error.h` |
| `wyrelog/wyl-traits-private.h` | inherits glib via `wyrelog/error.h` |
| `wyrelog/wyl-dl-static-private.h` | inherits glib via `wyrelog/error.h` |

No source `.c` files, meson build files, tests, or CI files are touched. Public ABI is unchanged in shape (the same enum, same function signatures, same opaque types).

`Closes #14`.

## Test plan

- [x] `./tools/gst-indent <header>` is idempotent on the second pass for every touched header (zero diff).
- [x] `meson test -C builddir smoke boot-smoke client-smoke traits-compile dl-static` reports 5/5 OK.
- [x] `wyrelog/meson.build` `install_headers` lists are unchanged: only `error.h`, `wyrelog.h`, `client.h` are public.
- [x] HEAD~1 still builds clean on Linux (no source-code regression).
- [ ] Cross-platform CI gate (Linux / macOS / Windows) validates the change on this PR.

## Note on PR stacking

This branch is cut from `feature/add-stratification-check` (the F0 PR #13 branch) because `wyl-dl-static-private.h` only exists there. If PR #13 merges first, this PR's base auto-rebases against the new main with no conflicts.