### PR TITLE
build: install access templates with install_subdir

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -70,29 +70,13 @@ libchronoid_dep = declare_dependency(
 subdir('wyrelog')
 subdir('tests')
 
-install_data(
-  'templates/access/bootstrap.dl',
-  install_dir : join_paths(get_option('datadir'), 'wyrelog', 'access'),
-)
-
-install_data(
-  'templates/access/decision.dl',
-  install_dir : join_paths(get_option('datadir'), 'wyrelog', 'access'),
-)
-
-install_data(
-  'templates/access/fsm/principal.dl',
-  install_dir : join_paths(get_option('datadir'), 'wyrelog', 'access', 'fsm'),
-)
-
-install_data(
-  'templates/access/fsm/session.dl',
-  install_dir : join_paths(get_option('datadir'), 'wyrelog', 'access', 'fsm'),
-)
-
-install_data(
-  'templates/access/fsm/permission_scope.dl',
-  install_dir : join_paths(get_option('datadir'), 'wyrelog', 'access', 'fsm'),
+# Install the access-control .dl template tree as a single subdir under
+# ${datadir}/wyrelog/access. install_subdir mirrors the source layout
+# (including the fsm/ subdirectory) and picks up future additions
+# without requiring a meson.build edit per template.
+install_subdir(
+  'templates/access',
+  install_dir : join_paths(get_option('datadir'), 'wyrelog'),
 )
 
 # Install git pre-commit hook for code style checking


### PR DESCRIPTION
## Summary

- Replace five per-file `install_data` blocks for the access-control `.dl` templates (`bootstrap`, `decision`, `fsm/principal`, `fsm/session`, `fsm/permission_scope`) with one `install_subdir('templates/access', install_dir: ${datadir}/wyrelog)`.
- On-disk layout for the `.dl` files is unchanged: `${datadir}/wyrelog/access/{*,fsm/*}.dl`.
- Side effect: `duckdb-schema.sql` and `sqlite-schema.sql` in `templates/access/` are now installed alongside the `.dl` files; the previous per-file `install_data` set silently omitted them. They are intended runtime resources for the policy-DB and audit-DB stages and should have been installed already.
- Future additions under `templates/access/` (additional `fsm/*.dl`, etc.) are picked up automatically without a `meson.build` edit.

No source-code change.

## Test plan

- [x] `meson setup builddir --reconfigure` succeeds
- [x] `meson install -C builddir --destdir=/tmp/check` lands the same five `.dl` files at the same paths as before, plus the two `.sql` schema files
- [x] `meson test -C builddir` passes 30/30