### PR TITLE
audit: add idempotent audit_events table DDL

### DIFF
--- a/tests/test-audit-conn.c
+++ b/tests/test-audit-conn.c
@@ -130,6 +130,45 @@ check_get_connection_null (void)
   return 0;
 }
 
+/* --- DDL schema creation -------------------------------------- */
+
+static gint
+check_create_schema (void)
+{
+  g_autoptr (wyl_audit_conn_t) conn = NULL;
+  if (wyl_audit_conn_open (NULL, &conn) != WYRELOG_E_OK)
+    return 70;
+  if (wyl_audit_conn_create_schema (conn) != WYRELOG_E_OK)
+    return 71;
+  /* Idempotent: a second call must also succeed because the DDL
+   * uses CREATE TABLE IF NOT EXISTS. */
+  if (wyl_audit_conn_create_schema (conn) != WYRELOG_E_OK)
+    return 72;
+
+  /* The freshly created table must be queryable and empty. */
+  duckdb_connection h = wyl_audit_conn_get_connection (conn);
+  duckdb_result result;
+  if (duckdb_query (h, "SELECT COUNT(*) FROM audit_events;",
+          &result) != DuckDBSuccess) {
+    duckdb_destroy_result (&result);
+    return 73;
+  }
+  if (duckdb_value_int64 (&result, 0, 0) != 0) {
+    duckdb_destroy_result (&result);
+    return 74;
+  }
+  duckdb_destroy_result (&result);
+  return 0;
+}
+
+static gint
+check_create_schema_null_arg (void)
+{
+  if (wyl_audit_conn_create_schema (NULL) != WYRELOG_E_INVALID)
+    return 80;
+  return 0;
+}
+
 int
 main (void)
 {
@@ -147,6 +186,10 @@ main (void)
   if ((rc = check_close_null_noop ()) != 0)
     return rc;
   if ((rc = check_get_connection_null ()) != 0)
+    return rc;
+  if ((rc = check_create_schema ()) != 0)
+    return rc;
+  if ((rc = check_create_schema_null_arg ()) != 0)
     return rc;
   return 0;
 }

--- a/wyrelog/wyl-audit-conn-private.h
+++ b/wyrelog/wyl-audit-conn-private.h
@@ -66,4 +66,21 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC (wyl_audit_conn_t, wyl_audit_conn_close);
  */
 duckdb_connection wyl_audit_conn_get_connection (wyl_audit_conn_t * conn);
 
+/*
+ * Ensures the audit_events table exists on the open connection.
+ * Idempotent: subsequent calls on the same connection are no-ops.
+ * The table mirrors the WylAuditEvent public surface:
+ *
+ *   id            VARCHAR PRIMARY KEY  -- canonical 36-char form
+ *   created_at_us BIGINT               -- g_get_real_time stamp
+ *   subject_id    VARCHAR
+ *   action        VARCHAR
+ *   resource_id   VARCHAR
+ *   decision      SMALLINT             -- 0 = DENY, 1 = ALLOW
+ *
+ * Returns WYRELOG_E_OK on success, WYRELOG_E_INVALID for a NULL
+ * argument, and WYRELOG_E_IO if DuckDB rejects the DDL.
+ */
+wyrelog_error_t wyl_audit_conn_create_schema (wyl_audit_conn_t * conn);
+
 G_END_DECLS;

--- a/wyrelog/wyl-audit-conn.c
+++ b/wyrelog/wyl-audit-conn.c
@@ -61,3 +61,26 @@ wyl_audit_conn_get_connection (wyl_audit_conn_t *conn)
   }
   return conn->conn;
 }
+
+wyrelog_error_t
+wyl_audit_conn_create_schema (wyl_audit_conn_t *conn)
+{
+  static const gchar *ddl =
+      "CREATE TABLE IF NOT EXISTS audit_events ("
+      "  id            VARCHAR PRIMARY KEY,"
+      "  created_at_us BIGINT  NOT NULL,"
+      "  subject_id    VARCHAR,"
+      "  action        VARCHAR,"
+      "  resource_id   VARCHAR," "  decision      SMALLINT NOT NULL" ");";
+
+  if (conn == NULL)
+    return WYRELOG_E_INVALID;
+
+  duckdb_result result;
+  if (duckdb_query (conn->conn, ddl, &result) != DuckDBSuccess) {
+    duckdb_destroy_result (&result);
+    return WYRELOG_E_IO;
+  }
+  duckdb_destroy_result (&result);
+  return WYRELOG_E_OK;
+}


### PR DESCRIPTION
## Summary

- Adds `wyl_audit_conn_create_schema` (private), a one-call helper that issues `CREATE TABLE IF NOT EXISTS audit_events (...)` on an open `wyl_audit_conn_t`.
- Idempotent: repeat calls on the same connection are no-ops via the IF NOT EXISTS clause in the DDL itself.
- Schema mirrors `WylAuditEvent`'s public surface: `id`, `created_at_us`, `subject_id`, `action`, `resource_id`, `decision`.
- Prerequisite for the INSERT path in `wyl_audit_emit` (follow-up); the emit stub is unchanged here.

## Test plan

- [x] `meson test -C builddir-audit audit-conn` (audit lane) — PASS, including 2 new checks: happy path + idempotency + COUNT(*) on fresh table; NULL-argument fail-closed.
- [x] Default lane (`builddir`) unchanged — 23/23 PASS.
- [x] `./tools/gst-indent` applied.
- [ ] CI green across Linux / macOS / Windows (default lane only — audit lane runs subproject mode on main push only, prebuilt on PR).