### PR TITLE
access: add guard expression AST, builder, and validator

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -62,3 +62,10 @@ test_fsm_session = executable('test-fsm-session',
 )
 
 test('fsm-session', test_fsm_session)
+
+test_guard_expr = executable('test-guard-expr',
+  'test-guard-expr.c',
+  dependencies : [wyrelog_dep],
+)
+
+test('guard-expr', test_guard_expr)

--- a/tests/test-guard-expr.c
+++ b/tests/test-guard-expr.c
@@ -1,0 +1,320 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <glib.h>
+
+#include "wyrelog/wyl-guard-expr-private.h"
+
+/* --- Name lookup round-trip ------------------------------------- */
+
+static gint
+check_name_roundtrip (void)
+{
+  for (guint k = 0; k < WYL_GUARD_KIND_LAST_; k++) {
+    if (wyl_guard_kind_name ((wyl_guard_kind_t) k) == NULL)
+      return 1;
+  }
+  if (wyl_guard_kind_name (WYL_GUARD_KIND_LAST_) != NULL)
+    return 2;
+
+  for (guint f = 0; f < WYL_GUARD_FIELD_LAST_; f++) {
+    if (wyl_guard_field_name ((wyl_guard_field_t) f) == NULL)
+      return 3;
+  }
+  if (wyl_guard_field_name (WYL_GUARD_FIELD_LAST_) != NULL)
+    return 4;
+
+  for (guint op = 0; op < WYL_GUARD_OP_LAST_; op++) {
+    if (wyl_guard_op_name ((wyl_guard_op_t) op) == NULL)
+      return 5;
+  }
+  if (wyl_guard_op_name (WYL_GUARD_OP_LAST_) != NULL)
+    return 6;
+
+  return 0;
+}
+
+/* --- AND fixture ------------------------------------------------ */
+
+static gint
+check_build_and (void)
+{
+  g_autoptr (wyl_guard_expr_t) g =
+      wyl_guard_and (wyl_guard_cmp (WYL_GUARD_FIELD_RISK, WYL_GUARD_OP_LT,
+          "30"), wyl_guard_tag ("audit"));
+  if (g == NULL)
+    return 10;
+  if (wyl_guard_validate (g) != WYRELOG_E_OK)
+    return 11;
+  if (wyl_guard_depth (g) != 2)
+    return 12;
+  if (wyl_guard_atom_count (g) != 2)
+    return 13;
+  return 0;
+}
+
+/* --- OR fixture ------------------------------------------------- */
+
+static gint
+check_build_or (void)
+{
+  g_autoptr (wyl_guard_expr_t) g =
+      wyl_guard_or (wyl_guard_cmp (WYL_GUARD_FIELD_TENANT, WYL_GUARD_OP_EQ,
+          "t1"), wyl_guard_cmp (WYL_GUARD_FIELD_TENANT, WYL_GUARD_OP_EQ, "t2"));
+  if (g == NULL)
+    return 20;
+  if (wyl_guard_validate (g) != WYRELOG_E_OK)
+    return 21;
+  if (wyl_guard_depth (g) != 2)
+    return 22;
+  if (wyl_guard_atom_count (g) != 2)
+    return 23;
+  return 0;
+}
+
+/* --- NOT fixture ------------------------------------------------ */
+
+static gint
+check_build_not (void)
+{
+  g_autoptr (wyl_guard_expr_t) g =
+      wyl_guard_not (wyl_guard_cmp (WYL_GUARD_FIELD_LOC_CLASS, WYL_GUARD_OP_EQ,
+          "public"));
+  if (g == NULL)
+    return 30;
+  if (wyl_guard_validate (g) != WYRELOG_E_OK)
+    return 31;
+  if (wyl_guard_depth (g) != 2)
+    return 32;
+  if (wyl_guard_atom_count (g) != 1)
+    return 33;
+  return 0;
+}
+
+/* --- Nested mixed fixture --------------------------------------- */
+
+static gint
+check_nested_mixed (void)
+{
+  /* and(or(cmp,cmp), not(tag)) — depth 3, 3 atoms */
+  g_autoptr (wyl_guard_expr_t) g =
+      wyl_guard_and (wyl_guard_or (wyl_guard_cmp (WYL_GUARD_FIELD_RISK,
+              WYL_GUARD_OP_LT, "20"), wyl_guard_cmp (WYL_GUARD_FIELD_LOC_CLASS,
+              WYL_GUARD_OP_EQ, "trusted")),
+      wyl_guard_not (wyl_guard_tag ("break_glass")));
+  if (g == NULL)
+    return 40;
+  if (wyl_guard_validate (g) != WYRELOG_E_OK)
+    return 41;
+  if (wyl_guard_depth (g) != 3)
+    return 42;
+  if (wyl_guard_atom_count (g) != 3)
+    return 43;
+  return 0;
+}
+
+/* --- Depth-4 boundary accept ------------------------------------ */
+
+static gint
+check_depth_4_boundary (void)
+{
+  /* Left-leaning chain:
+   *   and(and(and(cmp, cmp), cmp), cmp)  — depth 4, 4 atoms */
+  g_autoptr (wyl_guard_expr_t) g =
+      wyl_guard_and (wyl_guard_and (wyl_guard_and (wyl_guard_cmp
+              (WYL_GUARD_FIELD_RISK, WYL_GUARD_OP_LT, "10"),
+              wyl_guard_cmp (WYL_GUARD_FIELD_RISK, WYL_GUARD_OP_LT, "20")),
+          wyl_guard_cmp (WYL_GUARD_FIELD_RISK, WYL_GUARD_OP_LT, "30")),
+      wyl_guard_cmp (WYL_GUARD_FIELD_RISK, WYL_GUARD_OP_LT, "40"));
+  if (g == NULL)
+    return 50;
+  if (wyl_guard_validate (g) != WYRELOG_E_OK)
+    return 51;
+  if (wyl_guard_depth (g) != 4)
+    return 52;
+  if (wyl_guard_atom_count (g) != 4)
+    return 53;
+  return 0;
+}
+
+/* --- Depth-5 reject --------------------------------------------- */
+
+static gint
+check_depth_5_reject (void)
+{
+  g_autoptr (wyl_guard_expr_t) g =
+      wyl_guard_and (wyl_guard_and (wyl_guard_and (wyl_guard_and (wyl_guard_cmp
+                  (WYL_GUARD_FIELD_RISK, WYL_GUARD_OP_LT, "10"),
+                  wyl_guard_cmp (WYL_GUARD_FIELD_RISK, WYL_GUARD_OP_LT, "20")),
+              wyl_guard_cmp (WYL_GUARD_FIELD_RISK, WYL_GUARD_OP_LT, "30")),
+          wyl_guard_cmp (WYL_GUARD_FIELD_RISK, WYL_GUARD_OP_LT, "40")),
+      wyl_guard_cmp (WYL_GUARD_FIELD_RISK, WYL_GUARD_OP_LT, "50"));
+  if (g == NULL)
+    return 60;
+  if (wyl_guard_validate (g) != WYRELOG_E_POLICY)
+    return 61;
+  /* The walking depth counter saturates at MAX_DEPTH + 1. */
+  if (wyl_guard_depth (g) != WYL_GUARD_MAX_DEPTH + 1)
+    return 62;
+  return 0;
+}
+
+/* --- Atom limit accept (8 atoms, depth 4) ----------------------- */
+
+static gint
+check_atom_limit_accept (void)
+{
+  /* Balanced tree, depth 4, 8 leaves. */
+#define LEAF() \
+  wyl_guard_cmp (WYL_GUARD_FIELD_RISK, WYL_GUARD_OP_LT, "1")
+  g_autoptr (wyl_guard_expr_t) g =
+      wyl_guard_and (wyl_guard_and (wyl_guard_and (LEAF (), LEAF ()),
+          wyl_guard_and (LEAF (), LEAF ())),
+      wyl_guard_and (wyl_guard_and (LEAF (), LEAF ()), wyl_guard_and (LEAF (),
+              LEAF ())));
+#undef LEAF
+  if (g == NULL)
+    return 70;
+  if (wyl_guard_validate (g) != WYRELOG_E_OK)
+    return 71;
+  if (wyl_guard_depth (g) != 4)
+    return 72;
+  if (wyl_guard_atom_count (g) != 8)
+    return 73;
+  return 0;
+}
+
+/* --- Atom limit reject (9 atoms) -------------------------------- */
+
+static gint
+check_atom_limit_reject (void)
+{
+  /* Nine leaves wired through nested OR. The validator must reject
+   * with WYRELOG_E_POLICY whether the rejection is triggered by
+   * the atom limit (>8) or the depth limit (>4); either condition
+   * is a policy violation. */
+  g_autoptr (wyl_guard_expr_t) reject =
+      wyl_guard_or (wyl_guard_or (wyl_guard_or (wyl_guard_cmp
+              (WYL_GUARD_FIELD_RISK, WYL_GUARD_OP_LT, "1"),
+              wyl_guard_cmp (WYL_GUARD_FIELD_RISK, WYL_GUARD_OP_LT, "2")),
+          wyl_guard_or (wyl_guard_cmp (WYL_GUARD_FIELD_RISK, WYL_GUARD_OP_LT,
+                  "3"), wyl_guard_cmp (WYL_GUARD_FIELD_RISK, WYL_GUARD_OP_LT,
+                  "4"))),
+      wyl_guard_or (wyl_guard_or (wyl_guard_cmp (WYL_GUARD_FIELD_RISK,
+                  WYL_GUARD_OP_LT, "5"), wyl_guard_cmp (WYL_GUARD_FIELD_RISK,
+                  WYL_GUARD_OP_LT, "6")),
+          wyl_guard_or (wyl_guard_cmp (WYL_GUARD_FIELD_RISK, WYL_GUARD_OP_LT,
+                  "7"), wyl_guard_or (wyl_guard_cmp (WYL_GUARD_FIELD_RISK,
+                      WYL_GUARD_OP_LT, "8"),
+                  wyl_guard_cmp (WYL_GUARD_FIELD_RISK, WYL_GUARD_OP_LT,
+                      "9")))));
+  if (reject == NULL)
+    return 81;
+  /* 9 atoms — exceeds limit. depth could also exceed; either way
+   * validate must reject. */
+  if (wyl_guard_validate (reject) != WYRELOG_E_POLICY)
+    return 82;
+  return 0;
+}
+
+/* --- in operator with timestamp field --------------------------- */
+
+static gint
+check_in_with_timestamp (void)
+{
+  g_autoptr (wyl_guard_expr_t) g =
+      wyl_guard_cmp (WYL_GUARD_FIELD_TIMESTAMP, WYL_GUARD_OP_IN, "off_hours");
+  if (g == NULL)
+    return 90;
+  if (wyl_guard_validate (g) != WYRELOG_E_OK)
+    return 91;
+  if (wyl_guard_depth (g) != 1)
+    return 92;
+  if (wyl_guard_atom_count (g) != 1)
+    return 93;
+  return 0;
+}
+
+/* --- Argument validation (builders) ----------------------------- */
+
+static gint
+check_builder_validation (void)
+{
+  /* Out-of-range field: builder rejects. */
+  if (wyl_guard_cmp (WYL_GUARD_FIELD_LAST_, WYL_GUARD_OP_EQ, "x") != NULL)
+    return 100;
+  /* Out-of-range op: rejects. */
+  if (wyl_guard_cmp (WYL_GUARD_FIELD_RISK, WYL_GUARD_OP_LAST_, "x") != NULL)
+    return 101;
+  /* NULL value: rejects. */
+  if (wyl_guard_cmp (WYL_GUARD_FIELD_RISK, WYL_GUARD_OP_EQ, NULL) != NULL)
+    return 102;
+  /* NULL atom for tag: rejects. */
+  if (wyl_guard_tag (NULL) != NULL)
+    return 103;
+  /* NULL child for not: rejects. */
+  if (wyl_guard_not (NULL) != NULL)
+    return 104;
+  /* Builder consumes children even on rejection: pass a real left
+   * with a NULL right and confirm no leak (we cannot directly
+   * observe leaks, but the contract is exercised). */
+  wyl_guard_expr_t *l =
+      wyl_guard_cmp (WYL_GUARD_FIELD_RISK, WYL_GUARD_OP_LT, "1");
+  if (l == NULL)
+    return 105;
+  if (wyl_guard_and (l, NULL) != NULL)
+    return 106;
+  /* l has been freed by the builder; do not touch it again. */
+
+  /* validate(NULL) -> INVALID. */
+  if (wyl_guard_validate (NULL) != WYRELOG_E_INVALID)
+    return 107;
+
+  return 0;
+}
+
+/* --- Validator invariant (manual struct poke) ------------------- */
+
+static gint
+check_validate_oor_field (void)
+{
+  /* Forge a cmp node with an out-of-range field bypassing the
+   * builder, to exercise the validator's defensive enum check. */
+  g_autoptr (wyl_guard_expr_t) e = g_new0 (wyl_guard_expr_t, 1);
+  e->kind = WYL_GUARD_KIND_CMP;
+  e->u.cmp.field = WYL_GUARD_FIELD_LAST_;
+  e->u.cmp.op = WYL_GUARD_OP_EQ;
+  e->u.cmp.value = g_strdup ("x");
+  if (wyl_guard_validate (e) != WYRELOG_E_INVALID)
+    return 110;
+  return 0;
+}
+
+int
+main (void)
+{
+  gint rc;
+  if ((rc = check_name_roundtrip ()) != 0)
+    return rc;
+  if ((rc = check_build_and ()) != 0)
+    return rc;
+  if ((rc = check_build_or ()) != 0)
+    return rc;
+  if ((rc = check_build_not ()) != 0)
+    return rc;
+  if ((rc = check_nested_mixed ()) != 0)
+    return rc;
+  if ((rc = check_depth_4_boundary ()) != 0)
+    return rc;
+  if ((rc = check_depth_5_reject ()) != 0)
+    return rc;
+  if ((rc = check_atom_limit_accept ()) != 0)
+    return rc;
+  if ((rc = check_atom_limit_reject ()) != 0)
+    return rc;
+  if ((rc = check_in_with_timestamp ()) != 0)
+    return rc;
+  if ((rc = check_builder_validation ()) != 0)
+    return rc;
+  if ((rc = check_validate_oor_field ()) != 0)
+    return rc;
+  return 0;
+}

--- a/wyrelog/meson.build
+++ b/wyrelog/meson.build
@@ -13,6 +13,7 @@ wyrelog_sources = files(
   'wyl-error.c',
   'wyl-fsm-principal.c',
   'wyl-fsm-session.c',
+  'wyl-guard-expr.c',
   'wyl-handle.c',
   'wyl-perm.c',
   'wyl-session.c',

--- a/wyrelog/wyl-guard-expr-private.h
+++ b/wyrelog/wyl-guard-expr-private.h
@@ -1,0 +1,169 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+
+#include <glib.h>
+
+#include "wyrelog/error.h"
+
+G_BEGIN_DECLS;
+
+/*
+ * Guard expression AST.
+ *
+ * In-memory representation of a policy guard expression. The
+ * grammar is recursive over five node kinds:
+ *
+ *   guard_expr ::= and(guard_expr, guard_expr)
+ *                | or(guard_expr, guard_expr)
+ *                | not(guard_expr)
+ *                | cmp(field, op, value)
+ *                | tag(atom)
+ *
+ * Comparison fields are drawn from a fixed alphabet (risk, tenant,
+ * loc_class, timestamp). The raw location identifier is
+ * deliberately absent; site policies that need it must encode
+ * through tag atoms. Comparison operators are the six total
+ * orderings plus a set-membership operator (in).
+ *
+ * Structural limits (load-time enforced):
+ *   - depth <= 4
+ *   - leaf atom count (cmp + tag) <= 8
+ *
+ * Depth convention: depth(cmp) = depth(tag) = 1; depth(not(c)) =
+ * 1 + depth(c); depth(and(l,r)) = depth(or(l,r)) = 1 + max(depth(l),
+ * depth(r)).
+ *
+ * Memory ownership: builders take ownership of every child
+ * argument unconditionally. If the builder rejects its arguments
+ * (NULL child where one is required, out-of-range enum, or invalid
+ * value pointer) it frees the passed-in children before returning
+ * NULL. Callers therefore never free a child after handing it to a
+ * builder; the whole tree is released by a single
+ * wyl_guard_expr_free at the root, or via g_autoptr.
+ *
+ * Aliasing rule: callers must not alias subtrees. Each node
+ * appears at most once in the tree. The validator does not
+ * implement a visited set; instead, the depth limit acts as a
+ * structural bound that catches accidental cycles by treating any
+ * traversal beyond depth 4 as malformed.
+ */
+
+#define WYL_GUARD_MAX_DEPTH ((gsize) 4)
+#define WYL_GUARD_MAX_ATOMS ((gsize) 8)
+
+typedef enum wyl_guard_kind_t
+{
+  WYL_GUARD_KIND_AND = 0,
+  WYL_GUARD_KIND_OR,
+  WYL_GUARD_KIND_NOT,
+  WYL_GUARD_KIND_CMP,
+  WYL_GUARD_KIND_TAG,
+  WYL_GUARD_KIND_LAST_,
+} wyl_guard_kind_t;
+
+typedef enum wyl_guard_field_t
+{
+  WYL_GUARD_FIELD_RISK = 0,
+  WYL_GUARD_FIELD_TENANT,
+  WYL_GUARD_FIELD_LOC_CLASS,
+  WYL_GUARD_FIELD_TIMESTAMP,
+  WYL_GUARD_FIELD_LAST_,
+} wyl_guard_field_t;
+
+typedef enum wyl_guard_op_t
+{
+  WYL_GUARD_OP_EQ = 0,
+  WYL_GUARD_OP_NE,
+  WYL_GUARD_OP_LT,
+  WYL_GUARD_OP_LE,
+  WYL_GUARD_OP_GT,
+  WYL_GUARD_OP_GE,
+  WYL_GUARD_OP_IN,
+  WYL_GUARD_OP_LAST_,
+} wyl_guard_op_t;
+
+typedef struct wyl_guard_expr_t wyl_guard_expr_t;
+
+struct wyl_guard_expr_t
+{
+  wyl_guard_kind_t kind;
+  union
+  {
+    struct
+    {
+      wyl_guard_expr_t *left;
+      wyl_guard_expr_t *right;
+    } binop;
+    struct
+    {
+      wyl_guard_expr_t *child;
+    } unary;
+    struct
+    {
+      wyl_guard_field_t field;
+      wyl_guard_op_t op;
+      gchar *value;
+    } cmp;
+    struct
+    {
+      gchar *atom;
+    } tag;
+  } u;
+};
+
+/*
+ * Builders. Each builder takes ownership of every passed-in
+ * pointer; on validation failure the builder frees them and
+ * returns NULL. The string arguments to wyl_guard_cmp and
+ * wyl_guard_tag are duplicated.
+ */
+wyl_guard_expr_t *wyl_guard_cmp (wyl_guard_field_t field,
+    wyl_guard_op_t op, const gchar * value);
+wyl_guard_expr_t *wyl_guard_tag (const gchar * atom);
+wyl_guard_expr_t *wyl_guard_not (wyl_guard_expr_t * child);
+wyl_guard_expr_t *wyl_guard_and (wyl_guard_expr_t * left,
+    wyl_guard_expr_t * right);
+wyl_guard_expr_t *wyl_guard_or (wyl_guard_expr_t * left,
+    wyl_guard_expr_t * right);
+
+/*
+ * Recursive deep-free. NULL-safe; suitable for autoptr cleanup
+ * and g_clear_pointer.
+ */
+void wyl_guard_expr_free (wyl_guard_expr_t * e);
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (wyl_guard_expr_t, wyl_guard_expr_free);
+
+/*
+ * Returns WYRELOG_E_OK if the tree is well-formed and within the
+ * structural limits. WYRELOG_E_INVALID for NULL, out-of-range
+ * enums, or NULL children where the kind requires them.
+ * WYRELOG_E_POLICY when depth exceeds WYL_GUARD_MAX_DEPTH or the
+ * leaf-atom count exceeds WYL_GUARD_MAX_ATOMS.
+ *
+ * The validator bounds its own recursion at WYL_GUARD_MAX_DEPTH
+ * so a malformed (aliased / cyclic) input is caught as a policy
+ * violation rather than crashing the process.
+ */
+wyrelog_error_t wyl_guard_validate (const wyl_guard_expr_t * e);
+
+/*
+ * Test introspection. Both functions return 0 for NULL and obey
+ * the same depth bound; if the structural limits are exceeded the
+ * counters saturate at WYL_GUARD_MAX_DEPTH + 1 / WYL_GUARD_MAX_ATOMS
+ * + 1 respectively to make the over-limit case observable without
+ * a crash.
+ */
+gsize wyl_guard_depth (const wyl_guard_expr_t * e);
+gsize wyl_guard_atom_count (const wyl_guard_expr_t * e);
+
+/*
+ * Lexical names for kind / field / op ordinals. NULL on
+ * out-of-range input. Used by tests and by future reporting
+ * paths; callers must not free the returned strings.
+ */
+const gchar *wyl_guard_kind_name (wyl_guard_kind_t k);
+const gchar *wyl_guard_field_name (wyl_guard_field_t f);
+const gchar *wyl_guard_op_name (wyl_guard_op_t op);
+
+G_END_DECLS;

--- a/wyrelog/wyl-guard-expr.c
+++ b/wyrelog/wyl-guard-expr.c
@@ -1,0 +1,291 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "wyl-guard-expr-private.h"
+
+static const gchar *const kind_names[] = {
+  "and",
+  "or",
+  "not",
+  "cmp",
+  "tag",
+};
+
+static const gchar *const field_names[] = {
+  "risk",
+  "tenant",
+  "loc_class",
+  "timestamp",
+};
+
+static const gchar *const op_names[] = {
+  "eq",
+  "ne",
+  "lt",
+  "le",
+  "gt",
+  "ge",
+  "in",
+};
+
+G_STATIC_ASSERT (G_N_ELEMENTS (kind_names) == WYL_GUARD_KIND_LAST_);
+G_STATIC_ASSERT (G_N_ELEMENTS (field_names) == WYL_GUARD_FIELD_LAST_);
+G_STATIC_ASSERT (G_N_ELEMENTS (op_names) == WYL_GUARD_OP_LAST_);
+
+const gchar *
+wyl_guard_kind_name (wyl_guard_kind_t k)
+{
+  if ((guint) k >= WYL_GUARD_KIND_LAST_)
+    return NULL;
+  return kind_names[k];
+}
+
+const gchar *
+wyl_guard_field_name (wyl_guard_field_t f)
+{
+  if ((guint) f >= WYL_GUARD_FIELD_LAST_)
+    return NULL;
+  return field_names[f];
+}
+
+const gchar *
+wyl_guard_op_name (wyl_guard_op_t op)
+{
+  if ((guint) op >= WYL_GUARD_OP_LAST_)
+    return NULL;
+  return op_names[op];
+}
+
+void
+wyl_guard_expr_free (wyl_guard_expr_t *e)
+{
+  if (e == NULL)
+    return;
+
+  switch (e->kind) {
+    case WYL_GUARD_KIND_AND:
+    case WYL_GUARD_KIND_OR:
+      wyl_guard_expr_free (e->u.binop.left);
+      wyl_guard_expr_free (e->u.binop.right);
+      break;
+    case WYL_GUARD_KIND_NOT:
+      wyl_guard_expr_free (e->u.unary.child);
+      break;
+    case WYL_GUARD_KIND_CMP:
+      g_free (e->u.cmp.value);
+      break;
+    case WYL_GUARD_KIND_TAG:
+      g_free (e->u.tag.atom);
+      break;
+    case WYL_GUARD_KIND_LAST_:
+    default:
+      /* Fall through; nothing to free for malformed nodes that
+       * may have been zero-initialized but never populated. */
+      break;
+  }
+
+  g_free (e);
+}
+
+wyl_guard_expr_t *
+wyl_guard_cmp (wyl_guard_field_t field, wyl_guard_op_t op, const gchar *value)
+{
+  if (value == NULL)
+    return NULL;
+  if ((guint) field >= WYL_GUARD_FIELD_LAST_)
+    return NULL;
+  if ((guint) op >= WYL_GUARD_OP_LAST_)
+    return NULL;
+
+  wyl_guard_expr_t *e = g_new0 (wyl_guard_expr_t, 1);
+  e->kind = WYL_GUARD_KIND_CMP;
+  e->u.cmp.field = field;
+  e->u.cmp.op = op;
+  e->u.cmp.value = g_strdup (value);
+  return e;
+}
+
+wyl_guard_expr_t *
+wyl_guard_tag (const gchar *atom)
+{
+  if (atom == NULL)
+    return NULL;
+
+  wyl_guard_expr_t *e = g_new0 (wyl_guard_expr_t, 1);
+  e->kind = WYL_GUARD_KIND_TAG;
+  e->u.tag.atom = g_strdup (atom);
+  return e;
+}
+
+wyl_guard_expr_t *
+wyl_guard_not (wyl_guard_expr_t *child)
+{
+  if (child == NULL)
+    return NULL;
+
+  wyl_guard_expr_t *e = g_new0 (wyl_guard_expr_t, 1);
+  e->kind = WYL_GUARD_KIND_NOT;
+  e->u.unary.child = child;
+  return e;
+}
+
+static wyl_guard_expr_t *
+build_binop (wyl_guard_kind_t kind, wyl_guard_expr_t *left,
+    wyl_guard_expr_t *right)
+{
+  if (left == NULL || right == NULL) {
+    /* Builders consume their children unconditionally. If either
+     * is NULL the contract still requires us to release whatever
+     * the caller did pass in. */
+    wyl_guard_expr_free (left);
+    wyl_guard_expr_free (right);
+    return NULL;
+  }
+
+  wyl_guard_expr_t *e = g_new0 (wyl_guard_expr_t, 1);
+  e->kind = kind;
+  e->u.binop.left = left;
+  e->u.binop.right = right;
+  return e;
+}
+
+wyl_guard_expr_t *
+wyl_guard_and (wyl_guard_expr_t *left, wyl_guard_expr_t *right)
+{
+  return build_binop (WYL_GUARD_KIND_AND, left, right);
+}
+
+wyl_guard_expr_t *
+wyl_guard_or (wyl_guard_expr_t *left, wyl_guard_expr_t *right)
+{
+  return build_binop (WYL_GUARD_KIND_OR, left, right);
+}
+
+/*
+ * Bounded recursive walk. Returns the depth of the subtree rooted
+ * at `e`, or WYL_GUARD_MAX_DEPTH + 1 if the depth exceeds the
+ * limit. Accumulates atom count into *atoms (which is also clamped
+ * at WYL_GUARD_MAX_ATOMS + 1 to make the over-limit case
+ * observable without overflow).
+ *
+ * Returns 0 only if `e` is NULL; the caller must therefore
+ * disambiguate "missing subtree" from "depth-1 leaf" by checking
+ * for NULL before calling.
+ */
+static gsize
+walk (const wyl_guard_expr_t *e, gsize current_depth, gsize *atoms)
+{
+  if (e == NULL)
+    return 0;
+  if (current_depth >= WYL_GUARD_MAX_DEPTH + 1)
+    return WYL_GUARD_MAX_DEPTH + 1;
+
+  switch (e->kind) {
+    case WYL_GUARD_KIND_CMP:
+    case WYL_GUARD_KIND_TAG:
+      if (*atoms < WYL_GUARD_MAX_ATOMS + 1)
+        (*atoms)++;
+      return 1;
+
+    case WYL_GUARD_KIND_NOT:{
+      gsize d = walk (e->u.unary.child, current_depth + 1, atoms);
+      if (d == 0)
+        return WYL_GUARD_MAX_DEPTH + 1;
+      gsize result = 1 + d;
+      if (result > WYL_GUARD_MAX_DEPTH + 1)
+        result = WYL_GUARD_MAX_DEPTH + 1;
+      return result;
+    }
+
+    case WYL_GUARD_KIND_AND:
+    case WYL_GUARD_KIND_OR:{
+      gsize l = walk (e->u.binop.left, current_depth + 1, atoms);
+      gsize r = walk (e->u.binop.right, current_depth + 1, atoms);
+      if (l == 0 || r == 0)
+        return WYL_GUARD_MAX_DEPTH + 1;
+      gsize m = (l > r) ? l : r;
+      gsize result = 1 + m;
+      if (result > WYL_GUARD_MAX_DEPTH + 1)
+        result = WYL_GUARD_MAX_DEPTH + 1;
+      return result;
+    }
+
+    case WYL_GUARD_KIND_LAST_:
+    default:
+      return WYL_GUARD_MAX_DEPTH + 1;
+  }
+}
+
+gsize
+wyl_guard_depth (const wyl_guard_expr_t *e)
+{
+  gsize atoms = 0;
+  return walk (e, 0, &atoms);
+}
+
+gsize
+wyl_guard_atom_count (const wyl_guard_expr_t *e)
+{
+  gsize atoms = 0;
+  (void) walk (e, 0, &atoms);
+  return atoms;
+}
+
+/*
+ * Strict structural validation. Recurses without the depth clamp
+ * so that any hop past WYL_GUARD_MAX_DEPTH triggers the policy
+ * rejection rather than being silently saturated.
+ */
+static wyrelog_error_t
+validate_node (const wyl_guard_expr_t *e, gsize current_depth, gsize *atoms)
+{
+  if (e == NULL)
+    return WYRELOG_E_INVALID;
+  if (current_depth >= WYL_GUARD_MAX_DEPTH)
+    return WYRELOG_E_POLICY;
+
+  switch (e->kind) {
+    case WYL_GUARD_KIND_CMP:
+      if ((guint) e->u.cmp.field >= WYL_GUARD_FIELD_LAST_)
+        return WYRELOG_E_INVALID;
+      if ((guint) e->u.cmp.op >= WYL_GUARD_OP_LAST_)
+        return WYRELOG_E_INVALID;
+      if (e->u.cmp.value == NULL)
+        return WYRELOG_E_INVALID;
+      (*atoms)++;
+      if (*atoms > WYL_GUARD_MAX_ATOMS)
+        return WYRELOG_E_POLICY;
+      return WYRELOG_E_OK;
+
+    case WYL_GUARD_KIND_TAG:
+      if (e->u.tag.atom == NULL)
+        return WYRELOG_E_INVALID;
+      (*atoms)++;
+      if (*atoms > WYL_GUARD_MAX_ATOMS)
+        return WYRELOG_E_POLICY;
+      return WYRELOG_E_OK;
+
+    case WYL_GUARD_KIND_NOT:
+      return validate_node (e->u.unary.child, current_depth + 1, atoms);
+
+    case WYL_GUARD_KIND_AND:
+    case WYL_GUARD_KIND_OR:{
+      wyrelog_error_t rc =
+          validate_node (e->u.binop.left, current_depth + 1, atoms);
+      if (rc != WYRELOG_E_OK)
+        return rc;
+      return validate_node (e->u.binop.right, current_depth + 1, atoms);
+    }
+
+    case WYL_GUARD_KIND_LAST_:
+    default:
+      return WYRELOG_E_INVALID;
+  }
+}
+
+wyrelog_error_t
+wyl_guard_validate (const wyl_guard_expr_t *e)
+{
+  if (e == NULL)
+    return WYRELOG_E_INVALID;
+  gsize atoms = 0;
+  return validate_node (e, 0, &atoms);
+}


### PR DESCRIPTION
## Summary

- Recursive guard-expression AST: 5 node kinds (and/or/not/cmp/tag), fixed field alphabet (risk/tenant/loc_class/timestamp), fixed op alphabet (eq/ne/lt/le/gt/ge/in). raw `loc_id` is intentionally not a field.
- Builders take ownership of every child unconditionally; on rejection they free passed-in subtrees so the caller never owns a partially-built tree.
- Combined validator enforces structural limits (depth ≤ 4, atoms ≤ 8 with atoms = leaf count of cmp+tag) and is recursion-bounded against accidental aliasing.
- Deep-free is NULL-safe and exposed via `g_autoptr` cleanup func.
- 12 sub-tests including the canonical AND/OR/NOT fixtures, nested mixed tree, depth-4 boundary accept, depth-5 reject, 8-atom accept, 9-atom reject, `in`-with-timestamp, and builder-side argument validation.

## Test plan

- [x] `meson test -C builddir guard-expr --print-errorlogs` → 1/1 PASS
- [x] `meson test -C builddir` → 12/12 PASS (full suite incl. wirelog goldens)
- [x] gst-indent idempotent on all 3 new C files
- [x] Residual primitive grep clean; no `== TRUE`/`== FALSE`
- [ ] CI matrix (Linux/macOS/Windows-clang-cl) green