### PR TITLE
refactor: split wyrelog.h into per-prefix umbrella + domain headers

### DIFF
--- a/wyrelog/audit.h
+++ b/wyrelog/audit.h
@@ -1,0 +1,44 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+
+#include <glib.h>
+#include <glib-object.h>
+
+#include "wyrelog/error.h"
+#include "wyrelog/handle.h"
+
+G_BEGIN_DECLS;
+
+/*
+ * WylAuditEvent - immutable audit record passed to wyl_audit_emit.
+ *
+ * GObject-based so callers can keep refs while the daemon serializes
+ * the event to the audit chain.
+ */
+G_DECLARE_FINAL_TYPE (WylAuditEvent, wyl_audit_event,
+    WYL, AUDIT_EVENT, GObject);
+#define WYL_TYPE_AUDIT_EVENT (wyl_audit_event_get_type ())
+
+/*
+ * Construct a fresh audit event stamped with a freshly minted
+ * identifier and a wall-clock created_at. May abort the process via
+ * g_error if the entropy source declines: a zero-identifier event
+ * would collapse uniqueness for downstream serialisers, so fail-fast
+ * is preferred over silently shipping a partially-initialised object.
+ */
+WylAuditEvent *wyl_audit_event_new (void);
+
+gchar *wyl_audit_event_dup_id_string (const WylAuditEvent * self);
+
+/*
+ * Returns the construct-time wall-clock stamp in microseconds since
+ * the Unix epoch (g_get_real_time). Returns -1 on a NULL argument so
+ * callers can distinguish "no event" from a legitimate epoch-zero
+ * stamp.
+ */
+gint64 wyl_audit_event_get_created_at_us (const WylAuditEvent * self);
+
+wyrelog_error_t wyl_audit_emit (WylHandle * handle,
+    const WylAuditEvent * event);
+
+G_END_DECLS;

--- a/wyrelog/decide.h
+++ b/wyrelog/decide.h
@@ -1,0 +1,32 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+
+#include <glib.h>
+
+#include "wyrelog/error.h"
+#include "wyrelog/handle.h"
+
+G_BEGIN_DECLS;
+
+/*
+ * Opaque request/response carriers for decide.
+ *
+ * Constructed with the matching _new function, populated through
+ * setters (added in follow-up commits) and freed with the matching
+ * _free function or via g_autoptr.
+ */
+typedef struct _wyl_decide_req wyl_decide_req_t;
+typedef struct _wyl_decide_resp wyl_decide_resp_t;
+
+wyl_decide_req_t *wyl_decide_req_new (void);
+void wyl_decide_req_free (wyl_decide_req_t * req);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (wyl_decide_req_t, wyl_decide_req_free);
+
+wyl_decide_resp_t *wyl_decide_resp_new (void);
+void wyl_decide_resp_free (wyl_decide_resp_t * resp);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (wyl_decide_resp_t, wyl_decide_resp_free);
+
+wyrelog_error_t wyl_decide (WylHandle * handle,
+    const wyl_decide_req_t * req, wyl_decide_resp_t * resp);
+
+G_END_DECLS;

--- a/wyrelog/handle.h
+++ b/wyrelog/handle.h
@@ -1,0 +1,42 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+
+#include <glib.h>
+#include <glib-object.h>
+
+#include "wyrelog/error.h"
+
+G_BEGIN_DECLS;
+
+/*
+ * WylHandle - server-side embedding handle.
+ *
+ * Owns the policy database, audit log, and worker threads of an
+ * embedded wyrelog instance. Created with wyl_init, shut down with
+ * wyl_shutdown, released with g_object_unref (or g_autoptr(WylHandle)
+ * in scoped form).
+ */
+G_DECLARE_FINAL_TYPE (WylHandle, wyl_handle, WYL, HANDLE, GObject);
+#define WYL_TYPE_HANDLE (wyl_handle_get_type ())
+
+/* Lifecycle */
+wyrelog_error_t wyl_init (const gchar * config_path, WylHandle ** out_handle);
+void wyl_shutdown (WylHandle * handle);
+
+/*
+ * Returns the handle's construct-time identifier as a 36-character
+ * canonical string (caller frees with g_free or g_autofree). May
+ * return NULL only if the handle is NULL or not a WylHandle. The id
+ * is stable for the lifetime of the handle so log lines, audit
+ * events, and metrics emitted by the daemon can be correlated back
+ * to a specific embedding instance.
+ */
+gchar *wyl_handle_dup_id_string (const WylHandle * self);
+
+/*
+ * Returns the construct-time wall-clock stamp in microseconds since
+ * the Unix epoch (g_get_real_time). Returns -1 on a NULL argument.
+ */
+gint64 wyl_handle_get_created_at_us (const WylHandle * self);
+
+G_END_DECLS;

--- a/wyrelog/meson.build
+++ b/wyrelog/meson.build
@@ -1,7 +1,13 @@
 wyrelog_inc = include_directories('..')
 
 wyrelog_public_headers = files(
+  'audit.h',
+  'decide.h',
   'error.h',
+  'handle.h',
+  'perm.h',
+  'session.h',
+  'version.h',
   'wyrelog.h',
 )
 

--- a/wyrelog/perm.h
+++ b/wyrelog/perm.h
@@ -1,0 +1,34 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+
+#include <glib.h>
+
+#include "wyrelog/error.h"
+#include "wyrelog/handle.h"
+
+G_BEGIN_DECLS;
+
+/*
+ * Opaque admin request carriers for grant / revoke.
+ *
+ * Constructed with the matching _new function, populated through
+ * setters (added in follow-up commits) and freed with the matching
+ * _free function or via g_autoptr.
+ */
+typedef struct _wyl_grant_req wyl_grant_req_t;
+typedef struct _wyl_revoke_req wyl_revoke_req_t;
+
+wyl_grant_req_t *wyl_grant_req_new (void);
+void wyl_grant_req_free (wyl_grant_req_t * req);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (wyl_grant_req_t, wyl_grant_req_free);
+
+wyl_revoke_req_t *wyl_revoke_req_new (void);
+void wyl_revoke_req_free (wyl_revoke_req_t * req);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (wyl_revoke_req_t, wyl_revoke_req_free);
+
+wyrelog_error_t wyl_perm_grant (WylHandle * handle,
+    const wyl_grant_req_t * req);
+wyrelog_error_t wyl_perm_revoke (WylHandle * handle,
+    const wyl_revoke_req_t * req);
+
+G_END_DECLS;

--- a/wyrelog/session.h
+++ b/wyrelog/session.h
@@ -1,0 +1,59 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+
+#include <glib.h>
+#include <glib-object.h>
+
+#include "wyrelog/error.h"
+#include "wyrelog/handle.h"
+
+G_BEGIN_DECLS;
+
+/*
+ * WylSession - active authenticated session.
+ *
+ * Carries the principal identity, MFA state, and tenant binding for a
+ * sequence of decide calls. Acquired through wyl_session_login,
+ * released with g_object_unref / g_autoptr.
+ */
+G_DECLARE_FINAL_TYPE (WylSession, wyl_session, WYL, SESSION, GObject);
+#define WYL_TYPE_SESSION (wyl_session_get_type ())
+
+/*
+ * Plain integer session identifier. Stable across the lifetime of a
+ * WylHandle; not a GObject.
+ */
+typedef guint64 wyl_session_id_t;
+
+/*
+ * Opaque login-request carrier. Constructed with wyl_login_req_new,
+ * populated through setters (added in follow-up commits) and freed
+ * with wyl_login_req_free or via g_autoptr.
+ */
+typedef struct _wyl_login_req wyl_login_req_t;
+
+wyl_login_req_t *wyl_login_req_new (void);
+void wyl_login_req_free (wyl_login_req_t * req);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (wyl_login_req_t, wyl_login_req_free);
+
+wyrelog_error_t wyl_session_login (WylHandle * handle,
+    const wyl_login_req_t * req, WylSession ** out_session);
+wyrelog_error_t wyl_session_logout (WylHandle * handle, wyl_session_id_t sid);
+
+/*
+ * Returns the session's construct-time identifier as a 36-character
+ * canonical string (caller frees with g_free or g_autofree). May
+ * return NULL only if the session is NULL or not a WylSession. The
+ * id is independent of wyl_session_id_t (the integer handle used
+ * for logout dispatch) -- this is the long-lived persistence-side
+ * identifier carried into audit events.
+ */
+gchar *wyl_session_dup_id_string (const WylSession * self);
+
+/*
+ * Returns the construct-time wall-clock stamp in microseconds since
+ * the Unix epoch (g_get_real_time). Returns -1 on a NULL argument.
+ */
+gint64 wyl_session_get_created_at_us (const WylSession * self);
+
+G_END_DECLS;

--- a/wyrelog/version.h
+++ b/wyrelog/version.h
@@ -1,0 +1,10 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+
+#include <glib.h>
+
+G_BEGIN_DECLS;
+
+const gchar *wyrelog_version_string (void);
+
+G_END_DECLS;

--- a/wyrelog/wyrelog.h
+++ b/wyrelog/wyrelog.h
@@ -1,160 +1,19 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #pragma once
 
-#include <glib.h>
-#include <glib-object.h>
+/*
+ * Umbrella header for the wyrelog public API. Includes every per-
+ * domain header so callers that include <wyrelog/wyrelog.h> see the
+ * full surface in one shot. Direct inclusion of the per-domain
+ * headers (handle.h, session.h, audit.h, decide.h, perm.h,
+ * version.h) is supported and reduces compile coupling for callers
+ * that only touch one slice.
+ */
 
 #include "wyrelog/error.h"
-
-G_BEGIN_DECLS;
-
-/*
- * WylHandle - server-side embedding handle.
- *
- * Owns the policy database, audit log, and worker threads of an
- * embedded wyrelog instance. Created with wyl_init, shut down with
- * wyl_shutdown, released with g_object_unref (or g_autoptr(WylHandle)
- * in scoped form).
- */
-G_DECLARE_FINAL_TYPE (WylHandle, wyl_handle, WYL, HANDLE, GObject);
-#define WYL_TYPE_HANDLE (wyl_handle_get_type ())
-
-/*
- * WylSession - active authenticated session.
- *
- * Carries the principal identity, MFA state, and tenant binding for a
- * sequence of decide calls. Acquired through wyl_session_login,
- * released with g_object_unref / g_autoptr.
- */
-G_DECLARE_FINAL_TYPE (WylSession, wyl_session, WYL, SESSION, GObject);
-#define WYL_TYPE_SESSION (wyl_session_get_type ())
-
-/*
- * WylAuditEvent - immutable audit record passed to wyl_audit_emit.
- *
- * GObject-based so callers can keep refs while the daemon serializes
- * the event to the audit chain.
- */
-G_DECLARE_FINAL_TYPE (WylAuditEvent, wyl_audit_event,
-    WYL, AUDIT_EVENT, GObject);
-#define WYL_TYPE_AUDIT_EVENT (wyl_audit_event_get_type ())
-
-/*
- * Plain integer session identifier. Stable across the lifetime of a
- * WylHandle; not a GObject.
- */
-typedef guint64 wyl_session_id_t;
-
-/*
- * Opaque request/response carriers for decide / login / perm.
- *
- * Constructed with the matching _new function, populated through
- * setters (added in follow-up commits) and freed with the matching
- * _free function or via g_autoptr (GLib autoptr cleanup is wired
- * below).
- */
-typedef struct _wyl_decide_req wyl_decide_req_t;
-typedef struct _wyl_decide_resp wyl_decide_resp_t;
-typedef struct _wyl_login_req wyl_login_req_t;
-typedef struct _wyl_grant_req wyl_grant_req_t;
-typedef struct _wyl_revoke_req wyl_revoke_req_t;
-
-wyl_decide_req_t *wyl_decide_req_new (void);
-void wyl_decide_req_free (wyl_decide_req_t * req);
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (wyl_decide_req_t, wyl_decide_req_free);
-
-wyl_decide_resp_t *wyl_decide_resp_new (void);
-void wyl_decide_resp_free (wyl_decide_resp_t * resp);
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (wyl_decide_resp_t, wyl_decide_resp_free);
-
-wyl_login_req_t *wyl_login_req_new (void);
-void wyl_login_req_free (wyl_login_req_t * req);
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (wyl_login_req_t, wyl_login_req_free);
-
-wyl_grant_req_t *wyl_grant_req_new (void);
-void wyl_grant_req_free (wyl_grant_req_t * req);
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (wyl_grant_req_t, wyl_grant_req_free);
-
-wyl_revoke_req_t *wyl_revoke_req_new (void);
-void wyl_revoke_req_free (wyl_revoke_req_t * req);
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (wyl_revoke_req_t, wyl_revoke_req_free);
-
-/* Lifecycle */
-wyrelog_error_t wyl_init (const gchar * config_path, WylHandle ** out_handle);
-void wyl_shutdown (WylHandle * handle);
-
-/*
- * Returns the handle's construct-time identifier as a 36-character
- * canonical string (caller frees with g_free or g_autofree). May
- * return NULL only if the handle is NULL or not a WylHandle. The id
- * is stable for the lifetime of the handle so log lines, audit
- * events, and metrics emitted by the daemon can be correlated back
- * to a specific embedding instance.
- */
-gchar *wyl_handle_dup_id_string (const WylHandle * self);
-
-/*
- * Returns the construct-time wall-clock stamp in microseconds since
- * the Unix epoch (g_get_real_time). Returns -1 on a NULL argument.
- */
-gint64 wyl_handle_get_created_at_us (const WylHandle * self);
-
-/* Decide */
-wyrelog_error_t wyl_decide (WylHandle * handle,
-    const wyl_decide_req_t * req, wyl_decide_resp_t * resp);
-
-/* Sessions */
-wyrelog_error_t wyl_session_login (WylHandle * handle,
-    const wyl_login_req_t * req, WylSession ** out_session);
-wyrelog_error_t wyl_session_logout (WylHandle * handle, wyl_session_id_t sid);
-
-/*
- * Returns the session's construct-time identifier as a 36-character
- * canonical string (caller frees with g_free or g_autofree). May
- * return NULL only if the session is NULL or not a WylSession. The
- * id is independent of wyl_session_id_t (the integer handle used
- * for logout dispatch) -- this is the long-lived persistence-side
- * identifier carried into audit events.
- */
-gchar *wyl_session_dup_id_string (const WylSession * self);
-
-/*
- * Returns the construct-time wall-clock stamp in microseconds since
- * the Unix epoch (g_get_real_time). Returns -1 on a NULL argument.
- */
-gint64 wyl_session_get_created_at_us (const WylSession * self);
-
-/* Permissions (admin) */
-wyrelog_error_t wyl_perm_grant (WylHandle * handle,
-    const wyl_grant_req_t * req);
-wyrelog_error_t wyl_perm_revoke (WylHandle * handle,
-    const wyl_revoke_req_t * req);
-
-/* Audit */
-
-/*
- * Construct a fresh audit event stamped with a freshly minted
- * identifier and a wall-clock created_at. May abort the process via
- * g_error if the entropy source declines: a zero-identifier event
- * would collapse uniqueness for downstream serialisers, so fail-fast
- * is preferred over silently shipping a partially-initialised object.
- */
-WylAuditEvent *wyl_audit_event_new (void);
-
-gchar *wyl_audit_event_dup_id_string (const WylAuditEvent * self);
-
-/*
- * Returns the construct-time wall-clock stamp in microseconds since
- * the Unix epoch (g_get_real_time). Returns -1 on a NULL argument so
- * callers can distinguish "no event" from a legitimate epoch-zero
- * stamp.
- */
-gint64 wyl_audit_event_get_created_at_us (const WylAuditEvent * self);
-
-wyrelog_error_t wyl_audit_emit (WylHandle * handle,
-    const WylAuditEvent * event);
-
-/* Meta */
-const gchar *wyrelog_version_string (void);
-
-G_END_DECLS;
+#include "wyrelog/handle.h"
+#include "wyrelog/session.h"
+#include "wyrelog/audit.h"
+#include "wyrelog/decide.h"
+#include "wyrelog/perm.h"
+#include "wyrelog/version.h"


### PR DESCRIPTION
## Summary

- `wyrelog.h` was approaching 160 lines and continued to grow. Split into per-prefix domain headers and convert `wyrelog.h` into a pure umbrella.
- New per-domain headers: `handle.h`, `session.h`, `audit.h`, `decide.h`, `perm.h`, `version.h`.
- Mapping rule: a symbol whose name starts with the domain prefix lives in that domain's header.
- Cross-domain dependencies resolved by direct `#include` (every dependent domain `#include`s `handle.h` for `WylHandle *` parameters).
- `wyrelog.h` becomes 19 lines (SPDX + comment + 7 includes).

## Behavioural impact

Zero. The umbrella continues to expose the entire public API for callers that prefer the one-shot include, while callers that only touch one slice can include the per-domain header directly. Existing source files and tests all continue to include `wyrelog.h` and are unaffected.

## Test plan

- [x] `meson test -C builddir --suite wyrelog` — 17/17 PASS post-refactor (same as pre-refactor).
- [x] `./tools/gst-indent` applied to all new headers.
- [x] `meson.build` `install_headers` updated alphabetically; every new header shipped alongside the umbrella.
- [ ] CI green across Linux / macOS / Windows.