### PR TITLE
access: stamp WylHandle with id and created_at

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -138,3 +138,10 @@ test_audit_event = executable('test-audit-event',
 )
 
 test('audit-event', test_audit_event)
+
+test_handle_id = executable('test-handle-id',
+  'test-handle-id.c',
+  dependencies : [wyrelog_dep],
+)
+
+test('handle-id', test_handle_id)

--- a/tests/test-handle-id.c
+++ b/tests/test-handle-id.c
@@ -1,0 +1,107 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <glib.h>
+#include <string.h>
+
+#include "wyrelog/wyrelog.h"
+
+static gint
+check_init_yields_id (void)
+{
+  WylHandle *handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 10;
+  if (handle == NULL)
+    return 11;
+  g_autofree gchar *id = wyl_handle_dup_id_string (handle);
+  if (id == NULL)
+    return 12;
+  if (strlen (id) != 36)
+    return 13;
+  if (id[14] != '7')
+    return 14;
+  g_object_unref (handle);
+  return 0;
+}
+
+static gint
+check_id_is_stable (void)
+{
+  WylHandle *handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 20;
+  g_autofree gchar *first = wyl_handle_dup_id_string (handle);
+  g_autofree gchar *second = wyl_handle_dup_id_string (handle);
+  gint rc = 0;
+  if (first == NULL || second == NULL)
+    rc = 21;
+  else if (strcmp (first, second) != 0)
+    rc = 22;
+  g_object_unref (handle);
+  return rc;
+}
+
+static gint
+check_distinct_handles_have_distinct_ids (void)
+{
+  WylHandle *a = NULL;
+  WylHandle *b = NULL;
+  if (wyl_init (NULL, &a) != WYRELOG_E_OK)
+    return 30;
+  if (wyl_init (NULL, &b) != WYRELOG_E_OK)
+    return 31;
+  g_autofree gchar *ida = wyl_handle_dup_id_string (a);
+  g_autofree gchar *idb = wyl_handle_dup_id_string (b);
+  gint rc = 0;
+  if (ida == NULL || idb == NULL)
+    rc = 32;
+  else if (strcmp (ida, idb) == 0)
+    rc = 33;
+  g_object_unref (a);
+  g_object_unref (b);
+  return rc;
+}
+
+static gint
+check_created_at_is_recent (void)
+{
+  gint64 before = g_get_real_time ();
+  WylHandle *handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 40;
+  gint64 after = g_get_real_time ();
+  gint64 created = wyl_handle_get_created_at_us (handle);
+  gint rc = 0;
+  if (created < before || created > after)
+    rc = 41;
+  g_object_unref (handle);
+  return rc;
+}
+
+static gint
+check_accessor_null_safety (void)
+{
+  if (wyl_handle_get_created_at_us (NULL) != -1)
+    return 50;
+  if (wyl_handle_dup_id_string (NULL) != NULL)
+    return 51;
+  return 0;
+}
+
+int
+main (void)
+{
+  gint rc;
+
+  if ((rc = check_init_yields_id ()) != 0)
+    return rc;
+  if ((rc = check_id_is_stable ()) != 0)
+    return rc;
+  if ((rc = check_distinct_handles_have_distinct_ids ()) != 0)
+    return rc;
+  if ((rc = check_created_at_is_recent ()) != 0)
+    return rc;
+  if ((rc = check_accessor_null_safety ()) != 0)
+    return rc;
+
+  return 0;
+}

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -1,9 +1,13 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #include "wyrelog/wyrelog.h"
 
+#include "wyl-id-private.h"
+
 struct _WylHandle
 {
   GObject parent_instance;
+  wyl_id_t id;
+  gint64 created_at_us;
 };
 
 G_DEFINE_FINAL_TYPE (WylHandle, wyl_handle, G_TYPE_OBJECT);
@@ -17,7 +21,15 @@ wyl_handle_class_init (WylHandleClass *klass)
 static void
 wyl_handle_init (WylHandle *self)
 {
-  (void) self;
+  /* Stamp the handle with a fresh id and timestamp at construct time
+   * so log lines, audit events, and metrics emitted by the daemon can
+   * be correlated back to a specific embedding instance even when a
+   * process holds multiple handles. Failure to mint an id is fatal:
+   * a zero-id handle would collapse correlation, so abort rather than
+   * ship a partially-initialised object. */
+  if (wyl_id_new (&self->id) != WYRELOG_E_OK)
+    g_error ("wyl_handle_init: failed to mint identifier");
+  self->created_at_us = g_get_real_time ();
 }
 
 wyrelog_error_t
@@ -37,4 +49,23 @@ wyl_shutdown (WylHandle *handle)
 {
   (void) handle;
   /* Real implementation drains queues, closes DBs, finalizes TPM. */
+}
+
+gchar *
+wyl_handle_dup_id_string (const WylHandle *self)
+{
+  gchar buf[WYL_ID_STRING_BUF];
+
+  g_return_val_if_fail (WYL_IS_HANDLE (self), NULL);
+
+  if (wyl_id_format (&self->id, buf, sizeof buf) != WYRELOG_E_OK)
+    return NULL;
+  return g_strdup (buf);
+}
+
+gint64
+wyl_handle_get_created_at_us (const WylHandle *self)
+{
+  g_return_val_if_fail (WYL_IS_HANDLE (self), -1);
+  return self->created_at_us;
 }

--- a/wyrelog/wyrelog.h
+++ b/wyrelog/wyrelog.h
@@ -83,6 +83,22 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC (wyl_revoke_req_t, wyl_revoke_req_free);
 wyrelog_error_t wyl_init (const gchar * config_path, WylHandle ** out_handle);
 void wyl_shutdown (WylHandle * handle);
 
+/*
+ * Returns the handle's construct-time identifier as a 36-character
+ * canonical string (caller frees with g_free or g_autofree). May
+ * return NULL only if the handle is NULL or not a WylHandle. The id
+ * is stable for the lifetime of the handle so log lines, audit
+ * events, and metrics emitted by the daemon can be correlated back
+ * to a specific embedding instance.
+ */
+gchar *wyl_handle_dup_id_string (const WylHandle * self);
+
+/*
+ * Returns the construct-time wall-clock stamp in microseconds since
+ * the Unix epoch (g_get_real_time). Returns -1 on a NULL argument.
+ */
+gint64 wyl_handle_get_created_at_us (const WylHandle * self);
+
 /* Decide */
 wyrelog_error_t wyl_decide (WylHandle * handle,
     const wyl_decide_req_t * req, wyl_decide_resp_t * resp);


### PR DESCRIPTION
## Summary

- Gives `WylHandle` (previously a 40-line stub) construct-time identity: freshly minted `wyl_id_t` + microsecond-resolution wall-clock `created_at_us`.
- Adds two public accessors:
  - `wyl_handle_dup_id_string` — canonical 36-char `gchar *` (pairs with `g_autofree`)
  - `wyl_handle_get_created_at_us` — `gint64` µs since epoch, `-1` sentinel on NULL
- Mirrors the WylAuditEvent stamping pattern landed in PR #38.
- `wyl_id_t` stays private; public surface is string-based.
- Construct-time id minting is fail-fast (`g_error` on entropy failure); documented on the prototype.

## Test plan

- [x] `meson test -C builddir --suite wyrelog` — 16/16 PASS (was 15/15; new `handle-id` test).
- [x] 5 numbered checks: wyl_init populates handle id, id stability, distinct-handle id distinctness, created_at bracketing, NULL-safe accessors.
- [x] `./tools/gst-indent` applied.
- [ ] CI green across Linux / macOS / Windows.