### PR TITLE
access: add principal authentication state machine

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -47,6 +47,11 @@ install_data(
   install_dir : join_paths(get_option('datadir'), 'wyrelog', 'access'),
 )
 
+install_data(
+  'templates/access/fsm/principal.dl',
+  install_dir : join_paths(get_option('datadir'), 'wyrelog', 'access', 'fsm'),
+)
+
 # Install git pre-commit hook for code style checking
 git_hook_script = find_program('hooks/pre-commit.hook')
 git_dir = join_paths(meson.project_source_root(), '.git')

--- a/templates/access/fsm/principal.dl
+++ b/templates/access/fsm/principal.dl
@@ -1,0 +1,34 @@
+% principal.dl — Wyrelog Access Intelligence Principal FSM v0
+%
+% SPDX-License-Identifier: GPL-3.0-or-later
+% Copyright (C) 2026 wyrelog authors. Also available under a separate
+% commercial license; see LICENSE.md at the project root.
+%
+% Principal authentication state machine. Five states, seven events,
+% eight transitions (functional integrity constraint: at most one
+% (from, event) -> to row). The terminal state `revoked` has no
+% outgoing edge.
+%
+% States  : unverified, mfa_required, authenticated, locked, revoked.
+% Events  : login_ok, login_skip_mfa, mfa_ok, failed_attempt,
+%           lock, unlock, revoke.
+%
+% MFA is mandatory on the production path. The `login_skip_mfa`
+% event is permitted by the FSM itself but must be gated upstream
+% on non-production deployment modes; see the host-side ingress
+% policy.
+%
+% Row order is load-bearing: the test harness compares the rows
+% below line-by-line against the C mirror table, so reordering
+% one side without the other will fail the build.
+
+principal_transition(unverified,    login_ok,         mfa_required).
+principal_transition(unverified,    login_skip_mfa,   authenticated).
+principal_transition(mfa_required,  mfa_ok,           authenticated).
+principal_transition(mfa_required,  failed_attempt,   mfa_required).
+principal_transition(mfa_required,  lock,             locked).
+principal_transition(authenticated, lock,             locked).
+principal_transition(authenticated, revoke,           revoked).
+principal_transition(locked,        unlock,           unverified).
+
+principal_step(From, Ev, To) :- principal_transition(From, Ev, To).

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -32,3 +32,18 @@ test_dl_static = executable('test-dl-static',
 )
 
 test('dl-static', test_dl_static)
+
+fsm_principal_dl_path = join_paths(
+  meson.project_source_root(),
+  'templates', 'access', 'fsm', 'principal.dl',
+)
+
+test_fsm_principal = executable('test-fsm-principal',
+  'test-fsm-principal.c',
+  c_args : [
+    '-DWYL_TEST_FSM_PRINCIPAL_DL_PATH="' + fsm_principal_dl_path + '"',
+  ],
+  dependencies : [wyrelog_dep],
+)
+
+test('fsm-principal', test_fsm_principal)

--- a/tests/test-fsm-principal.c
+++ b/tests/test-fsm-principal.c
@@ -1,0 +1,229 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <glib.h>
+#include <glib/gstdio.h>
+#include <stdio.h>
+
+#include "wyrelog/wyl-fsm-principal-private.h"
+#include "wyrelog/wyl-dl-static-private.h"
+
+#ifndef WYL_TEST_FSM_PRINCIPAL_DL_PATH
+#error "WYL_TEST_FSM_PRINCIPAL_DL_PATH must be defined by the build."
+#endif
+
+/* --- Stratification self-check ---------------------------------- */
+
+/*
+ * Lifts the .dl transition table into wyl_dl_rule_t[] form so the
+ * existing F0 stratification checker can verify the program is
+ * trivially stratified (single non-recursive IDB rule, no negation).
+ */
+static gint
+check_stratification (void)
+{
+  gsize n = 0;
+  (void) wyl_fsm_principal_table (&n);
+
+  /* One rule per transition: head = "principal_transition",
+   * body = (state_name, event_name, state_name) literals. The
+   * stratification checker only cares about predicate names and
+   * negation flags; the literal arguments do not feed the SCC. */
+  g_autofree wyl_dl_rule_t *rules = g_new0 (wyl_dl_rule_t, n + 1);
+  for (gsize i = 0; i < n; i++) {
+    rules[i].head = "principal_transition";
+    rules[i].body = NULL;
+    rules[i].body_len = 0;
+  }
+
+  /* The IDB rule:
+   *   principal_step(From, Ev, To) :- principal_transition(From, Ev, To). */
+  static const wyl_dl_body_atom_t step_body[] = {
+    {.predicate = "principal_transition",.negated = FALSE},
+  };
+  rules[n].head = "principal_step";
+  rules[n].body = step_body;
+  rules[n].body_len = G_N_ELEMENTS (step_body);
+
+  if (wyl_dl_static_check (rules, n + 1) != WYRELOG_E_OK)
+    return 1;
+  return 0;
+}
+
+/* --- Golden trace ----------------------------------------------- */
+
+typedef struct
+{
+  wyl_principal_state_t from;
+  wyl_principal_event_t event;
+  wyrelog_error_t expected_rc;
+  wyl_principal_state_t expected_to;
+} step_case_t;
+
+static gint
+check_golden_trace (void)
+{
+  /* Drives the canonical login-through-revocation path plus every
+   * defined transition row at least once, plus one undefined
+   * transition for the negative path. */
+  static const step_case_t cases[] = {
+    /* canonical: unverified -> mfa_required -> authenticated -> revoked */
+    {WYL_PRINCIPAL_STATE_UNVERIFIED, WYL_PRINCIPAL_EVENT_LOGIN_OK,
+        WYRELOG_E_OK, WYL_PRINCIPAL_STATE_MFA_REQUIRED},
+    {WYL_PRINCIPAL_STATE_MFA_REQUIRED, WYL_PRINCIPAL_EVENT_MFA_OK,
+        WYRELOG_E_OK, WYL_PRINCIPAL_STATE_AUTHENTICATED},
+    {WYL_PRINCIPAL_STATE_AUTHENTICATED, WYL_PRINCIPAL_EVENT_REVOKE,
+        WYRELOG_E_OK, WYL_PRINCIPAL_STATE_REVOKED},
+    /* coverage of remaining defined transitions */
+    {WYL_PRINCIPAL_STATE_UNVERIFIED, WYL_PRINCIPAL_EVENT_LOGIN_SKIP_MFA,
+        WYRELOG_E_OK, WYL_PRINCIPAL_STATE_AUTHENTICATED},
+    {WYL_PRINCIPAL_STATE_MFA_REQUIRED, WYL_PRINCIPAL_EVENT_FAILED_ATTEMPT,
+        WYRELOG_E_OK, WYL_PRINCIPAL_STATE_MFA_REQUIRED},
+    {WYL_PRINCIPAL_STATE_MFA_REQUIRED, WYL_PRINCIPAL_EVENT_LOCK,
+        WYRELOG_E_OK, WYL_PRINCIPAL_STATE_LOCKED},
+    {WYL_PRINCIPAL_STATE_AUTHENTICATED, WYL_PRINCIPAL_EVENT_LOCK,
+        WYRELOG_E_OK, WYL_PRINCIPAL_STATE_LOCKED},
+    {WYL_PRINCIPAL_STATE_LOCKED, WYL_PRINCIPAL_EVENT_UNLOCK,
+        WYRELOG_E_OK, WYL_PRINCIPAL_STATE_UNVERIFIED},
+    /* negative: revoked is terminal, login_ok has no out-edge */
+    {WYL_PRINCIPAL_STATE_REVOKED, WYL_PRINCIPAL_EVENT_LOGIN_OK,
+        WYRELOG_E_POLICY, WYL_PRINCIPAL_STATE_REVOKED /* unused */ },
+  };
+
+  for (gsize i = 0; i < G_N_ELEMENTS (cases); i++) {
+    wyl_principal_state_t to = WYL_PRINCIPAL_STATE_LAST_;
+    wyrelog_error_t rc =
+        wyl_fsm_principal_step (cases[i].from, cases[i].event, &to);
+    if (rc != cases[i].expected_rc)
+      return (gint) (10 + i);
+    if (rc == WYRELOG_E_OK && to != cases[i].expected_to)
+      return (gint) (20 + i);
+  }
+  return 0;
+}
+
+/* --- Argument validation ---------------------------------------- */
+
+static gint
+check_argument_validation (void)
+{
+  wyl_principal_state_t to = WYL_PRINCIPAL_STATE_LAST_;
+  /* NULL out_to */
+  if (wyl_fsm_principal_step (WYL_PRINCIPAL_STATE_UNVERIFIED,
+          WYL_PRINCIPAL_EVENT_LOGIN_OK, NULL) != WYRELOG_E_INVALID)
+    return 31;
+  /* out-of-range state */
+  if (wyl_fsm_principal_step (WYL_PRINCIPAL_STATE_LAST_,
+          WYL_PRINCIPAL_EVENT_LOGIN_OK, &to) != WYRELOG_E_INVALID)
+    return 32;
+  /* out-of-range event */
+  if (wyl_fsm_principal_step (WYL_PRINCIPAL_STATE_UNVERIFIED,
+          WYL_PRINCIPAL_EVENT_LAST_, &to) != WYRELOG_E_INVALID)
+    return 33;
+  return 0;
+}
+
+/* --- Text mirror oracle ----------------------------------------- */
+
+/*
+ * Parses every `principal_transition(...)` line from the .dl file
+ * and asserts row-for-row equality with the C table. Mutating
+ * either side fails this test, which is the synchronization gate
+ * between the two artifacts.
+ */
+static gboolean
+parse_one_row (const gchar *line, gchar **out_from, gchar **out_event,
+    gchar **out_to)
+{
+  /* Expected shape (whitespace-tolerant inside parens):
+   *   principal_transition(<from>, <event>, <to>). */
+  const gchar *prefix = "principal_transition";
+  if (!g_str_has_prefix (line, prefix))
+    return FALSE;
+  const gchar *p = line + strlen (prefix);
+  while (*p == ' ' || *p == '\t')
+    p++;
+  if (*p != '(')
+    return FALSE;
+  p++;
+
+  g_auto (GStrv) fields = NULL;
+  const gchar *close = strchr (p, ')');
+  if (close == NULL)
+    return FALSE;
+  g_autofree gchar *inner = g_strndup (p, (gsize) (close - p));
+  fields = g_strsplit (inner, ",", -1);
+  if (g_strv_length (fields) != 3)
+    return FALSE;
+
+  *out_from = g_strstrip (g_strdup (fields[0]));
+  *out_event = g_strstrip (g_strdup (fields[1]));
+  *out_to = g_strstrip (g_strdup (fields[2]));
+  return TRUE;
+}
+
+static gint
+check_text_mirror (void)
+{
+  g_autofree gchar *contents = NULL;
+  gsize len = 0;
+  g_autoptr (GError) err = NULL;
+  if (!g_file_get_contents (WYL_TEST_FSM_PRINCIPAL_DL_PATH, &contents,
+          &len, &err)) {
+    g_printerr ("cannot read %s: %s\n", WYL_TEST_FSM_PRINCIPAL_DL_PATH,
+        err ? err->message : "?");
+    return 41;
+  }
+
+  g_auto (GStrv) lines = g_strsplit (contents, "\n", -1);
+  gsize parsed_n = 0;
+  gsize table_n = 0;
+  const wyl_principal_transition_t *table = wyl_fsm_principal_table (&table_n);
+
+  for (gsize i = 0; lines[i] != NULL; i++) {
+    g_autofree gchar *trimmed = g_strdup (g_strchug (lines[i]));
+    if (trimmed[0] == '%' || trimmed[0] == '\0')
+      continue;
+    if (!g_str_has_prefix (trimmed, "principal_transition"))
+      continue;
+
+    g_autofree gchar *from = NULL;
+    g_autofree gchar *event = NULL;
+    g_autofree gchar *to = NULL;
+    if (!parse_one_row (trimmed, &from, &event, &to))
+      return (gint) (50 + parsed_n);
+
+    if (parsed_n >= table_n)
+      return 60;
+
+    const gchar *expect_from = wyl_principal_state_name (table[parsed_n].from);
+    const gchar *expect_event =
+        wyl_principal_event_name (table[parsed_n].event);
+    const gchar *expect_to = wyl_principal_state_name (table[parsed_n].to);
+    if (g_strcmp0 (from, expect_from) != 0)
+      return (gint) (70 + parsed_n);
+    if (g_strcmp0 (event, expect_event) != 0)
+      return (gint) (80 + parsed_n);
+    if (g_strcmp0 (to, expect_to) != 0)
+      return (gint) (90 + parsed_n);
+
+    parsed_n++;
+  }
+
+  if (parsed_n != table_n)
+    return 100;
+  return 0;
+}
+
+int
+main (void)
+{
+  gint rc;
+  if ((rc = check_stratification ()) != 0)
+    return rc;
+  if ((rc = check_golden_trace ()) != 0)
+    return rc;
+  if ((rc = check_argument_validation ()) != 0)
+    return rc;
+  if ((rc = check_text_mirror ()) != 0)
+    return rc;
+  return 0;
+}

--- a/wyrelog/meson.build
+++ b/wyrelog/meson.build
@@ -11,6 +11,7 @@ wyrelog_sources = files(
   'wyl-decide.c',
   'wyl-dl-static.c',
   'wyl-error.c',
+  'wyl-fsm-principal.c',
   'wyl-handle.c',
   'wyl-perm.c',
   'wyl-session.c',

--- a/wyrelog/wyl-fsm-principal-private.h
+++ b/wyrelog/wyl-fsm-principal-private.h
@@ -1,0 +1,74 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+
+#include <glib.h>
+
+#include "wyrelog/error.h"
+
+G_BEGIN_DECLS;
+
+/*
+ * Principal FSM reference stepper.
+ *
+ * Mirrors the transition table shipped at
+ * <datadir>/wyrelog/access/fsm/principal.dl. The C side is a
+ * table-driven Mealy machine: callers feed (state, event), receive
+ * the next state, and an undefined (from, event) pair returns
+ * WYRELOG_E_POLICY without mutating *out_to.
+ *
+ * The .dl file is the system of record. The C table is kept in
+ * sync by tests/test-fsm-principal.c, which parses the .dl source
+ * and asserts row-for-row equality against the array exposed
+ * through wyl_fsm_principal_table.
+ */
+
+typedef enum wyl_principal_state_t
+{
+  WYL_PRINCIPAL_STATE_UNVERIFIED = 0,
+  WYL_PRINCIPAL_STATE_MFA_REQUIRED,
+  WYL_PRINCIPAL_STATE_AUTHENTICATED,
+  WYL_PRINCIPAL_STATE_LOCKED,
+  WYL_PRINCIPAL_STATE_REVOKED,
+  WYL_PRINCIPAL_STATE_LAST_,
+} wyl_principal_state_t;
+
+typedef enum wyl_principal_event_t
+{
+  WYL_PRINCIPAL_EVENT_LOGIN_OK = 0,
+  WYL_PRINCIPAL_EVENT_LOGIN_SKIP_MFA,
+  WYL_PRINCIPAL_EVENT_MFA_OK,
+  WYL_PRINCIPAL_EVENT_FAILED_ATTEMPT,
+  WYL_PRINCIPAL_EVENT_LOCK,
+  WYL_PRINCIPAL_EVENT_UNLOCK,
+  WYL_PRINCIPAL_EVENT_REVOKE,
+  WYL_PRINCIPAL_EVENT_LAST_,
+} wyl_principal_event_t;
+
+typedef struct wyl_principal_transition_t
+{
+  wyl_principal_state_t from;
+  wyl_principal_event_t event;
+  wyl_principal_state_t to;
+} wyl_principal_transition_t;
+
+/* Drives one step of the principal FSM. Returns WYRELOG_E_OK and
+ * writes the next state to *out_to on a defined transition.
+ * Returns WYRELOG_E_POLICY when no row matches (out_to is left
+ * untouched). Returns WYRELOG_E_INVALID when out_to is NULL or
+ * either input enum is out of range. */
+wyrelog_error_t wyl_fsm_principal_step (wyl_principal_state_t from,
+    wyl_principal_event_t event, wyl_principal_state_t * out_to);
+
+/* Read-only access to the transition table. Callers must not
+ * mutate the returned storage. The table is sorted in declaration
+ * order, matching the .dl source line order, so tests can compare
+ * row-by-row. */
+const wyl_principal_transition_t *wyl_fsm_principal_table (gsize * out_len);
+
+/* Lexical names for state and event ordinals. Used by the
+ * .dl text-mirror oracle in the test harness. NULL on out-of-range
+ * input. */
+const gchar *wyl_principal_state_name (wyl_principal_state_t s);
+const gchar *wyl_principal_event_name (wyl_principal_event_t ev);
+
+G_END_DECLS;

--- a/wyrelog/wyl-fsm-principal.c
+++ b/wyrelog/wyl-fsm-principal.c
@@ -1,0 +1,86 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "wyl-fsm-principal-private.h"
+
+static const wyl_principal_transition_t fsm_table[] = {
+  {WYL_PRINCIPAL_STATE_UNVERIFIED, WYL_PRINCIPAL_EVENT_LOGIN_OK,
+      WYL_PRINCIPAL_STATE_MFA_REQUIRED},
+  {WYL_PRINCIPAL_STATE_UNVERIFIED, WYL_PRINCIPAL_EVENT_LOGIN_SKIP_MFA,
+      WYL_PRINCIPAL_STATE_AUTHENTICATED},
+  {WYL_PRINCIPAL_STATE_MFA_REQUIRED, WYL_PRINCIPAL_EVENT_MFA_OK,
+      WYL_PRINCIPAL_STATE_AUTHENTICATED},
+  {WYL_PRINCIPAL_STATE_MFA_REQUIRED, WYL_PRINCIPAL_EVENT_FAILED_ATTEMPT,
+      WYL_PRINCIPAL_STATE_MFA_REQUIRED},
+  {WYL_PRINCIPAL_STATE_MFA_REQUIRED, WYL_PRINCIPAL_EVENT_LOCK,
+      WYL_PRINCIPAL_STATE_LOCKED},
+  {WYL_PRINCIPAL_STATE_AUTHENTICATED, WYL_PRINCIPAL_EVENT_LOCK,
+      WYL_PRINCIPAL_STATE_LOCKED},
+  {WYL_PRINCIPAL_STATE_AUTHENTICATED, WYL_PRINCIPAL_EVENT_REVOKE,
+      WYL_PRINCIPAL_STATE_REVOKED},
+  {WYL_PRINCIPAL_STATE_LOCKED, WYL_PRINCIPAL_EVENT_UNLOCK,
+      WYL_PRINCIPAL_STATE_UNVERIFIED},
+};
+
+static const gchar *const state_names[] = {
+  "unverified",
+  "mfa_required",
+  "authenticated",
+  "locked",
+  "revoked",
+};
+
+static const gchar *const event_names[] = {
+  "login_ok",
+  "login_skip_mfa",
+  "mfa_ok",
+  "failed_attempt",
+  "lock",
+  "unlock",
+  "revoke",
+};
+
+G_STATIC_ASSERT (G_N_ELEMENTS (state_names) == WYL_PRINCIPAL_STATE_LAST_);
+G_STATIC_ASSERT (G_N_ELEMENTS (event_names) == WYL_PRINCIPAL_EVENT_LAST_);
+
+wyrelog_error_t
+wyl_fsm_principal_step (wyl_principal_state_t from,
+    wyl_principal_event_t event, wyl_principal_state_t *out_to)
+{
+  if (out_to == NULL)
+    return WYRELOG_E_INVALID;
+  if ((guint) from >= WYL_PRINCIPAL_STATE_LAST_)
+    return WYRELOG_E_INVALID;
+  if ((guint) event >= WYL_PRINCIPAL_EVENT_LAST_)
+    return WYRELOG_E_INVALID;
+
+  for (gsize i = 0; i < G_N_ELEMENTS (fsm_table); i++) {
+    if (fsm_table[i].from == from && fsm_table[i].event == event) {
+      *out_to = fsm_table[i].to;
+      return WYRELOG_E_OK;
+    }
+  }
+  return WYRELOG_E_POLICY;
+}
+
+const wyl_principal_transition_t *
+wyl_fsm_principal_table (gsize *out_len)
+{
+  if (out_len != NULL)
+    *out_len = G_N_ELEMENTS (fsm_table);
+  return fsm_table;
+}
+
+const gchar *
+wyl_principal_state_name (wyl_principal_state_t s)
+{
+  if ((guint) s >= WYL_PRINCIPAL_STATE_LAST_)
+    return NULL;
+  return state_names[s];
+}
+
+const gchar *
+wyl_principal_event_name (wyl_principal_event_t ev)
+{
+  if ((guint) ev >= WYL_PRINCIPAL_EVENT_LAST_)
+    return NULL;
+  return event_names[ev];
+}


### PR DESCRIPTION
## Summary

- Add the first concrete FSM artifact: the principal authentication state machine, with five states (`unverified`, `mfa_required`, `authenticated`, `locked`, `revoked`) and seven events driving eight transitions.
- Ship the transition table in two synchronized forms: a Datalog source at `templates/access/fsm/principal.dl` installed to `${datadir}/wyrelog/access/fsm/`, and a static C table driving a table-driven stepper (`wyrelog/wyl-fsm-principal.{c,h}`).
- A new test (`tests/test-fsm-principal.c`) parses the `.dl` and asserts row-for-row equality with the C table, so the two artifacts cannot drift silently.
- Sub-tests also walk every defined transition, exercise the negative path on the terminal `revoked` state, validate `NULL`/out-of-range inputs, and lift the rules through the existing stratification analyzer to confirm the program is well-formed.

## Test plan

- [x] `meson setup builddir` clean
- [x] `meson compile -C builddir --clean && meson compile -C builddir` zero warnings (`warning_level=2`)
- [x] `meson test -C builddir` — 10/10 pass (existing suite + new `fsm-principal`)
- [x] `./tools/gst-indent` idempotent on all three new C files
- [x] Residual primitive grep clean (`gboolean`/`gsize`/`gchar`/`gpointer`/`gint` only; `int main` only)
- [x] No `== TRUE`/`== FALSE` patterns
- [ ] CI matrix (Linux/macOS/Windows-clang-cl) green