### PR TITLE
access: add decision rule set and deny-reason taxonomy

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -48,6 +48,11 @@ install_data(
 )
 
 install_data(
+  'templates/access/decision.dl',
+  install_dir : join_paths(get_option('datadir'), 'wyrelog', 'access'),
+)
+
+install_data(
   'templates/access/fsm/principal.dl',
   install_dir : join_paths(get_option('datadir'), 'wyrelog', 'access', 'fsm'),
 )

--- a/templates/access/decision.dl
+++ b/templates/access/decision.dl
@@ -1,0 +1,76 @@
+% decision.dl — Wyrelog Access Decision Rule Set v0
+%
+% SPDX-License-Identifier: GPL-3.0-or-later
+% Copyright (C) 2026 wyrelog authors. Also available under a separate
+% commercial license; see LICENSE.md at the project root.
+%
+% Conjunctive access decision plus a six-row deny-reason taxonomy.
+% The decision program produces a boolean projection (allow_bool/3)
+% from a conjunctive derivation (allow/3); when the conjunction
+% fails, deny_reason/5 emits one row per violated clause. The full
+% deny-reason set is recorded in the audit row; the engine selects
+% a single representative reason for the H1 result struct using a
+% fixed priority order documented in the C surface.
+%
+% EDB schemas (host-populated, no clauses below):
+%   has_permission(user, perm, scope)
+%   principal_state(user, state)
+%   session_state(scope, state)
+%   session_active(state)
+%   armed(user, perm, scope)            -- IDB defined in
+%                                          permission_scope.dl
+%   frozen(scope)
+%   disabled_role_for(user, perm)
+%   policy_violation(kind, user, perm, witness)
+%   now(timestamp)                      -- host-bridged context
+%   break_glass_used(user)              -- host-bridged context
+%
+% Row order in the deny_reason block is load-bearing: the test
+% harness compares the head signatures line by line against the
+% C catalogue, so reordering one side without the other will fail
+% the build.
+
+% --- allow / allow_bool ----------------------------------------------
+
+allow(U, P, S) :-
+    has_permission(U, P, S),
+    principal_state(U, "authenticated"),
+    session_state(S, ST),
+    session_active(ST),
+    armed(U, P, S),
+    \+ frozen(S),
+    \+ disabled_role_for(U, P),
+    \+ policy_violation("sod", U, P, _).
+
+allow_bool(U, P, S) :- allow(U, P, S).
+
+% --- deny_reason ----------------------------------------------------
+
+deny_reason(U, P, S, "frozen", "frozen") :-
+    has_permission(U, P, S),
+    frozen(S).
+
+deny_reason(U, P, S, "disabled_role", "disabled_role_for") :-
+    has_permission(U, P, S),
+    disabled_role_for(U, P).
+
+deny_reason(U, P, S, "sod", "policy_violation") :-
+    has_permission(U, P, S),
+    policy_violation("sod", U, P, _).
+
+deny_reason(U, P, S, "not_authenticated", "principal_state") :-
+    has_permission(U, P, S),
+    \+ principal_state(U, "authenticated").
+
+deny_reason(U, P, S, "session_inactive", "session_state") :-
+    has_permission(U, P, S),
+    principal_state(U, "authenticated"),
+    session_state(S, ST),
+    \+ session_active(ST).
+
+deny_reason(U, P, S, "not_armed", "perm_state") :-
+    has_permission(U, P, S),
+    principal_state(U, "authenticated"),
+    session_state(S, ST),
+    session_active(ST),
+    \+ armed(U, P, S).

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -84,3 +84,18 @@ test_fsm_permission_scope = executable('test-fsm-permission-scope',
 )
 
 test('fsm-permission-scope', test_fsm_permission_scope)
+
+access_decision_dl_path = join_paths(
+  meson.project_source_root(),
+  'templates', 'access', 'decision.dl',
+)
+
+test_access_decision = executable('test-access-decision',
+  'test-access-decision.c',
+  c_args : [
+    '-DWYL_TEST_ACCESS_DECISION_DL_PATH="' + access_decision_dl_path + '"',
+  ],
+  dependencies : [wyrelog_dep],
+)
+
+test('access-decision', test_access_decision)

--- a/tests/test-access-decision.c
+++ b/tests/test-access-decision.c
@@ -1,0 +1,312 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <glib.h>
+#include <glib/gstdio.h>
+#include <stdio.h>
+
+#include "wyrelog/wyl-access-decision-private.h"
+#include "wyrelog/wyl-dl-static-private.h"
+
+#ifndef WYL_TEST_ACCESS_DECISION_DL_PATH
+#error "WYL_TEST_ACCESS_DECISION_DL_PATH must be defined by the build."
+#endif
+
+/* --- Stratification self-check ---------------------------------- */
+
+/*
+ * Lifts the eight rule heads introduced by decision.dl into
+ * wyl_dl_rule_t form and asserts the program is stratified. Every
+ * negation edge from these rules lands on either an EDB predicate
+ * (frozen, disabled_role_for, policy_violation, principal_state,
+ * session_active) or on `armed` -- which is itself an IDB defined
+ * elsewhere but does not depend on any of the heads introduced
+ * here, so the negation does not close a cycle.
+ */
+static gint
+check_stratification (void)
+{
+  static const wyl_dl_body_atom_t allow_body[] = {
+    {.predicate = "has_permission",.negated = FALSE},
+    {.predicate = "principal_state",.negated = FALSE},
+    {.predicate = "session_state",.negated = FALSE},
+    {.predicate = "session_active",.negated = FALSE},
+    {.predicate = "armed",.negated = FALSE},
+    {.predicate = "frozen",.negated = TRUE},
+    {.predicate = "disabled_role_for",.negated = TRUE},
+    {.predicate = "policy_violation",.negated = TRUE},
+  };
+  static const wyl_dl_body_atom_t allow_bool_body[] = {
+    {.predicate = "allow",.negated = FALSE},
+  };
+  static const wyl_dl_body_atom_t dr_frozen_body[] = {
+    {.predicate = "has_permission",.negated = FALSE},
+    {.predicate = "frozen",.negated = FALSE},
+  };
+  static const wyl_dl_body_atom_t dr_disabled_role_body[] = {
+    {.predicate = "has_permission",.negated = FALSE},
+    {.predicate = "disabled_role_for",.negated = FALSE},
+  };
+  static const wyl_dl_body_atom_t dr_sod_body[] = {
+    {.predicate = "has_permission",.negated = FALSE},
+    {.predicate = "policy_violation",.negated = FALSE},
+  };
+  static const wyl_dl_body_atom_t dr_not_auth_body[] = {
+    {.predicate = "has_permission",.negated = FALSE},
+    {.predicate = "principal_state",.negated = TRUE},
+  };
+  static const wyl_dl_body_atom_t dr_session_inactive_body[] = {
+    {.predicate = "has_permission",.negated = FALSE},
+    {.predicate = "principal_state",.negated = FALSE},
+    {.predicate = "session_state",.negated = FALSE},
+    {.predicate = "session_active",.negated = TRUE},
+  };
+  static const wyl_dl_body_atom_t dr_not_armed_body[] = {
+    {.predicate = "has_permission",.negated = FALSE},
+    {.predicate = "principal_state",.negated = FALSE},
+    {.predicate = "session_state",.negated = FALSE},
+    {.predicate = "session_active",.negated = FALSE},
+    {.predicate = "armed",.negated = TRUE},
+  };
+  wyl_dl_rule_t rules[] = {
+    {.head = "allow",.body = allow_body,.body_len = G_N_ELEMENTS (allow_body)},
+    {.head = "allow_bool",.body = allow_bool_body,
+        .body_len = G_N_ELEMENTS (allow_bool_body)},
+    {.head = "deny_reason",.body = dr_frozen_body,
+        .body_len = G_N_ELEMENTS (dr_frozen_body)},
+    {.head = "deny_reason",.body = dr_disabled_role_body,
+        .body_len = G_N_ELEMENTS (dr_disabled_role_body)},
+    {.head = "deny_reason",.body = dr_sod_body,
+        .body_len = G_N_ELEMENTS (dr_sod_body)},
+    {.head = "deny_reason",.body = dr_not_auth_body,
+        .body_len = G_N_ELEMENTS (dr_not_auth_body)},
+    {.head = "deny_reason",.body = dr_session_inactive_body,
+        .body_len = G_N_ELEMENTS (dr_session_inactive_body)},
+    {.head = "deny_reason",.body = dr_not_armed_body,
+        .body_len = G_N_ELEMENTS (dr_not_armed_body)},
+  };
+
+  if (wyl_dl_static_check (rules, G_N_ELEMENTS (rules)) != WYRELOG_E_OK)
+    return 1;
+  return 0;
+}
+
+/* --- Code <-> name round-trip ----------------------------------- */
+
+static gint
+check_code_name_roundtrip (void)
+{
+  if (wyl_deny_reason_count () != 6)
+    return 10;
+  for (guint c = 0; c < WYL_DENY_REASON_LAST_; c++) {
+    const gchar *name = wyl_deny_reason_name ((wyl_deny_reason_code_t) c);
+    if (name == NULL)
+      return (gint) (11 + c);
+    if (wyl_deny_reason_from_name (name) != (wyl_deny_reason_code_t) c)
+      return (gint) (20 + c);
+    const gchar *origin = wyl_deny_reason_origin ((wyl_deny_reason_code_t) c);
+    if (origin == NULL)
+      return (gint) (30 + c);
+  }
+  if (wyl_deny_reason_name (WYL_DENY_REASON_LAST_) != NULL)
+    return 40;
+  if (wyl_deny_reason_origin (WYL_DENY_REASON_LAST_) != NULL)
+    return 41;
+  if (wyl_deny_reason_from_name (NULL) != WYL_DENY_REASON_LAST_)
+    return 42;
+  if (wyl_deny_reason_from_name ("does-not-exist") != WYL_DENY_REASON_LAST_)
+    return 43;
+  return 0;
+}
+
+/* --- Priority ordering ------------------------------------------ */
+
+/*
+ * Spec priority (high -> low):
+ *   frozen > disabled_role > sod > not_authenticated >
+ *   session_inactive > not_armed
+ *
+ * Lower returned value = higher priority.
+ */
+static gint
+check_priority_ordering (void)
+{
+  guint p_frozen = wyl_deny_reason_priority (WYL_DENY_REASON_FROZEN);
+  guint p_disabled = wyl_deny_reason_priority (WYL_DENY_REASON_DISABLED_ROLE);
+  guint p_sod = wyl_deny_reason_priority (WYL_DENY_REASON_SOD);
+  guint p_na = wyl_deny_reason_priority (WYL_DENY_REASON_NOT_AUTHENTICATED);
+  guint p_si = wyl_deny_reason_priority (WYL_DENY_REASON_SESSION_INACTIVE);
+  guint p_nar = wyl_deny_reason_priority (WYL_DENY_REASON_NOT_ARMED);
+
+  if (!(p_frozen < p_disabled))
+    return 50;
+  if (!(p_disabled < p_sod))
+    return 51;
+  if (!(p_sod < p_na))
+    return 52;
+  if (!(p_na < p_si))
+    return 53;
+  if (!(p_si < p_nar))
+    return 54;
+
+  if (wyl_deny_reason_priority (WYL_DENY_REASON_LAST_) != G_MAXUINT)
+    return 55;
+  return 0;
+}
+
+/* --- Origin tags align with spec -------------------------------- */
+
+static gint
+check_origin_tags (void)
+{
+  static const struct
+  {
+    wyl_deny_reason_code_t code;
+    const gchar *expected_name;
+    const gchar *expected_origin;
+  } expectations[] = {
+    {WYL_DENY_REASON_FROZEN, "frozen", "frozen"},
+    {WYL_DENY_REASON_DISABLED_ROLE, "disabled_role", "disabled_role_for"},
+    {WYL_DENY_REASON_SOD, "sod", "policy_violation"},
+    {WYL_DENY_REASON_NOT_AUTHENTICATED, "not_authenticated",
+        "principal_state"},
+    {WYL_DENY_REASON_SESSION_INACTIVE, "session_inactive", "session_state"},
+    {WYL_DENY_REASON_NOT_ARMED, "not_armed", "perm_state"},
+  };
+  for (gsize i = 0; i < G_N_ELEMENTS (expectations); i++) {
+    const gchar *name = wyl_deny_reason_name (expectations[i].code);
+    const gchar *origin = wyl_deny_reason_origin (expectations[i].code);
+    if (g_strcmp0 (name, expectations[i].expected_name) != 0)
+      return (gint) (60 + i);
+    if (g_strcmp0 (origin, expectations[i].expected_origin) != 0)
+      return (gint) (70 + i);
+  }
+  return 0;
+}
+
+/* --- .dl head-signature mirror oracle --------------------------- */
+
+/*
+ * Confirms that decision.dl declares exactly one allow/3 head, one
+ * allow_bool/3 head, and the six deny_reason/5 heads with literal
+ * (code, origin) string pairs identical to the C catalogue. Body
+ * compound terms are not parsed; the structural body equality is
+ * deferred to a future bisimulation oracle.
+ */
+static gboolean
+extract_deny_reason_pair (const gchar *line, gchar **out_name,
+    gchar **out_origin)
+{
+  /* Matches: deny_reason(U, P, S, "<code>", "<origin>") :- ...
+   * The first three positional args are variables; we skip them and
+   * pull the two quoted literals at positions 4 and 5. */
+  const gchar *prefix = "deny_reason(";
+  if (!g_str_has_prefix (line, prefix))
+    return FALSE;
+  const gchar *p = line + strlen (prefix);
+
+  /* Skip 3 comma-separated args. */
+  for (guint i = 0; i < 3; i++) {
+    while (*p != ',' && *p != '\0')
+      p++;
+    if (*p != ',')
+      return FALSE;
+    p++;
+    while (*p == ' ' || *p == '\t')
+      p++;
+  }
+
+  if (*p != '"')
+    return FALSE;
+  p++;
+  const gchar *end = strchr (p, '"');
+  if (end == NULL)
+    return FALSE;
+  gchar *name = g_strndup (p, (gsize) (end - p));
+  p = end + 1;
+  while (*p == ' ' || *p == '\t' || *p == ',')
+    p++;
+  if (*p != '"') {
+    g_free (name);
+    return FALSE;
+  }
+  p++;
+  end = strchr (p, '"');
+  if (end == NULL) {
+    g_free (name);
+    return FALSE;
+  }
+  *out_name = name;
+  *out_origin = g_strndup (p, (gsize) (end - p));
+  return TRUE;
+}
+
+static gint
+check_head_mirror (void)
+{
+  g_autofree gchar *contents = NULL;
+  gsize len = 0;
+  g_autoptr (GError) err = NULL;
+  if (!g_file_get_contents (WYL_TEST_ACCESS_DECISION_DL_PATH, &contents,
+          &len, &err)) {
+    g_printerr ("cannot read %s: %s\n", WYL_TEST_ACCESS_DECISION_DL_PATH,
+        err ? err->message : "?");
+    return 100;
+  }
+  g_auto (GStrv) lines = g_strsplit (contents, "\n", -1);
+  guint allow_count = 0;
+  guint allow_bool_count = 0;
+  gsize dr_parsed = 0;
+  for (gsize i = 0; lines[i] != NULL; i++) {
+    g_autofree gchar *trimmed = g_strdup (g_strchug (lines[i]));
+    if (trimmed[0] == '%' || trimmed[0] == '\0')
+      continue;
+    if (g_str_has_prefix (trimmed, "allow_bool(")) {
+      allow_bool_count++;
+      continue;
+    }
+    if (g_str_has_prefix (trimmed, "allow(")) {
+      allow_count++;
+      continue;
+    }
+    if (g_str_has_prefix (trimmed, "deny_reason(")) {
+      g_autofree gchar *name = NULL;
+      g_autofree gchar *origin = NULL;
+      if (!extract_deny_reason_pair (trimmed, &name, &origin))
+        return (gint) (110 + dr_parsed);
+      if (dr_parsed >= wyl_deny_reason_count ())
+        return 130;
+      const gchar *expect_name =
+          wyl_deny_reason_name ((wyl_deny_reason_code_t) dr_parsed);
+      const gchar *expect_origin =
+          wyl_deny_reason_origin ((wyl_deny_reason_code_t) dr_parsed);
+      if (g_strcmp0 (name, expect_name) != 0)
+        return (gint) (140 + dr_parsed);
+      if (g_strcmp0 (origin, expect_origin) != 0)
+        return (gint) (150 + dr_parsed);
+      dr_parsed++;
+    }
+  }
+  if (allow_count != 1)
+    return 160;
+  if (allow_bool_count != 1)
+    return 161;
+  if (dr_parsed != wyl_deny_reason_count ())
+    return 162;
+  return 0;
+}
+
+int
+main (void)
+{
+  gint rc;
+  if ((rc = check_stratification ()) != 0)
+    return rc;
+  if ((rc = check_code_name_roundtrip ()) != 0)
+    return rc;
+  if ((rc = check_priority_ordering ()) != 0)
+    return rc;
+  if ((rc = check_origin_tags ()) != 0)
+    return rc;
+  if ((rc = check_head_mirror ()) != 0)
+    return rc;
+  return 0;
+}

--- a/wyrelog/meson.build
+++ b/wyrelog/meson.build
@@ -6,6 +6,7 @@ wyrelog_public_headers = files(
 )
 
 wyrelog_sources = files(
+  'wyl-access-decision.c',
   'wyl-audit-event.c',
   'wyl-boot.c',
   'wyl-decide.c',

--- a/wyrelog/wyl-access-decision-private.h
+++ b/wyrelog/wyl-access-decision-private.h
@@ -1,0 +1,74 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+
+#include <glib.h>
+
+#include "wyrelog/error.h"
+
+G_BEGIN_DECLS;
+
+/*
+ * Access decision rule set support code.
+ *
+ * The Datalog source of truth lives at
+ * <datadir>/wyrelog/access/decision.dl. This module exposes the
+ * deny-reason taxonomy on the C side: the six v0 codes, their
+ * matching origin tags, and a fixed priority that the engine uses
+ * to pick a single representative reason for the H1 result struct
+ * when multiple deny_reason rows fire for the same (user, perm,
+ * scope) tuple. The full row set still goes to the audit log; the
+ * priority only collapses the user-visible single-reason field.
+ *
+ * Code uniqueness contract: the v0 catalogue keys by code alone.
+ * Every code maps to exactly one origin tag. A future row that
+ * reused a code with a different origin would force this enum to
+ * become a (code, origin) composite; until then the simple keying
+ * is correct and the test harness pins it.
+ *
+ * Lower ordinal = higher priority. Tests assert the ordinal
+ * ordering is monotonic with the spec priority.
+ */
+
+typedef enum wyl_deny_reason_code_t
+{
+  WYL_DENY_REASON_FROZEN = 0,
+  WYL_DENY_REASON_DISABLED_ROLE,
+  WYL_DENY_REASON_SOD,
+  WYL_DENY_REASON_NOT_AUTHENTICATED,
+  WYL_DENY_REASON_SESSION_INACTIVE,
+  WYL_DENY_REASON_NOT_ARMED,
+  WYL_DENY_REASON_LAST_,
+} wyl_deny_reason_code_t;
+
+/*
+ * Lexical names. The `name` is the string that appears as the
+ * fourth argument of the deny_reason/5 fact in decision.dl; the
+ * `origin` is the fifth argument. NULL on out-of-range input;
+ * callers must not free the returned strings.
+ */
+const gchar *wyl_deny_reason_name (wyl_deny_reason_code_t code);
+const gchar *wyl_deny_reason_origin (wyl_deny_reason_code_t code);
+
+/*
+ * Priority ordering used when multiple deny_reason rows fire for
+ * the same tuple and the H1 result must surface a single code.
+ * Lower values are higher priority. The current implementation
+ * returns the enum ordinal directly; callers must NOT rely on the
+ * absolute value, only on relative ordering.
+ */
+guint wyl_deny_reason_priority (wyl_deny_reason_code_t code);
+
+/*
+ * Resolves a name string back to its code. Returns
+ * WYL_DENY_REASON_LAST_ when the name does not match any v0 code.
+ */
+wyl_deny_reason_code_t wyl_deny_reason_from_name (const gchar * name);
+
+/*
+ * Catalogue accessors used by the test harness to round-trip the
+ * .dl source against the C mirror. Ordering matches the deny_reason
+ * row order in the .dl file.
+ */
+gsize wyl_deny_reason_count (void);
+
+G_END_DECLS;

--- a/wyrelog/wyl-access-decision.c
+++ b/wyrelog/wyl-access-decision.c
@@ -1,0 +1,65 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "wyl-access-decision-private.h"
+
+static const gchar *const reason_names[] = {
+  "frozen",
+  "disabled_role",
+  "sod",
+  "not_authenticated",
+  "session_inactive",
+  "not_armed",
+};
+
+static const gchar *const reason_origins[] = {
+  "frozen",
+  "disabled_role_for",
+  "policy_violation",
+  "principal_state",
+  "session_state",
+  "perm_state",
+};
+
+G_STATIC_ASSERT (G_N_ELEMENTS (reason_names) == WYL_DENY_REASON_LAST_);
+G_STATIC_ASSERT (G_N_ELEMENTS (reason_origins) == WYL_DENY_REASON_LAST_);
+
+const gchar *
+wyl_deny_reason_name (wyl_deny_reason_code_t code)
+{
+  if ((guint) code >= WYL_DENY_REASON_LAST_)
+    return NULL;
+  return reason_names[code];
+}
+
+const gchar *
+wyl_deny_reason_origin (wyl_deny_reason_code_t code)
+{
+  if ((guint) code >= WYL_DENY_REASON_LAST_)
+    return NULL;
+  return reason_origins[code];
+}
+
+guint
+wyl_deny_reason_priority (wyl_deny_reason_code_t code)
+{
+  if ((guint) code >= WYL_DENY_REASON_LAST_)
+    return G_MAXUINT;
+  return (guint) code;
+}
+
+wyl_deny_reason_code_t
+wyl_deny_reason_from_name (const gchar *name)
+{
+  if (name == NULL)
+    return WYL_DENY_REASON_LAST_;
+  for (guint i = 0; i < WYL_DENY_REASON_LAST_; i++) {
+    if (g_strcmp0 (name, reason_names[i]) == 0)
+      return (wyl_deny_reason_code_t) i;
+  }
+  return WYL_DENY_REASON_LAST_;
+}
+
+gsize
+wyl_deny_reason_count (void)
+{
+  return WYL_DENY_REASON_LAST_;
+}


### PR DESCRIPTION
## Summary

- Add `templates/access/decision.dl`: `allow/3` (8-conjunct), `allow_bool/3` projection, and 6 `deny_reason/5` rules. EDB schemas (`has_permission`, `principal_state`, `session_state`, `session_active`, `frozen`, `disabled_role_for`, `policy_violation`, `now/1`, `break_glass_used/1`) referenced via comment-only declarations; no host-bridge stubs.
- Add `wyl_deny_reason_code_t` (6 codes + sentinel) with name / origin / priority / from-name accessors. Priority is the enum ordinal: `frozen=0` (highest), `not_armed=5` (lowest), strictly monotonic.
- Test harness: stratification lift, code↔name round-trip, priority monotonic, origin tag alignment, `.dl ↔ C` head mirror oracle (deny_reason quoted literals 1-to-1, plus single-allow + single-allow_bool head pinning).

## Test plan

- [x] `meson test -C builddir --suite wyrelog` → 10/10 PASS (existing 9 + new `access-decision`)
- [x] gst-indent idempotent on all 3 new C files
- [x] No residual C primitives, no `== TRUE`/`== FALSE`, no internal jargon (verified via repo-wide grep)
- [ ] CI matrix (Linux/macOS/Windows-clang-cl) green