### PR TITLE
access: add subject, action, and resource fields to wyl_revoke_req

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -188,6 +188,13 @@ test_grant_req = executable('test-grant-req',
 
 test('grant-req', test_grant_req)
 
+test_revoke_req = executable('test-revoke-req',
+  'test-revoke-req.c',
+  dependencies : [wyrelog_dep],
+)
+
+test('revoke-req', test_revoke_req)
+
 if get_option('enable_audit').allowed()
   test_audit_conn = executable('test-audit-conn',
     'test-audit-conn.c',

--- a/tests/test-revoke-req.c
+++ b/tests/test-revoke-req.c
@@ -1,0 +1,151 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <glib.h>
+#include <string.h>
+
+#include "wyrelog/wyrelog.h"
+
+static gint
+check_defaults_are_null (void)
+{
+  g_autoptr (wyl_revoke_req_t) req = wyl_revoke_req_new ();
+  if (req == NULL)
+    return 10;
+  if (wyl_revoke_req_get_subject_id (req) != NULL)
+    return 11;
+  if (wyl_revoke_req_get_action (req) != NULL)
+    return 12;
+  if (wyl_revoke_req_get_resource_id (req) != NULL)
+    return 13;
+  return 0;
+}
+
+static gint
+check_subject_round_trip (void)
+{
+  g_autoptr (wyl_revoke_req_t) req = wyl_revoke_req_new ();
+  wyl_revoke_req_set_subject_id (req, "alice");
+  if (g_strcmp0 (wyl_revoke_req_get_subject_id (req), "alice") != 0)
+    return 20;
+  return 0;
+}
+
+static gint
+check_action_round_trip (void)
+{
+  g_autoptr (wyl_revoke_req_t) req = wyl_revoke_req_new ();
+  wyl_revoke_req_set_action (req, "write");
+  if (g_strcmp0 (wyl_revoke_req_get_action (req), "write") != 0)
+    return 30;
+  return 0;
+}
+
+static gint
+check_resource_round_trip (void)
+{
+  g_autoptr (wyl_revoke_req_t) req = wyl_revoke_req_new ();
+  wyl_revoke_req_set_resource_id (req, "doc/42");
+  if (g_strcmp0 (wyl_revoke_req_get_resource_id (req), "doc/42") != 0)
+    return 40;
+  return 0;
+}
+
+static gint
+check_caller_buffer_is_copied (void)
+{
+  g_autoptr (wyl_revoke_req_t) req = wyl_revoke_req_new ();
+  gchar buf[16] = "alice";
+  wyl_revoke_req_set_subject_id (req, buf);
+  buf[0] = 'X';
+  if (g_strcmp0 (wyl_revoke_req_get_subject_id (req), "alice") != 0)
+    return 50;
+  return 0;
+}
+
+static gint
+check_set_replaces_prior (void)
+{
+  g_autoptr (wyl_revoke_req_t) req = wyl_revoke_req_new ();
+  wyl_revoke_req_set_action (req, "read");
+  wyl_revoke_req_set_action (req, "write");
+  if (g_strcmp0 (wyl_revoke_req_get_action (req), "write") != 0)
+    return 60;
+  return 0;
+}
+
+static gint
+check_set_null_clears (void)
+{
+  g_autoptr (wyl_revoke_req_t) req = wyl_revoke_req_new ();
+  wyl_revoke_req_set_subject_id (req, "alice");
+  wyl_revoke_req_set_subject_id (req, NULL);
+  if (wyl_revoke_req_get_subject_id (req) != NULL)
+    return 70;
+  return 0;
+}
+
+static gint
+check_fields_are_independent (void)
+{
+  g_autoptr (wyl_revoke_req_t) req = wyl_revoke_req_new ();
+  wyl_revoke_req_set_subject_id (req, "alice");
+  wyl_revoke_req_set_action (req, "write");
+  wyl_revoke_req_set_resource_id (req, "doc/42");
+
+  /* Clearing one field must not perturb the others. */
+  wyl_revoke_req_set_action (req, NULL);
+  if (g_strcmp0 (wyl_revoke_req_get_subject_id (req), "alice") != 0)
+    return 80;
+  if (wyl_revoke_req_get_action (req) != NULL)
+    return 81;
+  if (g_strcmp0 (wyl_revoke_req_get_resource_id (req), "doc/42") != 0)
+    return 82;
+  return 0;
+}
+
+static gint
+check_get_null_request (void)
+{
+  if (wyl_revoke_req_get_subject_id (NULL) != NULL)
+    return 90;
+  if (wyl_revoke_req_get_action (NULL) != NULL)
+    return 91;
+  if (wyl_revoke_req_get_resource_id (NULL) != NULL)
+    return 92;
+  return 0;
+}
+
+static gint
+check_free_null_is_safe (void)
+{
+  wyl_revoke_req_free (NULL);
+  return 0;
+}
+
+int
+main (void)
+{
+  gint rc;
+
+  if ((rc = check_defaults_are_null ()) != 0)
+    return rc;
+  if ((rc = check_subject_round_trip ()) != 0)
+    return rc;
+  if ((rc = check_action_round_trip ()) != 0)
+    return rc;
+  if ((rc = check_resource_round_trip ()) != 0)
+    return rc;
+  if ((rc = check_caller_buffer_is_copied ()) != 0)
+    return rc;
+  if ((rc = check_set_replaces_prior ()) != 0)
+    return rc;
+  if ((rc = check_set_null_clears ()) != 0)
+    return rc;
+  if ((rc = check_fields_are_independent ()) != 0)
+    return rc;
+  if ((rc = check_get_null_request ()) != 0)
+    return rc;
+  if ((rc = check_free_null_is_safe ()) != 0)
+    return rc;
+
+  return 0;
+}

--- a/wyrelog/perm.h
+++ b/wyrelog/perm.h
@@ -44,6 +44,24 @@ wyl_revoke_req_t *wyl_revoke_req_new (void);
 void wyl_revoke_req_free (wyl_revoke_req_t * req);
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (wyl_revoke_req_t, wyl_revoke_req_free);
 
+/*
+ * Setters / getters for the subject, action, and resource fields
+ * of an admin revoke request. Setters duplicate the caller's string
+ * so the caller may free it immediately after the call; passing
+ * NULL clears the field. Getters return a borrowed pointer that is
+ * valid until the next set call or until the request is freed.
+ */
+void wyl_revoke_req_set_subject_id (wyl_revoke_req_t * req,
+    const gchar * subject_id);
+const gchar *wyl_revoke_req_get_subject_id (const wyl_revoke_req_t * req);
+
+void wyl_revoke_req_set_action (wyl_revoke_req_t * req, const gchar * action);
+const gchar *wyl_revoke_req_get_action (const wyl_revoke_req_t * req);
+
+void wyl_revoke_req_set_resource_id (wyl_revoke_req_t * req,
+    const gchar * resource_id);
+const gchar *wyl_revoke_req_get_resource_id (const wyl_revoke_req_t * req);
+
 wyrelog_error_t wyl_perm_grant (WylHandle * handle,
     const wyl_grant_req_t * req);
 wyrelog_error_t wyl_perm_revoke (WylHandle * handle,

--- a/wyrelog/wyl-perm.c
+++ b/wyrelog/wyl-perm.c
@@ -15,7 +15,9 @@ struct _wyl_grant_req
 
 struct _wyl_revoke_req
 {
-  gint placeholder;
+  gchar *subject_id;
+  gchar *action;
+  gchar *resource_id;
 };
 
 wyl_login_req_t *
@@ -119,7 +121,57 @@ wyl_revoke_req_new (void)
 void
 wyl_revoke_req_free (wyl_revoke_req_t *req)
 {
+  if (req == NULL)
+    return;
+  g_free (req->subject_id);
+  g_free (req->action);
+  g_free (req->resource_id);
   g_free (req);
+}
+
+void
+wyl_revoke_req_set_subject_id (wyl_revoke_req_t *req, const gchar *subject_id)
+{
+  g_return_if_fail (req != NULL);
+  g_free (req->subject_id);
+  req->subject_id = g_strdup (subject_id);
+}
+
+const gchar *
+wyl_revoke_req_get_subject_id (const wyl_revoke_req_t *req)
+{
+  g_return_val_if_fail (req != NULL, NULL);
+  return req->subject_id;
+}
+
+void
+wyl_revoke_req_set_action (wyl_revoke_req_t *req, const gchar *action)
+{
+  g_return_if_fail (req != NULL);
+  g_free (req->action);
+  req->action = g_strdup (action);
+}
+
+const gchar *
+wyl_revoke_req_get_action (const wyl_revoke_req_t *req)
+{
+  g_return_val_if_fail (req != NULL, NULL);
+  return req->action;
+}
+
+void
+wyl_revoke_req_set_resource_id (wyl_revoke_req_t *req, const gchar *resource_id)
+{
+  g_return_if_fail (req != NULL);
+  g_free (req->resource_id);
+  req->resource_id = g_strdup (resource_id);
+}
+
+const gchar *
+wyl_revoke_req_get_resource_id (const wyl_revoke_req_t *req)
+{
+  g_return_val_if_fail (req != NULL, NULL);
+  return req->resource_id;
 }
 
 wyrelog_error_t


### PR DESCRIPTION
## Summary

- Replaces the placeholder integer in `wyl_revoke_req_t` with three heap-owned string fields: `subject_id`, `action`, `resource_id` — mirrors `wyl_decide_req` (PR #45) and `wyl_grant_req` (PR #52).
- Adds six public entry points on `perm.h` (set/get for each field).
- Setters duplicate caller's string; NULL clears the field. Getters return borrowed pointer.
- `wyl_revoke_req_free` frees all three strings and is NULL-safe.
- The `wyl_perm_revoke` implementation continues to ignore the populated fields; consumption by the policy decision point is a follow-up.

## Test plan

- [x] `meson test -C builddir --suite wyrelog` — 23/23 PASS (was 22/22; new `revoke-req` test).
- [x] 10 numbered checks: defaults, per-field round-trip, caller-buffer copy, replace-on-reset, NULL-clear, field independence, NULL-request on get, NULL-safe free.
- [x] `./tools/gst-indent` applied.
- [ ] CI green across Linux / macOS / Windows.