### PR TITLE
access: carry login_req username into WylSession

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -159,3 +159,10 @@ test_login_req = executable('test-login-req',
 )
 
 test('login-req', test_login_req)
+
+test_session_username = executable('test-session-username',
+  'test-session-username.c',
+  dependencies : [wyrelog_dep],
+)
+
+test('session-username', test_session_username)

--- a/tests/test-session-username.c
+++ b/tests/test-session-username.c
@@ -1,0 +1,137 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <glib.h>
+#include <string.h>
+
+#include "wyrelog/wyrelog.h"
+
+static WylSession *
+login_with_username (const gchar *username)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return NULL;
+
+  g_autoptr (wyl_login_req_t) req = wyl_login_req_new ();
+  wyl_login_req_set_username (req, username);
+
+  WylSession *session = NULL;
+  if (wyl_session_login (handle, req, &session) != WYRELOG_E_OK)
+    return NULL;
+  return session;
+}
+
+static gint
+check_login_propagates_username (void)
+{
+  g_autoptr (WylSession) session = login_with_username ("alice");
+  if (session == NULL)
+    return 10;
+  g_autofree gchar *got = wyl_session_dup_username (session);
+  if (got == NULL)
+    return 11;
+  if (strcmp (got, "alice") != 0)
+    return 12;
+  return 0;
+}
+
+static gint
+check_login_with_null_request (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 20;
+  g_autoptr (WylSession) session = NULL;
+  if (wyl_session_login (handle, NULL, &session) != WYRELOG_E_OK)
+    return 21;
+  if (session == NULL)
+    return 22;
+  /* No request -> no username carried into the session. */
+  if (wyl_session_dup_username (session) != NULL)
+    return 23;
+  return 0;
+}
+
+static gint
+check_login_with_unset_username (void)
+{
+  g_autoptr (WylSession) session = login_with_username (NULL);
+  if (session == NULL)
+    return 30;
+  if (wyl_session_dup_username (session) != NULL)
+    return 31;
+  return 0;
+}
+
+static gint
+check_request_buffer_independent_of_session (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 40;
+
+  wyl_login_req_t *req = wyl_login_req_new ();
+  wyl_login_req_set_username (req, "bob");
+
+  g_autoptr (WylSession) session = NULL;
+  if (wyl_session_login (handle, req, &session) != WYRELOG_E_OK) {
+    wyl_login_req_free (req);
+    return 41;
+  }
+
+  /* Free the request before reading the session. The session's copy
+   * of the username must survive. */
+  wyl_login_req_free (req);
+
+  g_autofree gchar *got = wyl_session_dup_username (session);
+  if (got == NULL)
+    return 42;
+  if (strcmp (got, "bob") != 0)
+    return 43;
+  return 0;
+}
+
+static gint
+check_dup_returns_distinct_buffers (void)
+{
+  g_autoptr (WylSession) session = login_with_username ("carol");
+  if (session == NULL)
+    return 50;
+  g_autofree gchar *first = wyl_session_dup_username (session);
+  g_autofree gchar *second = wyl_session_dup_username (session);
+  if (first == NULL || second == NULL)
+    return 51;
+  if (first == second)
+    return 52;
+  if (strcmp (first, second) != 0)
+    return 53;
+  return 0;
+}
+
+static gint
+check_dup_null_session (void)
+{
+  if (wyl_session_dup_username (NULL) != NULL)
+    return 60;
+  return 0;
+}
+
+int
+main (void)
+{
+  gint rc;
+
+  if ((rc = check_login_propagates_username ()) != 0)
+    return rc;
+  if ((rc = check_login_with_null_request ()) != 0)
+    return rc;
+  if ((rc = check_login_with_unset_username ()) != 0)
+    return rc;
+  if ((rc = check_request_buffer_independent_of_session ()) != 0)
+    return rc;
+  if ((rc = check_dup_returns_distinct_buffers ()) != 0)
+    return rc;
+  if ((rc = check_dup_null_session ()) != 0)
+    return rc;
+
+  return 0;
+}

--- a/wyrelog/session.h
+++ b/wyrelog/session.h
@@ -71,4 +71,13 @@ gchar *wyl_session_dup_id_string (const WylSession * self);
  */
 gint64 wyl_session_get_created_at_us (const WylSession * self);
 
+/*
+ * Returns a heap-allocated copy of the principal username carried
+ * into the session by wyl_session_login (i.e. wyl_login_req's
+ * username field at login time). Returns NULL when the request
+ * supplied no username or when |self| is NULL or not a WylSession.
+ * Caller frees with g_free or g_autofree.
+ */
+gchar *wyl_session_dup_username (const WylSession * self);
+
 G_END_DECLS;

--- a/wyrelog/wyl-session.c
+++ b/wyrelog/wyl-session.c
@@ -8,14 +8,27 @@ struct _WylSession
   GObject parent_instance;
   wyl_id_t id;
   gint64 created_at_us;
+  gchar *username;
 };
 
 G_DEFINE_FINAL_TYPE (WylSession, wyl_session, G_TYPE_OBJECT);
 
 static void
+wyl_session_finalize (GObject *object)
+{
+  WylSession *self = WYL_SESSION (object);
+
+  g_free (self->username);
+
+  G_OBJECT_CLASS (wyl_session_parent_class)->finalize (object);
+}
+
+static void
 wyl_session_class_init (WylSessionClass *klass)
 {
-  (void) klass;
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->finalize = wyl_session_finalize;
 }
 
 static void
@@ -39,12 +52,15 @@ wyl_session_login (WylHandle *handle, const wyl_login_req_t *req,
     WylSession **out_session)
 {
   (void) handle;
-  (void) req;
 
   if (out_session == NULL)
     return WYRELOG_E_INVALID;
 
-  *out_session = g_object_new (WYL_TYPE_SESSION, NULL);
+  WylSession *session = g_object_new (WYL_TYPE_SESSION, NULL);
+  if (req != NULL)
+    session->username = g_strdup (wyl_login_req_get_username (req));
+
+  *out_session = session;
   return WYRELOG_E_OK;
 }
 
@@ -73,4 +89,13 @@ wyl_session_get_created_at_us (const WylSession *self)
 {
   g_return_val_if_fail (WYL_IS_SESSION (self), -1);
   return self->created_at_us;
+}
+
+gchar *
+wyl_session_dup_username (const WylSession *self)
+{
+  g_return_val_if_fail (WYL_IS_SESSION (self), NULL);
+  if (self->username == NULL)
+    return NULL;
+  return g_strdup (self->username);
 }


### PR DESCRIPTION
## Summary

- `wyl_session_login` previously ignored the populated `wyl_login_req_t`. Have it copy `req->username` into the session so callers can retrieve the authenticated principal identity from the session afterward.
- Adds one public accessor on `session.h`:
  - `wyl_session_dup_username` — heap-allocated copy, `NULL` when the request had no username.
- `WylSession` gains a `username` field freed in a new `_finalize` (chains to parent class after `g_free`).
- Login is independent of the request's lifetime: the request can be freed immediately after `wyl_session_login` returns; the session's copy survives until `g_object_unref`.

## Test plan

- [x] `meson test -C builddir --suite wyrelog` — 19/19 PASS (was 18/18; new `session-username` test).
- [x] 6 numbered checks: username propagation, NULL-request, unset-username, request-free-before-dup independence, distinct-buffer dup, NULL-session safety.
- [x] `./tools/gst-indent` applied.
- [ ] CI green across Linux / macOS / Windows.