### PR TITLE
error: add WYRELOG_E_EXEC for evaluator runtime faults

### DIFF
--- a/wyrelog/error.h
+++ b/wyrelog/error.h
@@ -15,6 +15,15 @@ typedef enum wyrelog_error_t
   WYRELOG_E_POLICY = -5,
   WYRELOG_E_AUTH = -6,
   WYRELOG_E_INTERNAL = -7,
+  /*
+   * Runtime fault inside the embedded Datalog evaluator after a
+   * successful policy load: e.g. recursion/aggregate overflow,
+   * dynamic negation cycle, or a fact-shape mismatch surfaced at
+   * evaluation time. Distinct from WYRELOG_E_POLICY (load-time
+   * shape error) and WYRELOG_E_INTERNAL (wyrelog-side invariant
+   * violation) so operators can route incidents correctly.
+   */
+  WYRELOG_E_EXEC = -8,
 } wyrelog_error_t;
 
 const gchar *wyrelog_error_string (wyrelog_error_t err);

--- a/wyrelog/wyl-error.c
+++ b/wyrelog/wyl-error.c
@@ -16,11 +16,13 @@ wyrelog_error_string (wyrelog_error_t err)
     case WYRELOG_E_CRYPTO:
       return "cryptographic operation failed";
     case WYRELOG_E_POLICY:
-      return "policy evaluation failed";
+      return "policy load or shape error";
     case WYRELOG_E_AUTH:
       return "authentication or authorization failure";
     case WYRELOG_E_INTERNAL:
       return "internal invariant violated";
+    case WYRELOG_E_EXEC:
+      return "policy evaluation runtime fault";
   }
   return "unknown error";
 }


### PR DESCRIPTION
## Summary

- Adds `WYRELOG_E_EXEC = -8` to the public `wyrelog_error_t` taxonomy.
- Distinguishes runtime evaluator faults (after a successful policy load) from policy-shape errors (`WYRELOG_E_POLICY`) and wyrelog-side invariant violations (`WYRELOG_E_INTERNAL`).
- Refines `WYRELOG_E_POLICY`'s diagnostic string from "policy evaluation failed" to "policy load or shape error" to make the boundary explicit. String is diagnostic only; no API contract change.
- Operators routing incidents from audit-log error codes can now distinguish "reload the policy" (`E_POLICY`) vs "inspect fact data / evaluator" (`E_EXEC`) vs "file a bug" (`E_INTERNAL`).

## Why this lands as its own atomic

The follow-up engine atomic introduces a translator that maps the embedded Datalog runtime's error codes onto `wyrelog_error_t`. The runtime distinguishes load-time vs evaluation-time faults; collapsing both into `E_INTERNAL` or `E_POLICY` would either lose the distinction or mis-categorise it. The new code lives in its own commit so the engine work that consumes it can stay focused on the engine.

## ABI

The new value is appended at the negative tail. Existing consumers reading the integer code observe no shift. Switch statements that exhausted prior values still compile and route the new value through their default branch. No SOVERSION bump required for v0.1.0.

## Test plan

- [x] Default lane (`builddir`): 26/26 PASS.
- [x] Audit lane (`builddir-audit`): 28/28 PASS.
- [x] `./tools/gst-indent` applied.
- [ ] CI green across Linux / macOS / Windows.