### PR TITLE
access: stamp WylSession with id and created_at

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -145,3 +145,10 @@ test_handle_id = executable('test-handle-id',
 )
 
 test('handle-id', test_handle_id)
+
+test_session_id = executable('test-session-id',
+  'test-session-id.c',
+  dependencies : [wyrelog_dep],
+)
+
+test('session-id', test_session_id)

--- a/tests/test-session-id.c
+++ b/tests/test-session-id.c
@@ -1,0 +1,107 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <glib.h>
+#include <string.h>
+
+#include "wyrelog/wyrelog.h"
+
+static WylSession *
+login_one (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return NULL;
+  WylSession *session = NULL;
+  if (wyl_session_login (handle, NULL, &session) != WYRELOG_E_OK)
+    return NULL;
+  return session;
+}
+
+static gint
+check_login_yields_id (void)
+{
+  g_autoptr (WylSession) session = login_one ();
+  if (session == NULL)
+    return 10;
+  g_autofree gchar *id = wyl_session_dup_id_string (session);
+  if (id == NULL)
+    return 11;
+  if (strlen (id) != 36)
+    return 12;
+  if (id[14] != '7')
+    return 13;
+  return 0;
+}
+
+static gint
+check_id_is_stable (void)
+{
+  g_autoptr (WylSession) session = login_one ();
+  if (session == NULL)
+    return 20;
+  g_autofree gchar *first = wyl_session_dup_id_string (session);
+  g_autofree gchar *second = wyl_session_dup_id_string (session);
+  if (first == NULL || second == NULL)
+    return 21;
+  if (strcmp (first, second) != 0)
+    return 22;
+  return 0;
+}
+
+static gint
+check_distinct_sessions_have_distinct_ids (void)
+{
+  g_autoptr (WylSession) a = login_one ();
+  g_autoptr (WylSession) b = login_one ();
+  if (a == NULL || b == NULL)
+    return 30;
+  g_autofree gchar *ida = wyl_session_dup_id_string (a);
+  g_autofree gchar *idb = wyl_session_dup_id_string (b);
+  if (ida == NULL || idb == NULL)
+    return 31;
+  if (strcmp (ida, idb) == 0)
+    return 32;
+  return 0;
+}
+
+static gint
+check_created_at_is_recent (void)
+{
+  gint64 before = g_get_real_time ();
+  g_autoptr (WylSession) session = login_one ();
+  gint64 after = g_get_real_time ();
+  if (session == NULL)
+    return 40;
+  gint64 created = wyl_session_get_created_at_us (session);
+  if (created < before || created > after)
+    return 41;
+  return 0;
+}
+
+static gint
+check_accessor_null_safety (void)
+{
+  if (wyl_session_get_created_at_us (NULL) != -1)
+    return 50;
+  if (wyl_session_dup_id_string (NULL) != NULL)
+    return 51;
+  return 0;
+}
+
+int
+main (void)
+{
+  gint rc;
+
+  if ((rc = check_login_yields_id ()) != 0)
+    return rc;
+  if ((rc = check_id_is_stable ()) != 0)
+    return rc;
+  if ((rc = check_distinct_sessions_have_distinct_ids ()) != 0)
+    return rc;
+  if ((rc = check_created_at_is_recent ()) != 0)
+    return rc;
+  if ((rc = check_accessor_null_safety ()) != 0)
+    return rc;
+
+  return 0;
+}

--- a/wyrelog/wyl-session.c
+++ b/wyrelog/wyl-session.c
@@ -1,9 +1,13 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #include "wyrelog/wyrelog.h"
 
+#include "wyl-id-private.h"
+
 struct _WylSession
 {
   GObject parent_instance;
+  wyl_id_t id;
+  gint64 created_at_us;
 };
 
 G_DEFINE_FINAL_TYPE (WylSession, wyl_session, G_TYPE_OBJECT);
@@ -17,7 +21,17 @@ wyl_session_class_init (WylSessionClass *klass)
 static void
 wyl_session_init (WylSession *self)
 {
-  (void) self;
+  /* Stamp the session with a fresh id and timestamp at login time so
+   * audit events emitted on its behalf can be correlated back to the
+   * specific session that produced them. The stamps are independent
+   * of wyl_session_id_t (the integer handle exposed for logout
+   * dispatch) -- this id is the long-lived persistence-side
+   * identifier. Failure to mint an id is fatal for the same reason
+   * it is on WylAuditEvent and WylHandle: a zero-id session would
+   * collapse correlation downstream. */
+  if (wyl_id_new (&self->id) != WYRELOG_E_OK)
+    g_error ("wyl_session_init: failed to mint identifier");
+  self->created_at_us = g_get_real_time ();
 }
 
 wyrelog_error_t
@@ -40,4 +54,23 @@ wyl_session_logout (WylHandle *handle, wyl_session_id_t sid)
   (void) handle;
   (void) sid;
   return WYRELOG_E_INTERNAL;
+}
+
+gchar *
+wyl_session_dup_id_string (const WylSession *self)
+{
+  gchar buf[WYL_ID_STRING_BUF];
+
+  g_return_val_if_fail (WYL_IS_SESSION (self), NULL);
+
+  if (wyl_id_format (&self->id, buf, sizeof buf) != WYRELOG_E_OK)
+    return NULL;
+  return g_strdup (buf);
+}
+
+gint64
+wyl_session_get_created_at_us (const WylSession *self)
+{
+  g_return_val_if_fail (WYL_IS_SESSION (self), -1);
+  return self->created_at_us;
 }

--- a/wyrelog/wyrelog.h
+++ b/wyrelog/wyrelog.h
@@ -108,6 +108,22 @@ wyrelog_error_t wyl_session_login (WylHandle * handle,
     const wyl_login_req_t * req, WylSession ** out_session);
 wyrelog_error_t wyl_session_logout (WylHandle * handle, wyl_session_id_t sid);
 
+/*
+ * Returns the session's construct-time identifier as a 36-character
+ * canonical string (caller frees with g_free or g_autofree). May
+ * return NULL only if the session is NULL or not a WylSession. The
+ * id is independent of wyl_session_id_t (the integer handle used
+ * for logout dispatch) -- this is the long-lived persistence-side
+ * identifier carried into audit events.
+ */
+gchar *wyl_session_dup_id_string (const WylSession * self);
+
+/*
+ * Returns the construct-time wall-clock stamp in microseconds since
+ * the Unix epoch (g_get_real_time). Returns -1 on a NULL argument.
+ */
+gint64 wyl_session_get_created_at_us (const WylSession * self);
+
 /* Permissions (admin) */
 wyrelog_error_t wyl_perm_grant (WylHandle * handle,
     const wyl_grant_req_t * req);


### PR DESCRIPTION
## Summary

- Gives `WylSession` (previously a stub) construct-time identity: freshly minted `wyl_id_t` + microsecond-resolution wall-clock `created_at_us`.
- Adds two public accessors:
  - `wyl_session_dup_id_string` — canonical 36-char `gchar *` (pairs with `g_autofree`)
  - `wyl_session_get_created_at_us` — `gint64` µs since epoch, `-1` sentinel on NULL
- Mirrors the WylHandle stamping pattern (PR #39) and the WylAuditEvent pattern (PR #38).
- Independent of `wyl_session_id_t` (the `guint64` handle for logout dispatch); the `wyl_id_t` is the persistence-side identifier carried into downstream audit events.

## Test plan

- [x] `meson test -C builddir --suite wyrelog` — 17/17 PASS (was 16/16; new `session-id` test).
- [x] 5 numbered checks: wyl_session_login populates id, id stability, distinct-session id distinctness, created_at bracketing, NULL-safe accessors.
- [x] `./tools/gst-indent` applied.
- [ ] CI green across Linux / macOS / Windows.