### PR TITLE
refactor: adopt GLib basic types across public and private surface

### DIFF
--- a/tests/test-boot-smoke.c
+++ b/tests/test-boot-smoke.c
@@ -1,12 +1,12 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
-#include <stddef.h>
+#include <glib.h>
 
 #include "wyrelog/wyl-boot-private.h"
 
-static int call_count;
+static gint call_count;
 
 static wyrelog_error_t
-phase_ok (void *ctx)
+phase_ok (gpointer ctx)
 {
   (void) ctx;
   call_count++;
@@ -14,7 +14,7 @@ phase_ok (void *ctx)
 }
 
 static wyrelog_error_t
-phase_failing (void *ctx)
+phase_failing (gpointer ctx)
 {
   (void) ctx;
   call_count++;
@@ -35,8 +35,8 @@ main (void)
   /* All-success sequence runs every phase and returns OK. */
   call_count = 0;
   const boot_phase_t happy[] = {
-    {BOOT_01_TPM_PROBE, "probe", phase_ok, true},
-    {BOOT_02_DEK_UNSEAL, "unseal", phase_ok, true},
+    {BOOT_01_TPM_PROBE, "probe", phase_ok, TRUE},
+    {BOOT_02_DEK_UNSEAL, "unseal", phase_ok, TRUE},
   };
   if (wyl_boot_run (happy, 2, NULL) != WYRELOG_E_OK)
     return 3;
@@ -46,8 +46,8 @@ main (void)
   /* Fail-closed failure short-circuits with the phase's return code. */
   call_count = 0;
   const boot_phase_t closed[] = {
-    {BOOT_01_TPM_PROBE, "probe", phase_failing, true},
-    {BOOT_02_DEK_UNSEAL, "unseal", phase_ok, true},
+    {BOOT_01_TPM_PROBE, "probe", phase_failing, TRUE},
+    {BOOT_02_DEK_UNSEAL, "unseal", phase_ok, TRUE},
   };
   if (wyl_boot_run (closed, 2, NULL) != WYRELOG_E_IO)
     return 5;
@@ -57,8 +57,8 @@ main (void)
   /* Non-fail-closed failure is logged and the run continues. */
   call_count = 0;
   const boot_phase_t open[] = {
-    {BOOT_01_TPM_PROBE, "probe", phase_failing, false},
-    {BOOT_02_DEK_UNSEAL, "unseal", phase_ok, true},
+    {BOOT_01_TPM_PROBE, "probe", phase_failing, FALSE},
+    {BOOT_02_DEK_UNSEAL, "unseal", phase_ok, TRUE},
   };
   if (wyl_boot_run (open, 2, NULL) != WYRELOG_E_OK)
     return 7;

--- a/tests/test-client-smoke.c
+++ b/tests/test-client-smoke.c
@@ -1,12 +1,12 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
-#include <stddef.h>
+#include <glib.h>
 
 #include "wyrelog/client.h"
 
 int
 main (void)
 {
-  const char *version = wyrelog_client_version_string ();
+  const gchar *version = wyrelog_client_version_string ();
   if (version == NULL || version[0] == '\0')
     return 1;
 
@@ -32,7 +32,7 @@ main (void)
   gboolean has_next = TRUE;
   if (wyl_audit_iter_next (iter, &has_next) != WYRELOG_E_OK)
     return 7;
-  if (has_next != FALSE)
+  if (has_next)
     return 8;
 
   return 0;

--- a/tests/test-dl-static.c
+++ b/tests/test-dl-static.c
@@ -1,12 +1,12 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
-#include <stddef.h>
+#include <glib.h>
 
 #include "wyrelog/wyl-dl-static-private.h"
 
-static int
-check (const wyl_dl_rule_t *rules, size_t n)
+static gint
+check (const wyl_dl_rule_t *rules, gsize n)
 {
-  return (int) wyl_dl_static_check (rules, n);
+  return (gint) wyl_dl_static_check (rules, n);
 }
 
 int
@@ -30,7 +30,7 @@ main (void)
 
   /* Case 4: NULL body predicate -> INVALID. */
   {
-    wyl_dl_body_atom_t body[] = { {NULL, false}
+    wyl_dl_body_atom_t body[] = { {NULL, FALSE}
     };
     wyl_dl_rule_t rules[] = { {"p", body, 1}
     };
@@ -48,9 +48,9 @@ main (void)
 
   /* Case 6: linear chain r :- q. q :- p. -> OK. */
   {
-    wyl_dl_body_atom_t body_r[] = { {"q", false}
+    wyl_dl_body_atom_t body_r[] = { {"q", FALSE}
     };
-    wyl_dl_body_atom_t body_q[] = { {"p", false}
+    wyl_dl_body_atom_t body_q[] = { {"p", FALSE}
     };
     wyl_dl_rule_t rules[] = {
       {"r", body_r, 1},
@@ -62,7 +62,7 @@ main (void)
 
   /* Case 7: self-loop without negation p :- p. -> OK. */
   {
-    wyl_dl_body_atom_t body[] = { {"p", false}
+    wyl_dl_body_atom_t body[] = { {"p", FALSE}
     };
     wyl_dl_rule_t rules[] = { {"p", body, 1}
     };
@@ -72,7 +72,7 @@ main (void)
 
   /* Case 8: self-loop with negation p :- \+ p. -> POLICY. */
   {
-    wyl_dl_body_atom_t body[] = { {"p", true}
+    wyl_dl_body_atom_t body[] = { {"p", TRUE}
     };
     wyl_dl_rule_t rules[] = { {"p", body, 1}
     };
@@ -83,9 +83,9 @@ main (void)
   /* Case 9: mutual recursion without negation
    *   p :- q.  q :- p.  -> OK. */
   {
-    wyl_dl_body_atom_t body_p[] = { {"q", false}
+    wyl_dl_body_atom_t body_p[] = { {"q", FALSE}
     };
-    wyl_dl_body_atom_t body_q[] = { {"p", false}
+    wyl_dl_body_atom_t body_q[] = { {"p", FALSE}
     };
     wyl_dl_rule_t rules[] = {
       {"p", body_p, 1},
@@ -98,9 +98,9 @@ main (void)
   /* Case 10: mutual recursion with negation in cycle
    *   p :- \+ q.  q :- p.  -> POLICY. */
   {
-    wyl_dl_body_atom_t body_p[] = { {"q", true}
+    wyl_dl_body_atom_t body_p[] = { {"q", TRUE}
     };
-    wyl_dl_body_atom_t body_q[] = { {"p", false}
+    wyl_dl_body_atom_t body_q[] = { {"p", FALSE}
     };
     wyl_dl_rule_t rules[] = {
       {"p", body_p, 1},
@@ -113,9 +113,9 @@ main (void)
   /* Case 11: cross-stratum negation (no cycle through negation)
    *   p :- q.  r :- \+ p.   -> OK. */
   {
-    wyl_dl_body_atom_t body_p[] = { {"q", false}
+    wyl_dl_body_atom_t body_p[] = { {"q", FALSE}
     };
-    wyl_dl_body_atom_t body_r[] = { {"p", true}
+    wyl_dl_body_atom_t body_r[] = { {"p", TRUE}
     };
     wyl_dl_rule_t rules[] = {
       {"p", body_p, 1},
@@ -132,11 +132,11 @@ main (void)
    *   q :- \+ p.         (negation crosses SCC boundary)
    *  -> OK. */
   {
-    wyl_dl_body_atom_t body_p_self[] = { {"p", false}
+    wyl_dl_body_atom_t body_p_self[] = { {"p", FALSE}
     };
-    wyl_dl_body_atom_t body_q_self[] = { {"q", false}
+    wyl_dl_body_atom_t body_q_self[] = { {"q", FALSE}
     };
-    wyl_dl_body_atom_t body_q_not_p[] = { {"p", true}
+    wyl_dl_body_atom_t body_q_not_p[] = { {"p", TRUE}
     };
     wyl_dl_rule_t rules[] = {
       {"p", body_p_self, 1},
@@ -150,9 +150,9 @@ main (void)
   /* Case 13: multi-rule same head (no cycle)
    *   p :- q.  p :- r.  -> OK. */
   {
-    wyl_dl_body_atom_t body_a[] = { {"q", false}
+    wyl_dl_body_atom_t body_a[] = { {"q", FALSE}
     };
-    wyl_dl_body_atom_t body_b[] = { {"r", false}
+    wyl_dl_body_atom_t body_b[] = { {"r", FALSE}
     };
     wyl_dl_rule_t rules[] = {
       {"p", body_a, 1},

--- a/tests/test-smoke.c
+++ b/tests/test-smoke.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
-#include <stddef.h>
+#include <glib.h>
 
 #include "wyrelog/error.h"
 #include "wyrelog/wyrelog.h"
@@ -7,12 +7,12 @@
 int
 main (void)
 {
-  const char *msg = wyrelog_error_string (WYRELOG_E_OK);
+  const gchar *msg = wyrelog_error_string (WYRELOG_E_OK);
 
   if (msg == NULL || msg[0] == '\0')
     return 1;
 
-  const char *version = wyrelog_version_string ();
+  const gchar *version = wyrelog_version_string ();
   if (version == NULL || version[0] == '\0')
     return 2;
 

--- a/tests/test-traits-compile.c
+++ b/tests/test-traits-compile.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
-#include <stddef.h>
+#include <glib.h>
 
 #include "wyrelog/wyl-traits-private.h"
 

--- a/wyrelog/client.h
+++ b/wyrelog/client.h
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #pragma once
 
+#include <glib.h>
 #include <glib-object.h>
 
 #include "wyrelog/error.h"
@@ -28,32 +29,33 @@ G_DECLARE_FINAL_TYPE (WylAuditIter, wyl_audit_iter, WYL, AUDIT_ITER, GObject);
 #define WYL_TYPE_AUDIT_ITER (wyl_audit_iter_get_type ())
 
 /* Lifecycle */
-wyrelog_error_t wyl_client_new (const char *base_url, WylClient ** out_client);
+wyrelog_error_t wyl_client_new (const gchar * base_url,
+    WylClient ** out_client);
 
 /* Authentication */
 wyrelog_error_t wyl_client_login (WylClient * client,
-    const char *username, const char *password);
+    const gchar * username, const gchar * password);
 wyrelog_error_t wyl_client_token_refresh (WylClient * client);
-wyrelog_error_t wyl_client_mfa_verify (WylClient * client, const char *otp);
+wyrelog_error_t wyl_client_mfa_verify (WylClient * client, const gchar * otp);
 
 /* Decide */
 wyrelog_error_t wyl_client_decide (WylClient * client,
-    const char *user,
-    const char *perm, const char *session_token, int *out_decision);
+    const gchar * user,
+    const gchar * perm, const gchar * session_token, gint * out_decision);
 
 /* Audit query (iterator) */
 wyrelog_error_t wyl_client_audit_query (WylClient * client,
-    const char *query_filter, WylAuditIter ** out_iter);
+    const gchar * query_filter, WylAuditIter ** out_iter);
 wyrelog_error_t wyl_audit_iter_next (WylAuditIter * iter,
     gboolean * out_has_next);
 
 /* Tenant / event */
 wyrelog_error_t wyl_client_tenant_select (WylClient * client,
-    const char *tenant);
+    const gchar * tenant);
 wyrelog_error_t wyl_client_event_emit (WylClient * client,
-    const char *event_kind, const char *event_payload_json);
+    const gchar * event_kind, const gchar * event_payload_json);
 
 /* Meta */
-const char *wyrelog_client_version_string (void);
+const gchar *wyrelog_client_version_string (void);
 
 G_END_DECLS;

--- a/wyrelog/error.h
+++ b/wyrelog/error.h
@@ -17,6 +17,6 @@ typedef enum wyrelog_error_t
   WYRELOG_E_INTERNAL = -7,
 } wyrelog_error_t;
 
-const char *wyrelog_error_string (wyrelog_error_t err);
+const gchar *wyrelog_error_string (wyrelog_error_t err);
 
 G_END_DECLS;

--- a/wyrelog/wyl-audit-iter.c
+++ b/wyrelog/wyl-audit-iter.c
@@ -21,7 +21,7 @@ wyl_audit_iter_init (WylAuditIter *self)
 }
 
 wyrelog_error_t
-wyl_client_audit_query (WylClient *client, const char *query_filter,
+wyl_client_audit_query (WylClient *client, const gchar *query_filter,
     WylAuditIter **out_iter)
 {
   (void) client;

--- a/wyrelog/wyl-boot-private.h
+++ b/wyrelog/wyl-boot-private.h
@@ -1,8 +1,7 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #pragma once
 
-#include <stdbool.h>
-#include <stddef.h>
+#include <glib.h>
 
 #include "wyrelog/error.h"
 
@@ -27,14 +26,14 @@ typedef enum boot_phase_id_t
   BOOT_LAST = 21,
 } boot_phase_id_t;
 
-typedef wyrelog_error_t (*boot_phase_fn_t) (void *ctx);
+typedef wyrelog_error_t (*boot_phase_fn_t) (gpointer ctx);
 
 typedef struct boot_phase_t
 {
   boot_phase_id_t id;
-  const char *name;
+  const gchar *name;
   boot_phase_fn_t fn;
-  bool fail_closed;
+  gboolean fail_closed;
 } boot_phase_t;
 
 /*
@@ -48,6 +47,6 @@ typedef struct boot_phase_t
  * non-zero return code otherwise. WYRELOG_E_INVALID if seq is
  * NULL while n > 0.
  */
-wyrelog_error_t wyl_boot_run (const boot_phase_t * seq, size_t n, void *ctx);
+wyrelog_error_t wyl_boot_run (const boot_phase_t * seq, gsize n, gpointer ctx);
 
 G_END_DECLS;

--- a/wyrelog/wyl-boot.c
+++ b/wyrelog/wyl-boot.c
@@ -1,11 +1,9 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
-#include <stddef.h>
-
 #include "wyl-boot-private.h"
 #include "wyl-common-private.h"
 
 wyrelog_error_t
-wyl_boot_run (const boot_phase_t *seq, size_t n, void *ctx)
+wyl_boot_run (const boot_phase_t *seq, gsize n, gpointer ctx)
 {
   if (n == 0)
     return WYRELOG_E_OK;
@@ -13,7 +11,7 @@ wyl_boot_run (const boot_phase_t *seq, size_t n, void *ctx)
   if (seq == NULL)
     return WYRELOG_E_INVALID;
 
-  for (size_t i = 0; i < n; i++) {
+  for (gsize i = 0; i < n; i++) {
     const boot_phase_t *phase = &seq[i];
     wyrelog_error_t rc;
 

--- a/wyrelog/wyl-client.c
+++ b/wyrelog/wyl-client.c
@@ -21,7 +21,7 @@ wyl_client_init (WylClient *self)
 }
 
 wyrelog_error_t
-wyl_client_new (const char *base_url, WylClient **out_client)
+wyl_client_new (const gchar *base_url, WylClient **out_client)
 {
   (void) base_url;
 
@@ -33,7 +33,8 @@ wyl_client_new (const char *base_url, WylClient **out_client)
 }
 
 wyrelog_error_t
-wyl_client_login (WylClient *client, const char *username, const char *password)
+wyl_client_login (WylClient *client, const gchar *username,
+    const gchar *password)
 {
   (void) client;
   (void) username;
@@ -49,7 +50,7 @@ wyl_client_token_refresh (WylClient *client)
 }
 
 wyrelog_error_t
-wyl_client_mfa_verify (WylClient *client, const char *otp)
+wyl_client_mfa_verify (WylClient *client, const gchar *otp)
 {
   (void) client;
   (void) otp;
@@ -57,8 +58,8 @@ wyl_client_mfa_verify (WylClient *client, const char *otp)
 }
 
 wyrelog_error_t
-wyl_client_decide (WylClient *client, const char *user, const char *perm,
-    const char *session_token, int *out_decision)
+wyl_client_decide (WylClient *client, const gchar *user, const gchar *perm,
+    const gchar *session_token, gint *out_decision)
 {
   (void) client;
   (void) user;
@@ -69,7 +70,7 @@ wyl_client_decide (WylClient *client, const char *user, const char *perm,
 }
 
 wyrelog_error_t
-wyl_client_tenant_select (WylClient *client, const char *tenant)
+wyl_client_tenant_select (WylClient *client, const gchar *tenant)
 {
   (void) client;
   (void) tenant;
@@ -77,8 +78,8 @@ wyl_client_tenant_select (WylClient *client, const char *tenant)
 }
 
 wyrelog_error_t
-wyl_client_event_emit (WylClient *client, const char *event_kind,
-    const char *event_payload_json)
+wyl_client_event_emit (WylClient *client, const gchar *event_kind,
+    const gchar *event_payload_json)
 {
   (void) client;
   (void) event_kind;
@@ -86,7 +87,7 @@ wyl_client_event_emit (WylClient *client, const char *event_kind,
   return WYRELOG_E_INTERNAL;
 }
 
-const char *
+const gchar *
 wyrelog_client_version_string (void)
 {
   return "0.1.0";

--- a/wyrelog/wyl-decide.c
+++ b/wyrelog/wyl-decide.c
@@ -3,12 +3,12 @@
 
 struct _wyl_decide_req
 {
-  int placeholder;
+  gint placeholder;
 };
 
 struct _wyl_decide_resp
 {
-  int placeholder;
+  gint placeholder;
 };
 
 wyl_decide_req_t *

--- a/wyrelog/wyl-dl-static-private.h
+++ b/wyrelog/wyl-dl-static-private.h
@@ -1,8 +1,7 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #pragma once
 
-#include <stdbool.h>
-#include <stddef.h>
+#include <glib.h>
 
 #include "wyrelog/error.h"
 
@@ -49,17 +48,17 @@ G_BEGIN_DECLS;
 
 typedef struct wyl_dl_body_atom_t
 {
-  const char *predicate;
-  bool negated;
+  const gchar *predicate;
+  gboolean negated;
 } wyl_dl_body_atom_t;
 
 typedef struct wyl_dl_rule_t
 {
-  const char *head;
+  const gchar *head;
   const wyl_dl_body_atom_t *body;
-  size_t body_len;
+  gsize body_len;
 } wyl_dl_rule_t;
 
-wyrelog_error_t wyl_dl_static_check (const wyl_dl_rule_t * rules, size_t n);
+wyrelog_error_t wyl_dl_static_check (const wyl_dl_rule_t * rules, gsize n);
 
 G_END_DECLS;

--- a/wyrelog/wyl-dl-static.c
+++ b/wyrelog/wyl-dl-static.c
@@ -3,7 +3,6 @@
 #include "wyl-common-private.h"
 
 #include <glib.h>
-#include <stdint.h>
 
 /*
  * Implementation overview.
@@ -29,54 +28,54 @@
 
 typedef struct edge_t
 {
-  int to;
-  bool negated;
+  gint to;
+  gboolean negated;
 } edge_t;
 
 typedef struct scc_state_t
 {
-  int n_predicates;
+  gint n_predicates;
 
   /* Per-predicate adjacency: out_edges[i] -> array of edge_t. */
   GArray **out_edges;
 
   /* Tarjan bookkeeping. */
-  int *index;
-  int *lowlink;
-  bool *on_stack;
-  int next_index;
+  gint *index;
+  gint *lowlink;
+  gboolean *on_stack;
+  gint next_index;
 
   GArray *stack;
-  int *comp_id;
-  int next_comp_id;
+  gint *comp_id;
+  gint next_comp_id;
 } scc_state_t;
 
 
-static int
-intern_predicate (GHashTable *names, const char *p, int *next_id)
+static gint
+intern_predicate (GHashTable *names, const gchar *p, gint *next_id)
 {
   gpointer slot = g_hash_table_lookup (names, p);
   if (slot != NULL)
     return GPOINTER_TO_INT (slot) - 1;
 
-  int id = (*next_id)++;
+  gint id = (*next_id)++;
   g_hash_table_insert (names, (gpointer) p, GINT_TO_POINTER (id + 1));
   return id;
 }
 
 static void
-strongconnect (scc_state_t *s, int v)
+strongconnect (scc_state_t *s, gint v)
 {
   s->index[v] = s->next_index;
   s->lowlink[v] = s->next_index;
   s->next_index++;
   g_array_append_val (s->stack, v);
-  s->on_stack[v] = true;
+  s->on_stack[v] = TRUE;
 
   GArray *out = s->out_edges[v];
   for (guint i = 0; i < out->len; i++) {
     edge_t e = g_array_index (out, edge_t, i);
-    int w = e.to;
+    gint w = e.to;
     if (s->index[w] == -1) {
       strongconnect (s, w);
       if (s->lowlink[w] < s->lowlink[v])
@@ -88,23 +87,23 @@ strongconnect (scc_state_t *s, int v)
   }
 
   if (s->lowlink[v] == s->index[v]) {
-    int comp = s->next_comp_id++;
-    int w;
+    gint comp = s->next_comp_id++;
+    gint w;
     do {
-      w = g_array_index (s->stack, int, s->stack->len - 1);
+      w = g_array_index (s->stack, gint, s->stack->len - 1);
       g_array_set_size (s->stack, s->stack->len - 1);
-      s->on_stack[w] = false;
+      s->on_stack[w] = FALSE;
       s->comp_id[w] = comp;
     } while (w != v);
   }
 }
 
 static void
-free_out_edges (GArray **out_edges, int n)
+free_out_edges (GArray **out_edges, gint n)
 {
   if (out_edges == NULL)
     return;
-  for (int i = 0; i < n; i++) {
+  for (gint i = 0; i < n; i++) {
     if (out_edges[i] != NULL)
       g_array_unref (out_edges[i]);
   }
@@ -112,7 +111,7 @@ free_out_edges (GArray **out_edges, int n)
 }
 
 wyrelog_error_t
-wyl_dl_static_check (const wyl_dl_rule_t *rules, size_t n)
+wyl_dl_static_check (const wyl_dl_rule_t *rules, gsize n)
 {
   if (n == 0)
     return WYRELOG_E_OK;
@@ -120,12 +119,12 @@ wyl_dl_static_check (const wyl_dl_rule_t *rules, size_t n)
     return WYRELOG_E_INVALID;
 
   /* Validate input shape before allocating anything. */
-  for (size_t i = 0; i < n; i++) {
+  for (gsize i = 0; i < n; i++) {
     if (rules[i].head == NULL)
       return WYRELOG_E_INVALID;
     if (rules[i].body_len > 0 && rules[i].body == NULL)
       return WYRELOG_E_INVALID;
-    for (size_t j = 0; j < rules[i].body_len; j++) {
+    for (gsize j = 0; j < rules[i].body_len; j++) {
       if (rules[i].body[j].predicate == NULL)
         return WYRELOG_E_INVALID;
     }
@@ -134,29 +133,29 @@ wyl_dl_static_check (const wyl_dl_rule_t *rules, size_t n)
   /* Pass 1: intern every distinct predicate name. The hash table
    * does not own the strings; the caller does. */
   g_autoptr (GHashTable) names = g_hash_table_new (g_str_hash, g_str_equal);
-  int next_id = 0;
-  for (size_t i = 0; i < n; i++) {
+  gint next_id = 0;
+  for (gsize i = 0; i < n; i++) {
     intern_predicate (names, rules[i].head, &next_id);
-    for (size_t j = 0; j < rules[i].body_len; j++)
+    for (gsize j = 0; j < rules[i].body_len; j++)
       intern_predicate (names, rules[i].body[j].predicate, &next_id);
   }
 
-  int V = next_id;
+  gint V = next_id;
   if (V == 0)
     return WYRELOG_E_OK;
 
   scc_state_t s = { 0 };
   s.n_predicates = V;
   s.out_edges = g_new0 (GArray *, V);
-  for (int i = 0; i < V; i++)
+  for (gint i = 0; i < V; i++)
     s.out_edges[i] = g_array_new (FALSE, FALSE, sizeof (edge_t));
 
   /* Pass 2: emit edges. */
-  for (size_t i = 0; i < n; i++) {
-    int head_id =
+  for (gsize i = 0; i < n; i++) {
+    gint head_id =
         GPOINTER_TO_INT (g_hash_table_lookup (names, rules[i].head)) - 1;
-    for (size_t j = 0; j < rules[i].body_len; j++) {
-      int body_id = GPOINTER_TO_INT (g_hash_table_lookup (names,
+    for (gsize j = 0; j < rules[i].body_len; j++) {
+      gint body_id = GPOINTER_TO_INT (g_hash_table_lookup (names,
               rules[i].body[j].predicate)) - 1;
       edge_t e = {.to = head_id,
         .negated = rules[i].body[j].negated
@@ -166,16 +165,16 @@ wyl_dl_static_check (const wyl_dl_rule_t *rules, size_t n)
   }
 
   /* Tarjan bookkeeping. */
-  g_autofree int *index = g_new (int, V);
-  g_autofree int *lowlink = g_new (int, V);
-  g_autofree bool *on_stack = g_new0 (bool, V);
-  g_autofree int *comp_id = g_new (int, V);
-  for (int i = 0; i < V; i++) {
+  g_autofree gint *index = g_new (gint, V);
+  g_autofree gint *lowlink = g_new (gint, V);
+  g_autofree gboolean *on_stack = g_new0 (gboolean, V);
+  g_autofree gint *comp_id = g_new (gint, V);
+  for (gint i = 0; i < V; i++) {
     index[i] = -1;
     lowlink[i] = 0;
     comp_id[i] = -1;
   }
-  g_autoptr (GArray) stack = g_array_new (FALSE, FALSE, sizeof (int));
+  g_autoptr (GArray) stack = g_array_new (FALSE, FALSE, sizeof (gint));
 
   s.index = index;
   s.lowlink = lowlink;
@@ -185,7 +184,7 @@ wyl_dl_static_check (const wyl_dl_rule_t *rules, size_t n)
   s.next_index = 0;
   s.next_comp_id = 0;
 
-  for (int i = 0; i < V; i++) {
+  for (gint i = 0; i < V; i++) {
     if (index[i] == -1)
       strongconnect (&s, i);
   }
@@ -194,7 +193,7 @@ wyl_dl_static_check (const wyl_dl_rule_t *rules, size_t n)
    * SCC. Self-loops (singleton SCC with a negated self-edge) are
    * caught by the same rule. */
   wyrelog_error_t rc = WYRELOG_E_OK;
-  for (int v = 0; v < V && rc == WYRELOG_E_OK; v++) {
+  for (gint v = 0; v < V && rc == WYRELOG_E_OK; v++) {
     GArray *out = s.out_edges[v];
     for (guint i = 0; i < out->len; i++) {
       edge_t e = g_array_index (out, edge_t, i);

--- a/wyrelog/wyl-error.c
+++ b/wyrelog/wyl-error.c
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #include "wyrelog/error.h"
 
-const char *
+const gchar *
 wyrelog_error_string (wyrelog_error_t err)
 {
   switch (err) {

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -21,7 +21,7 @@ wyl_handle_init (WylHandle *self)
 }
 
 wyrelog_error_t
-wyl_init (const char *config_path, WylHandle **out_handle)
+wyl_init (const gchar *config_path, WylHandle **out_handle)
 {
   (void) config_path;
 

--- a/wyrelog/wyl-perm.c
+++ b/wyrelog/wyl-perm.c
@@ -3,17 +3,17 @@
 
 struct _wyl_login_req
 {
-  int placeholder;
+  gint placeholder;
 };
 
 struct _wyl_grant_req
 {
-  int placeholder;
+  gint placeholder;
 };
 
 struct _wyl_revoke_req
 {
-  int placeholder;
+  gint placeholder;
 };
 
 wyl_login_req_t *

--- a/wyrelog/wyl-traits-private.h
+++ b/wyrelog/wyl-traits-private.h
@@ -1,9 +1,7 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #pragma once
 
-#include <stdbool.h>
-#include <stddef.h>
-#include <stdint.h>
+#include <glib.h>
 
 #include "wyrelog/error.h"
 
@@ -20,7 +18,7 @@ G_BEGIN_DECLS;
  * engine a single seam to register an implementation against.
  *
  * Each vtable is a plain C struct of function pointers. The first
- * argument of every method is `void *self` and identifies the
+ * argument of every method is `gpointer self` and identifies the
  * implementation's private state. None of the vtables are GObject
  * types: they are not introspected at runtime, they are not held by
  * autoptr scopes, and they are not finalized by the GObject system.
@@ -52,38 +50,38 @@ G_BEGIN_DECLS;
  */
 typedef struct wyl_sealed_blob_t
 {
-  uint8_t *bytes;
-  size_t len;
+  guint8 *bytes;
+  gsize len;
 } wyl_sealed_blob_t;
 
 typedef struct wyl_keyprovider_vtable_t
 {
   /* Verify that the backing key material is reachable and the
    * implementation is healthy enough to satisfy unseal calls. */
-  wyrelog_error_t (*probe) (void *self);
+  wyrelog_error_t (*probe) (gpointer self);
 
   /* Seal a plaintext key into an opaque blob suitable for at-rest
    * storage. Output blob ownership transfers to the caller. */
-  wyrelog_error_t (*seal) (void *self,
-      const uint8_t * plaintext,
-      size_t plaintext_len, wyl_sealed_blob_t * out_blob);
+  wyrelog_error_t (*seal) (gpointer self,
+      const guint8 * plaintext,
+      gsize plaintext_len, wyl_sealed_blob_t * out_blob);
 
   /* Reverse of seal: returns the plaintext into a caller-owned
    * buffer. */
-  wyrelog_error_t (*unseal) (void *self,
+  wyrelog_error_t (*unseal) (gpointer self,
       const wyl_sealed_blob_t * blob,
-      uint8_t * out_plaintext, size_t out_capacity, size_t *out_written);
+      guint8 * out_plaintext, gsize out_capacity, gsize * out_written);
 
   /* Derive a sub-key from an unsealed root through HKDF (or an
    * equivalent KDF the implementation chooses). The label scopes
    * the derivation so the same root yields independent sub-keys
    * for distinct uses. */
-  wyrelog_error_t (*derive) (void *self,
-      const char *label, uint8_t * out_key, size_t out_len);
+  wyrelog_error_t (*derive) (gpointer self,
+      const gchar * label, guint8 * out_key, gsize out_len);
 
   /* Zero out any in-memory copies the implementation holds. Called
    * during shutdown and on error paths. */
-  void (*wipe) (void *self);
+  void (*wipe) (gpointer self);
 } wyl_keyprovider_vtable_t;
 
 
@@ -100,18 +98,18 @@ typedef struct wyl_audit_record_t wyl_audit_record_t;
 typedef struct wyl_auditsink_vtable_t
 {
   /* Open the underlying store and prepare it for appends. */
-  wyrelog_error_t (*open) (void *self);
+  wyrelog_error_t (*open) (gpointer self);
 
   /* Append a single record. The sink may buffer; durability is
    * promised only after a subsequent flush. */
-  wyrelog_error_t (*append) (void *self, const wyl_audit_record_t * record);
+  wyrelog_error_t (*append) (gpointer self, const wyl_audit_record_t * record);
 
   /* Force any buffered records to durable storage. */
-  wyrelog_error_t (*flush) (void *self);
+  wyrelog_error_t (*flush) (gpointer self);
 
   /* Close the store cleanly. After close, append is invalid until a
    * subsequent open. */
-  wyrelog_error_t (*close) (void *self);
+  wyrelog_error_t (*close) (gpointer self);
 } wyl_auditsink_vtable_t;
 
 
@@ -130,22 +128,22 @@ typedef struct wyl_ingress_event_t wyl_ingress_event_t;
  * each event it produces; the callback returns OK to acknowledge,
  * non-OK to reject (the source may choose to retry or drop).
  */
-typedef wyrelog_error_t (*wyl_ingress_handler_fn) (void *user_data,
+typedef wyrelog_error_t (*wyl_ingress_handler_fn) (gpointer user_data,
     const wyl_ingress_event_t * event);
 
 typedef struct wyl_ingress_vtable_t
 {
   /* Register a handler. Subsequent poll calls dispatch events to it. */
-  wyrelog_error_t (*subscribe) (void *self,
-      wyl_ingress_handler_fn handler, void *user_data);
+  wyrelog_error_t (*subscribe) (gpointer self,
+      wyl_ingress_handler_fn handler, gpointer user_data);
 
   /* Drive a single iteration of the event loop. Implementations
    * decide whether this blocks, returns immediately on empty, or
    * yields after a fixed quantum. */
-  wyrelog_error_t (*poll) (void *self);
+  wyrelog_error_t (*poll) (gpointer self);
 
   /* Stop accepting new events and release source-side resources. */
-  void (*close) (void *self);
+  void (*close) (gpointer self);
 } wyl_ingress_vtable_t;
 
 
@@ -171,21 +169,21 @@ typedef struct wyl_ctxprovider_vtable_t
 {
   /* Take a consistent snapshot of current state. The handle must
    * remain valid until release is called against it. */
-  wyrelog_error_t (*snapshot) (void *self, wyl_ctx_snapshot_t ** out_snap);
+  wyrelog_error_t (*snapshot) (gpointer self, wyl_ctx_snapshot_t ** out_snap);
 
   /* Resolve a principal identifier inside a snapshot. Returns
    * WYRELOG_E_INVALID if the id has no entry in the snapshot. */
-  wyrelog_error_t (*get_principal) (void *self,
+  wyrelog_error_t (*get_principal) (gpointer self,
       wyl_ctx_snapshot_t * snap,
-      const char *principal_id, const wyl_ctx_principal_t ** out_principal);
+      const gchar * principal_id, const wyl_ctx_principal_t ** out_principal);
 
   /* Resolve a session identifier inside a snapshot. */
-  wyrelog_error_t (*get_session) (void *self,
+  wyrelog_error_t (*get_session) (gpointer self,
       wyl_ctx_snapshot_t * snap,
-      uint64_t session_id, const wyl_ctx_session_t ** out_session);
+      guint64 session_id, const wyl_ctx_session_t ** out_session);
 
   /* Release the snapshot and any handles derived from it. */
-  void (*release) (void *self, wyl_ctx_snapshot_t * snap);
+  void (*release) (gpointer self, wyl_ctx_snapshot_t * snap);
 } wyl_ctxprovider_vtable_t;
 
 

--- a/wyrelog/wyl-version.c
+++ b/wyrelog/wyl-version.c
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #include "wyrelog/wyrelog.h"
 
-const char *
+const gchar *
 wyrelog_version_string (void)
 {
   return "0.1.0";

--- a/wyrelog/wyrelog.h
+++ b/wyrelog/wyrelog.h
@@ -1,9 +1,8 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #pragma once
 
+#include <glib.h>
 #include <glib-object.h>
-#include <stddef.h>
-#include <stdint.h>
 
 #include "wyrelog/error.h"
 
@@ -44,7 +43,7 @@ G_DECLARE_FINAL_TYPE (WylAuditEvent, wyl_audit_event,
  * Plain integer session identifier. Stable across the lifetime of a
  * WylHandle; not a GObject.
  */
-typedef uint64_t wyl_session_id_t;
+typedef guint64 wyl_session_id_t;
 
 /*
  * Opaque request/response carriers for decide / login / perm.
@@ -81,7 +80,7 @@ void wyl_revoke_req_free (wyl_revoke_req_t * req);
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (wyl_revoke_req_t, wyl_revoke_req_free);
 
 /* Lifecycle */
-wyrelog_error_t wyl_init (const char *config_path, WylHandle ** out_handle);
+wyrelog_error_t wyl_init (const gchar * config_path, WylHandle ** out_handle);
 void wyl_shutdown (WylHandle * handle);
 
 /* Decide */
@@ -104,6 +103,6 @@ wyrelog_error_t wyl_audit_emit (WylHandle * handle,
     const WylAuditEvent * event);
 
 /* Meta */
-const char *wyrelog_version_string (void);
+const gchar *wyrelog_version_string (void);
 
 G_END_DECLS;


### PR DESCRIPTION
## Summary

- Replace ISO C primitives with GLib equivalents library-wide: `bool`/`true`/`false` → `gboolean`/`TRUE`/`FALSE`, `int` → `gint`, `size_t` → `gsize`, `uint{8,64}_t` → `guint{8,64}`, `void *` → `gpointer`, `const char *` → `const gchar *`.
- Remove direct `<stdbool.h>` / `<stdint.h>` / `<stddef.h>` includes; add an explicit `<glib.h>` to every header that exposes one of these types.
- Fix one non-substitution edit: `if (has_next != FALSE)` → `if (has_next)` in the client smoke test, since GLib's `gboolean` is `gint`-wide and equality-against-`FALSE` is unsafe.

The change is binary-compatible: every replaced type has identical width/alignment/representation on every supported platform, no public boolean fields exist, and library `soversion` stays at `0`.

## Test plan

- [x] `meson setup builddir` from a clean tree
- [x] `meson compile -C builddir` clean (zero warnings)
- [x] `meson test -C builddir` — 9/9 pass (smoke, client-smoke, traits-compile, dl-static, boot-smoke, plus 4 wirelog example goldens)
- [x] `./tools/gst-indent` applied to all 20 changed files; idempotent on a second pass
- [x] Residual primitive grep returns zero hits in `wyrelog/` and `tests/` (excluding `int main` and `tools/`)
- [x] No `== TRUE` / `== FALSE` / `== true` / `== false` patterns remain
- [ ] CI matrix (Linux gcc, macOS clang, Windows clang-cl) green