### PR TITLE
ci: bump actions/checkout to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
             tpm: disabled
     steps:
       - name: Check out source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install build dependencies (Linux)
         if: runner.os == 'Linux'
@@ -74,7 +74,7 @@ jobs:
       VCPKG_INSTALLED_DIR: C:\vcpkg\installed\x64-windows
     steps:
       - name: Check out source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install meson and ninja
         shell: cmd


### PR DESCRIPTION
## Summary

- Bumps both `actions/checkout` invocations from `@v4` to `@v5`.
- The only documented v4 → v5 delta is the Node runtime upgrade (20 → 24), which raises the minimum runner version to 2.327.1; all GitHub-hosted runners have been above that floor since 2024.
- Default-args usage in this workflow means no further changes are required (no `submodules`, `lfs`, `path`, or `persist-credentials` overrides exist).

## Why this is its own PR

Splitting the checkout bump from the upcoming NuGet binary-cache work in #34 keeps each commit single-concern and independently revertable.

## Test plan

- [x] `git diff` shows only the two `actions/checkout@v4` → `@v5` substitutions.
- [ ] CI green across Linux / macOS / Windows.

Refs #34