### PR TITLE
build: restore libchronoid SIMD now that the upstream fix is in

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -32,13 +32,7 @@ wirelog_dep = declare_dependency(
 
 libchronoid_proj = subproject(
   'libchronoid',
-  default_options : [
-    'tests=false',
-    'cli=false',
-    'simd=none',
-    'ssse3=disabled',
-    'avx2_batch=disabled',
-  ],
+  default_options : ['tests=false', 'cli=false'],
 )
 libchronoid_dep = declare_dependency(
   link_with : libchronoid_proj.get_variable('chronoid_lib'),


### PR DESCRIPTION
## Summary

The libchronoid compiler-detection branch was tightened upstream so that clang-cl is routed through the MSVC CPUID path for runtime AVX2 / SSSE3 dispatch. The wrap-git revision now picks up that fix on every fresh setup.

- Drop the wyrelog-side `simd=none`, `ssse3=disabled`, `avx2_batch=disabled` overrides from the libchronoid subproject default options block.
- Leave `tests=false`, `cli=false` (those are unrelated to the windows-clang-cl issue and still desired downstream).
- No code change to wyrelog itself; this is a pure subproject-options revert.

Closes #23.

## Test plan

- [x] Local Linux build: `meson test -C builddir --suite wyrelog` → 9/9 PASS with libchronoid SIMD enabled
- [ ] CI matrix (ubuntu-latest, macos-latest, windows-latest clang-cl) green; the windows lane is the load-bearing one because it confirms the upstream fix really did unblock the previously-broken SSSE3 compile