### PR TITLE
build: add local sanitizer build scripts (asan, tsan, ubsan)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Build directories
 builddir/
+builddir-*/
 build/
 dist/
 *.o

--- a/scripts/_sanitize-common.sh
+++ b/scripts/_sanitize-common.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Shared helper for the sanitizer build scripts. Sourced from each
+# build-{san,tsan,ubsan}.sh; not invoked directly.
+#
+# Strategy: skip the broad `meson compile` step and run
+# `meson test --suite wyrelog`, which only builds the targets the
+# wyrelog test suite actually depends on. Subprojects that wyrelog
+# does not link stay out of the sanitizer build, so their unrelated
+# sanitizer warnings cannot block this gate.
+
+set -euo pipefail
+
+run_sanitizer_build () {
+  local san_flag="$1"
+  local builddir_suffix="$2"
+  shift 2
+
+  local repo_root
+  repo_root="$(git rev-parse --show-toplevel)"
+  cd "$repo_root"
+
+  local builddir="builddir-${builddir_suffix}"
+  rm -rf "$builddir"
+
+  meson setup "$builddir" \
+    -Dbuildtype=debug \
+    -Db_sanitize="$san_flag" \
+    -Db_lundef=false \
+    "$@"
+
+  meson test -C "$builddir" --suite wyrelog --print-errorlogs
+}

--- a/scripts/build-san.sh
+++ b/scripts/build-san.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Local AddressSanitizer build + test runner. Runs the wyrelog test
+# suite under -fsanitize=address and exits non-zero on any failure.
+#
+# Common GLib hints for asan readability:
+#   G_SLICE=always-malloc G_DEBUG=gc-friendly ./scripts/build-san.sh
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/_sanitize-common.sh
+. "$SCRIPT_DIR/_sanitize-common.sh"
+run_sanitizer_build address asan "$@"

--- a/scripts/build-tsan.sh
+++ b/scripts/build-tsan.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Local ThreadSanitizer build + test runner. Runs the wyrelog test
+# suite under -fsanitize=thread. wyrelog is single-threaded in v0
+# so this is a forward-looking gate.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/_sanitize-common.sh
+. "$SCRIPT_DIR/_sanitize-common.sh"
+run_sanitizer_build thread tsan "$@"

--- a/scripts/build-ubsan.sh
+++ b/scripts/build-ubsan.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Local UndefinedBehaviorSanitizer build + test runner. Runs the
+# wyrelog test suite under -fsanitize=undefined.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/_sanitize-common.sh
+. "$SCRIPT_DIR/_sanitize-common.sh"
+run_sanitizer_build undefined ubsan "$@"


### PR DESCRIPTION
## Summary

- Add `scripts/build-{san,tsan,ubsan}.sh` + shared `scripts/_sanitize-common.sh` for running the wyrelog test suite under AddressSanitizer, ThreadSanitizer, UndefinedBehaviorSanitizer.
- Each script configures a dedicated `builddir-{asan,tsan,ubsan}/` with `-Dbuildtype=debug -Db_sanitize=<flag> -Db_lundef=false`, then `meson test --suite wyrelog --print-errorlogs`. Skipping `meson compile` keeps subprojects the wyrelog test suite does not depend on out of the sanitizer build.
- `.gitignore` gets `builddir-*/` so per-sanitizer build trees don't pollute `git status`.

## Test plan

- [x] `./scripts/build-san.sh` → exit 0 (asan green)
- [x] `./scripts/build-ubsan.sh` → exit 0 (ubsan green)
- [x] `./scripts/build-tsan.sh` → exit 0 (tsan green)
- [x] No CI yaml change (helpers are dev-time)
- [ ] CI matrix (Linux/macOS/Windows-clang-cl) green for the unrelated workflow runs