### PR TITLE
audit: implement wyl_audit_emit INSERT path

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -196,11 +196,6 @@ test_revoke_req = executable('test-revoke-req',
 test('revoke-req', test_revoke_req)
 
 if get_option('enable_audit').allowed()
-  test_audit_conn = executable('test-audit-conn',
-    'test-audit-conn.c',
-    dependencies : [wyrelog_dep, duckdb_dep],
-  )
-
   audit_conn_test_env = environment()
   if host_machine.system() == 'windows' \
       and get_option('duckdb_source') == 'prebuilt'
@@ -215,5 +210,18 @@ if get_option('enable_audit').allowed()
       separator : ';')
   endif
 
+  test_audit_conn = executable('test-audit-conn',
+    'test-audit-conn.c',
+    dependencies : [wyrelog_dep, duckdb_dep],
+  )
+
   test('audit-conn', test_audit_conn, env : audit_conn_test_env)
+
+  test_audit_emit = executable('test-audit-emit',
+    'test-audit-emit.c',
+    c_args : ['-DWYL_HAS_AUDIT'],
+    dependencies : [wyrelog_dep, duckdb_dep],
+  )
+
+  test('audit-emit', test_audit_emit, env : audit_conn_test_env)
 endif

--- a/tests/test-audit-emit.c
+++ b/tests/test-audit-emit.c
@@ -1,0 +1,143 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <glib.h>
+#include <duckdb.h>
+
+#include "wyrelog/wyrelog.h"
+#include "wyrelog/audit/conn-private.h"
+#include "wyrelog/wyl-handle-private.h"
+
+/*
+ * End-to-end audit-emit test. wyl_init opens the audit log and
+ * creates the schema; we then construct an audit event, hand it to
+ * wyl_audit_emit, and verify the row landed in the audit_events
+ * table by querying the underlying DuckDB connection through the
+ * private accessor pair.
+ */
+
+static gint
+check_emit_inserts_a_row (void)
+{
+  WylHandle *handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 10;
+
+  g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
+  wyl_audit_event_set_subject_id (ev, "alice");
+  wyl_audit_event_set_action (ev, "read");
+  wyl_audit_event_set_resource_id (ev, "doc/42");
+  wyl_audit_event_set_decision (ev, WYL_DECISION_ALLOW);
+
+  if (wyl_audit_emit (handle, ev) != WYRELOG_E_OK) {
+    g_object_unref (handle);
+    return 11;
+  }
+
+  duckdb_connection conn =
+      wyl_audit_conn_get_connection (wyl_handle_get_audit_conn (handle));
+  duckdb_result result;
+  if (duckdb_query (conn,
+          "SELECT COUNT(*) FROM audit_events;", &result) != DuckDBSuccess) {
+    duckdb_destroy_result (&result);
+    g_object_unref (handle);
+    return 12;
+  }
+  if (duckdb_value_int64 (&result, 0, 0) != 1) {
+    duckdb_destroy_result (&result);
+    g_object_unref (handle);
+    return 13;
+  }
+  duckdb_destroy_result (&result);
+  g_object_unref (handle);
+  return 0;
+}
+
+static gint
+check_emit_persists_event_fields (void)
+{
+  WylHandle *handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 20;
+
+  g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
+  wyl_audit_event_set_subject_id (ev, "bob");
+  wyl_audit_event_set_action (ev, "write");
+  wyl_audit_event_set_resource_id (ev, "doc/99");
+  wyl_audit_event_set_decision (ev, WYL_DECISION_DENY);
+
+  g_autofree gchar *expected_id = wyl_audit_event_dup_id_string (ev);
+
+  if (wyl_audit_emit (handle, ev) != WYRELOG_E_OK) {
+    g_object_unref (handle);
+    return 21;
+  }
+
+  duckdb_connection conn =
+      wyl_audit_conn_get_connection (wyl_handle_get_audit_conn (handle));
+  duckdb_result result;
+  if (duckdb_query (conn,
+          "SELECT id, subject_id, action, resource_id, decision "
+          "FROM audit_events;", &result) != DuckDBSuccess) {
+    duckdb_destroy_result (&result);
+    g_object_unref (handle);
+    return 22;
+  }
+  gint rc = 0;
+  const gchar *id = duckdb_value_varchar (&result, 0, 0);
+  const gchar *subject = duckdb_value_varchar (&result, 1, 0);
+  const gchar *action = duckdb_value_varchar (&result, 2, 0);
+  const gchar *resource = duckdb_value_varchar (&result, 3, 0);
+  gint16 decision = (gint16) duckdb_value_int64 (&result, 4, 0);
+
+  if (g_strcmp0 (id, expected_id) != 0)
+    rc = 23;
+  else if (g_strcmp0 (subject, "bob") != 0)
+    rc = 24;
+  else if (g_strcmp0 (action, "write") != 0)
+    rc = 25;
+  else if (g_strcmp0 (resource, "doc/99") != 0)
+    rc = 26;
+  else if (decision != WYL_DECISION_DENY)
+    rc = 27;
+
+  duckdb_free ((void *) id);
+  duckdb_free ((void *) subject);
+  duckdb_free ((void *) action);
+  duckdb_free ((void *) resource);
+  duckdb_destroy_result (&result);
+  g_object_unref (handle);
+  return rc;
+}
+
+static gint
+check_emit_rejects_null_args (void)
+{
+  WylHandle *handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 30;
+
+  g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
+
+  if (wyl_audit_emit (NULL, ev) != WYRELOG_E_INVALID) {
+    g_object_unref (handle);
+    return 31;
+  }
+  if (wyl_audit_emit (handle, NULL) != WYRELOG_E_INVALID) {
+    g_object_unref (handle);
+    return 32;
+  }
+  g_object_unref (handle);
+  return 0;
+}
+
+int
+main (void)
+{
+  gint rc;
+  if ((rc = check_emit_inserts_a_row ()) != 0)
+    return rc;
+  if ((rc = check_emit_persists_event_fields ()) != 0)
+    return rc;
+  if ((rc = check_emit_rejects_null_args ()) != 0)
+    return rc;
+  return 0;
+}

--- a/wyrelog/audit/event.c
+++ b/wyrelog/audit/event.c
@@ -3,6 +3,13 @@
 
 #include "wyl-id-private.h"
 
+#ifdef WYL_HAS_AUDIT
+#include <duckdb.h>
+
+#include "audit/conn-private.h"
+#include "wyl-handle-private.h"
+#endif
+
 struct _WylAuditEvent
 {
   GObject parent_instance;
@@ -143,7 +150,69 @@ wyl_audit_event_get_decision (const WylAuditEvent *self)
 wyrelog_error_t
 wyl_audit_emit (WylHandle *handle, const WylAuditEvent *event)
 {
+#ifdef WYL_HAS_AUDIT
+  wyl_audit_conn_t *audit_conn;
+  duckdb_connection conn;
+  duckdb_prepared_statement stmt;
+  duckdb_result result;
+  duckdb_state rc;
+  gchar id_buf[WYL_ID_STRING_BUF];
+  const gchar *value;
+
+  if (handle == NULL || event == NULL)
+    return WYRELOG_E_INVALID;
+
+  audit_conn = wyl_handle_get_audit_conn (handle);
+  if (audit_conn == NULL)
+    return WYRELOG_E_INTERNAL;
+
+  conn = wyl_audit_conn_get_connection (audit_conn);
+
+  static const gchar *sql =
+      "INSERT INTO audit_events "
+      "(id, created_at_us, subject_id, action, resource_id, decision) "
+      "VALUES (?, ?, ?, ?, ?, ?);";
+
+  if (duckdb_prepare (conn, sql, &stmt) != DuckDBSuccess) {
+    duckdb_destroy_prepare (&stmt);
+    return WYRELOG_E_IO;
+  }
+
+  if (wyl_id_format (&event->id, id_buf, sizeof id_buf) != WYRELOG_E_OK) {
+    duckdb_destroy_prepare (&stmt);
+    return WYRELOG_E_INTERNAL;
+  }
+  duckdb_bind_varchar (stmt, 1, id_buf);
+  duckdb_bind_int64 (stmt, 2, event->created_at_us);
+
+  value = event->subject_id;
+  if (value != NULL)
+    duckdb_bind_varchar (stmt, 3, value);
+  else
+    duckdb_bind_null (stmt, 3);
+
+  value = event->action;
+  if (value != NULL)
+    duckdb_bind_varchar (stmt, 4, value);
+  else
+    duckdb_bind_null (stmt, 4);
+
+  value = event->resource_id;
+  if (value != NULL)
+    duckdb_bind_varchar (stmt, 5, value);
+  else
+    duckdb_bind_null (stmt, 5);
+
+  duckdb_bind_int16 (stmt, 6, (int16_t) event->decision);
+
+  rc = duckdb_execute_prepared (stmt, &result);
+  duckdb_destroy_result (&result);
+  duckdb_destroy_prepare (&stmt);
+
+  return (rc == DuckDBSuccess) ? WYRELOG_E_OK : WYRELOG_E_IO;
+#else
   (void) handle;
   (void) event;
   return WYRELOG_E_INTERNAL;
+#endif
 }

--- a/wyrelog/wyl-handle-private.h
+++ b/wyrelog/wyl-handle-private.h
@@ -1,0 +1,25 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+
+#include <glib.h>
+
+#include "wyrelog/handle.h"
+
+#ifdef WYL_HAS_AUDIT
+#include "audit/conn-private.h"
+#endif
+
+G_BEGIN_DECLS;
+
+#ifdef WYL_HAS_AUDIT
+/*
+ * Returns the borrowed audit connection owned by |self|. Lifetime
+ * is tied to the WylHandle: the pointer is valid until wyl_shutdown
+ * or g_object_unref. Available only when libwyrelog is built with
+ * the audit feature option allowed; the function does not exist in
+ * non-audit builds (and neither does the underlying type).
+ */
+wyl_audit_conn_t *wyl_handle_get_audit_conn (WylHandle * self);
+#endif
+
+G_END_DECLS;

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -118,3 +118,12 @@ wyl_handle_get_created_at_us (const WylHandle *self)
   g_return_val_if_fail (WYL_IS_HANDLE (self), -1);
   return self->created_at_us;
 }
+
+#ifdef WYL_HAS_AUDIT
+wyl_audit_conn_t *
+wyl_handle_get_audit_conn (WylHandle *self)
+{
+  g_return_val_if_fail (WYL_IS_HANDLE (self), NULL);
+  return self->audit_conn;
+}
+#endif


### PR DESCRIPTION
## Summary

- Replaces the `wyl_audit_emit` stub with a real INSERT against the `audit_events` table.
- Adds a new private header `wyrelog/wyl-handle-private.h` exposing `wyl_handle_get_audit_conn` (gated on `WYL_HAS_AUDIT`) so the audit subsystem can reach the conn that `wyl_init` opened.
- Uses DuckDB prepared statements with positional parameters; binds `id` (formatted), `created_at_us`, three nullable string fields, and `decision` SMALLINT.
- Non-audit builds: `wyl_audit_emit` continues to return `WYRELOG_E_INTERNAL`; ABI signature unchanged.

## Test plan

- [x] `meson test -C builddir-audit --suite wyrelog` — 25/25 PASS, including new `audit-emit` test (3 numbered checks: row count, full-field round-trip, NULL-arg rejection).
- [x] Default build: 23/23 PASS, no behavioural change.
- [x] `./tools/gst-indent` applied.
- [ ] CI green across Linux / macOS / Windows.

## Why a separate test file

`test-audit-emit.c` reaches into both private accessors (`wyl_handle_get_audit_conn` + `wyl_audit_conn_get_connection`) to query the underlying DuckDB connection and verify the row landed. That cross-domain seam is its own test concern; keeping it out of `test-audit-event.c` (which validates only the GObject's own surface) keeps each test single-responsibility.