### PR TITLE
access: implement wyl_session_logout v0

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -209,6 +209,13 @@ test_perm = executable('test-perm',
 
 test('perm', test_perm)
 
+test_session_logout = executable('test-session-logout',
+  'test-session-logout.c',
+  dependencies : [wyrelog_dep],
+)
+
+test('session-logout', test_session_logout)
+
 if get_option('enable_audit').allowed()
   audit_conn_test_env = environment()
   if host_machine.system() == 'windows' \

--- a/tests/test-session-logout.c
+++ b/tests/test-session-logout.c
@@ -1,0 +1,60 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <glib.h>
+
+#include "wyrelog/wyrelog.h"
+
+/*
+ * v0 contract for wyl_session_logout: validate handle, record the
+ * logout in the audit log when audit is enabled, and return
+ * WYRELOG_E_OK without touching a durable session table. The
+ * session-store teardown is a follow-up.
+ */
+
+static gint
+check_logout_returns_ok (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 10;
+
+  if (wyl_session_logout (handle, 42) != WYRELOG_E_OK)
+    return 11;
+  return 0;
+}
+
+static gint
+check_logout_rejects_null_handle (void)
+{
+  if (wyl_session_logout (NULL, 42) != WYRELOG_E_INVALID)
+    return 20;
+  return 0;
+}
+
+static gint
+check_logout_accepts_zero_sid (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 30;
+
+  /* sid is an opaque integer at this layer; the session-table
+   * implementation will reject unknown ids in a future commit, but
+   * v0 has no table to consult so any well-formed integer is
+   * accepted. */
+  if (wyl_session_logout (handle, 0) != WYRELOG_E_OK)
+    return 31;
+  return 0;
+}
+
+int
+main (void)
+{
+  gint rc;
+  if ((rc = check_logout_returns_ok ()) != 0)
+    return rc;
+  if ((rc = check_logout_rejects_null_handle ()) != 0)
+    return rc;
+  if ((rc = check_logout_accepts_zero_sid ()) != 0)
+    return rc;
+  return 0;
+}

--- a/wyrelog/wyl-session.c
+++ b/wyrelog/wyl-session.c
@@ -67,9 +67,29 @@ wyl_session_login (WylHandle *handle, const wyl_login_req_t *req,
 wyrelog_error_t
 wyl_session_logout (WylHandle *handle, wyl_session_id_t sid)
 {
-  (void) handle;
+  if (handle == NULL)
+    return WYRELOG_E_INVALID;
+
+#ifdef WYL_HAS_AUDIT
+  /* Mirror the logout in the audit log so session terminations are
+   * observable even before the session table that owns the sid is
+   * wired. The action column carries "logout" semantics; the
+   * subject_id column carries the integer session handle as text
+   * so log readers can tie the event back to the originating
+   * wyl_session_login. */
+  g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
+  g_autofree gchar *sid_str = g_strdup_printf ("%" G_GUINT64_FORMAT, sid);
+  wyl_audit_event_set_subject_id (ev, sid_str);
+  wyl_audit_event_set_action (ev, "logout");
+  wyl_audit_event_set_decision (ev, WYL_DECISION_ALLOW);
+  (void) wyl_audit_emit (handle, ev);
+#else
   (void) sid;
-  return WYRELOG_E_INTERNAL;
+#endif
+
+  /* Real session-table teardown lands in a follow-up; v0 returns
+   * E_OK after argument validation and audit recording. */
+  return WYRELOG_E_OK;
 }
 
 gchar *


### PR DESCRIPTION
## Summary

- Replaces `wyl_session_logout` stub with v0 implementation matching the contract used by decide / perm_grant / perm_revoke (PR #60, #61).
- v0 contract: validate handle (NULL → `WYRELOG_E_INVALID`), audit-mirror on enable_audit (action="logout", subject_id=stringified sid), return `WYRELOG_E_OK`.
- Real session-table teardown is a follow-up.

## Why this completes the A group

This is the **last** public-API stub returning `WYRELOG_E_INTERNAL`. Every entry point now does meaningful validation and, where applicable, audit recording. The four atomics `wyl_audit_emit` (PR #59), `wyl_decide` (PR #60), `wyl_perm_grant`/`_revoke` (PR #61), and now `wyl_session_logout` together close the A group from the earlier work plan.

## Test plan

- [x] Default build: 26/26 PASS.
- [x] Audit build: 28/28 PASS.
- [x] 3 numbered checks: positive sid happy path, NULL handle rejection, sid=0 accepted.
- [x] `./tools/gst-indent` applied.
- [ ] CI green across Linux / macOS / Windows.