### PR TITLE
access: implement wyl_decide with fail-closed v0 verdict

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -195,6 +195,13 @@ test_revoke_req = executable('test-revoke-req',
 
 test('revoke-req', test_revoke_req)
 
+test_decide = executable('test-decide',
+  'test-decide.c',
+  dependencies : [wyrelog_dep],
+)
+
+test('decide', test_decide)
+
 if get_option('enable_audit').allowed()
   audit_conn_test_env = environment()
   if host_machine.system() == 'windows' \

--- a/tests/test-decide.c
+++ b/tests/test-decide.c
@@ -1,0 +1,81 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <glib.h>
+
+#include "wyrelog/wyrelog.h"
+
+/*
+ * wyl_decide v0 contract: every decide call returns WYRELOG_E_OK
+ * with a DENY verdict (the policy decision point is not yet wired
+ * to a configured allow-list). Validates argument-handling and the
+ * fail-closed default.
+ */
+
+static gint
+check_decide_returns_ok_and_deny (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 10;
+
+  g_autoptr (wyl_decide_req_t) req = wyl_decide_req_new ();
+  wyl_decide_req_set_subject_id (req, "alice");
+  wyl_decide_req_set_action (req, "read");
+  wyl_decide_req_set_resource_id (req, "doc/42");
+
+  g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
+  if (wyl_decide (handle, req, resp) != WYRELOG_E_OK)
+    return 11;
+  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_DENY)
+    return 12;
+  return 0;
+}
+
+static gint
+check_decide_rejects_null_args (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 20;
+
+  g_autoptr (wyl_decide_req_t) req = wyl_decide_req_new ();
+  g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
+
+  if (wyl_decide (NULL, req, resp) != WYRELOG_E_INVALID)
+    return 21;
+  if (wyl_decide (handle, NULL, resp) != WYRELOG_E_INVALID)
+    return 22;
+  if (wyl_decide (handle, req, NULL) != WYRELOG_E_INVALID)
+    return 23;
+  return 0;
+}
+
+static gint
+check_decide_default_resp_stays_deny (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 30;
+
+  g_autoptr (wyl_decide_req_t) req = wyl_decide_req_new ();
+  g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
+  /* Pre-set ALLOW; decide must overwrite back to DENY. */
+  wyl_decide_resp_set_decision (resp, WYL_DECISION_ALLOW);
+  if (wyl_decide (handle, req, resp) != WYRELOG_E_OK)
+    return 31;
+  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_DENY)
+    return 32;
+  return 0;
+}
+
+int
+main (void)
+{
+  gint rc;
+  if ((rc = check_decide_returns_ok_and_deny ()) != 0)
+    return rc;
+  if ((rc = check_decide_rejects_null_args ()) != 0)
+    return rc;
+  if ((rc = check_decide_default_resp_stays_deny ()) != 0)
+    return rc;
+  return 0;
+}

--- a/wyrelog/wyl-decide.c
+++ b/wyrelog/wyl-decide.c
@@ -108,8 +108,29 @@ wyrelog_error_t
 wyl_decide (WylHandle *handle, const wyl_decide_req_t *req,
     wyl_decide_resp_t *resp)
 {
-  (void) handle;
-  (void) req;
-  (void) resp;
-  return WYRELOG_E_INTERNAL;
+  if (handle == NULL || req == NULL || resp == NULL)
+    return WYRELOG_E_INVALID;
+
+  /* The policy decision point is not yet wired to the principal /
+   * session FSMs or to a configured allow-list, so every decide
+   * call returns DENY. This keeps the public contract fail-closed
+   * by default; a future commit will replace this with the actual
+   * Datalog evaluation. */
+  wyl_decide_resp_set_decision (resp, WYL_DECISION_DENY);
+
+#ifdef WYL_HAS_AUDIT
+  /* Mirror the decision into the audit log so every decide call
+   * leaves a row regardless of whether downstream callers also
+   * emit explicitly. Failures from emit are intentionally not
+   * propagated: a decision was made and reported; the audit-side
+   * write is best-effort relative to the caller's contract. */
+  g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
+  wyl_audit_event_set_subject_id (ev, wyl_decide_req_get_subject_id (req));
+  wyl_audit_event_set_action (ev, wyl_decide_req_get_action (req));
+  wyl_audit_event_set_resource_id (ev, wyl_decide_req_get_resource_id (req));
+  wyl_audit_event_set_decision (ev, wyl_decide_resp_get_decision (resp));
+  (void) wyl_audit_emit (handle, ev);
+#endif
+
+  return WYRELOG_E_OK;
 }


### PR DESCRIPTION
## Summary

- Replaces the `wyl_decide` stub with a real (but minimal) implementation.
- v0 contract: validate args, always return `WYL_DECISION_DENY`, always return `WYRELOG_E_OK` for valid input.
- When audit is enabled, mirrors the decision into the audit log via `wyl_audit_emit` (failures intentionally swallowed — the caller's contract is "decision produced", audit is best-effort relative to that).
- The Datalog policy evaluation that replaces the always-DENY verdict is a follow-up.

## Test plan

- [x] Default build: 24/24 PASS, no audit-mirror code compiled.
- [x] Audit build: 26/26 PASS, every decide call appends to the audit_events table.
- [x] 3 numbered checks: full happy path, NULL-arg rejection, response-clobber.
- [x] `./tools/gst-indent` applied.
- [ ] CI green across Linux / macOS / Windows.

## Why DENY by default

The actual policy decision point (Datalog evaluation against principal/session FSMs and a configured allow-list) is its own atomic. Until then, the safest contract is fail-closed: callers either get an explicit DENY they can trust, or an error. They never get an accidental ALLOW from a half-implemented decide.