### PR TITLE
access: add decision-context fields to WylAuditEvent

### DIFF
--- a/tests/test-audit-event.c
+++ b/tests/test-audit-event.c
@@ -92,6 +92,100 @@ check_accessor_null_safety (void)
   return 0;
 }
 
+static gint
+check_decision_default_is_deny (void)
+{
+  g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
+  if (wyl_audit_event_get_decision (ev) != WYL_DECISION_DENY)
+    return 110;
+  return 0;
+}
+
+static gint
+check_set_decision_round_trip (void)
+{
+  g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
+  wyl_audit_event_set_decision (ev, WYL_DECISION_ALLOW);
+  if (wyl_audit_event_get_decision (ev) != WYL_DECISION_ALLOW)
+    return 120;
+  wyl_audit_event_set_decision (ev, WYL_DECISION_DENY);
+  if (wyl_audit_event_get_decision (ev) != WYL_DECISION_DENY)
+    return 121;
+  return 0;
+}
+
+static gint
+check_get_decision_null_is_deny (void)
+{
+  if (wyl_audit_event_get_decision (NULL) != WYL_DECISION_DENY)
+    return 130;
+  return 0;
+}
+
+static gint
+check_string_field_defaults_are_null (void)
+{
+  g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
+  if (wyl_audit_event_get_subject_id (ev) != NULL)
+    return 140;
+  if (wyl_audit_event_get_action (ev) != NULL)
+    return 141;
+  if (wyl_audit_event_get_resource_id (ev) != NULL)
+    return 142;
+  return 0;
+}
+
+static gint
+check_string_field_round_trips (void)
+{
+  g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
+  wyl_audit_event_set_subject_id (ev, "alice");
+  wyl_audit_event_set_action (ev, "read");
+  wyl_audit_event_set_resource_id (ev, "doc/42");
+  if (g_strcmp0 (wyl_audit_event_get_subject_id (ev), "alice") != 0)
+    return 150;
+  if (g_strcmp0 (wyl_audit_event_get_action (ev), "read") != 0)
+    return 151;
+  if (g_strcmp0 (wyl_audit_event_get_resource_id (ev), "doc/42") != 0)
+    return 152;
+  return 0;
+}
+
+static gint
+check_string_set_null_clears (void)
+{
+  g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
+  wyl_audit_event_set_subject_id (ev, "alice");
+  wyl_audit_event_set_subject_id (ev, NULL);
+  if (wyl_audit_event_get_subject_id (ev) != NULL)
+    return 160;
+  return 0;
+}
+
+static gint
+check_string_caller_buffer_is_copied (void)
+{
+  g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
+  gchar buf[16] = "alice";
+  wyl_audit_event_set_subject_id (ev, buf);
+  buf[0] = 'X';
+  if (g_strcmp0 (wyl_audit_event_get_subject_id (ev), "alice") != 0)
+    return 170;
+  return 0;
+}
+
+static gint
+check_string_get_null_event (void)
+{
+  if (wyl_audit_event_get_subject_id (NULL) != NULL)
+    return 180;
+  if (wyl_audit_event_get_action (NULL) != NULL)
+    return 181;
+  if (wyl_audit_event_get_resource_id (NULL) != NULL)
+    return 182;
+  return 0;
+}
+
 int
 main (void)
 {
@@ -110,6 +204,22 @@ main (void)
   if ((rc = check_created_at_monotonic_with_minting_order ()) != 0)
     return rc;
   if ((rc = check_accessor_null_safety ()) != 0)
+    return rc;
+  if ((rc = check_decision_default_is_deny ()) != 0)
+    return rc;
+  if ((rc = check_set_decision_round_trip ()) != 0)
+    return rc;
+  if ((rc = check_get_decision_null_is_deny ()) != 0)
+    return rc;
+  if ((rc = check_string_field_defaults_are_null ()) != 0)
+    return rc;
+  if ((rc = check_string_field_round_trips ()) != 0)
+    return rc;
+  if ((rc = check_string_set_null_clears ()) != 0)
+    return rc;
+  if ((rc = check_string_caller_buffer_is_copied ()) != 0)
+    return rc;
+  if ((rc = check_string_get_null_event ()) != 0)
     return rc;
 
   return 0;

--- a/wyrelog/audit.h
+++ b/wyrelog/audit.h
@@ -4,6 +4,7 @@
 #include <glib.h>
 #include <glib-object.h>
 
+#include "wyrelog/decide.h"
 #include "wyrelog/error.h"
 #include "wyrelog/handle.h"
 
@@ -37,6 +38,40 @@ gchar *wyl_audit_event_dup_id_string (const WylAuditEvent * self);
  * stamp.
  */
 gint64 wyl_audit_event_get_created_at_us (const WylAuditEvent * self);
+
+/*
+ * Setters / getters for the decision-context fields of an audit
+ * event. Setters duplicate the caller's string so the event becomes
+ * independent of the caller's buffer; passing NULL clears the
+ * field. Getters return a borrowed pointer valid until the next set
+ * call or until the event is finalised.
+ */
+void wyl_audit_event_set_subject_id (WylAuditEvent * self,
+    const gchar * subject_id);
+const gchar *wyl_audit_event_get_subject_id (const WylAuditEvent * self);
+
+void wyl_audit_event_set_action (WylAuditEvent * self, const gchar * action);
+const gchar *wyl_audit_event_get_action (const WylAuditEvent * self);
+
+void wyl_audit_event_set_resource_id (WylAuditEvent * self,
+    const gchar * resource_id);
+const gchar *wyl_audit_event_get_resource_id (const WylAuditEvent * self);
+
+/*
+ * Records the verdict produced for the request the event describes.
+ * Default for a freshly constructed event is WYL_DECISION_DENY so
+ * an event the daemon never populated stays fail-closed at the
+ * audit boundary.
+ */
+void wyl_audit_event_set_decision (WylAuditEvent * self,
+    wyl_decision_t decision);
+
+/*
+ * Returns the verdict carried by |self|. Returns WYL_DECISION_DENY
+ * on a NULL argument or non-WylAuditEvent so the fail-closed
+ * contract holds across the API boundary.
+ */
+wyl_decision_t wyl_audit_event_get_decision (const WylAuditEvent * self);
 
 wyrelog_error_t wyl_audit_emit (WylHandle * handle,
     const WylAuditEvent * event);

--- a/wyrelog/wyl-audit-event.c
+++ b/wyrelog/wyl-audit-event.c
@@ -8,14 +8,32 @@ struct _WylAuditEvent
   GObject parent_instance;
   wyl_id_t id;
   gint64 created_at_us;
+  gchar *subject_id;
+  gchar *action;
+  gchar *resource_id;
+  wyl_decision_t decision;
 };
 
 G_DEFINE_FINAL_TYPE (WylAuditEvent, wyl_audit_event, G_TYPE_OBJECT);
 
 static void
+wyl_audit_event_finalize (GObject *object)
+{
+  WylAuditEvent *self = WYL_AUDIT_EVENT (object);
+
+  g_free (self->subject_id);
+  g_free (self->action);
+  g_free (self->resource_id);
+
+  G_OBJECT_CLASS (wyl_audit_event_parent_class)->finalize (object);
+}
+
+static void
 wyl_audit_event_class_init (WylAuditEventClass *klass)
 {
-  (void) klass;
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->finalize = wyl_audit_event_finalize;
 }
 
 static void
@@ -59,6 +77,67 @@ wyl_audit_event_get_created_at_us (const WylAuditEvent *self)
 {
   g_return_val_if_fail (WYL_IS_AUDIT_EVENT (self), -1);
   return self->created_at_us;
+}
+
+void
+wyl_audit_event_set_subject_id (WylAuditEvent *self, const gchar *subject_id)
+{
+  g_return_if_fail (WYL_IS_AUDIT_EVENT (self));
+  g_free (self->subject_id);
+  self->subject_id = g_strdup (subject_id);
+}
+
+const gchar *
+wyl_audit_event_get_subject_id (const WylAuditEvent *self)
+{
+  g_return_val_if_fail (WYL_IS_AUDIT_EVENT (self), NULL);
+  return self->subject_id;
+}
+
+void
+wyl_audit_event_set_action (WylAuditEvent *self, const gchar *action)
+{
+  g_return_if_fail (WYL_IS_AUDIT_EVENT (self));
+  g_free (self->action);
+  self->action = g_strdup (action);
+}
+
+const gchar *
+wyl_audit_event_get_action (const WylAuditEvent *self)
+{
+  g_return_val_if_fail (WYL_IS_AUDIT_EVENT (self), NULL);
+  return self->action;
+}
+
+void
+wyl_audit_event_set_resource_id (WylAuditEvent *self, const gchar *resource_id)
+{
+  g_return_if_fail (WYL_IS_AUDIT_EVENT (self));
+  g_free (self->resource_id);
+  self->resource_id = g_strdup (resource_id);
+}
+
+const gchar *
+wyl_audit_event_get_resource_id (const WylAuditEvent *self)
+{
+  g_return_val_if_fail (WYL_IS_AUDIT_EVENT (self), NULL);
+  return self->resource_id;
+}
+
+void
+wyl_audit_event_set_decision (WylAuditEvent *self, wyl_decision_t decision)
+{
+  g_return_if_fail (WYL_IS_AUDIT_EVENT (self));
+  self->decision = decision;
+}
+
+wyl_decision_t
+wyl_audit_event_get_decision (const WylAuditEvent *self)
+{
+  /* Fail-closed default for a NULL or unset event: an audit event
+   * that was never populated must not silently appear as ALLOW. */
+  g_return_val_if_fail (WYL_IS_AUDIT_EVENT (self), WYL_DECISION_DENY);
+  return self->decision;
 }
 
 wyrelog_error_t


### PR DESCRIPTION
## Summary

- Adds four decision-context fields to `WylAuditEvent`: `subject_id`, `action`, `resource_id` (heap strings), and `decision` (`wyl_decision_t`).
- 8 new public entry points on `audit.h` (set + get for each).
- `audit.h` now `#include`s `decide.h` to expose `wyl_decision_t`.
- `WylAuditEvent` gains a `finalize` override to free the heap strings before chaining up.
- `decision` defaults to `WYL_DECISION_DENY` (= 0) so an unpopulated event stays fail-closed; `get_decision` on a NULL handle also returns `DENY`.

## Test plan

- [x] `meson test -C builddir --suite wyrelog` — 23/23 PASS, 8 new audit-event checks (110-182) covering decision default/round-trip/NULL fallback and the three string fields' defaults/round-trip/NULL-clear/caller-buffer/NULL-handle.
- [x] `./tools/gst-indent` applied.
- [ ] CI green across Linux / macOS / Windows.

## Follow-up

- The `wyl_audit_emit` stub remains; the sink that consumes the populated event lands in a separate atomic.