### PR TITLE
access: derive armed permissions via guard-expression evaluator

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -63,6 +63,11 @@ install_data(
   install_dir : join_paths(get_option('datadir'), 'wyrelog', 'access', 'fsm'),
 )
 
+install_data(
+  'templates/access/fsm/permission_scope.dl',
+  install_dir : join_paths(get_option('datadir'), 'wyrelog', 'access', 'fsm'),
+)
+
 # Install git pre-commit hook for code style checking
 git_hook_script = find_program('hooks/pre-commit.hook')
 git_dir = join_paths(meson.project_source_root(), '.git')

--- a/templates/access/fsm/permission_scope.dl
+++ b/templates/access/fsm/permission_scope.dl
@@ -1,0 +1,68 @@
+% permission_scope.dl — Wyrelog Access Intelligence Permission Scope v0
+%
+% SPDX-License-Identifier: GPL-3.0-or-later
+% Copyright (C) 2026 wyrelog authors. Also available under a separate
+% commercial license; see LICENSE.md at the project root.
+%
+% Stateless armed/3 derivation. The version-0 perm-scope is a pure
+% IDB rule set with no transition lifecycle: a permission is either
+% ungated (no perm_arm_rule entry, in which case it is always
+% armed when the principal holds it) or gated by a guard expression
+% evaluated against the request scope.
+%
+% EDB schemas (host-populated, no clauses below):
+%   perm_state(user, perm, scope, state)        -- v0 row count = 0
+%   has_permission(user, perm, scope)
+%   perm_arm_rule(perm, guard_expr_term)
+%   loc_class(loc_id, class)
+%   in_window(ts, window_name)
+%   context_now(user, scope, ctx_term)
+%   eval_guard(guard_expr_term, ctx_term)        -- host-bridged on
+%                                                   the C side; this
+%                                                   .dl declares the
+%                                                   predicate but
+%                                                   ships no clauses
+%                                                   for it. The
+%                                                   wyrelog engine
+%                                                   resolves
+%                                                   eval_guard via
+%                                                   wyl_eval_guard
+%                                                   in libwyrelog.
+%
+% Row order in the perm_arm_rule block is load-bearing: the test
+% harness compares the perm-id list line by line against the C
+% catalogue, so reordering one side without the other will fail
+% the build.
+
+% --- armed/3 (3-rule union) -----------------------------------------
+
+% rule-1: dead clause for v0; preserved so v0.x stateful lifecycle
+% can populate perm_state without a .dl change.
+armed(U, P, S) :- perm_state(U, P, S, "armed").
+
+% rule-2: ungated permission -- no perm_arm_rule entry means the
+% permission is always armed when held.
+armed(U, P, S) :-
+    has_permission(U, P, S),
+    \+ perm_arm_rule(P, _).
+
+% rule-3: gated permission -- evaluate the guard against the
+% current request context.
+armed(U, P, S) :-
+    has_permission(U, P, S),
+    context_now(U, S, Ctx),
+    perm_arm_rule(P, G),
+    eval_guard(G, Ctx).
+
+% --- perm_arm_rule baseline catalogue -------------------------------
+
+perm_arm_rule("wr.sys.admin",        and(cmp(risk,lt,30), cmp(loc_class,eq,"trusted"))).
+perm_arm_rule("wr.sys.key_rotate",   and(cmp(risk,lt,20), cmp(loc_class,eq,"trusted"))).
+perm_arm_rule("wr.sys.merkle_seal",  cmp(loc_class,eq,"trusted")).
+perm_arm_rule("wr.policy.write",     cmp(risk,lt,50)).
+perm_arm_rule("wr.policy.grant_role", cmp(risk,lt,30)).
+perm_arm_rule("wr.svc.freeze",       cmp(risk,lt,40)).
+perm_arm_rule("wr.svc.unfreeze",     and(cmp(risk,lt,30), cmp(loc_class,eq,"trusted"))).
+perm_arm_rule("wr.svc.grant_role",   cmp(risk,lt,30)).
+perm_arm_rule("wr.audit.read",       cmp(risk,lt,70)).
+perm_arm_rule("wr.audit.explain",    and(cmp(risk,lt,50), cmp(loc_class,eq,"trusted"))).

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -69,3 +69,18 @@ test_guard_expr = executable('test-guard-expr',
 )
 
 test('guard-expr', test_guard_expr)
+
+fsm_permission_scope_dl_path = join_paths(
+  meson.project_source_root(),
+  'templates', 'access', 'fsm', 'permission_scope.dl',
+)
+
+test_fsm_permission_scope = executable('test-fsm-permission-scope',
+  'test-fsm-permission-scope.c',
+  c_args : [
+    '-DWYL_TEST_FSM_PERMISSION_SCOPE_DL_PATH="' + fsm_permission_scope_dl_path + '"',
+  ],
+  dependencies : [wyrelog_dep],
+)
+
+test('fsm-permission-scope', test_fsm_permission_scope)

--- a/tests/test-fsm-permission-scope.c
+++ b/tests/test-fsm-permission-scope.c
@@ -1,0 +1,428 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <glib.h>
+#include <glib/gstdio.h>
+#include <stdio.h>
+
+#include "wyrelog/wyl-permission-scope-private.h"
+#include "wyrelog/wyl-guard-expr-private.h"
+#include "wyrelog/wyl-dl-static-private.h"
+
+#ifndef WYL_TEST_FSM_PERMISSION_SCOPE_DL_PATH
+#error "WYL_TEST_FSM_PERMISSION_SCOPE_DL_PATH must be defined by the build."
+#endif
+
+/* --- Stratification self-check ---------------------------------- */
+
+/*
+ * Lifts the three armed/3 rules + the eval_guard host bridge fact
+ * into wyl_dl_rule_t form and asserts the program is stratified.
+ * The two negation edges (rule-2 references \+ perm_arm_rule, and
+ * the rule-3 path goes through eval_guard / context_now) cannot
+ * close a cycle because perm_arm_rule, perm_state, has_permission,
+ * context_now, eval_guard and in_window are EDB-only — none of
+ * them appears as a head predicate in the lifted rule set.
+ */
+static gint
+check_stratification (void)
+{
+  static const wyl_dl_body_atom_t rule1_body[] = {
+    {.predicate = "perm_state",.negated = FALSE},
+  };
+  static const wyl_dl_body_atom_t rule2_body[] = {
+    {.predicate = "has_permission",.negated = FALSE},
+    {.predicate = "perm_arm_rule",.negated = TRUE},
+  };
+  static const wyl_dl_body_atom_t rule3_body[] = {
+    {.predicate = "has_permission",.negated = FALSE},
+    {.predicate = "context_now",.negated = FALSE},
+    {.predicate = "perm_arm_rule",.negated = FALSE},
+    {.predicate = "eval_guard",.negated = FALSE},
+  };
+  wyl_dl_rule_t rules[] = {
+    {.head = "armed",.body = rule1_body,.body_len = G_N_ELEMENTS (rule1_body)},
+    {.head = "armed",.body = rule2_body,.body_len = G_N_ELEMENTS (rule2_body)},
+    {.head = "armed",.body = rule3_body,.body_len = G_N_ELEMENTS (rule3_body)},
+  };
+
+  if (wyl_dl_static_check (rules, G_N_ELEMENTS (rules)) != WYRELOG_E_OK)
+    return 1;
+  return 0;
+}
+
+/* --- Catalogue size + lookup invariants ------------------------- */
+
+static gint
+check_catalogue_invariants (void)
+{
+  if (wyl_perm_arm_rule_count () != 10)
+    return 11;
+  if (wyl_perm_arm_rule_lookup (NULL) != NULL)
+    return 12;
+  if (wyl_perm_arm_rule_lookup ("nope.unregistered") != NULL)
+    return 13;
+  if (wyl_perm_arm_rule_lookup ("wr.sys.admin") == NULL)
+    return 14;
+  /* The accessor view of the catalogue must agree with the lookup
+   * view on every row. */
+  for (gsize i = 0; i < wyl_perm_arm_rule_count (); i++) {
+    const gchar *id = wyl_perm_arm_rule_perm_id (i);
+    if (id == NULL)
+      return (gint) (15 + i);
+    const wyl_guard_expr_t *via_idx = wyl_perm_arm_rule_expr (i);
+    const wyl_guard_expr_t *via_lookup = wyl_perm_arm_rule_lookup (id);
+    if (via_idx == NULL || via_idx != via_lookup)
+      return (gint) (30 + i);
+    if (wyl_guard_validate (via_idx) != WYRELOG_E_OK)
+      return (gint) (50 + i);
+  }
+  return 0;
+}
+
+/* --- Eval guard fixtures --------------------------------------- */
+
+static const wyl_scope_t scope_trusted_low_risk = {
+  .user = "u1",
+  .timestamp = 0,
+  .loc_class = "trusted",
+  .risk = 10,
+  .in_window = NULL,
+  .in_window_user_data = NULL,
+};
+
+static const wyl_scope_t scope_public_low_risk = {
+  .user = "u2",
+  .timestamp = 0,
+  .loc_class = "public",
+  .risk = 10,
+  .in_window = NULL,
+  .in_window_user_data = NULL,
+};
+
+static const wyl_scope_t scope_trusted_high_risk = {
+  .user = "u3",
+  .timestamp = 0,
+  .loc_class = "trusted",
+  .risk = 90,
+  .in_window = NULL,
+  .in_window_user_data = NULL,
+};
+
+static gint
+check_catalogue_derivation (void)
+{
+  /* wr.sys.admin = and(risk<30, loc_class=trusted) */
+  const wyl_guard_expr_t *admin = wyl_perm_arm_rule_lookup ("wr.sys.admin");
+  if (admin == NULL)
+    return 70;
+  if (!wyl_eval_guard (admin, &scope_trusted_low_risk))
+    return 71;
+  if (wyl_eval_guard (admin, &scope_public_low_risk))
+    return 72;
+  if (wyl_eval_guard (admin, &scope_trusted_high_risk))
+    return 73;
+
+  /* wr.audit.read = risk<70 — passes regardless of loc_class. */
+  const wyl_guard_expr_t *read = wyl_perm_arm_rule_lookup ("wr.audit.read");
+  if (read == NULL)
+    return 74;
+  if (!wyl_eval_guard (read, &scope_public_low_risk))
+    return 75;
+  if (wyl_eval_guard (read, &scope_trusted_high_risk))
+    return 76;
+
+  /* wr.sys.merkle_seal = loc_class=trusted — risk-agnostic. */
+  const wyl_guard_expr_t *seal =
+      wyl_perm_arm_rule_lookup ("wr.sys.merkle_seal");
+  if (seal == NULL)
+    return 77;
+  if (!wyl_eval_guard (seal, &scope_trusted_high_risk))
+    return 78;
+  if (wyl_eval_guard (seal, &scope_public_low_risk))
+    return 79;
+  return 0;
+}
+
+/* --- Synthetic AND/OR/NOT/nested/depth-4 fixtures --------------- */
+
+static gint
+check_synthetic_fixtures (void)
+{
+  /* AND fixture (depth 2). */
+  g_autoptr (wyl_guard_expr_t) f_and =
+      wyl_guard_and (wyl_guard_cmp (WYL_GUARD_FIELD_RISK, WYL_GUARD_OP_LT,
+          "30"), wyl_guard_cmp (WYL_GUARD_FIELD_LOC_CLASS, WYL_GUARD_OP_EQ,
+          "trusted"));
+  if (f_and == NULL)
+    return 80;
+  if (!wyl_eval_guard (f_and, &scope_trusted_low_risk))
+    return 81;
+  if (wyl_eval_guard (f_and, &scope_public_low_risk))
+    return 82;
+
+  /* OR fixture (depth 2). Left leg accepts risk strictly below
+   * 20; right leg accepts a trusted location. */
+  g_autoptr (wyl_guard_expr_t) f_or =
+      wyl_guard_or (wyl_guard_cmp (WYL_GUARD_FIELD_RISK, WYL_GUARD_OP_LT, "20"),
+      wyl_guard_cmp (WYL_GUARD_FIELD_LOC_CLASS, WYL_GUARD_OP_EQ, "trusted"));
+  if (f_or == NULL)
+    return 83;
+  /* risk=90 fails left, loc_class=trusted satisfies right. */
+  if (!wyl_eval_guard (f_or, &scope_trusted_high_risk))
+    return 84;
+  /* risk=10 satisfies left, loc_class=public fails right; OR overall true. */
+  if (!wyl_eval_guard (f_or, &scope_public_low_risk))
+    return 85;
+  /* Force a scope where both sides fail. */
+  static const wyl_scope_t scope_all_fail = {
+    .user = "u4",.timestamp = 0,.loc_class = "public",.risk = 90,
+    .in_window = NULL,.in_window_user_data = NULL,
+  };
+  if (wyl_eval_guard (f_or, &scope_all_fail))
+    return 86;
+
+  /* NOT fixture (depth 2). */
+  g_autoptr (wyl_guard_expr_t) f_not =
+      wyl_guard_not (wyl_guard_cmp (WYL_GUARD_FIELD_RISK, WYL_GUARD_OP_GE,
+          "80"));
+  if (f_not == NULL)
+    return 87;
+  if (!wyl_eval_guard (f_not, &scope_trusted_low_risk))
+    return 88;
+  if (wyl_eval_guard (f_not, &scope_trusted_high_risk))
+    return 89;
+
+  /* Nested mixed (depth 3). */
+  g_autoptr (wyl_guard_expr_t) f_nested =
+      wyl_guard_and (wyl_guard_or (wyl_guard_cmp (WYL_GUARD_FIELD_RISK,
+              WYL_GUARD_OP_LT, "20"), wyl_guard_cmp (WYL_GUARD_FIELD_LOC_CLASS,
+              WYL_GUARD_OP_EQ, "trusted")),
+      wyl_guard_not (wyl_guard_cmp (WYL_GUARD_FIELD_RISK, WYL_GUARD_OP_GE,
+              "80")));
+  if (f_nested == NULL)
+    return 90;
+  if (!wyl_eval_guard (f_nested, &scope_trusted_low_risk))
+    return 91;
+  /* high risk fails the NOT branch even with loc_class trusted. */
+  if (wyl_eval_guard (f_nested, &scope_trusted_high_risk))
+    return 92;
+
+  /* Depth-4 boundary fixture. */
+  g_autoptr (wyl_guard_expr_t) f_depth4 =
+      wyl_guard_and (wyl_guard_and (wyl_guard_and (wyl_guard_cmp
+              (WYL_GUARD_FIELD_RISK, WYL_GUARD_OP_LT, "30"),
+              wyl_guard_cmp (WYL_GUARD_FIELD_LOC_CLASS, WYL_GUARD_OP_EQ,
+                  "trusted")), wyl_guard_cmp (WYL_GUARD_FIELD_RISK,
+              WYL_GUARD_OP_GE, "0")), wyl_guard_cmp (WYL_GUARD_FIELD_RISK,
+          WYL_GUARD_OP_LT, "100"));
+  if (f_depth4 == NULL)
+    return 93;
+  if (wyl_guard_validate (f_depth4) != WYRELOG_E_OK)
+    return 94;
+  if (wyl_guard_depth (f_depth4) != 4)
+    return 95;
+  if (!wyl_eval_guard (f_depth4, &scope_trusted_low_risk))
+    return 96;
+
+  /* Depth-5 negative — validator rejects before any eval would run. */
+  g_autoptr (wyl_guard_expr_t) f_depth5 =
+      wyl_guard_and (wyl_guard_and (wyl_guard_and (wyl_guard_and (wyl_guard_cmp
+                  (WYL_GUARD_FIELD_RISK, WYL_GUARD_OP_LT, "10"),
+                  wyl_guard_cmp (WYL_GUARD_FIELD_RISK, WYL_GUARD_OP_LT, "20")),
+              wyl_guard_cmp (WYL_GUARD_FIELD_RISK, WYL_GUARD_OP_LT, "30")),
+          wyl_guard_cmp (WYL_GUARD_FIELD_RISK, WYL_GUARD_OP_LT, "40")),
+      wyl_guard_cmp (WYL_GUARD_FIELD_RISK, WYL_GUARD_OP_LT, "50"));
+  if (f_depth5 == NULL)
+    return 97;
+  if (wyl_guard_validate (f_depth5) != WYRELOG_E_POLICY)
+    return 98;
+  return 0;
+}
+
+/* --- in_window host injection ----------------------------------- */
+
+typedef struct
+{
+  const gchar *expected_window;
+  gint64 expected_ts;
+  gboolean answer;
+  guint calls;
+} window_stub_t;
+
+static gboolean
+window_stub_cb (gint64 ts, const gchar *window_name, gpointer user_data)
+{
+  window_stub_t *st = (window_stub_t *) user_data;
+  st->calls++;
+  if (g_strcmp0 (window_name, st->expected_window) != 0)
+    return FALSE;
+  if (ts != st->expected_ts)
+    return FALSE;
+  return st->answer;
+}
+
+static gint
+check_in_window_callback (void)
+{
+  g_autoptr (wyl_guard_expr_t) g =
+      wyl_guard_cmp (WYL_GUARD_FIELD_TIMESTAMP, WYL_GUARD_OP_IN, "off_hours");
+  if (g == NULL)
+    return 110;
+
+  /* Without a callback, the timestamp-in test fails closed. */
+  wyl_scope_t no_cb = {
+    .user = "u",.timestamp = 1234,.loc_class = "trusted",.risk = 0,
+    .in_window = NULL,.in_window_user_data = NULL,
+  };
+  if (wyl_eval_guard (g, &no_cb))
+    return 111;
+
+  /* With a callback that says yes, eval returns TRUE. */
+  window_stub_t st_yes = {
+    .expected_window = "off_hours",.expected_ts = 1234,
+    .answer = TRUE,.calls = 0,
+  };
+  wyl_scope_t cb_yes = {
+    .user = "u",.timestamp = 1234,.loc_class = "trusted",.risk = 0,
+    .in_window = window_stub_cb,.in_window_user_data = &st_yes,
+  };
+  if (!wyl_eval_guard (g, &cb_yes))
+    return 112;
+  if (st_yes.calls != 1)
+    return 113;
+
+  /* Same callback, says no. */
+  window_stub_t st_no = {
+    .expected_window = "off_hours",.expected_ts = 1234,
+    .answer = FALSE,.calls = 0,
+  };
+  wyl_scope_t cb_no = {
+    .user = "u",.timestamp = 1234,.loc_class = "trusted",.risk = 0,
+    .in_window = window_stub_cb,.in_window_user_data = &st_no,
+  };
+  if (wyl_eval_guard (g, &cb_no))
+    return 114;
+  if (st_no.calls != 1)
+    return 115;
+  return 0;
+}
+
+/* --- Argument validation ---------------------------------------- */
+
+static gint
+check_argument_validation (void)
+{
+  const wyl_scope_t s = {.loc_class = "trusted",.risk = 0 };
+  if (wyl_eval_guard (NULL, &s))
+    return 130;
+  g_autoptr (wyl_guard_expr_t) e =
+      wyl_guard_cmp (WYL_GUARD_FIELD_RISK, WYL_GUARD_OP_LT, "10");
+  if (wyl_eval_guard (e, NULL))
+    return 131;
+  /* Tag node is always FALSE in v0. */
+  g_autoptr (wyl_guard_expr_t) t = wyl_guard_tag ("anything");
+  if (wyl_eval_guard (t, &s))
+    return 132;
+  /* Tenant cmp is reserved for tenant-scoped policy wiring; v0 fails closed. */
+  g_autoptr (wyl_guard_expr_t) tenant_cmp =
+      wyl_guard_cmp (WYL_GUARD_FIELD_TENANT, WYL_GUARD_OP_EQ, "anything");
+  if (wyl_eval_guard (tenant_cmp, &s))
+    return 133;
+  /* Malformed risk value is rejected. */
+  g_autoptr (wyl_guard_expr_t) bad_value =
+      wyl_guard_cmp (WYL_GUARD_FIELD_RISK, WYL_GUARD_OP_LT, "not-a-number");
+  if (wyl_eval_guard (bad_value, &s))
+    return 134;
+  return 0;
+}
+
+/* --- .dl <-> C name mirror oracle ------------------------------- */
+
+/*
+ * Parses the perm_arm_rule(...) lines from the .dl source and
+ * asserts that the perm-id list matches the C catalogue row by
+ * row. Structural equality of the guard expression is deferred to
+ * a future bisimulation oracle; this v0 mirror only pins ordering
+ * and identity of the perm ids.
+ */
+static gboolean
+extract_perm_id (const gchar *line, gchar **out_id)
+{
+  const gchar *prefix = "perm_arm_rule";
+  if (!g_str_has_prefix (line, prefix))
+    return FALSE;
+  const gchar *p = line + strlen (prefix);
+  while (*p == ' ' || *p == '\t')
+    p++;
+  if (*p != '(')
+    return FALSE;
+  p++;
+  while (*p == ' ' || *p == '\t')
+    p++;
+  if (*p != '"')
+    return FALSE;
+  p++;
+  const gchar *end = strchr (p, '"');
+  if (end == NULL)
+    return FALSE;
+  *out_id = g_strndup (p, (gsize) (end - p));
+  return TRUE;
+}
+
+static gint
+check_name_mirror (void)
+{
+  g_autofree gchar *contents = NULL;
+  gsize len = 0;
+  g_autoptr (GError) err = NULL;
+  if (!g_file_get_contents (WYL_TEST_FSM_PERMISSION_SCOPE_DL_PATH,
+          &contents, &len, &err)) {
+    g_printerr ("cannot read %s: %s\n",
+        WYL_TEST_FSM_PERMISSION_SCOPE_DL_PATH, err ? err->message : "?");
+    return 200;
+  }
+  g_auto (GStrv) lines = g_strsplit (contents, "\n", -1);
+  gsize parsed = 0;
+  gsize expected = wyl_perm_arm_rule_count ();
+  for (gsize i = 0; lines[i] != NULL; i++) {
+    g_autofree gchar *trimmed = g_strdup (g_strchug (lines[i]));
+    if (trimmed[0] == '%' || trimmed[0] == '\0')
+      continue;
+    /* Catalogue rows always quote the perm id immediately. The
+     * rule-3 body has `perm_arm_rule(P, G)` which would otherwise
+     * trip the parser; this stricter prefix skips it. */
+    if (!g_str_has_prefix (trimmed, "perm_arm_rule(\""))
+      continue;
+    g_autofree gchar *id = NULL;
+    if (!extract_perm_id (trimmed, &id))
+      return (gint) (210 + parsed);
+    if (parsed >= expected)
+      return 220;
+    if (g_strcmp0 (id, wyl_perm_arm_rule_perm_id (parsed)) != 0)
+      return (gint) (230 + parsed);
+    parsed++;
+  }
+  if (parsed != expected)
+    return 240;
+  return 0;
+}
+
+int
+main (void)
+{
+  gint rc;
+  if ((rc = check_stratification ()) != 0)
+    return rc;
+  if ((rc = check_catalogue_invariants ()) != 0)
+    return rc;
+  if ((rc = check_catalogue_derivation ()) != 0)
+    return rc;
+  if ((rc = check_synthetic_fixtures ()) != 0)
+    return rc;
+  if ((rc = check_in_window_callback ()) != 0)
+    return rc;
+  if ((rc = check_argument_validation ()) != 0)
+    return rc;
+  if ((rc = check_name_mirror ()) != 0)
+    return rc;
+  return 0;
+}

--- a/wyrelog/meson.build
+++ b/wyrelog/meson.build
@@ -16,6 +16,7 @@ wyrelog_sources = files(
   'wyl-guard-expr.c',
   'wyl-handle.c',
   'wyl-perm.c',
+  'wyl-permission-scope.c',
   'wyl-session.c',
   'wyl-version.c',
 )

--- a/wyrelog/wyl-permission-scope-private.h
+++ b/wyrelog/wyl-permission-scope-private.h
@@ -1,0 +1,98 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+
+#include <glib.h>
+
+#include "wyrelog/error.h"
+#include "wyl-guard-expr-private.h"
+
+G_BEGIN_DECLS;
+
+/*
+ * Permission scope evaluator and perm_arm_rule baseline catalogue.
+ *
+ * The Datalog source of truth lives at
+ * <datadir>/wyrelog/access/fsm/permission_scope.dl. This module
+ * mirrors the catalogue rows on the C side and provides a guard
+ * evaluator the engine can call to resolve eval_guard/2 against a
+ * request scope.
+ *
+ * scope/4 in the .dl is laid out as (user, timestamp, loc_class,
+ * risk). The fourth slot is `risk` rather than `tenant` because
+ * the version-0 catalogue exercises `risk` heavily and `tenant`
+ * not at all; the tenant slot is reserved for tenant-scoped policy
+ * wiring in a follow-up commit.
+ *
+ * Evaluation contract: every uncertain or undefined branch
+ * returns FALSE (fail-closed). This includes a NULL expression, a
+ * NULL scope, an unknown enum value, a malformed comparison value,
+ * a tag node (the tag predicate has no v0 binding and is reserved
+ * for future site policy), and an undefined window name when a
+ * caller-installed in_window matcher is missing.
+ */
+
+/*
+ * Request-time context delivered to the guard evaluator. Owned by
+ * the caller for the duration of one wyl_eval_guard invocation;
+ * the evaluator does not retain pointers across the call.
+ *
+ *   user      : opaque principal identifier; not interpreted by
+ *               the evaluator. May be NULL.
+ *   timestamp : monotonic nanoseconds since the wyrelog epoch;
+ *               passed verbatim to the in_window matcher.
+ *   loc_class : one of "trusted", "semi_trusted", "public",
+ *               "untrusted"; compared by string equality. NULL is
+ *               treated as a non-matching value.
+ *   risk      : numeric risk score in [0, 100], host-attested;
+ *               compared against the cmp value parsed as a signed
+ *               integer.
+ *   in_window : caller-installed matcher invoked for the
+ *               cmp(timestamp, in, "<window>") path. May be NULL,
+ *               in which case every timestamp-in test fails
+ *               closed. The matcher receives the exact timestamp
+ *               from this struct and the window name from the
+ *               cmp value.
+ */
+typedef struct wyl_scope_t
+{
+  const gchar *user;
+  gint64 timestamp;
+  const gchar *loc_class;
+  gint64 risk;
+    gboolean (*in_window) (gint64 ts, const gchar * window_name,
+      gpointer user_data);
+  gpointer in_window_user_data;
+} wyl_scope_t;
+
+/*
+ * Evaluates `e` against `s`. Returns TRUE iff the guard is
+ * satisfied. Fail-closed on every failure mode (see header
+ * comment).
+ */
+gboolean wyl_eval_guard (const wyl_guard_expr_t * e, const wyl_scope_t * s);
+
+/*
+ * Looks up the guard expression registered for `perm_id`. Returns
+ * a borrowed pointer to a module-owned expression tree on hit, or
+ * NULL when the permission has no entry in the baseline
+ * catalogue. Callers MUST NOT free the returned pointer; the
+ * catalogue retains ownership for process lifetime.
+ *
+ * The first call into the catalogue performs a one-time lazy
+ * build of all entries via the guard expression builder API. The
+ * build is thread-safe through g_once and validates every entry
+ * with wyl_guard_validate; a validation failure aborts the
+ * process because the catalogue text is part of the binary and a
+ * validation failure means the source of truth was corrupted.
+ */
+const wyl_guard_expr_t *wyl_perm_arm_rule_lookup (const gchar * perm_id);
+
+/* Read-only accessors for the in-memory catalogue, used by the
+ * test harness to round-trip the .dl source against the C
+ * mirror. The accessors are stable across calls; ordering matches
+ * the catalogue row order in the .dl file. */
+gsize wyl_perm_arm_rule_count (void);
+const gchar *wyl_perm_arm_rule_perm_id (gsize idx);
+const wyl_guard_expr_t *wyl_perm_arm_rule_expr (gsize idx);
+
+G_END_DECLS;

--- a/wyrelog/wyl-permission-scope.c
+++ b/wyrelog/wyl-permission-scope.c
@@ -1,0 +1,274 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "wyl-permission-scope-private.h"
+
+#include <errno.h>
+#include <stdlib.h>
+
+/* --- baseline catalogue ------------------------------------------ */
+
+static wyl_guard_expr_t *
+build_admin (void)
+{
+  return wyl_guard_and (wyl_guard_cmp (WYL_GUARD_FIELD_RISK, WYL_GUARD_OP_LT,
+          "30"), wyl_guard_cmp (WYL_GUARD_FIELD_LOC_CLASS, WYL_GUARD_OP_EQ,
+          "trusted"));
+}
+
+static wyl_guard_expr_t *
+build_key_rotate (void)
+{
+  return wyl_guard_and (wyl_guard_cmp (WYL_GUARD_FIELD_RISK, WYL_GUARD_OP_LT,
+          "20"), wyl_guard_cmp (WYL_GUARD_FIELD_LOC_CLASS, WYL_GUARD_OP_EQ,
+          "trusted"));
+}
+
+static wyl_guard_expr_t *
+build_merkle_seal (void)
+{
+  return wyl_guard_cmp (WYL_GUARD_FIELD_LOC_CLASS, WYL_GUARD_OP_EQ, "trusted");
+}
+
+static wyl_guard_expr_t *
+build_policy_write (void)
+{
+  return wyl_guard_cmp (WYL_GUARD_FIELD_RISK, WYL_GUARD_OP_LT, "50");
+}
+
+static wyl_guard_expr_t *
+build_policy_grant_role (void)
+{
+  return wyl_guard_cmp (WYL_GUARD_FIELD_RISK, WYL_GUARD_OP_LT, "30");
+}
+
+static wyl_guard_expr_t *
+build_svc_freeze (void)
+{
+  return wyl_guard_cmp (WYL_GUARD_FIELD_RISK, WYL_GUARD_OP_LT, "40");
+}
+
+static wyl_guard_expr_t *
+build_svc_unfreeze (void)
+{
+  return wyl_guard_and (wyl_guard_cmp (WYL_GUARD_FIELD_RISK, WYL_GUARD_OP_LT,
+          "30"), wyl_guard_cmp (WYL_GUARD_FIELD_LOC_CLASS, WYL_GUARD_OP_EQ,
+          "trusted"));
+}
+
+static wyl_guard_expr_t *
+build_svc_grant_role (void)
+{
+  return wyl_guard_cmp (WYL_GUARD_FIELD_RISK, WYL_GUARD_OP_LT, "30");
+}
+
+static wyl_guard_expr_t *
+build_audit_read (void)
+{
+  return wyl_guard_cmp (WYL_GUARD_FIELD_RISK, WYL_GUARD_OP_LT, "70");
+}
+
+static wyl_guard_expr_t *
+build_audit_explain (void)
+{
+  return wyl_guard_and (wyl_guard_cmp (WYL_GUARD_FIELD_RISK, WYL_GUARD_OP_LT,
+          "50"), wyl_guard_cmp (WYL_GUARD_FIELD_LOC_CLASS, WYL_GUARD_OP_EQ,
+          "trusted"));
+}
+
+typedef struct catalogue_entry_t
+{
+  const gchar *perm_id;
+  wyl_guard_expr_t *(*build) (void);
+} catalogue_entry_t;
+
+static const catalogue_entry_t catalogue[] = {
+  {"wr.sys.admin", build_admin},
+  {"wr.sys.key_rotate", build_key_rotate},
+  {"wr.sys.merkle_seal", build_merkle_seal},
+  {"wr.policy.write", build_policy_write},
+  {"wr.policy.grant_role", build_policy_grant_role},
+  {"wr.svc.freeze", build_svc_freeze},
+  {"wr.svc.unfreeze", build_svc_unfreeze},
+  {"wr.svc.grant_role", build_svc_grant_role},
+  {"wr.audit.read", build_audit_read},
+  {"wr.audit.explain", build_audit_explain},
+};
+
+/* The compiled trees are owned by this module for process
+ * lifetime; freeing them on shutdown would race with any other
+ * cleanup that invokes wyl_eval_guard. */
+static wyl_guard_expr_t *catalogue_trees[G_N_ELEMENTS (catalogue)];
+static GHashTable *catalogue_index;
+
+static gpointer
+catalogue_init_once (gpointer user_data)
+{
+  (void) user_data;
+  catalogue_index = g_hash_table_new (g_str_hash, g_str_equal);
+  for (gsize i = 0; i < G_N_ELEMENTS (catalogue); i++) {
+    wyl_guard_expr_t *tree = catalogue[i].build ();
+    if (tree == NULL || wyl_guard_validate (tree) != WYRELOG_E_OK) {
+      g_error ("permission-scope catalogue row %" G_GSIZE_FORMAT
+          " (%s) failed to build or validate", i, catalogue[i].perm_id);
+    }
+    catalogue_trees[i] = tree;
+    g_hash_table_insert (catalogue_index, (gpointer) catalogue[i].perm_id,
+        tree);
+  }
+  return NULL;
+}
+
+static void
+catalogue_ensure (void)
+{
+  static GOnce once = G_ONCE_INIT;
+  g_once (&once, catalogue_init_once, NULL);
+}
+
+const wyl_guard_expr_t *
+wyl_perm_arm_rule_lookup (const gchar *perm_id)
+{
+  if (perm_id == NULL)
+    return NULL;
+  catalogue_ensure ();
+  return g_hash_table_lookup (catalogue_index, perm_id);
+}
+
+gsize
+wyl_perm_arm_rule_count (void)
+{
+  return G_N_ELEMENTS (catalogue);
+}
+
+const gchar *
+wyl_perm_arm_rule_perm_id (gsize idx)
+{
+  if (idx >= G_N_ELEMENTS (catalogue))
+    return NULL;
+  return catalogue[idx].perm_id;
+}
+
+const wyl_guard_expr_t *
+wyl_perm_arm_rule_expr (gsize idx)
+{
+  if (idx >= G_N_ELEMENTS (catalogue))
+    return NULL;
+  catalogue_ensure ();
+  return catalogue_trees[idx];
+}
+
+/* --- evaluator --------------------------------------------------- */
+
+static gboolean
+parse_signed_int (const gchar *value, gint64 *out)
+{
+  if (value == NULL || value[0] == '\0')
+    return FALSE;
+  errno = 0;
+  gchar *end = NULL;
+  gint64 v = (gint64) g_ascii_strtoll (value, &end, 10);
+  if (errno != 0 || end == NULL || *end != '\0')
+    return FALSE;
+  *out = v;
+  return TRUE;
+}
+
+static gboolean
+eval_int_op (wyl_guard_op_t op, gint64 lhs, gint64 rhs)
+{
+  switch (op) {
+    case WYL_GUARD_OP_EQ:
+      return lhs == rhs;
+    case WYL_GUARD_OP_NE:
+      return lhs != rhs;
+    case WYL_GUARD_OP_LT:
+      return lhs < rhs;
+    case WYL_GUARD_OP_LE:
+      return lhs <= rhs;
+    case WYL_GUARD_OP_GT:
+      return lhs > rhs;
+    case WYL_GUARD_OP_GE:
+      return lhs >= rhs;
+    case WYL_GUARD_OP_IN:
+    case WYL_GUARD_OP_LAST_:
+    default:
+      return FALSE;
+  }
+}
+
+static gboolean
+eval_string_op (wyl_guard_op_t op, const gchar *lhs, const gchar *rhs)
+{
+  if (lhs == NULL || rhs == NULL)
+    return FALSE;
+  switch (op) {
+    case WYL_GUARD_OP_EQ:
+      return g_strcmp0 (lhs, rhs) == 0;
+    case WYL_GUARD_OP_NE:
+      return g_strcmp0 (lhs, rhs) != 0;
+    case WYL_GUARD_OP_LT:
+    case WYL_GUARD_OP_LE:
+    case WYL_GUARD_OP_GT:
+    case WYL_GUARD_OP_GE:
+    case WYL_GUARD_OP_IN:
+    case WYL_GUARD_OP_LAST_:
+    default:
+      return FALSE;
+  }
+}
+
+static gboolean
+eval_cmp (const wyl_guard_expr_t *e, const wyl_scope_t *s)
+{
+  switch (e->u.cmp.field) {
+    case WYL_GUARD_FIELD_RISK:{
+      gint64 rhs = 0;
+      if (!parse_signed_int (e->u.cmp.value, &rhs))
+        return FALSE;
+      return eval_int_op (e->u.cmp.op, s->risk, rhs);
+    }
+    case WYL_GUARD_FIELD_LOC_CLASS:
+      return eval_string_op (e->u.cmp.op, s->loc_class, e->u.cmp.value);
+    case WYL_GUARD_FIELD_TENANT:
+      /* Tenant is reserved for tenant-scoped policy wiring in a
+       * follow-up commit; v0 has no tenant slot in scope so any
+       * tenant cmp fails closed. */
+      return FALSE;
+    case WYL_GUARD_FIELD_TIMESTAMP:
+      if (e->u.cmp.op != WYL_GUARD_OP_IN)
+        return FALSE;
+      if (s->in_window == NULL)
+        return FALSE;
+      return s->in_window (s->timestamp, e->u.cmp.value,
+          s->in_window_user_data);
+    case WYL_GUARD_FIELD_LAST_:
+    default:
+      return FALSE;
+  }
+}
+
+gboolean
+wyl_eval_guard (const wyl_guard_expr_t *e, const wyl_scope_t *s)
+{
+  if (e == NULL || s == NULL)
+    return FALSE;
+
+  switch (e->kind) {
+    case WYL_GUARD_KIND_AND:
+      return wyl_eval_guard (e->u.binop.left, s) &&
+          wyl_eval_guard (e->u.binop.right, s);
+    case WYL_GUARD_KIND_OR:
+      return wyl_eval_guard (e->u.binop.left, s) ||
+          wyl_eval_guard (e->u.binop.right, s);
+    case WYL_GUARD_KIND_NOT:
+      return !wyl_eval_guard (e->u.unary.child, s);
+    case WYL_GUARD_KIND_CMP:
+      return eval_cmp (e, s);
+    case WYL_GUARD_KIND_TAG:
+      /* Tag predicate is reserved for site policy in a future
+       * commit; v0 fails closed. */
+      return FALSE;
+    case WYL_GUARD_KIND_LAST_:
+    default:
+      return FALSE;
+  }
+}


### PR DESCRIPTION
## Summary

- Add the stateless `armed/3` derivation: 3 IDB rules (dead-clause `perm_state` rule for forward-compat, ungated path with `\+ perm_arm_rule`, gated path through `eval_guard`).
- Ship a baseline `perm_arm_rule` catalogue of 10 entries (system admin / policy / service / audit) as both a Datalog source and a synchronized C catalogue.
- Add `wyl_eval_guard`: recursive evaluator over the existing guard expression AST. Field dispatch — numeric for `risk`, string equality for `loc_class`, caller-installed callback for `timestamp in <window>`. Tenant cmp, tag node, malformed numeric value, and missing window callback all fail closed.
- Catalogue is built lazily through `g_once` and validated against the depth/atom limits at first use; trees are owned for process lifetime.
- 7 sub-tests: stratification self-check, catalogue invariants, real-catalogue derivation per fixture, synthetic AND/OR/NOT/nested/depth-4 fixtures, depth-5 reject, `in_window` callback (NULL/yes/no), argument validation, `.dl ↔ C` perm-id name mirror oracle.

## Test plan

- [x] `meson test -C builddir --suite wyrelog --print-errorlogs` — 9/9 pass (existing 8 + new `fsm-permission-scope`)
- [x] gst-indent idempotent on all 3 new C files
- [x] No residual C primitives, no `== TRUE`/`== FALSE`, no internal jargon
- [ ] CI matrix (Linux/macOS/Windows-clang-cl) green