### PR TITLE
ci(windows): switch vcpkg binary cache to filesystem provider

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,17 +94,21 @@ jobs:
         shell: cmd
         run: choco install pkgconfiglite -y --allow-empty-checksums
 
-      - name: Enable vcpkg GitHub Actions binary cache
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/github-script@v7
+      - name: Prepare vcpkg binary cache directory
+        shell: cmd
+        run: |
+          @echo off
+          set "CACHE_DIR=%RUNNER_TEMP%\vcpkg-cache"
+          if not exist "%CACHE_DIR%" mkdir "%CACHE_DIR%"
+          echo VCPKG_DEFAULT_BINARY_CACHE=%CACHE_DIR%>> %GITHUB_ENV%
+
+      - name: Restore vcpkg binary cache
+        uses: actions/cache@v4
         with:
-          script: |
-            const token = process.env.ACTIONS_RUNTIME_TOKEN || '';
-            const url = process.env.ACTIONS_CACHE_URL || '';
-            if (token) core.setSecret(token);
-            core.exportVariable('ACTIONS_CACHE_URL', url);
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', token);
-            core.exportVariable('VCPKG_BINARY_SOURCES', 'clear;x-gha,readwrite');
+          path: ${{ runner.temp }}\vcpkg-cache
+          key: windows-vcpkg-${{ hashFiles('.github/workflows/ci.yml') }}-v1
+          restore-keys: |
+            windows-vcpkg-
 
       - name: Install C dependencies (vcpkg)
         shell: cmd


### PR DESCRIPTION
## Summary

The vcpkg `x-gha` binary cache backend has been removed upstream — the windows-latest build now warns and falls back to source compilation every run.

Replace it with the filesystem provider:
- `VCPKG_DEFAULT_BINARY_CACHE` env points at a `runner.temp` subdirectory at job scope.
- A small cmd step pre-creates the directory (idempotent).
- `actions/cache@v4` persists the directory across runs, keyed on the workflow file hash with a manual `-v1` suffix and a `windows-vcpkg-` restore-keys fallback.
- The previous `actions/github-script@v7` step that exported `ACTIONS_CACHE_URL`/`ACTIONS_RUNTIME_TOKEN` is removed; `actions/cache@v4` auto-downgrades to read-only on fork PRs, so no token gating is needed.

POSIX matrix is untouched.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` clean
- [ ] First windows run on this PR: cache miss, vcpkg builds glib + libsodium from source, archives uploaded
- [ ] Trivial follow-up push observes a cache hit (`Restored vcpkg-... package(s)` in the install log)
- [ ] Linux/macOS lanes unchanged