### PR TITLE
access: add wyl_id_t time-ordered identifier

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -124,3 +124,10 @@ test_keyprovider_dev = executable('test-keyprovider-dev',
 )
 
 test('keyprovider-dev', test_keyprovider_dev)
+
+test_id = executable('test-id',
+  'test-id.c',
+  dependencies : [wyrelog_dep, libchronoid_dep],
+)
+
+test('id', test_id)

--- a/tests/test-id.c
+++ b/tests/test-id.c
@@ -1,0 +1,427 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <glib.h>
+#include <string.h>
+
+#include <chronoid/ksuid.h>
+
+#include "wyrelog/wyl-id-private.h"
+
+static gint
+failing_rng (void *ctx, uint8_t *buf, size_t n)
+{
+  (void) ctx;
+  (void) buf;
+  (void) n;
+  return -1;
+}
+
+static gint
+check_nil_sentinel (void)
+{
+  for (gsize i = 0; i < WYL_ID_BYTES; i++) {
+    if (WYL_ID_NIL.bytes[i] != 0)
+      return 10;
+  }
+  if (!wyl_id_equal (&WYL_ID_NIL, &WYL_ID_NIL))
+    return 11;
+  return 0;
+}
+
+static gint
+check_generation_succeeds (void)
+{
+  wyl_id_t id;
+  if (wyl_id_new (&id) != WYRELOG_E_OK)
+    return 20;
+  if (wyl_id_equal (&id, &WYL_ID_NIL))
+    return 21;
+  return 0;
+}
+
+static gint
+check_generation_null (void)
+{
+  if (wyl_id_new (NULL) != WYRELOG_E_INVALID)
+    return 30;
+  return 0;
+}
+
+static gint
+check_generation_uniqueness (void)
+{
+  GHashTable *seen = g_hash_table_new_full (g_str_hash, g_str_equal,
+      g_free, NULL);
+  for (guint i = 0; i < 1000; i++) {
+    wyl_id_t id;
+    gchar buf[WYL_ID_STRING_BUF];
+    if (wyl_id_new (&id) != WYRELOG_E_OK) {
+      g_hash_table_destroy (seen);
+      return 40;
+    }
+    if (wyl_id_format (&id, buf, sizeof buf) != WYRELOG_E_OK) {
+      g_hash_table_destroy (seen);
+      return 41;
+    }
+    if (g_hash_table_contains (seen, buf)) {
+      g_hash_table_destroy (seen);
+      return 42;
+    }
+    g_hash_table_add (seen, g_strdup (buf));
+  }
+  g_hash_table_destroy (seen);
+  return 0;
+}
+
+static gint
+check_monotonicity (void)
+{
+  wyl_id_t a, b;
+  if (wyl_id_new (&a) != WYRELOG_E_OK)
+    return 50;
+  g_usleep (2000);
+  if (wyl_id_new (&b) != WYRELOG_E_OK)
+    return 51;
+  if (wyl_id_compare (&a, &b) >= 0)
+    return 52;
+  return 0;
+}
+
+static gint
+check_format_length (void)
+{
+  wyl_id_t id;
+  gchar buf[WYL_ID_STRING_BUF];
+  if (wyl_id_new (&id) != WYRELOG_E_OK)
+    return 60;
+  if (wyl_id_format (&id, buf, sizeof buf) != WYRELOG_E_OK)
+    return 61;
+  if (strlen (buf) != WYL_ID_STRING_LEN)
+    return 62;
+  if (buf[WYL_ID_STRING_LEN] != '\0')
+    return 63;
+  return 0;
+}
+
+static gint
+check_format_canonical_shape (void)
+{
+  wyl_id_t id;
+  gchar buf[WYL_ID_STRING_BUF];
+  if (wyl_id_new (&id) != WYRELOG_E_OK)
+    return 70;
+  if (wyl_id_format (&id, buf, sizeof buf) != WYRELOG_E_OK)
+    return 71;
+  if (buf[8] != '-' || buf[13] != '-' || buf[18] != '-' || buf[23] != '-')
+    return 72;
+  for (gsize i = 0; i < WYL_ID_STRING_LEN; i++) {
+    gchar c = buf[i];
+    if (i == 8 || i == 13 || i == 18 || i == 23)
+      continue;
+    if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')))
+      return 73;
+  }
+  if (buf[14] != '7')
+    return 74;
+  if (buf[19] != '8' && buf[19] != '9' && buf[19] != 'a' && buf[19] != 'b')
+    return 75;
+  return 0;
+}
+
+static gint
+check_format_buffer_too_small (void)
+{
+  wyl_id_t id;
+  gchar buf[WYL_ID_STRING_BUF];
+  if (wyl_id_new (&id) != WYRELOG_E_OK)
+    return 80;
+  buf[0] = '!';
+  if (wyl_id_format (&id, buf, WYL_ID_STRING_LEN) != WYRELOG_E_INVALID)
+    return 81;
+  if (buf[0] != '!')
+    return 82;
+  return 0;
+}
+
+static gint
+check_format_null_inputs (void)
+{
+  wyl_id_t id;
+  gchar buf[WYL_ID_STRING_BUF];
+  if (wyl_id_new (&id) != WYRELOG_E_OK)
+    return 90;
+  if (wyl_id_format (NULL, buf, sizeof buf) != WYRELOG_E_INVALID)
+    return 91;
+  if (wyl_id_format (&id, NULL, sizeof buf) != WYRELOG_E_INVALID)
+    return 92;
+  return 0;
+}
+
+static gint
+check_round_trip (void)
+{
+  for (guint i = 0; i < 100; i++) {
+    wyl_id_t original, parsed;
+    gchar buf[WYL_ID_STRING_BUF];
+    if (wyl_id_new (&original) != WYRELOG_E_OK)
+      return 100;
+    if (wyl_id_format (&original, buf, sizeof buf) != WYRELOG_E_OK)
+      return 101;
+    if (wyl_id_parse (buf, &parsed) != WYRELOG_E_OK)
+      return 102;
+    if (!wyl_id_equal (&original, &parsed))
+      return 103;
+  }
+  return 0;
+}
+
+static gint
+check_parse_fixed_vector (void)
+{
+  static const gchar *canonical = "01890c10-2e3f-7000-8000-000000000001";
+  wyl_id_t parsed;
+  gchar buf[WYL_ID_STRING_BUF];
+
+  if (wyl_id_parse (canonical, &parsed) != WYRELOG_E_OK)
+    return 110;
+  if (wyl_id_format (&parsed, buf, sizeof buf) != WYRELOG_E_OK)
+    return 111;
+  if (strcmp (buf, canonical) != 0)
+    return 112;
+  return 0;
+}
+
+static gint
+check_parse_rejects_short (void)
+{
+  wyl_id_t out;
+  if (wyl_id_parse ("00000000-0000-0000-0000-00000000000", &out)
+      != WYRELOG_E_INVALID)
+    return 120;
+  return 0;
+}
+
+static gint
+check_parse_rejects_long (void)
+{
+  wyl_id_t out;
+  if (wyl_id_parse ("00000000-0000-0000-0000-0000000000000", &out)
+      != WYRELOG_E_INVALID)
+    return 130;
+  return 0;
+}
+
+static gint
+check_parse_rejects_non_hex (void)
+{
+  wyl_id_t out;
+  if (wyl_id_parse ("zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz", &out)
+      != WYRELOG_E_INVALID)
+    return 140;
+  return 0;
+}
+
+static gint
+check_parse_rejects_misplaced_hyphens (void)
+{
+  wyl_id_t out;
+  if (wyl_id_parse ("000000000-000-0000-0000-000000000000", &out)
+      != WYRELOG_E_INVALID)
+    return 150;
+  return 0;
+}
+
+static gint
+check_parse_preserves_out_on_error (void)
+{
+  wyl_id_t out;
+  memset (out.bytes, 0xab, WYL_ID_BYTES);
+  if (wyl_id_parse ("not-a-uuid", &out) != WYRELOG_E_INVALID)
+    return 160;
+  for (gsize i = 0; i < WYL_ID_BYTES; i++) {
+    if (out.bytes[i] != 0xab)
+      return 161;
+  }
+  return 0;
+}
+
+static gint
+check_parse_accepts_uppercase (void)
+{
+  static const gchar *upper = "01890C10-2E3F-7000-8000-00000000000A";
+  wyl_id_t parsed;
+  gchar buf[WYL_ID_STRING_BUF];
+  if (wyl_id_parse (upper, &parsed) != WYRELOG_E_OK)
+    return 170;
+  if (wyl_id_format (&parsed, buf, sizeof buf) != WYRELOG_E_OK)
+    return 171;
+  if (strcmp (buf, "01890c10-2e3f-7000-8000-00000000000a") != 0)
+    return 172;
+  return 0;
+}
+
+static gint
+check_parse_null_inputs (void)
+{
+  wyl_id_t out;
+  if (wyl_id_parse (NULL, &out) != WYRELOG_E_INVALID)
+    return 180;
+  if (wyl_id_parse ("01890c10-2e3f-7000-8000-000000000000", NULL)
+      != WYRELOG_E_INVALID)
+    return 181;
+  return 0;
+}
+
+static gint
+check_equal_null_handling (void)
+{
+  wyl_id_t id;
+  if (wyl_id_new (&id) != WYRELOG_E_OK)
+    return 190;
+  if (wyl_id_equal (NULL, &id))
+    return 191;
+  if (wyl_id_equal (&id, NULL))
+    return 192;
+  if (wyl_id_equal (NULL, NULL))
+    return 193;
+  return 0;
+}
+
+static gint
+check_compare_total_order (void)
+{
+  enum
+  { COUNT = 16 };
+  wyl_id_t ids[COUNT];
+  for (guint i = 0; i < COUNT; i++) {
+    if (wyl_id_new (&ids[i]) != WYRELOG_E_OK)
+      return 200;
+    g_usleep (2000);
+  }
+  for (guint i = 1; i < COUNT; i++) {
+    if (wyl_id_compare (&ids[i - 1], &ids[i]) >= 0)
+      return 201;
+  }
+  return 0;
+}
+
+static gint
+check_parse_rejects_bad_version (void)
+{
+  wyl_id_t out;
+  /* Version nibble at offset 14 set to '6' (UUIDv6, not v7). */
+  if (wyl_id_parse ("01890c10-2e3f-6000-8000-000000000000", &out)
+      != WYRELOG_E_INVALID)
+    return 210;
+  return 0;
+}
+
+static gint
+check_parse_rejects_bad_variant (void)
+{
+  wyl_id_t out;
+  /* Variant nibble at offset 19 set to 'c' (RFC 4122 variant 11x,
+   * reserved). RFC 9562 requires '8'..'b' (variant 10xx). */
+  if (wyl_id_parse ("01890c10-2e3f-7000-c000-000000000000", &out)
+      != WYRELOG_E_INVALID)
+    return 220;
+  return 0;
+}
+
+static gint
+check_compare_null_handling (void)
+{
+  wyl_id_t id;
+  if (wyl_id_new (&id) != WYRELOG_E_OK)
+    return 230;
+  if (wyl_id_compare (NULL, NULL) != 0)
+    return 231;
+  if (wyl_id_compare (&WYL_ID_NIL, NULL) != 0)
+    return 232;
+  if (wyl_id_compare (NULL, &WYL_ID_NIL) != 0)
+    return 233;
+  if (wyl_id_compare (NULL, &id) >= 0)
+    return 234;
+  if (wyl_id_compare (&id, NULL) <= 0)
+    return 235;
+  return 0;
+}
+
+static gint
+check_rng_failure_fail_closed (void)
+{
+  wyl_id_t out;
+  wyrelog_error_t rc;
+
+  memset (out.bytes, 0xab, WYL_ID_BYTES);
+  chronoid_set_rand (failing_rng, NULL);
+  rc = wyl_id_new (&out);
+  chronoid_set_rand (NULL, NULL);
+
+  if (rc != WYRELOG_E_CRYPTO)
+    return 240;
+  /* Fail-closed contract: |*out| must remain untouched on entropy
+   * failure so a caller cannot accidentally proceed with a half-
+   * written or zero-initialised id. */
+  for (gsize i = 0; i < WYL_ID_BYTES; i++) {
+    if (out.bytes[i] != 0xab)
+      return 241;
+  }
+  return 0;
+}
+
+int
+main (void)
+{
+  gint rc;
+
+  if ((rc = check_nil_sentinel ()) != 0)
+    return rc;
+  if ((rc = check_generation_succeeds ()) != 0)
+    return rc;
+  if ((rc = check_generation_null ()) != 0)
+    return rc;
+  if ((rc = check_generation_uniqueness ()) != 0)
+    return rc;
+  if ((rc = check_monotonicity ()) != 0)
+    return rc;
+  if ((rc = check_format_length ()) != 0)
+    return rc;
+  if ((rc = check_format_canonical_shape ()) != 0)
+    return rc;
+  if ((rc = check_format_buffer_too_small ()) != 0)
+    return rc;
+  if ((rc = check_format_null_inputs ()) != 0)
+    return rc;
+  if ((rc = check_round_trip ()) != 0)
+    return rc;
+  if ((rc = check_parse_fixed_vector ()) != 0)
+    return rc;
+  if ((rc = check_parse_rejects_short ()) != 0)
+    return rc;
+  if ((rc = check_parse_rejects_long ()) != 0)
+    return rc;
+  if ((rc = check_parse_rejects_non_hex ()) != 0)
+    return rc;
+  if ((rc = check_parse_rejects_misplaced_hyphens ()) != 0)
+    return rc;
+  if ((rc = check_parse_preserves_out_on_error ()) != 0)
+    return rc;
+  if ((rc = check_parse_accepts_uppercase ()) != 0)
+    return rc;
+  if ((rc = check_parse_null_inputs ()) != 0)
+    return rc;
+  if ((rc = check_equal_null_handling ()) != 0)
+    return rc;
+  if ((rc = check_compare_total_order ()) != 0)
+    return rc;
+  if ((rc = check_parse_rejects_bad_version ()) != 0)
+    return rc;
+  if ((rc = check_parse_rejects_bad_variant ()) != 0)
+    return rc;
+  if ((rc = check_compare_null_handling ()) != 0)
+    return rc;
+  if ((rc = check_rng_failure_fail_closed ()) != 0)
+    return rc;
+
+  return 0;
+}

--- a/wyrelog/meson.build
+++ b/wyrelog/meson.build
@@ -17,6 +17,7 @@ wyrelog_sources = files(
   'wyl-fsm-session.c',
   'wyl-guard-expr.c',
   'wyl-handle.c',
+  'wyl-id.c',
   'wyl-keyprovider-dev.c',
   'wyl-perm.c',
   'wyl-permission-scope.c',
@@ -27,7 +28,7 @@ wyrelog_sources = files(
 libwyrelog = library('wyrelog',
   wyrelog_sources,
   include_directories : wyrelog_inc,
-  dependencies : [glib_dep, gio_dep],
+  dependencies : [glib_dep, gio_dep, libchronoid_dep],
   install : true,
   soversion : '0',
 )

--- a/wyrelog/wyl-id-private.h
+++ b/wyrelog/wyl-id-private.h
@@ -1,0 +1,94 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+
+#include <glib.h>
+
+#include "wyrelog/error.h"
+
+G_BEGIN_DECLS;
+
+/*
+ * Time-ordered identifier used by long-lived persistent records.
+ *
+ * Backed by a vendored generator that emits an RFC 9562 UUIDv7-shaped
+ * 16-byte value: a 48-bit big-endian millisecond timestamp prefix
+ * followed by version and variant nibbles and 74 random bits. Bytewise
+ * lexicographic order on the 16-byte representation tracks creation
+ * order at millisecond granularity, so sorting an array of ids yields
+ * coarse chronological order without a separate timestamp field.
+ *
+ * Ordering contract: best-effort coarse-time. Two ids minted within
+ * the same millisecond (or across a backward wall-clock step) are NOT
+ * guaranteed to compare in mint order. Callers that need strict per-
+ * call monotonic sequencing must layer a separate sequence number on
+ * top of this id rather than rely on the embedded timestamp.
+ *
+ * Thread-safety: wyl_id_new is callable from any thread. The backing
+ * generator uses a per-thread CSPRNG and does not require external
+ * synchronisation. Re-entrant calls from within a single thread (e.g.
+ * from a signal handler) are not supported.
+ *
+ * Value type by design: 16 bytes, no padding, safe to embed by value,
+ * copy with assignment, and compare with memcmp. There is no heap
+ * ownership to free, so this type intentionally has no autoptr
+ * cleanup function.
+ */
+
+#define WYL_ID_BYTES        16
+#define WYL_ID_STRING_LEN   36
+#define WYL_ID_STRING_BUF   37
+
+typedef struct wyl_id_t
+{
+  guint8 bytes[WYL_ID_BYTES];
+} wyl_id_t;
+
+G_STATIC_ASSERT (sizeof (wyl_id_t) == WYL_ID_BYTES);
+
+extern const wyl_id_t WYL_ID_NIL;
+
+/*
+ * Generate a fresh time-ordered id stamped with the current wall-
+ * clock time. On entropy failure returns WYRELOG_E_CRYPTO and leaves
+ * |*out| untouched. On wall-clock-out-of-range (a year >= 10889 or
+ * a clock pre-1970) returns WYRELOG_E_INTERNAL and leaves |*out|
+ * untouched. NULL |out| returns WYRELOG_E_INVALID.
+ *
+ * Fail-closed: callers MUST NOT proceed with a zero-initialised id
+ * on error. The all-zero sentinel WYL_ID_NIL is reserved for "no id
+ * present" slots and would collapse uniqueness if returned by mint.
+ */
+wyrelog_error_t wyl_id_new (wyl_id_t * out);
+
+/*
+ * Render |id| into |buf| as the 36-character canonical hyphenated
+ * lowercase form, NUL-terminated. |buf_len| must be at least
+ * WYL_ID_STRING_BUF (37). Returns WYRELOG_E_INVALID for NULL inputs
+ * or undersized buffer; on error |buf| is left untouched.
+ */
+wyrelog_error_t wyl_id_format (const wyl_id_t * id, gchar * buf, gsize buf_len);
+
+/*
+ * Parse the 36-character canonical form at |str| (NUL-terminated)
+ * into |out|. Accepts upper- or lower-case hex. Returns
+ * WYRELOG_E_INVALID for any format violation (length, hex, hyphen
+ * placement, version != 7, variant != 10xx) or NULL inputs; on
+ * error |*out| is left untouched. The wrapper enforces the RFC 9562
+ * version and variant nibbles in addition to whatever structural
+ * checks the backing parser performs, so accepted bytes are
+ * guaranteed to round-trip through wyl_id_format.
+ */
+wyrelog_error_t wyl_id_parse (const gchar * str, wyl_id_t * out);
+
+/*
+ * Bytewise equality. NULL on either side returns FALSE.
+ */
+gboolean wyl_id_equal (const wyl_id_t * a, const wyl_id_t * b);
+
+/*
+ * Bytewise total order: returns <0, 0, >0 in memcmp fashion. NULL
+ * arguments are substituted with WYL_ID_NIL for ordering purposes.
+ */
+gint wyl_id_compare (const wyl_id_t * a, const wyl_id_t * b);
+
+G_END_DECLS;

--- a/wyrelog/wyl-id.c
+++ b/wyrelog/wyl-id.c
@@ -1,0 +1,90 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "wyl-id-private.h"
+
+#include <string.h>
+
+#include <chronoid/uuidv7.h>
+
+G_STATIC_ASSERT (sizeof (wyl_id_t) == sizeof (chronoid_uuidv7_t));
+G_STATIC_ASSERT (WYL_ID_BYTES == CHRONOID_UUIDV7_BYTES);
+G_STATIC_ASSERT (WYL_ID_STRING_LEN == CHRONOID_UUIDV7_STRING_LEN);
+
+const wyl_id_t WYL_ID_NIL = { {0} };
+
+wyrelog_error_t
+wyl_id_new (wyl_id_t *out)
+{
+  chronoid_uuidv7_err_t rc;
+
+  if (out == NULL)
+    return WYRELOG_E_INVALID;
+
+  rc = chronoid_uuidv7_new ((chronoid_uuidv7_t *) out);
+
+  switch (rc) {
+    case CHRONOID_UUIDV7_OK:
+      return WYRELOG_E_OK;
+    case CHRONOID_UUIDV7_ERR_RNG:
+      return WYRELOG_E_CRYPTO;
+    case CHRONOID_UUIDV7_ERR_TIME_RANGE:
+      return WYRELOG_E_INTERNAL;
+    default:
+      return WYRELOG_E_INTERNAL;
+  }
+}
+
+wyrelog_error_t
+wyl_id_format (const wyl_id_t *id, gchar *buf, gsize buf_len)
+{
+  if (id == NULL || buf == NULL || buf_len < WYL_ID_STRING_BUF)
+    return WYRELOG_E_INVALID;
+
+  chronoid_uuidv7_format ((const chronoid_uuidv7_t *) id, buf);
+  buf[WYL_ID_STRING_LEN] = '\0';
+  return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
+wyl_id_parse (const gchar *str, wyl_id_t *out)
+{
+  chronoid_uuidv7_err_t rc;
+  wyl_id_t tmp;
+  gsize len;
+
+  if (str == NULL || out == NULL)
+    return WYRELOG_E_INVALID;
+
+  len = strlen (str);
+  rc = chronoid_uuidv7_parse ((chronoid_uuidv7_t *) & tmp, str, len);
+  if (rc != CHRONOID_UUIDV7_OK)
+    return WYRELOG_E_INVALID;
+
+  /* The backing parser validates length, hex characters, and hyphen
+   * placement, but does not enforce the RFC 9562 version (=7) or
+   * variant (=10xx) nibbles. Reject those at the wrapper boundary so
+   * the wyl_id_t parse contract is strictly stronger than the bytes
+   * the parser will accept. */
+  if ((tmp.bytes[6] & 0xF0u) != 0x70u)
+    return WYRELOG_E_INVALID;
+  if ((tmp.bytes[8] & 0xC0u) != 0x80u)
+    return WYRELOG_E_INVALID;
+
+  *out = tmp;
+  return WYRELOG_E_OK;
+}
+
+gboolean
+wyl_id_equal (const wyl_id_t *a, const wyl_id_t *b)
+{
+  if (a == NULL || b == NULL)
+    return FALSE;
+  return memcmp (a->bytes, b->bytes, WYL_ID_BYTES) == 0;
+}
+
+gint
+wyl_id_compare (const wyl_id_t *a, const wyl_id_t *b)
+{
+  const wyl_id_t *lhs = (a != NULL) ? a : &WYL_ID_NIL;
+  const wyl_id_t *rhs = (b != NULL) ? b : &WYL_ID_NIL;
+  return memcmp (lhs->bytes, rhs->bytes, WYL_ID_BYTES);
+}


### PR DESCRIPTION
## Summary

- Introduces `wyl_id_t` — a 16-byte value-type identifier that long-lived persistent records can embed by value.
- Backed by a vendored generator subproject; renders to the canonical 36-character hyphenated lowercase form.
- Public surface: `WYL_ID_NIL`, size macros (`WYL_ID_BYTES`, `WYL_ID_STRING_LEN`, `WYL_ID_STRING_BUF`), and five entry points: `wyl_id_new` / `wyl_id_format` / `wyl_id_parse` / `wyl_id_equal` / `wyl_id_compare`.
- `wyl_id_parse` adds RFC 9562 version (=7) and variant (=10xx) nibble validation on top of the parser's structural checks.
- Subproject dependency is wired into `libwyrelog` only; `wyrelog_dep` does NOT propagate it. Public consumers cannot transitively pick up generator headers.

## Test plan

- [x] `meson setup builddir` succeeds.
- [x] `meson test -C builddir --suite wyrelog` — 14/14 PASS including new `id` test.
- [x] 24 numbered checks: nil sentinel, generation success/NULL, 1000-id uniqueness, monotonicity, format length, canonical shape, undersized buffer, NULL inputs, 100x round-trip, fixed vector, length / non-hex / misplaced-hyphen / bad-version / bad-variant rejection, output-untouched-on-error, uppercase acceptance, NULL parse, NULL equality / NULL compare handling, 16-element compare-total-order, RNG-failure fail-closed via deterministic RNG override.
- [x] `./tools/gst-indent` applied.
- [ ] CI green across Linux / macOS / Windows.

## Follow-ups (deferred to separate atomics)

- Subproject wrap revision pinning across all wraps (currently `revision = main`).
- License-file redistribution wiring for the vendored generator's MIT NOTICE.
- Parse-direction strictness re-validation when the generator subproject updates.