### PR TITLE
feat: add load-time integrity checks for fact rows

### DIFF
--- a/tests/test-dl-static.c
+++ b/tests/test-dl-static.c
@@ -162,5 +162,174 @@ main (void)
       return 13;
   }
 
+  /* --- Functional integrity constraint check ----------------- */
+
+  /* Case 100: NULL rows with n > 0 -> INVALID. */
+  if (wyl_dl_check_functional_ic (NULL, 1, 2, NULL) != WYRELOG_E_INVALID)
+    return 100;
+
+  /* Case 101: row.arity <= key_arity -> INVALID. */
+  {
+    const gchar *args[] = { "a", "b" };
+    wyl_dl_fact_row_t rows[] = {
+      {.head = "t",.args = args,.arity = 2},
+    };
+    if (wyl_dl_check_functional_ic (rows, 1, 2, NULL) != WYRELOG_E_INVALID)
+      return 101;
+  }
+
+  /* Case 102: NULL args[k] -> INVALID. */
+  {
+    const gchar *args[] = { "a", NULL, "c" };
+    wyl_dl_fact_row_t rows[] = {
+      {.head = "t",.args = args,.arity = 3},
+    };
+    if (wyl_dl_check_functional_ic (rows, 1, 2, NULL) != WYRELOG_E_INVALID)
+      return 102;
+  }
+
+  /* Case 103: pass -- two distinct keys. */
+  {
+    const gchar *r0[] = { "auth", "login_ok", "active" };
+    const gchar *r1[] = { "anon", "login_ok", "auth" };
+    wyl_dl_fact_row_t rows[] = {
+      {.head = "principal_transition",.args = r0,.arity = 3},
+      {.head = "principal_transition",.args = r1,.arity = 3},
+    };
+    if (wyl_dl_check_functional_ic (rows, 2, 2, NULL) != WYRELOG_E_OK)
+      return 103;
+  }
+
+  /* Case 104: reject (B) -- (auth, login_ok) -> {mfa_required, active}. */
+  {
+    const gchar *r0[] = { "auth", "login_ok", "mfa_required" };
+    const gchar *r1[] = { "auth", "login_ok", "active" };
+    wyl_dl_fact_row_t rows[] = {
+      {.head = "principal_transition",.args = r0,.arity = 3},
+      {.head = "principal_transition",.args = r1,.arity = 3},
+    };
+    wyl_dl_ic_violation_t w = { 0 };
+    if (wyl_dl_check_functional_ic (rows, 2, 2, &w) != WYRELOG_E_POLICY)
+      return 104;
+    if (g_strcmp0 (w.head, "principal_transition") != 0)
+      return 1041;
+    if (w.key_arity != 2)
+      return 1042;
+    if (g_strcmp0 (w.key[0], "auth") != 0)
+      return 1043;
+    if (g_strcmp0 (w.key[1], "login_ok") != 0)
+      return 1044;
+    if (g_strcmp0 (w.value_a, "mfa_required") != 0)
+      return 1045;
+    if (g_strcmp0 (w.value_b, "active") != 0)
+      return 1046;
+    if (w.first_index != 0)
+      return 1047;
+    if (w.conflict_index != 1)
+      return 1048;
+  }
+
+  /* Case 105: reject (C) -- mix of valid + non-functional rows. */
+  {
+    const gchar *r0[] = { "x", "e1", "y" };
+    const gchar *r1[] = { "y", "e2", "z" };
+    const gchar *r2[] = { "z", "e3", "w" };
+    const gchar *r3[] = { "x", "e1", "different" };
+    wyl_dl_fact_row_t rows[] = {
+      {.head = "t",.args = r0,.arity = 3},
+      {.head = "t",.args = r1,.arity = 3},
+      {.head = "t",.args = r2,.arity = 3},
+      {.head = "t",.args = r3,.arity = 3},
+    };
+    wyl_dl_ic_violation_t w = { 0 };
+    if (wyl_dl_check_functional_ic (rows, 4, 2, &w) != WYRELOG_E_POLICY)
+      return 105;
+    if (w.first_index != 0 || w.conflict_index != 3)
+      return 1051;
+  }
+
+  /* Case 106: literal duplicate (same key, same tail) -> OK. */
+  {
+    const gchar *r0[] = { "a", "b", "c" };
+    const gchar *r1[] = { "a", "b", "c" };
+    wyl_dl_fact_row_t rows[] = {
+      {.head = "t",.args = r0,.arity = 3},
+      {.head = "t",.args = r1,.arity = 3},
+    };
+    if (wyl_dl_check_functional_ic (rows, 2, 2, NULL) != WYRELOG_E_OK)
+      return 106;
+  }
+
+  /* Case 107: NULL out_witness on POLICY case -> still POLICY. */
+  {
+    const gchar *r0[] = { "a", "b", "c" };
+    const gchar *r1[] = { "a", "b", "d" };
+    wyl_dl_fact_row_t rows[] = {
+      {.head = "t",.args = r0,.arity = 3},
+      {.head = "t",.args = r1,.arity = 3},
+    };
+    if (wyl_dl_check_functional_ic (rows, 2, 2, NULL) != WYRELOG_E_POLICY)
+      return 107;
+  }
+
+  /* Case 108: cross-head same key -> OK (heads differentiate the group). */
+  {
+    const gchar *r0[] = { "a", "b", "c" };
+    const gchar *r1[] = { "a", "b", "d" };
+    wyl_dl_fact_row_t rows[] = {
+      {.head = "principal_transition",.args = r0,.arity = 3},
+      {.head = "session_transition",.args = r1,.arity = 3},
+    };
+    if (wyl_dl_check_functional_ic (rows, 2, 2, NULL) != WYRELOG_E_OK)
+      return 108;
+  }
+
+  /* --- Empty-extension assertion ----------------------------- */
+
+  /* Case 110: empty rows -> OK. */
+  if (wyl_dl_assert_edb_empty (NULL, 0, "policy_violation",
+          NULL) != WYRELOG_E_OK)
+    return 110;
+
+  /* Case 111: rows present but none match expected_head -> OK. */
+  {
+    const gchar *r0[] = { "x" };
+    wyl_dl_fact_row_t rows[] = {
+      {.head = "other",.args = r0,.arity = 1},
+    };
+    if (wyl_dl_assert_edb_empty (rows, 1, "policy_violation",
+            NULL) != WYRELOG_E_OK)
+      return 111;
+  }
+
+  /* Case 112: one matching row -> POLICY + witness pointer. */
+  {
+    const gchar *r0[] = { "sod", "u", "p", "w" };
+    wyl_dl_fact_row_t rows[] = {
+      {.head = "policy_violation",.args = r0,.arity = 4},
+    };
+    const wyl_dl_fact_row_t *wit = NULL;
+    if (wyl_dl_assert_edb_empty (rows, 1, "policy_violation",
+            &wit) != WYRELOG_E_POLICY)
+      return 112;
+    if (wit != &rows[0])
+      return 1121;
+  }
+
+  /* Case 113: NULL expected_head with non-empty rows -> POLICY. */
+  {
+    const gchar *r0[] = { "x" };
+    wyl_dl_fact_row_t rows[] = {
+      {.head = "anything",.args = r0,.arity = 1},
+    };
+    if (wyl_dl_assert_edb_empty (rows, 1, NULL, NULL) != WYRELOG_E_POLICY)
+      return 113;
+  }
+
+  /* Case 114: NULL rows with n > 0 -> INVALID. */
+  if (wyl_dl_assert_edb_empty (NULL, 1, "policy_violation",
+          NULL) != WYRELOG_E_INVALID)
+    return 114;
+
   return 0;
 }

--- a/wyrelog/wyl-dl-static-private.h
+++ b/wyrelog/wyl-dl-static-private.h
@@ -61,4 +61,100 @@ typedef struct wyl_dl_rule_t
 
 wyrelog_error_t wyl_dl_static_check (const wyl_dl_rule_t * rules, gsize n);
 
+
+/*
+ * Load-time integrity checks over flat fact rows.
+ *
+ * The checks below operate on caller-owned arrays of fact rows.
+ * A row carries the head predicate name plus a borrowed pointer
+ * vector of argument strings. The checkers borrow every pointer;
+ * the caller must keep the row backing storage alive across the
+ * call. No string is copied, no row is rewritten, and no memory
+ * is retained after the call returns.
+ */
+
+typedef struct wyl_dl_fact_row_t
+{
+  const gchar *head;
+  const gchar *const *args;
+  gsize arity;
+} wyl_dl_fact_row_t;
+
+/*
+ * Witness populated when wyl_dl_check_functional_ic refuses a
+ * program. All pointer fields borrow from the rows array passed
+ * in; callers must not free them and must not retain them past
+ * the lifetime of that array.
+ *
+ *   head            : the predicate that violated the constraint
+ *   key             : pointer to the first key_arity strings of
+ *                     the conflicting rows (the same key on both)
+ *   key_arity       : echoes the key_arity argument
+ *   value_a         : tail value of the first sighting
+ *   value_b         : tail value of the conflicting row
+ *   first_index     : index of the first sighting in rows[]
+ *   conflict_index  : index of the conflicting row in rows[]
+ *
+ * Multi-way conflicts (three or more distinct tails for the same
+ * key) surface only the first detected pair; existential witness
+ * is sufficient for the load-time refusal contract.
+ */
+typedef struct wyl_dl_ic_violation_t
+{
+  const gchar *head;
+  const gchar *const *key;
+  gsize key_arity;
+  const gchar *value_a;
+  const gchar *value_b;
+  gsize first_index;
+  gsize conflict_index;
+} wyl_dl_ic_violation_t;
+
+/*
+ * Functional integrity constraint: for every group of rows that
+ * share the same (head, args[0..key_arity-1]) the tail value at
+ * args[key_arity] must agree. Used to reject a non-functional
+ * FSM transition table at load time, where two rows for the same
+ * (from, event) point at distinct destinations.
+ *
+ * Each row must satisfy arity > key_arity; the tail comparison
+ * uses args[key_arity] only, additional tail columns are ignored
+ * (callers that need multi-column tail equality can encode the
+ * tuple into one string before calling).
+ *
+ * Return codes:
+ *   WYRELOG_E_OK       no group has conflicting tails (or trivially empty)
+ *   WYRELOG_E_POLICY   first conflict surfaces in *out_witness when non-NULL
+ *   WYRELOG_E_INVALID  rows == NULL with n > 0, any row.head is NULL, any
+ *                      args == NULL while arity > 0, any args[k] is NULL
+ *                      for k < arity, or any row.arity <= key_arity.
+ */
+wyrelog_error_t wyl_dl_check_functional_ic (const wyl_dl_fact_row_t * rows,
+    gsize n, gsize key_arity, wyl_dl_ic_violation_t * out_witness);
+
+/*
+ * Empty-extension assertion: refuse the program if any row in
+ * the input bears a head equal to expected_head. When
+ * expected_head is NULL every row counts as a violation, which
+ * is useful for a pre-filtered fact list.
+ *
+ *   *out_witness_row, when non-NULL, is set to the first matching
+ *   row pointer on policy refusal; left untouched on OK or INVALID.
+ *
+ * Used to implement the load-time SoD contract by passing a
+ * post-evaluation snapshot of the policy_violation EDB and
+ * expected_head = "policy_violation"; non-empty input refuses
+ * the load.
+ *
+ * Return codes:
+ *   WYRELOG_E_OK       no row matches expected_head (or rows is empty)
+ *   WYRELOG_E_POLICY   at least one row matches; first match in
+ *                      *out_witness_row when non-NULL
+ *   WYRELOG_E_INVALID  rows == NULL with n > 0, or any row.head is
+ *                      NULL when needed for the comparison.
+ */
+wyrelog_error_t wyl_dl_assert_edb_empty (const wyl_dl_fact_row_t * rows,
+    gsize n, const gchar * expected_head,
+    const wyl_dl_fact_row_t ** out_witness_row);
+
 G_END_DECLS;

--- a/wyrelog/wyl-dl-static.c
+++ b/wyrelog/wyl-dl-static.c
@@ -3,6 +3,7 @@
 #include "wyl-common-private.h"
 
 #include <glib.h>
+#include <string.h>
 
 /*
  * Implementation overview.
@@ -206,4 +207,115 @@ wyl_dl_static_check (const wyl_dl_rule_t *rules, gsize n)
 
   free_out_edges (s.out_edges, V);
   return rc;
+}
+
+/* --- Functional integrity constraint check ---------------------- */
+
+/*
+ * Build a length-prefixed concatenation of head + key args for use
+ * as the GHashTable key. Each segment is preceded by its size
+ * encoded as a base-10 string and a separator so that distinct
+ * argument tuples cannot alias under naive concatenation.
+ */
+static gchar *
+group_key_for (const wyl_dl_fact_row_t *row, gsize key_arity)
+{
+  GString *out = g_string_new (NULL);
+  g_string_append_printf (out, "%zu|", strlen (row->head));
+  g_string_append (out, row->head);
+  g_string_append_c (out, '|');
+  for (gsize i = 0; i < key_arity; i++) {
+    g_string_append_printf (out, "%zu|", strlen (row->args[i]));
+    g_string_append (out, row->args[i]);
+    g_string_append_c (out, '|');
+  }
+  return g_string_free (out, FALSE);
+}
+
+static wyrelog_error_t
+validate_row (const wyl_dl_fact_row_t *row, gsize key_arity)
+{
+  if (row->head == NULL)
+    return WYRELOG_E_INVALID;
+  if (row->arity <= key_arity)
+    return WYRELOG_E_INVALID;
+  if (row->args == NULL)
+    return WYRELOG_E_INVALID;
+  for (gsize i = 0; i < row->arity; i++) {
+    if (row->args[i] == NULL)
+      return WYRELOG_E_INVALID;
+  }
+  return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
+wyl_dl_check_functional_ic (const wyl_dl_fact_row_t *rows, gsize n,
+    gsize key_arity, wyl_dl_ic_violation_t *out_witness)
+{
+  if (n == 0)
+    return WYRELOG_E_OK;
+  if (rows == NULL)
+    return WYRELOG_E_INVALID;
+
+  for (gsize i = 0; i < n; i++) {
+    wyrelog_error_t rc = validate_row (&rows[i], key_arity);
+    if (rc != WYRELOG_E_OK)
+      return rc;
+  }
+
+  /* Map joined key string -> first row index that contributed it. */
+  g_autoptr (GHashTable) seen =
+      g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
+
+  for (gsize i = 0; i < n; i++) {
+    g_autofree gchar *key = group_key_for (&rows[i], key_arity);
+    gpointer slot = NULL;
+    if (g_hash_table_lookup_extended (seen, key, NULL, &slot)) {
+      gsize first_index = (gsize) GPOINTER_TO_SIZE (slot);
+      const gchar *value_a = rows[first_index].args[key_arity];
+      const gchar *value_b = rows[i].args[key_arity];
+      if (g_strcmp0 (value_a, value_b) != 0) {
+        if (out_witness != NULL) {
+          out_witness->head = rows[first_index].head;
+          out_witness->key = rows[first_index].args;
+          out_witness->key_arity = key_arity;
+          out_witness->value_a = value_a;
+          out_witness->value_b = value_b;
+          out_witness->first_index = first_index;
+          out_witness->conflict_index = i;
+        }
+        return WYRELOG_E_POLICY;
+      }
+      /* Same key, same tail value: a literal duplicate row, which
+       * does not violate the functional constraint. */
+      continue;
+    }
+    g_hash_table_insert (seen, g_strdup (key), GSIZE_TO_POINTER (i));
+  }
+  return WYRELOG_E_OK;
+}
+
+/* --- Empty-extension assertion ---------------------------------- */
+
+wyrelog_error_t
+wyl_dl_assert_edb_empty (const wyl_dl_fact_row_t *rows, gsize n,
+    const gchar *expected_head, const wyl_dl_fact_row_t **out_witness_row)
+{
+  if (n == 0)
+    return WYRELOG_E_OK;
+  if (rows == NULL)
+    return WYRELOG_E_INVALID;
+
+  for (gsize i = 0; i < n; i++) {
+    if (expected_head != NULL) {
+      if (rows[i].head == NULL)
+        return WYRELOG_E_INVALID;
+      if (g_strcmp0 (rows[i].head, expected_head) != 0)
+        continue;
+    }
+    if (out_witness_row != NULL)
+      *out_witness_row = &rows[i];
+    return WYRELOG_E_POLICY;
+  }
+  return WYRELOG_E_OK;
 }


### PR DESCRIPTION
## Summary

Extends the static Datalog gate with two load-time primitives:

- `wyl_dl_check_functional_ic ()` — refuses any fact-row set where two rows share the same `(head, args[0..key_arity-1])` but disagree on `args[key_arity]`. Surfaces an optional witness (head, key, two tails, two indices) borrowing into the caller's row array. Used to reject non-functional FSM transition tables (e.g. two `principal_transition(authenticated, login_ok, ...)` rows with different destinations).
- `wyl_dl_assert_edb_empty ()` — refuses if any row in the input matches a caller-supplied predicate (NULL = match every row). Used by the engine wrap to enforce contract-empty EDBs at load time (e.g. `policy_violation`).

Both primitives borrow caller-owned strings under the same lifetime contract as the existing stratification check, return `WYRELOG_E_INVALID` on shape errors, `WYRELOG_E_POLICY` on refusal, and `WYRELOG_E_OK` otherwise. The existing `wyl_dl_static_check` stratification pass and ABI are unchanged; no new `wyrelog_error_t` variants.

## Test plan

- [x] `meson test -C builddir --suite wyrelog` → 10/10 PASS (existing 9 + extended `dl-static` cases 100-114)
- [x] gst-indent idempotent (no reflow on either pass)
- [x] No residual C primitives, no `== TRUE`/`== FALSE`, no internal jargon
- [x] F0 stratification cases 1-13 unchanged
- [ ] CI matrix (Linux/macOS/Windows-clang-cl) green