### PR TITLE
ci(windows): pin vendored vcpkg to release 2026.04.27

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
         shell: cmd
         run: |
           @echo off
-          git clone --depth 1 https://github.com/microsoft/vcpkg.git "%VCPKG_ROOT%"
+          git clone --depth 1 --branch 2026.04.27 https://github.com/microsoft/vcpkg.git "%VCPKG_ROOT%"
           call "%VCPKG_ROOT%\bootstrap-vcpkg.bat" -disableMetrics
 
       - name: Register NuGet source


### PR DESCRIPTION
## Summary

- Pins the in-workflow `git clone --depth 1` of `microsoft/vcpkg` to the `2026.04.27` release tag (commit `dc8d75cf`).
- Closes the supply-chain-drift hole previously flagged as the W4 follow-up on the NuGet binary-cache work.

## Why now

- vcpkg HEAD changes ≈ monthly. Every HEAD drift shifts the binary-cache ABI hash, busting the NuGet feed cache that the Windows lane depends on.
- `--x-abi-tools-use-exact-versions` only stabilises the toolchain portion of the ABI hash, not the vcpkg-helper-functions portion.
- Without a pin, NuGet hit rate is stochastic per runner image refresh + vcpkg HEAD drift.

## Test plan

- [ ] CI green across Linux / macOS / Windows.
- [ ] Subsequent Windows runs hit the NuGet feed (look for `Restored N package(s) from NuGet` in the install step) instead of building from source.

## Follow-up

- Pin advancement workflow: bump the tag manually when adopting a newer vcpkg release; consider Dependabot or a scheduled workflow if this becomes burdensome.