### PR TITLE
access: stamp WylAuditEvent with id and created_at

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -131,3 +131,10 @@ test_id = executable('test-id',
 )
 
 test('id', test_id)
+
+test_audit_event = executable('test-audit-event',
+  'test-audit-event.c',
+  dependencies : [wyrelog_dep],
+)
+
+test('audit-event', test_audit_event)

--- a/tests/test-audit-event.c
+++ b/tests/test-audit-event.c
@@ -1,0 +1,116 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <glib.h>
+#include <string.h>
+
+#include "wyrelog/wyrelog.h"
+
+static gint
+check_construction (void)
+{
+  g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
+  if (ev == NULL)
+    return 10;
+  if (!WYL_IS_AUDIT_EVENT (ev))
+    return 11;
+  return 0;
+}
+
+static gint
+check_id_is_nonempty_and_canonical (void)
+{
+  g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
+  g_autofree gchar *id = wyl_audit_event_dup_id_string (ev);
+  if (id == NULL)
+    return 20;
+  if (strlen (id) != 36)
+    return 21;
+  if (id[8] != '-' || id[13] != '-' || id[18] != '-' || id[23] != '-')
+    return 22;
+  if (id[14] != '7')
+    return 23;
+  return 0;
+}
+
+static gint
+check_id_is_stable_across_calls (void)
+{
+  g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
+  g_autofree gchar *first = wyl_audit_event_dup_id_string (ev);
+  g_autofree gchar *second = wyl_audit_event_dup_id_string (ev);
+  if (first == NULL || second == NULL)
+    return 30;
+  if (strcmp (first, second) != 0)
+    return 31;
+  return 0;
+}
+
+static gint
+check_distinct_events_have_distinct_ids (void)
+{
+  g_autoptr (WylAuditEvent) a = wyl_audit_event_new ();
+  g_autoptr (WylAuditEvent) b = wyl_audit_event_new ();
+  g_autofree gchar *ida = wyl_audit_event_dup_id_string (a);
+  g_autofree gchar *idb = wyl_audit_event_dup_id_string (b);
+  if (ida == NULL || idb == NULL)
+    return 40;
+  if (strcmp (ida, idb) == 0)
+    return 41;
+  return 0;
+}
+
+static gint
+check_created_at_is_recent (void)
+{
+  gint64 before = g_get_real_time ();
+  g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
+  gint64 after = g_get_real_time ();
+  gint64 created = wyl_audit_event_get_created_at_us (ev);
+  if (created < before || created > after)
+    return 50;
+  return 0;
+}
+
+static gint
+check_created_at_monotonic_with_minting_order (void)
+{
+  g_autoptr (WylAuditEvent) a = wyl_audit_event_new ();
+  g_usleep (2000);
+  g_autoptr (WylAuditEvent) b = wyl_audit_event_new ();
+  if (wyl_audit_event_get_created_at_us (a)
+      >= wyl_audit_event_get_created_at_us (b))
+    return 60;
+  return 0;
+}
+
+static gint
+check_accessor_null_safety (void)
+{
+  if (wyl_audit_event_get_created_at_us (NULL) != -1)
+    return 70;
+  if (wyl_audit_event_dup_id_string (NULL) != NULL)
+    return 71;
+  return 0;
+}
+
+int
+main (void)
+{
+  gint rc;
+
+  if ((rc = check_construction ()) != 0)
+    return rc;
+  if ((rc = check_id_is_nonempty_and_canonical ()) != 0)
+    return rc;
+  if ((rc = check_id_is_stable_across_calls ()) != 0)
+    return rc;
+  if ((rc = check_distinct_events_have_distinct_ids ()) != 0)
+    return rc;
+  if ((rc = check_created_at_is_recent ()) != 0)
+    return rc;
+  if ((rc = check_created_at_monotonic_with_minting_order ()) != 0)
+    return rc;
+  if ((rc = check_accessor_null_safety ()) != 0)
+    return rc;
+
+  return 0;
+}

--- a/wyrelog/wyl-audit-event.c
+++ b/wyrelog/wyl-audit-event.c
@@ -1,9 +1,13 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #include "wyrelog/wyrelog.h"
 
+#include "wyl-id-private.h"
+
 struct _WylAuditEvent
 {
   GObject parent_instance;
+  wyl_id_t id;
+  gint64 created_at_us;
 };
 
 G_DEFINE_FINAL_TYPE (WylAuditEvent, wyl_audit_event, G_TYPE_OBJECT);
@@ -17,7 +21,44 @@ wyl_audit_event_class_init (WylAuditEventClass *klass)
 static void
 wyl_audit_event_init (WylAuditEvent *self)
 {
-  (void) self;
+  /* Construct-time stamping: every WylAuditEvent gets a fresh
+   * time-ordered identifier and a microsecond-resolution wall-clock
+   * timestamp. The pair survives any future field additions because
+   * id and created_at_us are treated as the immutable witnesses of
+   * the event's existence; downstream serialisers can rely on them
+   * to deduplicate and to order events without consulting any other
+   * field. Failure to mint an id is fatal for this construction --
+   * a zero-id event would collapse the uniqueness guarantee that
+   * downstream readers depend on, so we abort rather than ship a
+   * partially-initialised object. */
+  if (wyl_id_new (&self->id) != WYRELOG_E_OK)
+    g_error ("wyl_audit_event_init: failed to mint identifier");
+  self->created_at_us = g_get_real_time ();
+}
+
+WylAuditEvent *
+wyl_audit_event_new (void)
+{
+  return g_object_new (WYL_TYPE_AUDIT_EVENT, NULL);
+}
+
+gchar *
+wyl_audit_event_dup_id_string (const WylAuditEvent *self)
+{
+  gchar buf[WYL_ID_STRING_BUF];
+
+  g_return_val_if_fail (WYL_IS_AUDIT_EVENT (self), NULL);
+
+  if (wyl_id_format (&self->id, buf, sizeof buf) != WYRELOG_E_OK)
+    return NULL;
+  return g_strdup (buf);
+}
+
+gint64
+wyl_audit_event_get_created_at_us (const WylAuditEvent *self)
+{
+  g_return_val_if_fail (WYL_IS_AUDIT_EVENT (self), -1);
+  return self->created_at_us;
 }
 
 wyrelog_error_t

--- a/wyrelog/wyrelog.h
+++ b/wyrelog/wyrelog.h
@@ -99,6 +99,26 @@ wyrelog_error_t wyl_perm_revoke (WylHandle * handle,
     const wyl_revoke_req_t * req);
 
 /* Audit */
+
+/*
+ * Construct a fresh audit event stamped with a freshly minted
+ * identifier and a wall-clock created_at. May abort the process via
+ * g_error if the entropy source declines: a zero-identifier event
+ * would collapse uniqueness for downstream serialisers, so fail-fast
+ * is preferred over silently shipping a partially-initialised object.
+ */
+WylAuditEvent *wyl_audit_event_new (void);
+
+gchar *wyl_audit_event_dup_id_string (const WylAuditEvent * self);
+
+/*
+ * Returns the construct-time wall-clock stamp in microseconds since
+ * the Unix epoch (g_get_real_time). Returns -1 on a NULL argument so
+ * callers can distinguish "no event" from a legitimate epoch-zero
+ * stamp.
+ */
+gint64 wyl_audit_event_get_created_at_us (const WylAuditEvent * self);
+
 wyrelog_error_t wyl_audit_emit (WylHandle * handle,
     const WylAuditEvent * event);
 


### PR DESCRIPTION
## Summary

- Gives `WylAuditEvent` (previously a 29-line stub) construct-time identity: freshly minted `wyl_id_t` + microsecond-resolution wall-clock `created_at_us`.
- Adds three public entry points:
  - `wyl_audit_event_new` — construct a fresh event
  - `wyl_audit_event_dup_id_string` — canonical 36-char `gchar *` (pairs with `g_autofree`)
  - `wyl_audit_event_get_created_at_us` — `gint64` µs since epoch, `-1` sentinel on NULL
- `wyl_id_t` stays private; public surface is string-based.
- Construct-time id minting is fail-fast (`g_error` on entropy failure); documented on the prototype.
- `wyl_audit_emit` stub unchanged — audit sink wiring lands in a follow-up.

## Test plan

- [x] `meson test -C builddir --suite wyrelog` — 15/15 PASS (was 14/14; new `audit-event` test).
- [x] 7 numbered checks: construction, canonical id shape (length/hyphens/version nibble), id stability across dup calls, distinct-event id distinctness, `created_at` bracketing against `g_get_real_time`, monotonic ordering across 2 ms gap, NULL-safe accessors.
- [x] `./tools/gst-indent` applied.
- [ ] CI green across Linux / macOS / Windows.