### PR TITLE
build: pin libchronoid to v1.0.1

### DIFF
--- a/subprojects/libchronoid.wrap
+++ b/subprojects/libchronoid.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 url = https://github.com/semantic-reasoning/libchronoid.git
-revision = main
+revision = v1.0.1
 depth = 1


### PR DESCRIPTION
## Summary

- Pins `subprojects/libchronoid.wrap` from `revision = main` to `revision = v1.0.1`.
- v1.0.1 underlying commit: `dbb5d02ee74089d2ee13ea13c77337e95b37c800`.
- Closes the reproducibility hole previously flagged as a deferred follow-up on the wyl_id atomic.

## Test plan

- [x] `rm -rf builddir subprojects/libchronoid && meson setup builddir` — succeeds, libchronoid v1.0.1 fetched.
- [x] `meson test -C builddir --suite wyrelog` — 14/14 PASS, including `test-id` (wyl_id_t API exercises libchronoid UUIDv7).
- [ ] CI green across Linux / macOS / Windows.

## Out of scope

- Pinning `subprojects/wirelog.wrap` (still `revision = main`) — deferred to a separate atomic for independent review/revert.