### PR TITLE
audit: introduce DuckDB connection lifecycle wrapper

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -16,7 +16,12 @@ libsoup_dep = dependency('libsoup-3.0',
 )
 sodium_dep = dependency('libsodium', required : true)
 tss2_esys_dep = dependency('tss2-esys', required : get_option('enable_tpm'))
-duckdb_dep = dependency('duckdb', fallback : ['duckdb', 'duckdb_dep'])
+enable_audit_opt = get_option('enable_audit')
+if enable_audit_opt.allowed()
+  duckdb_dep = dependency('duckdb', fallback : ['duckdb', 'duckdb_dep'])
+else
+  duckdb_dep = disabler()
+endif
 
 wirelog_proj = subproject(
   'wirelog',

--- a/subprojects/packagefiles/duckdb/meson.build
+++ b/subprojects/packagefiles/duckdb/meson.build
@@ -20,7 +20,6 @@ duckdb_lib = library('duckdb',
   'duckdb.cpp',
   dependencies : duckdb_deps,
   include_directories : include_directories('.'),
-  gnu_symbol_visibility : 'hidden',
   install : true,
 )
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -180,3 +180,12 @@ test_decide_resp = executable('test-decide-resp',
 )
 
 test('decide-resp', test_decide_resp)
+
+if get_option('enable_audit').allowed()
+  test_audit_conn = executable('test-audit-conn',
+    'test-audit-conn.c',
+    dependencies : [wyrelog_dep, duckdb_dep],
+  )
+
+  test('audit-conn', test_audit_conn)
+endif

--- a/tests/test-audit-conn.c
+++ b/tests/test-audit-conn.c
@@ -1,0 +1,152 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <glib.h>
+#include <glib/gstdio.h>
+#include <duckdb.h>
+
+#include "wyrelog/wyl-audit-conn-private.h"
+
+/* --- in-memory open/close lifecycle ---------------------------- */
+
+static gint
+check_open_memory_null_path (void)
+{
+  g_autoptr (wyl_audit_conn_t) conn = NULL;
+  if (wyl_audit_conn_open (NULL, &conn) != WYRELOG_E_OK)
+    return 1;
+  if (conn == NULL)
+    return 2;
+  return 0;
+}
+
+static gint
+check_open_memory_literal (void)
+{
+  g_autoptr (wyl_audit_conn_t) conn = NULL;
+  if (wyl_audit_conn_open (":memory:", &conn) != WYRELOG_E_OK)
+    return 10;
+  if (conn == NULL)
+    return 11;
+  return 0;
+}
+
+/* --- on-disk open + DDL round-trip ----------------------------- */
+
+static gint
+check_open_tempfile_and_query (void)
+{
+  g_autoptr (GError) err = NULL;
+  g_autofree gchar *tmpdir = g_dir_make_tmp ("wyl-audit-XXXXXX", &err);
+  if (tmpdir == NULL)
+    return 20;
+  g_autofree gchar *path = g_build_filename (tmpdir, "audit.db", NULL);
+
+  g_autoptr (wyl_audit_conn_t) conn = NULL;
+  if (wyl_audit_conn_open (path, &conn) != WYRELOG_E_OK) {
+    g_rmdir (tmpdir);
+    return 21;
+  }
+  duckdb_connection h = wyl_audit_conn_get_connection (conn);
+  duckdb_result result;
+  if (duckdb_query (h, "CREATE TABLE t (x INTEGER);", &result) != DuckDBSuccess) {
+    duckdb_destroy_result (&result);
+    g_unlink (path);
+    g_rmdir (tmpdir);
+    return 22;
+  }
+  duckdb_destroy_result (&result);
+
+  /* close before unlink so the database file is no longer mapped. */
+  wyl_audit_conn_close (g_steal_pointer (&conn));
+  g_unlink (path);
+  g_rmdir (tmpdir);
+  return 0;
+}
+
+/* --- bad path fails closed ------------------------------------- */
+
+static gint
+check_open_bad_path (void)
+{
+  /* An obviously unwritable parent. The sentinel pointer must
+   * survive the call untouched. */
+  wyl_audit_conn_t *sentinel = (wyl_audit_conn_t *) (gpointer) 0xDEADBEEF;
+  wyl_audit_conn_t *conn = sentinel;
+  wyrelog_error_t rc =
+      wyl_audit_conn_open ("/nonexistent-dir-wyrelog-audit/audit.db", &conn);
+  if (rc == WYRELOG_E_OK)
+    return 30;
+  if (conn != sentinel)
+    return 31;
+  return 0;
+}
+
+/* --- argument validation --------------------------------------- */
+
+static gint
+check_invalid_args (void)
+{
+  if (wyl_audit_conn_open ("anything", NULL) != WYRELOG_E_INVALID)
+    return 40;
+  return 0;
+}
+
+/* --- close semantics ------------------------------------------- */
+
+static gint
+check_close_null_noop (void)
+{
+  /* Direct NULL close is a no-op. */
+  wyl_audit_conn_close (NULL);
+
+  /* Open then explicit close, then a second close on a NULL local
+   * is also a no-op. autoptr cleanup at scope-end on the same
+   * NULL-after-steal pointer is a no-op too. */
+  g_autoptr (wyl_audit_conn_t) conn = NULL;
+  if (wyl_audit_conn_open (NULL, &conn) != WYRELOG_E_OK)
+    return 50;
+  wyl_audit_conn_close (g_steal_pointer (&conn));
+  /* conn is now NULL; the autoptr scope-end will see NULL. */
+  if (conn != NULL)
+    return 51;
+  return 0;
+}
+
+/* --- handle accessor on NULL ---------------------------------- */
+
+static gint
+check_get_connection_null (void)
+{
+  duckdb_connection h = wyl_audit_conn_get_connection (NULL);
+  /* The accessor returns a zero-initialised handle on NULL input;
+   * DuckDB treats that as not-a-connection. We can't dereference
+   * it here without crashing, but we can confirm the field is
+   * zero by reading the bytes. Since the type is opaque we
+   * compare against a freshly memset zero buffer of the same
+   * size. */
+  duckdb_connection zero;
+  memset (&zero, 0, sizeof (zero));
+  if (memcmp (&h, &zero, sizeof (h)) != 0)
+    return 60;
+  return 0;
+}
+
+int
+main (void)
+{
+  gint rc;
+  if ((rc = check_open_memory_null_path ()) != 0)
+    return rc;
+  if ((rc = check_open_memory_literal ()) != 0)
+    return rc;
+  if ((rc = check_open_tempfile_and_query ()) != 0)
+    return rc;
+  if ((rc = check_open_bad_path ()) != 0)
+    return rc;
+  if ((rc = check_invalid_args ()) != 0)
+    return rc;
+  if ((rc = check_close_null_noop ()) != 0)
+    return rc;
+  if ((rc = check_get_connection_null ()) != 0)
+    return rc;
+  return 0;
+}

--- a/wyrelog/meson.build
+++ b/wyrelog/meson.build
@@ -31,10 +31,17 @@ wyrelog_sources = files(
   'wyl-version.c',
 )
 
+wyrelog_deps = [glib_dep, gio_dep, libchronoid_dep]
+
+if get_option('enable_audit').allowed()
+  wyrelog_sources += files('wyl-audit-conn.c')
+  wyrelog_deps += duckdb_dep
+endif
+
 libwyrelog = library('wyrelog',
   wyrelog_sources,
   include_directories : wyrelog_inc,
-  dependencies : [glib_dep, gio_dep, libchronoid_dep],
+  dependencies : wyrelog_deps,
   install : true,
   soversion : '0',
 )

--- a/wyrelog/wyl-audit-conn-private.h
+++ b/wyrelog/wyl-audit-conn-private.h
@@ -1,0 +1,69 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+
+#include <glib.h>
+#include <duckdb.h>
+
+#include "wyrelog/error.h"
+
+G_BEGIN_DECLS;
+
+/*
+ * Audit-log connection lifecycle wrapper.
+ *
+ * Owns a DuckDB database handle and a single connection to it,
+ * which downstream audit modules consume to issue DDL and append
+ * statements. The handle pair is opaque from outside this header
+ * but the borrowed `duckdb_connection` returned by the accessor
+ * is the raw DuckDB ABI; callers must remain inside libwyrelog.
+ *
+ * Lifecycle:
+ *   1. wyl_audit_conn_open(path, &conn) -- on success owns *conn.
+ *   2. wyl_audit_conn_get_connection(conn) -- borrowed, lifetime
+ *      tied to *conn.
+ *   3. wyl_audit_conn_close(conn) -- disconnect then close, in
+ *      that order (DuckDB requirement). NULL-safe and idempotent.
+ *
+ * Threading: a connection is not safe for concurrent use; the
+ * engine layer serialises writers. Tests run single-threaded.
+ *
+ * Path semantics: NULL or the literal ":memory:" both yield an
+ * in-memory database. Other paths are passed verbatim to DuckDB,
+ * which interprets them as filesystem paths.
+ */
+
+typedef struct wyl_audit_conn_t wyl_audit_conn_t;
+
+/*
+ * Opens an audit log at `path`. On WYRELOG_E_OK *out_conn owns
+ * the new handle pair; on any non-OK return *out_conn is left
+ * untouched.
+ *
+ *   WYRELOG_E_OK       database opened and connected.
+ *   WYRELOG_E_INVALID  out_conn == NULL.
+ *   WYRELOG_E_IO       DuckDB rejected the path or could not
+ *                      create the database file.
+ *   WYRELOG_E_INTERNAL DuckDB connect failed against an
+ *                      already-opened database (rare; OOM-class).
+ */
+wyrelog_error_t wyl_audit_conn_open (const gchar * path,
+    wyl_audit_conn_t ** out_conn);
+
+/*
+ * Closes the connection and releases the database. NULL-safe;
+ * after the call the pointer is invalid.
+ */
+void wyl_audit_conn_close (wyl_audit_conn_t * conn);
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (wyl_audit_conn_t, wyl_audit_conn_close);
+
+/*
+ * Returns the borrowed underlying DuckDB connection handle.
+ * Lifetime is bounded by the parent wyl_audit_conn_t. Returns a
+ * zero-initialised handle on NULL input so callers passing a
+ * stale pointer get a deterministic fail-closed shape rather than
+ * a crash.
+ */
+duckdb_connection wyl_audit_conn_get_connection (wyl_audit_conn_t * conn);
+
+G_END_DECLS;

--- a/wyrelog/wyl-audit-conn.c
+++ b/wyrelog/wyl-audit-conn.c
@@ -1,0 +1,63 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "wyl-audit-conn-private.h"
+
+#include <string.h>
+
+struct wyl_audit_conn_t
+{
+  duckdb_database db;
+  duckdb_connection conn;
+};
+
+wyrelog_error_t
+wyl_audit_conn_open (const gchar *path, wyl_audit_conn_t **out_conn)
+{
+  if (out_conn == NULL)
+    return WYRELOG_E_INVALID;
+
+  /* DuckDB treats NULL as "open an in-memory database"; the
+   * literal ":memory:" string maps to the same outcome but going
+   * through NULL avoids a DuckDB-version-dependent string parse. */
+  const gchar *effective_path = path;
+  if (path != NULL && g_strcmp0 (path, ":memory:") == 0)
+    effective_path = NULL;
+
+  wyl_audit_conn_t *self = g_new0 (wyl_audit_conn_t, 1);
+  if (duckdb_open (effective_path, &self->db) != DuckDBSuccess) {
+    g_free (self);
+    return WYRELOG_E_IO;
+  }
+  if (duckdb_connect (self->db, &self->conn) != DuckDBSuccess) {
+    duckdb_close (&self->db);
+    g_free (self);
+    return WYRELOG_E_INTERNAL;
+  }
+
+  *out_conn = self;
+  return WYRELOG_E_OK;
+}
+
+void
+wyl_audit_conn_close (wyl_audit_conn_t *conn)
+{
+  if (conn == NULL)
+    return;
+  /* DuckDB requires disconnect before close, in that order; both
+   * APIs zero their handle so re-entering this function on an
+   * already-closed conn would still be safe, but the caller has
+   * already free'd the wrapper at that point. */
+  duckdb_disconnect (&conn->conn);
+  duckdb_close (&conn->db);
+  g_free (conn);
+}
+
+duckdb_connection
+wyl_audit_conn_get_connection (wyl_audit_conn_t *conn)
+{
+  if (conn == NULL) {
+    duckdb_connection zero;
+    memset (&zero, 0, sizeof (zero));
+    return zero;
+  }
+  return conn->conn;
+}


### PR DESCRIPTION
## Summary

(Re-opening PR #48 after base branch was rebased into main.)

- Adds `wyl_audit_conn_t`, a private opaque wrapper around the DuckDB `duckdb_database` + `duckdb_connection` pair.
- `wyl_audit_conn_open` accepts NULL or `":memory:"` for in-memory; any other string as a filesystem path.
- `wyl_audit_conn_close` is NULL-safe and disconnects before closing per DuckDB's ordering requirement; plugs into `G_DEFINE_AUTOPTR_CLEANUP_FUNC`.
- Borrowed `wyl_audit_conn_get_connection` returns raw `duckdb_connection` for downstream audit modules; private, not propagated through `wyrelog_dep`.
- Wiring gated on `get_option('enable_audit').allowed()` in `wyrelog/meson.build` and `tests/meson.build`.

## Test plan

- [x] Default build (`enable_audit=disabled`): `meson test --suite wyrelog` → 21/21 PASS.
- [x] Audit build (`enable_audit=enabled`): 22/22 PASS including new `audit-conn` test.
- [x] 7 numbered checks: NULL-path memory, `:memory:` literal, on-disk DDL round-trip, fail-closed bad path, NULL-out_conn validation, NULL-safe close + autoptr semantics, NULL-handle accessor zero-fill.
- [x] `./tools/gst-indent` applied.
- [ ] CI green (default lane only — audit lane not in current CI matrix).

## Follow-ups

- Add CI lane that exercises `enable_audit=enabled` (currently the new gated path is not validated by CI).
- Replace duckdb source mechanism per separate atomic: PR builds use system pkg-config (`libduckdb-dev` / `brew duckdb` / vcpkg duckdb); main builds use CMake subproject from upstream.
- `enable_break_glass → enable_audit` build-time invariant assertion still pending from PR #32 meta-review.