### PR TITLE
ci: enable vcpkg binary cache on Windows runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,9 +94,23 @@ jobs:
         shell: cmd
         run: choco install pkgconfiglite -y --allow-empty-checksums
 
+      - name: Enable vcpkg GitHub Actions binary cache
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const token = process.env.ACTIONS_RUNTIME_TOKEN || '';
+            const url = process.env.ACTIONS_CACHE_URL || '';
+            if (token) core.setSecret(token);
+            core.exportVariable('ACTIONS_CACHE_URL', url);
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', token);
+            core.exportVariable('VCPKG_BINARY_SOURCES', 'clear;x-gha,readwrite');
+
       - name: Install C dependencies (vcpkg)
         shell: cmd
-        run: vcpkg install glib:x64-windows libsodium:x64-windows
+        run: |
+          @echo off
+          vcpkg install glib:x64-windows libsodium:x64-windows
 
       - name: Cache meson packagecache
         uses: actions/cache@v4
@@ -109,6 +123,7 @@ jobs:
       - name: Configure (clang-cl)
         shell: cmd
         run: |
+          @echo off
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           set PKG_CONFIG_PATH=%VCPKG_INSTALLED_DIR%\lib\pkgconfig
           set CC=clang-cl
@@ -117,12 +132,14 @@ jobs:
       - name: Build wyrelog targets (clang-cl)
         shell: cmd
         run: |
+          @echo off
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           meson compile -C builddir wyrelog test-smoke test-boot-smoke test-traits-compile
 
       - name: Test (clang-cl)
         shell: cmd
         run: |
+          @echo off
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           meson test -C builddir --print-errorlogs smoke boot-smoke traits-compile
 


### PR DESCRIPTION
## Summary

- Activate vcpkg's built-in `x-gha` GitHub Actions binary cache backend on the Windows job so prebuilt `glib` and `libsodium` archives are reused across runs.
- Export `ACTIONS_CACHE_URL` / `ACTIONS_RUNTIME_TOKEN` to the runner env via `actions/github-script@v7`, masking the token with `core.setSecret`.
- Add `@echo off` to every `cmd` step that runs while the token is in env (defense-in-depth against accidental log echo).
- Gate the export step on `github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository`, so PRs from forks (read-only token) fall back to a from-source build instead of failing.

## Expected effect

- **First run on this PR**: cache miss; builds glib + libsodium normally and uploads binaries (~unchanged wall-clock).
- **Subsequent runs**: cache hit; vcpkg install completes in seconds.
- POSIX cache layer (`actions/cache@v4` for meson packagecache) is unchanged.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` clean
- [ ] First Windows run on this PR completes green (cache write)
- [ ] A trivial follow-up push observes a cache hit (vcpkg log shows restored packages)
- [ ] POSIX matrix unaffected