### PR TITLE
ci(windows): use NuGet feed for vcpkg binary cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,11 +70,40 @@ jobs:
   build-windows:
     name: build-windows
     runs-on: windows-latest
+    permissions:
+      contents: read
+      packages: write
     env:
-      VCPKG_INSTALLED_DIR: C:\vcpkg\installed\x64-windows
+      VCPKG_ROOT: ${{ github.workspace }}\vcpkg
+      VCPKG_INSTALLED_DIR: ${{ github.workspace }}\vcpkg\installed\x64-windows
+      VCPKG_BINARY_SOURCES: "clear;nuget,https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json,readwrite"
     steps:
       - name: Check out source
         uses: actions/checkout@v5
+
+      - name: Remove system vcpkg
+        shell: bash
+        run: rm -rf "$VCPKG_INSTALLATION_ROOT"
+
+      - name: Bootstrap vendored vcpkg
+        shell: cmd
+        run: |
+          @echo off
+          git clone --depth 1 https://github.com/microsoft/vcpkg.git "%VCPKG_ROOT%"
+          call "%VCPKG_ROOT%\bootstrap-vcpkg.bat" -disableMetrics
+
+      - name: Register NuGet source
+        shell: pwsh
+        run: |
+          $nuget = & "$env:VCPKG_ROOT\vcpkg.exe" fetch nuget | Select-Object -Last 1
+          $feed  = "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
+          & $nuget sources add `
+            -Source $feed `
+            -StorePasswordInClearText `
+            -Name GitHubPackages `
+            -UserName "${{ github.repository_owner }}" `
+            -Password "${{ secrets.GITHUB_TOKEN }}"
+          & $nuget setapikey "${{ secrets.GITHUB_TOKEN }}" -Source $feed
 
       - name: Install meson and ninja
         shell: cmd
@@ -84,27 +113,11 @@ jobs:
         shell: cmd
         run: choco install pkgconfiglite -y --allow-empty-checksums
 
-      - name: Prepare vcpkg binary cache directory
-        shell: cmd
-        run: |
-          @echo off
-          set "CACHE_DIR=%RUNNER_TEMP%\vcpkg-cache"
-          if not exist "%CACHE_DIR%" mkdir "%CACHE_DIR%"
-          echo VCPKG_DEFAULT_BINARY_CACHE=%CACHE_DIR%>> %GITHUB_ENV%
-
-      - name: Restore vcpkg binary cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ runner.temp }}\vcpkg-cache
-          key: windows-vcpkg-${{ hashFiles('.github/workflows/ci.yml') }}-v1
-          restore-keys: |
-            windows-vcpkg-
-
       - name: Install C dependencies (vcpkg)
         shell: cmd
         run: |
           @echo off
-          vcpkg install glib:x64-windows libsodium:x64-windows
+          "%VCPKG_ROOT%\vcpkg.exe" install glib:x64-windows libsodium:x64-windows --x-abi-tools-use-exact-versions
 
       - name: Cache meson packagecache
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary

- Switches the Windows lane from `actions/cache@v4` filesystem-backed vcpkg binary cache to a GitHub Packages NuGet feed.
- Vendors vcpkg in-workflow (`git clone --depth 1 microsoft/vcpkg` + bootstrap) — system vcpkg is documented-stale and its ABI-hash drift defeats binary caching.
- Adds `--x-abi-tools-use-exact-versions` to stabilise the tools portion of the ABI hash across runner image refreshes.
- Grants job-level `permissions: contents: read + packages: write`.

## Threat model

- **Fork PRs**: `GITHUB_TOKEN` is auto-restricted to read-only by GitHub enforcement regardless of declaration. Push attempts will 401/403 and fall back to source build (vcpkg fail-open posture). Acceptable.
- **Same-repo PRs / pushes**: trusted under the single-maintainer model. Event-gating `packages: write` to push-only is deferred pending multi-maintainer scenarios.

## Failure modes (intentional)

- **Cold feed (first run)**: NuGet GETs return 404, vcpkg builds glib + libsodium from source, NuGet PUTs populate the feed. Slow first run is expected.
- **Sustained NuGet 401/403**: vcpkg falls back to source build. Warning logs expected, build still passes.
- **GitHub Packages outage / 5xx**: same fallback. Cache fail-open is intentional — outages degrade speed, not correctness.

## Deferred follow-ups

- Pin vcpkg to a known-good SHA (currently HEAD of `microsoft/vcpkg`).
- Schedule `actions/delete-package-versions` for retention (no auto-retention on public-repo packages).
- Re-evaluate `packages: write` event-gating if multi-maintainer scenarios arise.

## Test plan

- [ ] First-run CI on this PR builds glib/libsodium from source, populates feed (slow run; expected).
- [ ] Re-run job after success → NuGet GET returns 200, "Restored from binary cache" log lines appear; wall-time materially faster.
- [ ] `build-posix` lane unaffected (orthogonal to this change).
- [ ] No 401/403 on NuGet PUT (would indicate `permissions:` block dropped `contents: read` or `GITHUB_TOKEN` mis-scoped — see threat model).

Refs #34