### PR TITLE
access: add username field to wyl_login_req

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -152,3 +152,10 @@ test_session_id = executable('test-session-id',
 )
 
 test('session-id', test_session_id)
+
+test_login_req = executable('test-login-req',
+  'test-login-req.c',
+  dependencies : [wyrelog_dep],
+)
+
+test('login-req', test_login_req)

--- a/tests/test-login-req.c
+++ b/tests/test-login-req.c
@@ -1,0 +1,108 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <glib.h>
+#include <string.h>
+
+#include "wyrelog/wyrelog.h"
+
+static gint
+check_default_username_is_null (void)
+{
+  g_autoptr (wyl_login_req_t) req = wyl_login_req_new ();
+  if (req == NULL)
+    return 10;
+  if (wyl_login_req_get_username (req) != NULL)
+    return 11;
+  return 0;
+}
+
+static gint
+check_set_then_get (void)
+{
+  g_autoptr (wyl_login_req_t) req = wyl_login_req_new ();
+  wyl_login_req_set_username (req, "alice");
+  const gchar *got = wyl_login_req_get_username (req);
+  if (got == NULL)
+    return 20;
+  if (strcmp (got, "alice") != 0)
+    return 21;
+  return 0;
+}
+
+static gint
+check_caller_buffer_is_copied (void)
+{
+  g_autoptr (wyl_login_req_t) req = wyl_login_req_new ();
+  gchar buf[16] = "bob";
+  wyl_login_req_set_username (req, buf);
+  /* Mutate the caller's buffer; the request should be unaffected. */
+  buf[0] = 'X';
+  const gchar *got = wyl_login_req_get_username (req);
+  if (got == NULL)
+    return 30;
+  if (strcmp (got, "bob") != 0)
+    return 31;
+  return 0;
+}
+
+static gint
+check_set_replaces_prior_value (void)
+{
+  g_autoptr (wyl_login_req_t) req = wyl_login_req_new ();
+  wyl_login_req_set_username (req, "first");
+  wyl_login_req_set_username (req, "second");
+  const gchar *got = wyl_login_req_get_username (req);
+  if (got == NULL)
+    return 40;
+  if (strcmp (got, "second") != 0)
+    return 41;
+  return 0;
+}
+
+static gint
+check_set_null_clears (void)
+{
+  g_autoptr (wyl_login_req_t) req = wyl_login_req_new ();
+  wyl_login_req_set_username (req, "carol");
+  wyl_login_req_set_username (req, NULL);
+  if (wyl_login_req_get_username (req) != NULL)
+    return 50;
+  return 0;
+}
+
+static gint
+check_get_null_request (void)
+{
+  if (wyl_login_req_get_username (NULL) != NULL)
+    return 60;
+  return 0;
+}
+
+static gint
+check_free_null_is_safe (void)
+{
+  wyl_login_req_free (NULL);
+  return 0;
+}
+
+int
+main (void)
+{
+  gint rc;
+
+  if ((rc = check_default_username_is_null ()) != 0)
+    return rc;
+  if ((rc = check_set_then_get ()) != 0)
+    return rc;
+  if ((rc = check_caller_buffer_is_copied ()) != 0)
+    return rc;
+  if ((rc = check_set_replaces_prior_value ()) != 0)
+    return rc;
+  if ((rc = check_set_null_clears ()) != 0)
+    return rc;
+  if ((rc = check_get_null_request ()) != 0)
+    return rc;
+  if ((rc = check_free_null_is_safe ()) != 0)
+    return rc;
+
+  return 0;
+}

--- a/wyrelog/session.h
+++ b/wyrelog/session.h
@@ -36,6 +36,21 @@ wyl_login_req_t *wyl_login_req_new (void);
 void wyl_login_req_free (wyl_login_req_t * req);
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (wyl_login_req_t, wyl_login_req_free);
 
+/*
+ * Set the principal username carried by the login request. Replaces
+ * any previously set value (the prior string is freed). |username|
+ * may be NULL to clear the field; the caller's string is duplicated
+ * into the request so it may be freed immediately after the call.
+ */
+void wyl_login_req_set_username (wyl_login_req_t * req, const gchar * username);
+
+/*
+ * Returns the borrowed username carried by |req|, or NULL when
+ * unset. The pointer is owned by the request and remains valid
+ * until the next set call or until the request is freed.
+ */
+const gchar *wyl_login_req_get_username (const wyl_login_req_t * req);
+
 wyrelog_error_t wyl_session_login (WylHandle * handle,
     const wyl_login_req_t * req, WylSession ** out_session);
 wyrelog_error_t wyl_session_logout (WylHandle * handle, wyl_session_id_t sid);

--- a/wyrelog/wyl-perm.c
+++ b/wyrelog/wyl-perm.c
@@ -3,7 +3,7 @@
 
 struct _wyl_login_req
 {
-  gint placeholder;
+  gchar *username;
 };
 
 struct _wyl_grant_req
@@ -25,7 +25,25 @@ wyl_login_req_new (void)
 void
 wyl_login_req_free (wyl_login_req_t *req)
 {
+  if (req == NULL)
+    return;
+  g_free (req->username);
   g_free (req);
+}
+
+void
+wyl_login_req_set_username (wyl_login_req_t *req, const gchar *username)
+{
+  g_return_if_fail (req != NULL);
+  g_free (req->username);
+  req->username = g_strdup (username);
+}
+
+const gchar *
+wyl_login_req_get_username (const wyl_login_req_t *req)
+{
+  g_return_val_if_fail (req != NULL, NULL);
+  return req->username;
 }
 
 wyl_grant_req_t *


### PR DESCRIPTION
## Summary

- Replaces the `gint placeholder` field on `wyl_login_req_t` with a heap-owned `gchar *username`.
- Adds two public entry points on `session.h`:
  - `wyl_login_req_set_username` — duplicates caller's string; NULL clears
  - `wyl_login_req_get_username` — borrowed pointer
- `wyl_login_req_free` now frees the embedded string and is NULL-safe.
- The `wyl_session_login` implementation continues to ignore the populated username; consumption by the principal authentication FSM is a follow-up.

## Test plan

- [x] `meson test -C builddir --suite wyrelog` — 18/18 PASS (was 17/17; new `login-req` test).
- [x] 7 numbered checks: default NULL, set/get round-trip, caller-buffer copy semantics, replace-on-reset, NULL-clear, NULL-request on get, NULL-safe free.
- [x] `./tools/gst-indent` applied.
- [ ] CI green across Linux / macOS / Windows.