### PR TITLE
ci(windows): pin duckdb_source to prebuilt regardless of event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           set PKG_CONFIG_PATH=%VCPKG_INSTALLED_DIR%\lib\pkgconfig
           set CC=clang-cl
-          meson setup builddir -Denable_tpm=disabled -Denable_client=disabled -Ddefault_library=static -Denable_audit=enabled -Dduckdb_source=${{ github.event_name == 'pull_request' && 'prebuilt' || 'subproject' }}
+          meson setup builddir -Denable_tpm=disabled -Denable_client=disabled -Ddefault_library=static -Denable_audit=enabled -Dduckdb_source=prebuilt
 
       - name: Build and test (clang-cl)
         shell: cmd


### PR DESCRIPTION
## Summary

- Windows clang-cl cannot compile the upstream DuckDB amalgamated `duckdb.cpp` (C2236 / C2332 / C2027 errors at line 80339 around a nested forward-declared struct that MSVC's C++ parser rejects). This is upstream behaviour with the v1.5.1 zip.
- Hardcode `duckdb_source=prebuilt` for the Windows job. Linux and macOS still switch on `github.event_name` so PRs use prebuilt and main-branch runs exercise the amalgamated subproject path.
- Audit-conn coverage on Windows is preserved via the prebuilt path (same path PR runs already validate).

## Why this matters

Without this pin, every push to main fails the Windows lane. Linux and macOS are unaffected by the parser issue.

## Test plan

- [x] YAML parses.
- [ ] PR CI green (Linux/macOS/Windows all in prebuilt).
- [ ] Post-merge main push: Linux+macOS do amalgamated subproject build; Windows stays on prebuilt.

## Follow-up

- A future atomic could either (a) wait for upstream DuckDB to fix the MSVC parser issue, or (b) explore whether MSVC `/permissive-` or `/Zc:strictStrings-` flags accept the source. Out of scope here.