### PR TITLE
ci: build whole tree and scope tests to wyrelog suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,10 +56,7 @@ jobs:
       - name: Configure
         run: meson setup builddir -Denable_tpm=${{ matrix.tpm }}
 
-      - name: Build
-        run: meson compile -C builddir
-
-      - name: Test
+      - name: Build and test
         run: meson test -C builddir --print-errorlogs --suite wyrelog
 
       - name: Upload meson logs on failure
@@ -126,14 +123,7 @@ jobs:
           set CC=clang-cl
           meson setup builddir -Denable_tpm=disabled -Denable_client=disabled -Ddefault_library=static
 
-      - name: Build (clang-cl)
-        shell: cmd
-        run: |
-          @echo off
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-          meson compile -C builddir
-
-      - name: Test (clang-cl)
+      - name: Build and test (clang-cl)
         shell: cmd
         run: |
           @echo off

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,18 +56,11 @@ jobs:
       - name: Configure
         run: meson setup builddir -Denable_tpm=${{ matrix.tpm }}
 
-      - name: Build wyrelog targets
-        run: |
-          meson compile -C builddir \
-            wyrelog \
-            wyrelog-client \
-            test-smoke \
-            test-boot-smoke \
-            test-client-smoke \
-            test-traits-compile
+      - name: Build
+        run: meson compile -C builddir
 
       - name: Test
-        run: meson test -C builddir --print-errorlogs smoke boot-smoke client-smoke traits-compile
+        run: meson test -C builddir --print-errorlogs --suite wyrelog
 
       - name: Upload meson logs on failure
         if: failure()
@@ -133,19 +126,19 @@ jobs:
           set CC=clang-cl
           meson setup builddir -Denable_tpm=disabled -Denable_client=disabled -Ddefault_library=static
 
-      - name: Build wyrelog targets (clang-cl)
+      - name: Build (clang-cl)
         shell: cmd
         run: |
           @echo off
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-          meson compile -C builddir wyrelog test-smoke test-boot-smoke test-traits-compile
+          meson compile -C builddir
 
       - name: Test (clang-cl)
         shell: cmd
         run: |
           @echo off
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-          meson test -C builddir --print-errorlogs smoke boot-smoke traits-compile
+          meson test -C builddir --print-errorlogs --suite wyrelog
 
       - name: Upload meson logs on failure
         if: failure()

--- a/meson.build
+++ b/meson.build
@@ -32,7 +32,13 @@ wirelog_dep = declare_dependency(
 
 libchronoid_proj = subproject(
   'libchronoid',
-  default_options : ['tests=false', 'cli=false'],
+  default_options : [
+    'tests=false',
+    'cli=false',
+    'simd=none',
+    'ssse3=disabled',
+    'avx2_batch=disabled',
+  ],
 )
 libchronoid_dep = declare_dependency(
   link_with : libchronoid_proj.get_variable('chronoid_lib'),


### PR DESCRIPTION
## Summary

The POSIX and Windows CI jobs were compiling and testing a hand-picked list of names. Every new test landed in the repo (most recently `dl-static`, `fsm-principal`, `fsm-session`) was silently skipped by CI until someone remembered to update the workflow — meaning F-series acceptance gates were not actually gated.

- Drop the explicit name lists from both jobs.
- Run `meson compile -C builddir` (whole tree) and `meson test -C builddir --print-errorlogs --suite wyrelog` (all wyrelog tests, no subproject goldens).
- The Windows lane stays on `enable_client=disabled`; `client-smoke` is auto-pruned via `disabler()` for `wyrelog_client_dep`.

Future contract: any new `test()` registration in `tests/meson.build` is a CI gate by default. Tests that need network/root/etc. must opt out of the `wyrelog` suite.

## Test plan

- [x] `meson test -C builddir --suite wyrelog --print-errorlogs` locally → 7/7 PASS (smoke, client-smoke, traits-compile, dl-static, fsm-principal, fsm-session, boot-smoke)
- [x] `meson setup /tmp/x -Denable_client=disabled` produces a build with no client-smoke target (disabler propagation verified)
- [ ] CI matrix (Linux/macOS/Windows-clang-cl) green