### PR TITLE
access: add decision verdict to wyl_decide_resp

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -173,3 +173,10 @@ test_decide_req = executable('test-decide-req',
 )
 
 test('decide-req', test_decide_req)
+
+test_decide_resp = executable('test-decide-resp',
+  'test-decide-resp.c',
+  dependencies : [wyrelog_dep],
+)
+
+test('decide-resp', test_decide_resp)

--- a/tests/test-decide-resp.c
+++ b/tests/test-decide-resp.c
@@ -1,0 +1,75 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <glib.h>
+
+#include "wyrelog/wyrelog.h"
+
+static gint
+check_default_is_deny (void)
+{
+  g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
+  if (resp == NULL)
+    return 10;
+  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_DENY)
+    return 11;
+  return 0;
+}
+
+static gint
+check_set_allow (void)
+{
+  g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
+  wyl_decide_resp_set_decision (resp, WYL_DECISION_ALLOW);
+  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_ALLOW)
+    return 20;
+  return 0;
+}
+
+static gint
+check_set_deny (void)
+{
+  g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
+  wyl_decide_resp_set_decision (resp, WYL_DECISION_ALLOW);
+  wyl_decide_resp_set_decision (resp, WYL_DECISION_DENY);
+  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_DENY)
+    return 30;
+  return 0;
+}
+
+static gint
+check_get_null_is_deny (void)
+{
+  /* Fail-closed contract: NULL response means "no decision was
+   * produced", which downstream consumers must treat as a denial. */
+  if (wyl_decide_resp_get_decision (NULL) != WYL_DECISION_DENY)
+    return 40;
+  return 0;
+}
+
+static gint
+check_deny_is_zero (void)
+{
+  /* g_new0 zero-initialises the struct; that zero value must mean
+   * DENY so a forgotten populate path stays fail-closed. */
+  if (WYL_DECISION_DENY != 0)
+    return 50;
+  return 0;
+}
+
+int
+main (void)
+{
+  gint rc;
+
+  if ((rc = check_default_is_deny ()) != 0)
+    return rc;
+  if ((rc = check_set_allow ()) != 0)
+    return rc;
+  if ((rc = check_set_deny ()) != 0)
+    return rc;
+  if ((rc = check_get_null_is_deny ()) != 0)
+    return rc;
+  if ((rc = check_deny_is_zero ()) != 0)
+    return rc;
+
+  return 0;
+}

--- a/wyrelog/decide.h
+++ b/wyrelog/decide.h
@@ -9,6 +9,18 @@
 G_BEGIN_DECLS;
 
 /*
+ * Decision verdict carried by a decide response. The numeric value
+ * of WYL_DECISION_DENY is deliberately zero so that g_new0-style
+ * zero-initialised responses default to fail-closed: a caller that
+ * forgets to populate the response must not silently observe ALLOW.
+ */
+typedef enum wyl_decision_t
+{
+  WYL_DECISION_DENY = 0,
+  WYL_DECISION_ALLOW = 1,
+} wyl_decision_t;
+
+/*
  * Opaque request/response carriers for decide.
  *
  * Constructed with the matching _new function, populated through
@@ -43,6 +55,20 @@ const gchar *wyl_decide_req_get_resource_id (const wyl_decide_req_t * req);
 wyl_decide_resp_t *wyl_decide_resp_new (void);
 void wyl_decide_resp_free (wyl_decide_resp_t * resp);
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (wyl_decide_resp_t, wyl_decide_resp_free);
+
+/*
+ * Sets the decision carried by |resp|. Replaces any previously set
+ * verdict.
+ */
+void wyl_decide_resp_set_decision (wyl_decide_resp_t * resp,
+    wyl_decision_t decision);
+
+/*
+ * Returns the decision carried by |resp|. Returns WYL_DECISION_DENY
+ * on a NULL argument so callers that forget the error path see
+ * fail-closed semantics.
+ */
+wyl_decision_t wyl_decide_resp_get_decision (const wyl_decide_resp_t * resp);
 
 wyrelog_error_t wyl_decide (WylHandle * handle,
     const wyl_decide_req_t * req, wyl_decide_resp_t * resp);

--- a/wyrelog/wyl-decide.c
+++ b/wyrelog/wyl-decide.c
@@ -10,7 +10,7 @@ struct _wyl_decide_req
 
 struct _wyl_decide_resp
 {
-  gint placeholder;
+  wyl_decision_t decision;
 };
 
 wyl_decide_req_t *
@@ -85,6 +85,23 @@ void
 wyl_decide_resp_free (wyl_decide_resp_t *resp)
 {
   g_free (resp);
+}
+
+void
+wyl_decide_resp_set_decision (wyl_decide_resp_t *resp, wyl_decision_t decision)
+{
+  g_return_if_fail (resp != NULL);
+  resp->decision = decision;
+}
+
+wyl_decision_t
+wyl_decide_resp_get_decision (const wyl_decide_resp_t *resp)
+{
+  /* Fail-closed default for a NULL or unset response: a caller that
+   * forgets to inspect the error path or never populates the
+   * response must not silently observe an ALLOW. */
+  g_return_val_if_fail (resp != NULL, WYL_DECISION_DENY);
+  return resp->decision;
 }
 
 wyrelog_error_t


### PR DESCRIPTION
## Summary

- Replaces the placeholder integer in `wyl_decide_resp_t` with a `wyl_decision_t` enum field.
- New enum: `WYL_DECISION_DENY = 0`, `WYL_DECISION_ALLOW = 1`. DENY = 0 is load-bearing — `g_new0` zero-init defaults to fail-closed.
- Adds two public entry points on `decide.h`:
  - `wyl_decide_resp_set_decision`
  - `wyl_decide_resp_get_decision` — returns `WYL_DECISION_DENY` on `NULL` response so fail-closed holds across the API boundary.
- The `wyl_decide` implementation continues to ignore the populated response; the policy decision point that produces ALLOW/DENY is a follow-up.

## Test plan

- [x] `meson test -C builddir --suite wyrelog` — 21/21 PASS (was 20/20; new `decide-resp` test).
- [x] 5 numbered checks: zero-init default, ALLOW round-trip, DENY replace, NULL-response fail-closed, compile-time pin that `DENY = 0`.
- [x] `./tools/gst-indent` applied.
- [ ] CI green across Linux / macOS / Windows.