### PR TITLE
build: gate duckdb subproject behind enable_audit feature

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -16,7 +16,12 @@ libsoup_dep = dependency('libsoup-3.0',
 )
 sodium_dep = dependency('libsodium', required : true)
 tss2_esys_dep = dependency('tss2-esys', required : get_option('enable_tpm'))
-duckdb_dep = dependency('duckdb', fallback : ['duckdb', 'duckdb_dep'])
+enable_audit_opt = get_option('enable_audit')
+if enable_audit_opt.allowed()
+  duckdb_dep = dependency('duckdb', fallback : ['duckdb', 'duckdb_dep'])
+else
+  duckdb_dep = disabler()
+endif
 
 wirelog_proj = subproject(
   'wirelog',

--- a/subprojects/packagefiles/duckdb/meson.build
+++ b/subprojects/packagefiles/duckdb/meson.build
@@ -20,7 +20,6 @@ duckdb_lib = library('duckdb',
   'duckdb.cpp',
   dependencies : duckdb_deps,
   include_directories : include_directories('.'),
-  gnu_symbol_visibility : 'hidden',
   install : true,
 )
 


### PR DESCRIPTION
## Summary

- Wraps the project-level `duckdb_dep` declaration in `meson.build` with a feature-option check. When `enable_audit` is `disabled` (default), `duckdb_dep` becomes `disabler()` and the duckdb subproject is not fetched or built.
- Drops `gnu_symbol_visibility : 'hidden'` from the vendored duckdb subproject recipe. On POSIX the upstream header has no visibility attribute on its C ABI declarations, so the meson option was silently hiding every `duckdb_*` C symbol and preventing consumers from linking. The Windows path is unaffected (upstream header uses `__declspec(dllexport)` directly).
- Build-hygiene precondition for the audit-conn lifecycle wrapper that follows in a separate atomic.

## Verified locally

- `meson setup builddir` (default, audit=disabled) — succeeds; duckdb subproject NOT configured.
- `meson test -C builddir --suite wyrelog` — 21/21 PASS unchanged.
- `meson setup builddir-audit -Denable_audit=enabled` — duckdb subproject fetched and configured cleanly.

## Test plan

- [x] Default build configures faster than before (no duckdb compile).
- [x] All existing tests pass under default build.
- [x] `enable_audit=enabled` configures cleanly.
- [ ] CI green across Linux / macOS / Windows.