### PR TITLE
build: add duckdb_source selector with amalgamated-subproject mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,11 @@ jobs:
             ${{ runner.os }}-packagecache-
 
       - name: Configure
-        run: meson setup builddir -Denable_tpm=${{ matrix.tpm }}
+        run: |
+          meson setup builddir \
+            -Denable_tpm=${{ matrix.tpm }} \
+            -Denable_audit=enabled \
+            -Dduckdb_source=${{ github.event_name == 'pull_request' && 'prebuilt' || 'subproject' }}
 
       - name: Build and test
         run: meson test -C builddir --print-errorlogs --suite wyrelog
@@ -134,7 +138,7 @@ jobs:
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           set PKG_CONFIG_PATH=%VCPKG_INSTALLED_DIR%\lib\pkgconfig
           set CC=clang-cl
-          meson setup builddir -Denable_tpm=disabled -Denable_client=disabled -Ddefault_library=static
+          meson setup builddir -Denable_tpm=disabled -Denable_client=disabled -Ddefault_library=static -Denable_audit=enabled -Dduckdb_source=${{ github.event_name == 'pull_request' && 'prebuilt' || 'subproject' }}
 
       - name: Build and test (clang-cl)
         shell: cmd

--- a/meson.build
+++ b/meson.build
@@ -18,18 +18,29 @@ sodium_dep = dependency('libsodium', required : true)
 tss2_esys_dep = dependency('tss2-esys', required : get_option('enable_tpm'))
 enable_audit_opt = get_option('enable_audit')
 if enable_audit_opt.allowed()
-  if host_machine.system() == 'linux'
-    duckdb_dep = dependency('duckdb-prebuilt-linux',
-      fallback : ['duckdb-prebuilt-linux', 'duckdb_dep'])
-  elif host_machine.system() == 'darwin'
-    duckdb_dep = dependency('duckdb-prebuilt-osx',
-      fallback : ['duckdb-prebuilt-osx', 'duckdb_dep'])
-  elif host_machine.system() == 'windows'
-    duckdb_dep = dependency('duckdb-prebuilt-windows',
-      fallback : ['duckdb-prebuilt-windows', 'duckdb_dep'])
+  duckdb_source = get_option('duckdb_source')
+  if duckdb_source == 'prebuilt'
+    if host_machine.system() == 'linux'
+      duckdb_dep = dependency('duckdb-prebuilt-linux',
+        fallback : ['duckdb-prebuilt-linux', 'duckdb_dep'])
+    elif host_machine.system() == 'darwin'
+      duckdb_dep = dependency('duckdb-prebuilt-osx',
+        fallback : ['duckdb-prebuilt-osx', 'duckdb_dep'])
+    elif host_machine.system() == 'windows'
+      duckdb_dep = dependency('duckdb-prebuilt-windows',
+        fallback : ['duckdb-prebuilt-windows', 'duckdb_dep'])
+    else
+      error('duckdb_source=prebuilt is not supported on host system: '
+          + host_machine.system())
+    endif
   else
-    error('enable_audit is not supported on host system: '
-        + host_machine.system())
+    # From-source build of the upstream DuckDB amalgamated single-TU
+    # release. Slow (multi-minute single-TU C++ compile) but uses the
+    # same source layout the upstream project ships and exercises the
+    # full link path. Intended for main-branch CI to validate that
+    # wyrelog still links cleanly against a freshly built libduckdb.
+    duckdb_dep = dependency('duckdb-amalgamated',
+      fallback : ['duckdb-amalgamated', 'duckdb_dep'])
   endif
 else
   duckdb_dep = disabler()

--- a/meson.options
+++ b/meson.options
@@ -44,6 +44,21 @@ option('enable_audit',
               + 'linkage).'
 )
 
+option('duckdb_source',
+  type : 'combo',
+  choices : ['prebuilt', 'subproject'],
+  value : 'prebuilt',
+  description : 'How libduckdb is sourced when enable_audit is on. '
+              + '"prebuilt" downloads the upstream-published library '
+              + 'binary for the host platform (fast: ~30 MB download '
+              + 'and zero compile). "subproject" downloads the '
+              + 'upstream amalgamated source release at v1.5.1 and '
+              + 'compiles the single 25 MB duckdb.cpp translation unit '
+              + 'in tree (slow: multi-minute single-TU compile). '
+              + 'Default is prebuilt; main-branch CI overrides to '
+              + 'subproject for from-source validation.'
+)
+
 option('enable_break_glass',
   type : 'boolean',
   value : false,

--- a/subprojects/.gitignore
+++ b/subprojects/.gitignore
@@ -1,5 +1,6 @@
 *
 !.gitignore
+!duckdb-amalgamated.wrap
 !duckdb-prebuilt-linux.wrap
 !duckdb-prebuilt-osx.wrap
 !duckdb-prebuilt-windows.wrap

--- a/subprojects/duckdb-amalgamated.wrap
+++ b/subprojects/duckdb-amalgamated.wrap
@@ -1,0 +1,10 @@
+[wrap-file]
+directory = duckdb-amalgamated-src
+source_url = https://github.com/duckdb/duckdb/releases/download/v1.5.1/libduckdb-src-v1.5.1.zip
+source_filename = libduckdb-src-v1.5.1.zip
+source_hash = e5b4e9c449bb1ae0e005bb23a48b208efbe813556c12eb7f9cd3e4c9dbe01fdc
+lead_directory_missing = true
+patch_directory = duckdb-amalgamated
+
+[provide]
+duckdb-amalgamated = duckdb_dep

--- a/subprojects/packagefiles/duckdb-amalgamated/meson.build
+++ b/subprojects/packagefiles/duckdb-amalgamated/meson.build
@@ -1,0 +1,31 @@
+project('duckdb-amalgamated', 'cpp',
+  version : '1.5.1',
+  license : 'MIT',
+  default_options : [
+    'cpp_std=c++17',
+    'warning_level=0',
+  ],
+)
+
+cpp = meson.get_compiler('cpp')
+
+duckdb_deps = []
+
+if host_machine.system() == 'linux'
+  duckdb_deps += cpp.find_library('pthread', required : true)
+  duckdb_deps += cpp.find_library('dl', required : true)
+endif
+
+duckdb_lib = library('duckdb',
+  'duckdb.cpp',
+  dependencies : duckdb_deps,
+  include_directories : include_directories('.'),
+  install : true,
+)
+
+duckdb_dep = declare_dependency(
+  link_with : duckdb_lib,
+  include_directories : include_directories('.'),
+)
+
+install_headers('duckdb.h')

--- a/subprojects/packagefiles/duckdb-prebuilt-windows/meson.build
+++ b/subprojects/packagefiles/duckdb-prebuilt-windows/meson.build
@@ -10,13 +10,15 @@ duckdb_lib = cc.find_library('duckdb',
   required : true,
 )
 
-# Copy duckdb.dll into the build root so test executables can locate it
-# at runtime via the Windows loader's same-directory search rule.
-fs = import('fs')
-duckdb_runtime_dll = fs.copyfile('duckdb.dll', install : false)
-
+# duckdb.dll lives next to the import library duckdb.lib found above.
+# Tests need the DLL on the loader search path at run time; the
+# wrapping consumer (wyrelog/meson.build) is responsible for staging
+# it next to the test executables. We deliberately do NOT add the
+# DLL to declare_dependency's sources because that would feed it
+# into the consumer's lib.exe / link.exe input list and break the
+# static archive build on MSVC.
 duckdb_dep = declare_dependency(
   dependencies : duckdb_lib,
-  sources : duckdb_runtime_dll,
   include_directories : include_directories('.'),
 )
+

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -187,5 +187,19 @@ if get_option('enable_audit').allowed()
     dependencies : [wyrelog_dep, duckdb_dep],
   )
 
-  test('audit-conn', test_audit_conn)
+  audit_conn_test_env = environment()
+  if host_machine.system() == 'windows' \
+      and get_option('duckdb_source') == 'prebuilt'
+    # Prepend the prebuilt subproject directory to PATH so the
+    # Windows loader can find duckdb.dll at test run time. The DLL
+    # is not in dependency.sources (that would feed it into the
+    # static-archive link step and fail). Instead we add its
+    # directory here.
+    audit_conn_test_env.prepend('PATH',
+      meson.project_source_root() / 'subprojects'
+        / 'duckdb-prebuilt-windows-amd64',
+      separator : ';')
+  endif
+
+  test('audit-conn', test_audit_conn, env : audit_conn_test_env)
 endif


### PR DESCRIPTION
## Summary

- Adds a `duckdb_source` meson option (combo: `prebuilt` | `subproject`, default `prebuilt`).
- `prebuilt` keeps the existing platform-specific upstream binary download — ~30 MB, zero compile.
- `subproject` downloads the upstream amalgamated source release and compiles the single `duckdb.cpp` TU in-tree — multi-minute one-shot, but exercises the full from-source link path.
- CI workflow wires the selector via GHA event expression: PR runs use `prebuilt`, push-to-main runs use `subproject`. `enable_audit=enabled` is forced on for both lanes so the audit-conn test runs everywhere the option is consulted.

## Why amalgamated, not CMake subproject

A first attempt routed the `subproject` mode through meson's `cmake.subproject` helper to consume DuckDB's CMakeLists. It failed: the upstream CMake graph relies on generator expressions (e.g. `$<TARGET_FILE:duckdb_platform_binary>`) and dynamic loadable-extension targets that meson's translation can't reconcile with PIC requirements. The amalgamated single-TU build is the from-source path the upstream project itself recommends for embedded use.

## Verified locally

- Default (audit=disabled): 21/21 PASS, no duckdb fetched.
- Prebuilt mode (`-Denable_audit=enabled`, default `duckdb_source=prebuilt`): 22/22 PASS, configure ~30s.
- Subproject mode (`-Denable_audit=enabled -Dduckdb_source=subproject`): 22/22 PASS, full amalgamation compile multi-minute one-shot.

## Test plan

- [x] PR CI uses prebuilt path (this PR's CI).
- [ ] CI green across Linux / macOS / Windows on PR (prebuilt).
- [ ] Post-merge push to main exercises subproject path (slower) — first observation after merge.

## Known concern (per critic)

The "PR=prebuilt, main=subproject" split means a regression in subproject mode is only caught after merge. Accepted trade-off for now; a follow-up could add a nightly job exercising the slow path on a separate cadence.