### PR TITLE
access: add deterministic XOR dev stub for key provider

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -117,3 +117,10 @@ test_events = executable('test-events',
 )
 
 test('events', test_events)
+
+test_keyprovider_dev = executable('test-keyprovider-dev',
+  'test-keyprovider-dev.c',
+  dependencies : [wyrelog_dep],
+)
+
+test('keyprovider-dev', test_keyprovider_dev)

--- a/tests/test-keyprovider-dev.c
+++ b/tests/test-keyprovider-dev.c
@@ -1,0 +1,217 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <glib.h>
+#include <string.h>
+
+#include "wyrelog/wyl-keyprovider-dev-private.h"
+
+/* --- Round-trip tests ------------------------------------------- */
+
+static gint
+check_probe_ok_on_fresh (void)
+{
+  g_autoptr (wyl_keyprovider_dev_t) self = wyl_keyprovider_dev_new ();
+  const wyl_keyprovider_vtable_t *vt = wyl_keyprovider_dev_get_vtable ();
+  if (vt->probe (self) != WYRELOG_E_OK)
+    return 1;
+  return 0;
+}
+
+static gint
+roundtrip_for (const guint8 *plaintext, gsize plaintext_len)
+{
+  g_autoptr (wyl_keyprovider_dev_t) self = wyl_keyprovider_dev_new ();
+  const wyl_keyprovider_vtable_t *vt = wyl_keyprovider_dev_get_vtable ();
+  wyl_sealed_blob_t blob = { 0 };
+  if (vt->seal (self, plaintext, plaintext_len, &blob) != WYRELOG_E_OK)
+    return 10;
+  if (blob.len != plaintext_len)
+    return 11;
+  if (plaintext_len > 0 && blob.bytes == NULL)
+    return 12;
+
+  /* Ciphertext must differ from plaintext (proves XOR is exercised)
+   * for non-empty inputs whose first key byte is nonzero. */
+  if (plaintext_len > 0 && memcmp (blob.bytes, plaintext, plaintext_len) == 0)
+    return 13;
+
+  g_autofree guint8 *recovered = g_malloc (plaintext_len + 1);
+  recovered[plaintext_len] = 0xCC;      /* canary */
+  gsize written = 0;
+  if (vt->unseal (self, &blob, recovered, plaintext_len,
+          &written) != WYRELOG_E_OK)
+    return 14;
+  if (written != plaintext_len)
+    return 15;
+  if (recovered[plaintext_len] != 0xCC)
+    return 16;
+  if (plaintext_len > 0 && memcmp (recovered, plaintext, plaintext_len) != 0)
+    return 17;
+
+  g_free (blob.bytes);
+  return 0;
+}
+
+static gint
+check_roundtrip_basic (void)
+{
+  const guint8 *plaintext = (const guint8 *) "hello world";
+  gint rc = roundtrip_for (plaintext, strlen ((const gchar *) plaintext));
+  return (rc == 0) ? 0 : (20 + rc);
+}
+
+static gint
+check_roundtrip_binary (void)
+{
+  guint8 plaintext[256];
+  for (gsize i = 0; i < 256; i++)
+    plaintext[i] = (guint8) i;
+  gint rc = roundtrip_for (plaintext, 256);
+  return (rc == 0) ? 0 : (40 + rc);
+}
+
+/* --- Capacity check fail-closed --------------------------------- */
+
+static gint
+check_unseal_capacity_too_small (void)
+{
+  g_autoptr (wyl_keyprovider_dev_t) self = wyl_keyprovider_dev_new ();
+  const wyl_keyprovider_vtable_t *vt = wyl_keyprovider_dev_get_vtable ();
+  const guint8 plaintext[] = { 1, 2, 3, 4, 5 };
+  wyl_sealed_blob_t blob = { 0 };
+  if (vt->seal (self, plaintext, sizeof (plaintext), &blob) != WYRELOG_E_OK)
+    return 60;
+
+  guint8 small_buf[3];
+  memset (small_buf, 0xAA, sizeof (small_buf));
+  gsize written = 0xDEAD;
+  wyrelog_error_t rc = vt->unseal (self, &blob, small_buf, 3, &written);
+  if (rc == WYRELOG_E_OK)
+    return 61;
+  /* On invalid: out parameters must be untouched. */
+  if (small_buf[0] != 0xAA || small_buf[1] != 0xAA || small_buf[2] != 0xAA)
+    return 62;
+  if (written != 0xDEAD)
+    return 63;
+
+  g_free (blob.bytes);
+  return 0;
+}
+
+/* --- derive determinism + label distinctness ------------------- */
+
+static gint
+check_derive_determinism (void)
+{
+  g_autoptr (wyl_keyprovider_dev_t) self = wyl_keyprovider_dev_new ();
+  const wyl_keyprovider_vtable_t *vt = wyl_keyprovider_dev_get_vtable ();
+  guint8 a1[16], a2[16], b[16];
+  if (vt->derive (self, "label_a", a1, sizeof (a1)) != WYRELOG_E_OK)
+    return 70;
+  if (vt->derive (self, "label_a", a2, sizeof (a2)) != WYRELOG_E_OK)
+    return 71;
+  if (memcmp (a1, a2, sizeof (a1)) != 0)
+    return 72;
+  if (vt->derive (self, "label_b", b, sizeof (b)) != WYRELOG_E_OK)
+    return 73;
+  if (memcmp (a1, b, sizeof (a1)) == 0)
+    return 74;
+  return 0;
+}
+
+/* --- Wipe semantics: all ops fail-closed ------------------------ */
+
+static gint
+check_wipe_fail_closed (void)
+{
+  g_autoptr (wyl_keyprovider_dev_t) self = wyl_keyprovider_dev_new ();
+  const wyl_keyprovider_vtable_t *vt = wyl_keyprovider_dev_get_vtable ();
+  vt->wipe (self);
+
+  if (vt->probe (self) != WYRELOG_E_INTERNAL)
+    return 80;
+
+  const guint8 plaintext[] = { 0xFF };
+  wyl_sealed_blob_t blob = { 0 };
+  if (vt->seal (self, plaintext, 1, &blob) != WYRELOG_E_INTERNAL)
+    return 81;
+  /* On internal: out_blob must be untouched. */
+  if (blob.bytes != NULL || blob.len != 0)
+    return 82;
+
+  guint8 buf[1] = { 0xAA };
+  gsize written = 0xBEEF;
+  wyl_sealed_blob_t fake = {.bytes = (guint8 *) plaintext,.len = 1 };
+  if (vt->unseal (self, &fake, buf, sizeof (buf), &written)
+      != WYRELOG_E_INTERNAL)
+    return 83;
+  if (buf[0] != 0xAA || written != 0xBEEF)
+    return 84;
+
+  guint8 dk[8];
+  memset (dk, 0xAA, sizeof (dk));
+  if (vt->derive (self, "anything", dk, sizeof (dk)) != WYRELOG_E_INTERNAL)
+    return 85;
+  for (gsize i = 0; i < sizeof (dk); i++) {
+    if (dk[i] != 0xAA)
+      return 86;
+  }
+
+  /* Double wipe must be a no-op. */
+  vt->wipe (self);
+  if (vt->probe (self) != WYRELOG_E_INTERNAL)
+    return 87;
+  return 0;
+}
+
+/* --- Argument validation --------------------------------------- */
+
+static gint
+check_argument_validation (void)
+{
+  g_autoptr (wyl_keyprovider_dev_t) self = wyl_keyprovider_dev_new ();
+  const wyl_keyprovider_vtable_t *vt = wyl_keyprovider_dev_get_vtable ();
+
+  if (vt->probe (NULL) != WYRELOG_E_INVALID)
+    return 100;
+  wyl_sealed_blob_t blob = { 0 };
+  if (vt->seal (self, NULL, 4, &blob) != WYRELOG_E_INVALID)
+    return 101;
+  if (vt->seal (self, (const guint8 *) "x", 1, NULL) != WYRELOG_E_INVALID)
+    return 102;
+
+  guint8 buf[8];
+  gsize written = 0;
+  if (vt->unseal (self, NULL, buf, sizeof (buf), &written)
+      != WYRELOG_E_INVALID)
+    return 103;
+  if (vt->unseal (self, &blob, buf, sizeof (buf), NULL) != WYRELOG_E_INVALID)
+    return 104;
+
+  guint8 dk[4];
+  if (vt->derive (self, NULL, dk, sizeof (dk)) != WYRELOG_E_INVALID)
+    return 105;
+  if (vt->derive (self, "x", NULL, 4) != WYRELOG_E_INVALID)
+    return 106;
+  return 0;
+}
+
+int
+main (void)
+{
+  gint rc;
+  if ((rc = check_probe_ok_on_fresh ()) != 0)
+    return rc;
+  if ((rc = check_roundtrip_basic ()) != 0)
+    return rc;
+  if ((rc = check_roundtrip_binary ()) != 0)
+    return rc;
+  if ((rc = check_unseal_capacity_too_small ()) != 0)
+    return rc;
+  if ((rc = check_derive_determinism ()) != 0)
+    return rc;
+  if ((rc = check_wipe_fail_closed ()) != 0)
+    return rc;
+  if ((rc = check_argument_validation ()) != 0)
+    return rc;
+  return 0;
+}

--- a/wyrelog/meson.build
+++ b/wyrelog/meson.build
@@ -17,6 +17,7 @@ wyrelog_sources = files(
   'wyl-fsm-session.c',
   'wyl-guard-expr.c',
   'wyl-handle.c',
+  'wyl-keyprovider-dev.c',
   'wyl-perm.c',
   'wyl-permission-scope.c',
   'wyl-session.c',

--- a/wyrelog/wyl-keyprovider-dev-private.h
+++ b/wyrelog/wyl-keyprovider-dev-private.h
@@ -1,0 +1,72 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+
+#include <glib.h>
+
+#include "wyrelog/error.h"
+#include "wyl-traits-private.h"
+
+G_BEGIN_DECLS;
+
+/*
+ * DEVELOPMENT ONLY -- NOT FOR PRODUCTION USE
+ *
+ * This module ships a deterministic, fixed-key implementation of
+ * the key-provider trait for use as a unit-test fixture and an
+ * early integration target while the hardware-backed provider is
+ * still in flight. The seal operation XORs the plaintext against
+ * a compile-time constant byte pattern; ciphertext provides no
+ * confidentiality, no authentication, and no replay resistance.
+ * Treat any byte that passes through this provider as if it were
+ * pasted into a public chat log -- one known plaintext byte
+ * recovers the corresponding key byte.
+ *
+ * Lifecycle: callers create a fresh state via
+ * wyl_keyprovider_dev_new and release it through
+ * wyl_keyprovider_dev_free; the vtable returned by
+ * wyl_keyprovider_dev_get_vtable is a process-lifetime singleton
+ * keyed off the per-state pointer passed as the trait's `self`
+ * argument. Multiple concurrent states are independent.
+ *
+ * Wipe semantics: every method honours the trait fail-closed
+ * contract. After wipe, probe / seal / unseal / derive each
+ * return WYRELOG_E_INTERNAL until the state is released. There is
+ * no implicit re-init.
+ *
+ * Sealed blob layout: raw XOR ciphertext, no header, no MAC,
+ * length equal to the plaintext length. Real backends (TPM /
+ * libsodium) will adopt an authenticated layout in a later
+ * commit; nothing outside this module is allowed to depend on
+ * the dev layout.
+ *
+ * derive() is NOT a key-derivation function. The label string is
+ * folded against the fixed key with g_str_hash and a wrapping
+ * pattern. Real backends will use HKDF.
+ *
+ * This header is private; it is not exported via install_headers.
+ */
+
+typedef struct wyl_keyprovider_dev_t wyl_keyprovider_dev_t;
+
+/*
+ * Allocates a fresh dev key-provider state. The returned pointer
+ * is opaque; pass it as the `self` argument when calling the
+ * vtable methods. Free with wyl_keyprovider_dev_free.
+ */
+wyl_keyprovider_dev_t *wyl_keyprovider_dev_new (void);
+
+/*
+ * Wipes and releases a state previously returned by
+ * wyl_keyprovider_dev_new. NULL-safe.
+ */
+void wyl_keyprovider_dev_free (wyl_keyprovider_dev_t * self);
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (wyl_keyprovider_dev_t, wyl_keyprovider_dev_free);
+
+/*
+ * Returns the dev key-provider vtable. The pointer is stable for
+ * the process lifetime and may be safely cached.
+ */
+const wyl_keyprovider_vtable_t *wyl_keyprovider_dev_get_vtable (void);
+
+G_END_DECLS;

--- a/wyrelog/wyl-keyprovider-dev.c
+++ b/wyrelog/wyl-keyprovider-dev.c
@@ -1,0 +1,145 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+/*
+ * DEVELOPMENT ONLY -- NOT FOR PRODUCTION USE
+ *
+ * Deterministic XOR-based stub of the key-provider trait. See
+ * wyl-keyprovider-dev-private.h for the security disclaimer and
+ * the lifecycle / wipe / blob-layout contracts.
+ */
+#include "wyl-keyprovider-dev-private.h"
+
+#include <string.h>
+
+#define WYL_KEYPROVIDER_DEV_KEY_LEN 32
+
+struct wyl_keyprovider_dev_t
+{
+  guint8 key[WYL_KEYPROVIDER_DEV_KEY_LEN];
+  gboolean wiped;
+};
+
+static void
+fill_default_key (guint8 *out)
+{
+  /* Compile-time constant pattern; no RNG. The byte values are
+   * not cryptographically meaningful. */
+  for (gsize i = 0; i < WYL_KEYPROVIDER_DEV_KEY_LEN; i++)
+    out[i] = (guint8) (0xA5 ^ (guint8) i);
+}
+
+wyl_keyprovider_dev_t *
+wyl_keyprovider_dev_new (void)
+{
+  wyl_keyprovider_dev_t *self = g_new0 (wyl_keyprovider_dev_t, 1);
+  fill_default_key (self->key);
+  self->wiped = FALSE;
+  return self;
+}
+
+void
+wyl_keyprovider_dev_free (wyl_keyprovider_dev_t *self)
+{
+  if (self == NULL)
+    return;
+  memset (self->key, 0, WYL_KEYPROVIDER_DEV_KEY_LEN);
+  self->wiped = TRUE;
+  g_free (self);
+}
+
+/* --- vtable bodies ----------------------------------------------- */
+
+static wyrelog_error_t
+dev_probe (gpointer self_p)
+{
+  wyl_keyprovider_dev_t *self = (wyl_keyprovider_dev_t *) self_p;
+  if (self == NULL)
+    return WYRELOG_E_INVALID;
+  if (self->wiped)
+    return WYRELOG_E_INTERNAL;
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+dev_seal (gpointer self_p, const guint8 *plaintext, gsize plaintext_len,
+    wyl_sealed_blob_t *out_blob)
+{
+  wyl_keyprovider_dev_t *self = (wyl_keyprovider_dev_t *) self_p;
+  if (self == NULL || out_blob == NULL)
+    return WYRELOG_E_INVALID;
+  if (self->wiped)
+    return WYRELOG_E_INTERNAL;
+  if (plaintext_len > 0 && plaintext == NULL)
+    return WYRELOG_E_INVALID;
+
+  guint8 *bytes = g_malloc (plaintext_len);
+  for (gsize i = 0; i < plaintext_len; i++)
+    bytes[i] = plaintext[i] ^ self->key[i % WYL_KEYPROVIDER_DEV_KEY_LEN];
+  out_blob->bytes = bytes;
+  out_blob->len = plaintext_len;
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+dev_unseal (gpointer self_p, const wyl_sealed_blob_t *blob,
+    guint8 *out_plaintext, gsize out_capacity, gsize *out_written)
+{
+  wyl_keyprovider_dev_t *self = (wyl_keyprovider_dev_t *) self_p;
+  if (self == NULL || blob == NULL || out_written == NULL)
+    return WYRELOG_E_INVALID;
+  if (self->wiped)
+    return WYRELOG_E_INTERNAL;
+  if (blob->len > 0 && blob->bytes == NULL)
+    return WYRELOG_E_INVALID;
+  if (out_capacity < blob->len)
+    return WYRELOG_E_INVALID;
+  if (blob->len > 0 && out_plaintext == NULL)
+    return WYRELOG_E_INVALID;
+
+  for (gsize i = 0; i < blob->len; i++) {
+    out_plaintext[i] =
+        blob->bytes[i] ^ self->key[i % WYL_KEYPROVIDER_DEV_KEY_LEN];
+  }
+  *out_written = blob->len;
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+dev_derive (gpointer self_p, const gchar *label, guint8 *out_key, gsize out_len)
+{
+  wyl_keyprovider_dev_t *self = (wyl_keyprovider_dev_t *) self_p;
+  if (self == NULL || label == NULL || (out_len > 0 && out_key == NULL))
+    return WYRELOG_E_INVALID;
+  if (self->wiped)
+    return WYRELOG_E_INTERNAL;
+
+  guint32 seed = g_str_hash (label);
+  for (gsize i = 0; i < out_len; i++) {
+    guint8 seed_byte = (guint8) (seed >> ((i & 3) * 8));
+    out_key[i] = seed_byte ^ self->key[i % WYL_KEYPROVIDER_DEV_KEY_LEN];
+  }
+  return WYRELOG_E_OK;
+}
+
+static void
+dev_wipe (gpointer self_p)
+{
+  wyl_keyprovider_dev_t *self = (wyl_keyprovider_dev_t *) self_p;
+  if (self == NULL)
+    return;
+  memset (self->key, 0, WYL_KEYPROVIDER_DEV_KEY_LEN);
+  self->wiped = TRUE;
+}
+
+static const wyl_keyprovider_vtable_t dev_vtable = {
+  .probe = dev_probe,
+  .seal = dev_seal,
+  .unseal = dev_unseal,
+  .derive = dev_derive,
+  .wipe = dev_wipe,
+};
+
+const wyl_keyprovider_vtable_t *
+wyl_keyprovider_dev_get_vtable (void)
+{
+  return &dev_vtable;
+}


### PR DESCRIPTION
## Summary

- Add a development-only key-provider implementation behind the existing trait vtable. 32-byte compile-time XOR key, deterministic seal/unseal round-trip, label-hash derive placeholder.
- Header carries explicit "DEVELOPMENT ONLY" banner (no confidentiality / authentication / replay resistance). Symbols namespaced `wyl_keyprovider_dev_*`.
- Lifecycle: `wyl_keyprovider_dev_new` / `_free` + `G_DEFINE_AUTOPTR_CLEANUP_FUNC`. After wipe, all 4 ops return `WYRELOG_E_INTERNAL` and leave out-parameters untouched. Double-wipe idempotent.
- 7 sub-tests: probe-on-fresh, ASCII round-trip, 256-byte binary round-trip, unseal capacity-too-small fail-closed (canary verified), derive determinism + label distinctness, post-wipe fail-closed for all 4 ops, NULL-argument validation.

## Test plan

- [x] `meson test -C builddir --suite wyrelog` → 13/13 PASS (existing 12 + new `keyprovider-dev`)
- [x] gst-indent idempotent
- [x] No residual C primitives, no `== TRUE`/`== FALSE`, no internal jargon
- [x] Trait header `wyl-traits-private.h` untouched (deferred sealed-blob-clear helper noted)
- [ ] CI matrix (Linux/macOS/Windows-clang-cl) green