### PR TITLE
access: add event envelope over principal and session FSMs

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -110,3 +110,10 @@ test_fsm_bisim = executable('test-fsm-bisim',
 )
 
 test('fsm-bisim', test_fsm_bisim)
+
+test_events = executable('test-events',
+  'test-events.c',
+  dependencies : [wyrelog_dep],
+)
+
+test('events', test_events)

--- a/tests/test-events.c
+++ b/tests/test-events.c
@@ -1,0 +1,143 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <glib.h>
+
+#include "wyrelog/wyl-events-private.h"
+
+/* --- Domain name round-trip ------------------------------------- */
+
+static gint
+check_domain_names (void)
+{
+  for (guint d = 0; d < WYL_ACCESS_EVENT_DOMAIN_LAST_; d++) {
+    const gchar *name =
+        wyl_access_event_domain_name ((wyl_access_event_domain_t) d);
+    if (name == NULL || name[0] == '\0')
+      return (gint) (1 + d);
+  }
+  if (wyl_access_event_domain_name (WYL_ACCESS_EVENT_DOMAIN_LAST_) != NULL)
+    return 5;
+  return 0;
+}
+
+/* --- Total kinds counter --------------------------------------- */
+
+static gint
+check_total_kinds (void)
+{
+  /* 7 principal events + 6 session events = 13 carried variants. */
+  if (wyl_access_event_total_kinds () !=
+      (gsize) WYL_PRINCIPAL_EVENT_LAST_ + (gsize) WYL_SESSION_EVENT_LAST_)
+    return 10;
+  if (wyl_access_event_total_kinds () != 13)
+    return 11;
+  return 0;
+}
+
+/* --- Exhaustive event-kind name coverage ----------------------- */
+
+static gint
+check_exhaustive_kind_names (void)
+{
+  /* Every principal event ordinal under the principal domain
+   * yields a non-NULL name and matches the F1 accessor. */
+  for (guint e = 0; e < WYL_PRINCIPAL_EVENT_LAST_; e++) {
+    wyl_access_event_t ev = {
+      .domain = WYL_ACCESS_EVENT_DOMAIN_PRINCIPAL,
+      .event = {.principal = (wyl_principal_event_t) e},
+      .timestamp_us = 0,
+      .user_id = NULL,
+      .session_id = NULL,
+    };
+    const gchar *got = wyl_access_event_kind_name (&ev);
+    const gchar *expect = wyl_principal_event_name ((wyl_principal_event_t) e);
+    if (g_strcmp0 (got, expect) != 0)
+      return (gint) (20 + e);
+  }
+  /* Same for the session domain. */
+  for (guint e = 0; e < WYL_SESSION_EVENT_LAST_; e++) {
+    wyl_access_event_t ev = {
+      .domain = WYL_ACCESS_EVENT_DOMAIN_SESSION,
+      .event = {.session = (wyl_session_event_t) e},
+      .timestamp_us = 0,
+      .user_id = NULL,
+      .session_id = NULL,
+    };
+    const gchar *got = wyl_access_event_kind_name (&ev);
+    const gchar *expect = wyl_session_event_name ((wyl_session_event_t) e);
+    if (g_strcmp0 (got, expect) != 0)
+      return (gint) (40 + e);
+  }
+  return 0;
+}
+
+/* --- Out-of-range envelopes fail closed ------------------------ */
+
+static gint
+check_out_of_range (void)
+{
+  if (wyl_access_event_kind_name (NULL) != NULL)
+    return 60;
+
+  wyl_access_event_t bad_domain = {
+    .domain = WYL_ACCESS_EVENT_DOMAIN_LAST_,
+    .event = {.principal = WYL_PRINCIPAL_EVENT_LOGIN_OK},
+  };
+  if (wyl_access_event_kind_name (&bad_domain) != NULL)
+    return 61;
+
+  wyl_access_event_t bad_principal = {
+    .domain = WYL_ACCESS_EVENT_DOMAIN_PRINCIPAL,
+    .event = {.principal = WYL_PRINCIPAL_EVENT_LAST_},
+  };
+  if (wyl_access_event_kind_name (&bad_principal) != NULL)
+    return 62;
+
+  wyl_access_event_t bad_session = {
+    .domain = WYL_ACCESS_EVENT_DOMAIN_SESSION,
+    .event = {.session = WYL_SESSION_EVENT_LAST_},
+  };
+  if (wyl_access_event_kind_name (&bad_session) != NULL)
+    return 63;
+  return 0;
+}
+
+/* --- Zero-init carries the principal LOGIN_OK kind ------------- */
+
+static gint
+check_zero_init (void)
+{
+  /* Stack zero-init: domain==PRINCIPAL (0), event.principal==LOGIN_OK
+   * (0), all metadata pointers NULL, timestamp 0. The envelope
+   * is observably valid in this state. */
+  wyl_access_event_t ev = { 0 };
+  if (ev.domain != WYL_ACCESS_EVENT_DOMAIN_PRINCIPAL)
+    return 70;
+  if (ev.event.principal != WYL_PRINCIPAL_EVENT_LOGIN_OK)
+    return 71;
+  if (ev.timestamp_us != 0)
+    return 72;
+  if (ev.user_id != NULL)
+    return 73;
+  if (ev.session_id != NULL)
+    return 74;
+  if (g_strcmp0 (wyl_access_event_kind_name (&ev), "login_ok") != 0)
+    return 75;
+  return 0;
+}
+
+int
+main (void)
+{
+  gint rc;
+  if ((rc = check_domain_names ()) != 0)
+    return rc;
+  if ((rc = check_total_kinds ()) != 0)
+    return rc;
+  if ((rc = check_exhaustive_kind_names ()) != 0)
+    return rc;
+  if ((rc = check_out_of_range ()) != 0)
+    return rc;
+  if ((rc = check_zero_init ()) != 0)
+    return rc;
+  return 0;
+}

--- a/wyrelog/meson.build
+++ b/wyrelog/meson.build
@@ -12,6 +12,7 @@ wyrelog_sources = files(
   'wyl-decide.c',
   'wyl-dl-static.c',
   'wyl-error.c',
+  'wyl-events.c',
   'wyl-fsm-principal.c',
   'wyl-fsm-session.c',
   'wyl-guard-expr.c',

--- a/wyrelog/wyl-events-private.h
+++ b/wyrelog/wyl-events-private.h
@@ -1,0 +1,78 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+
+#include <glib.h>
+
+#include "wyrelog/error.h"
+#include "wyl-fsm-principal-private.h"
+#include "wyl-fsm-session-private.h"
+
+G_BEGIN_DECLS;
+
+/*
+ * Access event envelope.
+ *
+ * The ingress layer translates external requests into a stream of
+ * events that the engine routes to one of two state machines: the
+ * principal authentication FSM or the per-session lifecycle FSM.
+ * The envelope here is the carrier for that decision: a domain
+ * discriminator that picks which FSM to drive plus a tagged union
+ * over the two FSM event vocabularies, alongside common metadata
+ * (timestamp, user, session) that every event carries regardless
+ * of domain.
+ *
+ * Composition rather than redefinition: the principal and session
+ * event enumerations are owned by their respective FSM headers
+ * (F1 and F2). This module re-uses them through the union so that
+ * a future change to either FSM's event vocabulary propagates
+ * automatically without a third source of truth to keep in sync.
+ *
+ * The total number of distinct events the envelope can carry is
+ * therefore equal to the sum of the two FSM event counts -- seven
+ * principal events plus six session events for thirteen variants
+ * in v0. The earlier ten-event sketch in the design notes
+ * predates the FSM lock; it is superseded here so that no FSM
+ * transition is orphaned at the ingress boundary.
+ */
+
+typedef enum wyl_access_event_domain_t
+{
+  WYL_ACCESS_EVENT_DOMAIN_PRINCIPAL = 0,
+  WYL_ACCESS_EVENT_DOMAIN_SESSION,
+  WYL_ACCESS_EVENT_DOMAIN_LAST_,
+} wyl_access_event_domain_t;
+
+typedef struct wyl_access_event_t
+{
+  wyl_access_event_domain_t domain;
+  union
+  {
+    wyl_principal_event_t principal;
+    wyl_session_event_t session;
+  } event;
+  gint64 timestamp_us;
+  const gchar *user_id;
+  const gchar *session_id;
+} wyl_access_event_t;
+
+/*
+ * Lexical name of the domain ordinal. NULL on out-of-range input.
+ */
+const gchar *wyl_access_event_domain_name (wyl_access_event_domain_t domain);
+
+/*
+ * Lexical name of the carried FSM event. Dispatches to the
+ * corresponding F1/F2 accessor. Returns NULL when the envelope
+ * pointer is NULL, when the domain is out of range, or when the
+ * carried FSM event ordinal is out of range for its domain.
+ */
+const gchar *wyl_access_event_kind_name (const wyl_access_event_t * event);
+
+/*
+ * Total number of distinct event variants representable by the
+ * envelope. Equals the sum of the principal and session FSM event
+ * counts; useful as a loop bound for exhaustive coverage tests.
+ */
+gsize wyl_access_event_total_kinds (void);
+
+G_END_DECLS;

--- a/wyrelog/wyl-events.c
+++ b/wyrelog/wyl-events.c
@@ -1,0 +1,39 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "wyl-events-private.h"
+
+static const gchar *const domain_names[] = {
+  "principal",
+  "session",
+};
+
+G_STATIC_ASSERT (G_N_ELEMENTS (domain_names) == WYL_ACCESS_EVENT_DOMAIN_LAST_);
+
+const gchar *
+wyl_access_event_domain_name (wyl_access_event_domain_t domain)
+{
+  if ((guint) domain >= WYL_ACCESS_EVENT_DOMAIN_LAST_)
+    return NULL;
+  return domain_names[domain];
+}
+
+const gchar *
+wyl_access_event_kind_name (const wyl_access_event_t *event)
+{
+  if (event == NULL)
+    return NULL;
+  switch (event->domain) {
+    case WYL_ACCESS_EVENT_DOMAIN_PRINCIPAL:
+      return wyl_principal_event_name (event->event.principal);
+    case WYL_ACCESS_EVENT_DOMAIN_SESSION:
+      return wyl_session_event_name (event->event.session);
+    case WYL_ACCESS_EVENT_DOMAIN_LAST_:
+    default:
+      return NULL;
+  }
+}
+
+gsize
+wyl_access_event_total_kinds (void)
+{
+  return (gsize) WYL_PRINCIPAL_EVENT_LAST_ + (gsize) WYL_SESSION_EVENT_LAST_;
+}


### PR DESCRIPTION
## Summary

- Introduce `wyl_access_event_t`: domain discriminator (principal/session) + tagged union over the two FSM event enums + common metadata (timestamp_us, user_id, session_id).
- Composition: re-uses F1's `wyl_principal_event_t` and F2's `wyl_session_event_t` through the union; no third source of truth.
- Total carried variants = 7 + 6 = 13 (the original spec sketch said 10; superseded by the locked FSM tables to avoid orphaning transitions at the ingress boundary).
- 3 accessors (domain name, kind name with dispatch, total_kinds bound) + private header (not installed).

## Test plan

- [x] `meson test -C builddir --suite wyrelog` → 12/12 PASS (existing 11 + new `events`)
- [x] gst-indent idempotent
- [x] No residual C primitives, no `== TRUE`/`== FALSE`, no internal jargon
- [x] Tests cover domain round-trip, exhaustive kind names per domain, NULL/LAST_ fail-closed, zero-init contract
- [ ] CI matrix (Linux/macOS/Windows-clang-cl) green