### PR TITLE
log: WYL_LOG observability surface (parser, file sink, ceilings, CRITICAL invariant, CI guard)

### DIFF
--- a/meson.options
+++ b/meson.options
@@ -59,6 +59,20 @@ option('duckdb_source',
               + 'subproject for from-source validation.'
 )
 
+option('wyrelog_log_max_level',
+  type : 'combo',
+  choices : ['none', 'error', 'warn', 'info', 'debug', 'trace'],
+  value : 'debug',
+  description : 'Compile-time ceiling for the WYL_LOG structured '
+              + 'logger. Levels above this value have their call '
+              + 'sites stripped at compile time so no .text bytes '
+              + 'and no argument evaluation occur. Use "error" or '
+              + '"warn" for release/production builds. Default '
+              + '"debug" suits in-tree development. The runtime '
+              + 'WYL_LOG environment variable filters within this '
+              + 'compile-time ceiling but cannot raise it.'
+)
+
 option('enable_break_glass',
   type : 'boolean',
   value : false,

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -40,6 +40,16 @@ test_log = executable('test-log',
 
 test('log', test_log)
 
+# Compile with ceiling=WARN (2) to verify disabled levels do not
+# evaluate their arguments and CRITICAL still bypasses the ceiling.
+test_log_ceiling = executable('test-log-ceiling',
+  'test-log-ceiling.c',
+  c_args : ['-DWYL_LOG_MAX_LEVEL=2'],
+  dependencies : [wyrelog_dep],
+)
+
+test('log-ceiling', test_log_ceiling)
+
 fsm_principal_dl_path = join_paths(
   meson.project_source_root(),
   'templates', 'access', 'fsm', 'principal.dl',
@@ -222,6 +232,12 @@ test_session_logout = executable('test-session-logout',
 )
 
 test('session-logout', test_session_logout)
+
+check_private_headers = find_program(
+  '../tools/check-private-headers-not-installed.sh',
+)
+
+test('check-private-headers-not-installed', check_private_headers)
 
 if get_option('enable_audit').allowed()
   audit_conn_test_env = environment()

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -33,6 +33,13 @@ test_dl_static = executable('test-dl-static',
 
 test('dl-static', test_dl_static)
 
+test_log = executable('test-log',
+  'test-log.c',
+  dependencies : [wyrelog_dep],
+)
+
+test('log', test_log)
+
 fsm_principal_dl_path = join_paths(
   meson.project_source_root(),
   'templates', 'access', 'fsm', 'principal.dl',

--- a/tests/test-log-ceiling.c
+++ b/tests/test-log-ceiling.c
@@ -84,6 +84,11 @@ test_error_evaluates_args (void)
 static void
 test_critical_aborts_process (void)
 {
+#ifdef G_OS_WIN32
+  g_test_skip ("g_test_trap_subprocess is not portable to Windows; "
+      "the abort/bypass invariant is verified on POSIX hosts only.");
+  return;
+#endif
   if (g_test_subprocess ()) {
     /* Child: fire CRITICAL — expected to abort via G_LOG_LEVEL_ERROR. */
     WYL_LOG_CRITICAL (WYL_LOG_SECTION_GENERAL, "boom");
@@ -113,6 +118,11 @@ test_critical_aborts_process (void)
 static void
 test_critical_bypasses_ceiling (void)
 {
+#ifdef G_OS_WIN32
+  g_test_skip ("g_test_trap_subprocess is not portable to Windows; "
+      "the abort/bypass invariant is verified on POSIX hosts only.");
+  return;
+#endif
   if (g_test_subprocess ()) {
     /* Child path: read unique tmpdir from env, silence the runtime
      * threshold, then fire CRITICAL.  The sentinel file is written

--- a/tests/test-log-ceiling.c
+++ b/tests/test-log-ceiling.c
@@ -1,0 +1,88 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * test-log-ceiling.c — compile-time ceiling side-effect test.
+ *
+ * This test is compiled with -DWYL_LOG_MAX_LEVEL=2 (WARN) to verify
+ * that macros whose required level exceeds the ceiling do NOT evaluate
+ * their arguments (no side-effects), while macros at or below the
+ * ceiling DO evaluate arguments.
+ *
+ * Expected behaviour under ceiling=WARN (2):
+ *   WYL_LOG_DEBUG  (level 4) -> no-op, arguments not evaluated
+ *   WYL_LOG_INFO   (level 3) -> no-op, arguments not evaluated
+ *   WYL_LOG_WARN   (level 2) -> active, arguments evaluated
+ *   WYL_LOG_ERROR  (level 1) -> active, arguments evaluated
+ *   WYL_LOG_CRITICAL         -> always active (bypasses ceiling)
+ */
+
+#include <glib.h>
+
+/* Override the ceiling before including the private header. */
+#ifdef WYL_LOG_MAX_LEVEL
+#undef WYL_LOG_MAX_LEVEL
+#endif
+#define WYL_LOG_MAX_LEVEL 2     /* WYL_LOG_LEVEL_WARN */
+
+#include "wyrelog/wyl-log-private.h"
+
+static gint side_effect_counter = 0;
+
+static gint
+side_effect (void)
+{
+  side_effect_counter++;
+  return side_effect_counter;
+}
+
+static void
+test_debug_no_side_effect (void)
+{
+  side_effect_counter = 0;
+  /* DEBUG level (4) > ceiling (2): macro must be a no-op. */
+  WYL_LOG_DEBUG (WYL_LOG_SECTION_GENERAL, "%d", side_effect ());
+  g_assert_cmpint (side_effect_counter, ==, 0);
+}
+
+static void
+test_info_no_side_effect (void)
+{
+  side_effect_counter = 0;
+  /* INFO level (3) > ceiling (2): macro must be a no-op. */
+  WYL_LOG_INFO (WYL_LOG_SECTION_GENERAL, "%d", side_effect ());
+  g_assert_cmpint (side_effect_counter, ==, 0);
+}
+
+static void
+test_warn_evaluates_args (void)
+{
+  side_effect_counter = 0;
+  /* WARN level (2) == ceiling (2): macro must evaluate arguments. */
+  WYL_LOG_WARN (WYL_LOG_SECTION_GENERAL, "%d", side_effect ());
+  g_assert_cmpint (side_effect_counter, ==, 1);
+}
+
+static void
+test_error_evaluates_args (void)
+{
+  side_effect_counter = 0;
+  /* ERROR level (1) < ceiling (2): macro must evaluate arguments. */
+  WYL_LOG_ERROR (WYL_LOG_SECTION_GENERAL, "%d", side_effect ());
+  g_assert_cmpint (side_effect_counter, ==, 1);
+}
+
+int
+main (int argc, char **argv)
+{
+  g_test_init (&argc, &argv, NULL);
+
+  g_test_add_func ("/wyl-log-ceiling/debug-no-side-effect",
+      test_debug_no_side_effect);
+  g_test_add_func ("/wyl-log-ceiling/info-no-side-effect",
+      test_info_no_side_effect);
+  g_test_add_func ("/wyl-log-ceiling/warn-evaluates-args",
+      test_warn_evaluates_args);
+  g_test_add_func ("/wyl-log-ceiling/error-evaluates-args",
+      test_error_evaluates_args);
+
+  return g_test_run ();
+}

--- a/tests/test-log-ceiling.c
+++ b/tests/test-log-ceiling.c
@@ -77,15 +77,23 @@ test_error_evaluates_args (void)
  *
  * Strategy: the child writes a sentinel file before the abort fires.
  * If args are not evaluated the sentinel never appears.  The parent
- * verifies the child aborted AND the sentinel exists. */
+ * verifies the child aborted AND the sentinel exists.
+ *
+ * Isolation: a process-unique tmpdir (via g_dir_make_tmp) is created by
+ * the parent and communicated to the child via WYL_TEST_CRITICAL_TMPDIR.
+ * This prevents collisions between concurrent test runs (CI matrix,
+ * meson test --repeat=N, parallel runners sharing /tmp). */
 static void
 test_critical_bypasses_ceiling (void)
 {
   if (g_test_subprocess ()) {
-    /* Child path: silence the runtime threshold, then fire CRITICAL.
-     * The sentinel file is written first so we have proof of arg
-     * evaluation regardless of where the abort signal lands. */
-    g_autofree gchar *marker = g_build_filename (g_get_tmp_dir (),
+    /* Child path: read unique tmpdir from env, silence the runtime
+     * threshold, then fire CRITICAL.  The sentinel file is written
+     * first so we have proof of arg evaluation regardless of where
+     * the abort signal lands. */
+    const gchar *tmpdir = g_getenv ("WYL_TEST_CRITICAL_TMPDIR");
+    g_autofree gchar *marker =
+        g_build_filename (tmpdir ? tmpdir : g_get_tmp_dir (),
         "wyl-critical-bypass-marker", NULL);
 
     g_unsetenv ("WYL_LOG_FILE");
@@ -100,9 +108,18 @@ test_critical_bypasses_ceiling (void)
     return;
   }
 
-  g_autofree gchar *marker = g_build_filename (g_get_tmp_dir (),
-      "wyl-critical-bypass-marker", NULL);
-  g_unlink (marker);
+  /* Parent path: create a process-unique tmpdir and pass its path to
+   * the subprocess via env var so parallel test runs cannot collide
+   * on the same sentinel filename. */
+  GError *err = NULL;
+  g_autofree gchar *tmpdir = g_dir_make_tmp ("wyl-critical-XXXXXX", &err);
+  g_assert_no_error (err);
+  g_assert_nonnull (tmpdir);
+
+  g_setenv ("WYL_TEST_CRITICAL_TMPDIR", tmpdir, TRUE);
+
+  g_autofree gchar *marker =
+      g_build_filename (tmpdir, "wyl-critical-bypass-marker", NULL);
 
   g_test_trap_subprocess (NULL, 0, 0);
   g_test_trap_assert_failed ();
@@ -112,7 +129,12 @@ test_critical_bypasses_ceiling (void)
   gboolean ok = g_file_get_contents (marker, &contents, NULL, NULL);
   g_assert_true (ok);
   g_free (contents);
-  g_unlink (marker);
+
+  /* Cleanup: remove sentinel then unique tmpdir. */
+  g_remove (marker);
+  g_rmdir (tmpdir);
+
+  g_unsetenv ("WYL_TEST_CRITICAL_TMPDIR");
 }
 
 int

--- a/tests/test-log-ceiling.c
+++ b/tests/test-log-ceiling.c
@@ -16,6 +16,7 @@
  */
 
 #include <glib.h>
+#include <glib/gstdio.h>
 
 /* Override the ceiling before including the private header. */
 #ifdef WYL_LOG_MAX_LEVEL
@@ -70,19 +71,65 @@ test_error_evaluates_args (void)
   g_assert_cmpint (side_effect_counter, ==, 1);
 }
 
+/* Test that WYL_LOG_CRITICAL evaluates its arguments even when:
+ *   - WYL_LOG_MAX_LEVEL=2  (compile-time ceiling, set at build time)
+ *   - WYL_LOG=*:none       (runtime threshold suppresses all sections)
+ *
+ * Strategy: the child writes a sentinel file before the abort fires.
+ * If args are not evaluated the sentinel never appears.  The parent
+ * verifies the child aborted AND the sentinel exists. */
+static void
+test_critical_bypasses_ceiling (void)
+{
+  if (g_test_subprocess ()) {
+    /* Child path: silence the runtime threshold, then fire CRITICAL.
+     * The sentinel file is written first so we have proof of arg
+     * evaluation regardless of where the abort signal lands. */
+    g_autofree gchar *marker = g_build_filename (g_get_tmp_dir (),
+        "wyl-critical-bypass-marker", NULL);
+
+    g_unsetenv ("WYL_LOG_FILE");
+    g_setenv ("WYL_LOG", "*:none", TRUE);
+    wyl_log_internal_reconfigure ();
+
+    /* Write the sentinel before calling CRITICAL. */
+    g_file_set_contents (marker, "1", 1, NULL);
+
+    WYL_LOG_CRITICAL (WYL_LOG_SECTION_GENERAL, "bypass-test");
+    /* Unreachable: WYL_LOG_CRITICAL aborts. */
+    return;
+  }
+
+  g_autofree gchar *marker = g_build_filename (g_get_tmp_dir (),
+      "wyl-critical-bypass-marker", NULL);
+  g_unlink (marker);
+
+  g_test_trap_subprocess (NULL, 0, 0);
+  g_test_trap_assert_failed ();
+
+  /* Verify the sentinel (side-effect) ran in the child. */
+  gchar *contents = NULL;
+  gboolean ok = g_file_get_contents (marker, &contents, NULL, NULL);
+  g_assert_true (ok);
+  g_free (contents);
+  g_unlink (marker);
+}
+
 int
 main (int argc, char **argv)
 {
   g_test_init (&argc, &argv, NULL);
 
-  g_test_add_func ("/wyl-log-ceiling/debug-no-side-effect",
+  g_test_add_func ("/wyl-log/ceiling/debug-no-side-effect",
       test_debug_no_side_effect);
-  g_test_add_func ("/wyl-log-ceiling/info-no-side-effect",
+  g_test_add_func ("/wyl-log/ceiling/info-no-side-effect",
       test_info_no_side_effect);
-  g_test_add_func ("/wyl-log-ceiling/warn-evaluates-args",
+  g_test_add_func ("/wyl-log/ceiling/warn-evaluates-args",
       test_warn_evaluates_args);
-  g_test_add_func ("/wyl-log-ceiling/error-evaluates-args",
+  g_test_add_func ("/wyl-log/ceiling/error-evaluates-args",
       test_error_evaluates_args);
+  g_test_add_func ("/wyl-log/ceiling/critical-bypasses-ceiling",
+      test_critical_bypasses_ceiling);
 
   return g_test_run ();
 }

--- a/tests/test-log-ceiling.c
+++ b/tests/test-log-ceiling.c
@@ -71,6 +71,33 @@ test_error_evaluates_args (void)
   g_assert_cmpint (side_effect_counter, ==, 1);
 }
 
+/* T6 — Death test: WYL_LOG_CRITICAL triggers abort() via G_LOG_LEVEL_ERROR.
+ *
+ * Uses g_test_trap_subprocess to spawn a child that calls
+ * WYL_LOG_CRITICAL(GENERAL, "boom"). GLib raises G_LOG_LEVEL_ERROR which
+ * always calls abort(). The parent verifies the child did not exit cleanly
+ * (g_test_trap_assert_failed) and that GLib's abort-class message reached
+ * stderr.
+ *
+ * This is distinct from test_critical_bypasses_ceiling, which proves side-
+ * effect evaluation under ceiling=2. T6 proves the abort itself fires. */
+static void
+test_critical_aborts_process (void)
+{
+  if (g_test_subprocess ()) {
+    /* Child: fire CRITICAL — expected to abort via G_LOG_LEVEL_ERROR. */
+    WYL_LOG_CRITICAL (WYL_LOG_SECTION_GENERAL, "boom");
+    /* Unreachable. */
+    return;
+  }
+
+  g_test_trap_subprocess (NULL, 0, 0);
+  g_test_trap_assert_failed ();
+  /* The child's stderr carries the wyrelog-formatted record that
+   * triggered the abort; verify the message text reached stderr. */
+  g_test_trap_assert_stderr ("*boom*");
+}
+
 /* Test that WYL_LOG_CRITICAL evaluates its arguments even when:
  *   - WYL_LOG_MAX_LEVEL=2  (compile-time ceiling, set at build time)
  *   - WYL_LOG=*:none       (runtime threshold suppresses all sections)
@@ -152,6 +179,8 @@ main (int argc, char **argv)
       test_error_evaluates_args);
   g_test_add_func ("/wyl-log/ceiling/critical-bypasses-ceiling",
       test_critical_bypasses_ceiling);
+  g_test_add_func ("/wyl-log/ceiling/critical-aborts-process",
+      test_critical_aborts_process);
 
   return g_test_run ();
 }

--- a/tests/test-log.c
+++ b/tests/test-log.c
@@ -180,16 +180,16 @@ test_file_sink_redirection (void)
 
   g_setenv ("WYL_LOG_FILE", path, TRUE);
   g_setenv ("WYL_LOG", "*:5", TRUE);
-  wyl_log_internal_reload_for_tests ();
+  wyl_log_internal_reconfigure ();
 
   wyl_log_structured (WYL_LOG_SECTION_GENERAL, G_LOG_LEVEL_WARNING,
       "redirect-test-marker %d", 42);
 
   /* Flush any pending writes. */
-  wyl_log_internal_reload_for_tests (); /* closes the file */
+  wyl_log_internal_reconfigure ();      /* closes the file */
   g_unsetenv ("WYL_LOG_FILE");
   g_unsetenv ("WYL_LOG");
-  wyl_log_internal_reload_for_tests ();
+  wyl_log_internal_reconfigure ();
 
   g_autofree gchar *contents = NULL;
   gsize len = 0;
@@ -210,13 +210,13 @@ test_file_sink_fallback_on_invalid_path (void)
   g_setenv ("WYL_LOG", "*:5", TRUE);
 
   /* Must not crash — stderr fallback applies (FC1: do not refuse to boot). */
-  wyl_log_internal_reload_for_tests ();
+  wyl_log_internal_reconfigure ();
   wyl_log_structured (WYL_LOG_SECTION_GENERAL, G_LOG_LEVEL_WARNING,
       "fallback-test-marker");
 
   g_unsetenv ("WYL_LOG_FILE");
   g_unsetenv ("WYL_LOG");
-  wyl_log_internal_reload_for_tests ();
+  wyl_log_internal_reconfigure ();
 }
 
 static void
@@ -229,7 +229,7 @@ test_runtime_filter_end_to_end (void)
   g_setenv ("WYL_LOG_FILE", path, TRUE);
   /* GENERAL threshold = ERROR (1); POLICY threshold = TRACE (5). */
   g_setenv ("WYL_LOG", "GENERAL:1,POLICY:5", TRUE);
-  wyl_log_internal_reload_for_tests ();
+  wyl_log_internal_reconfigure ();
 
   /* DEBUG (wyl level 4) > GENERAL threshold (1) -> should be suppressed. */
   wyl_log_structured (WYL_LOG_SECTION_GENERAL, G_LOG_LEVEL_DEBUG,
@@ -241,7 +241,7 @@ test_runtime_filter_end_to_end (void)
   /* Close the file by reloading with no WYL_LOG_FILE. */
   g_unsetenv ("WYL_LOG_FILE");
   g_unsetenv ("WYL_LOG");
-  wyl_log_internal_reload_for_tests ();
+  wyl_log_internal_reconfigure ();
 
   g_autofree gchar *contents = NULL;
   gsize len = 0;
@@ -259,7 +259,7 @@ test_runtime_filter_end_to_end (void)
 }
 
 static void
-test_same_path_coexistence_no_crash (void)
+test_file_sink_reopen_same_path_no_crash (void)
 {
   g_autofree gchar *tmpdir = g_dir_make_tmp ("wyrelog-test-XXXXXX", NULL);
   g_assert_nonnull (tmpdir);
@@ -272,7 +272,7 @@ test_same_path_coexistence_no_crash (void)
   g_setenv ("WL_LOG_FILE", path, TRUE);
   g_setenv ("WYL_LOG_FILE", path, TRUE);
   g_setenv ("WYL_LOG", "*:5", TRUE);
-  wyl_log_internal_reload_for_tests ();
+  wyl_log_internal_reconfigure ();
 
   wyl_log_structured (WYL_LOG_SECTION_GENERAL, G_LOG_LEVEL_WARNING,
       "coexistence-test-marker");
@@ -280,7 +280,7 @@ test_same_path_coexistence_no_crash (void)
   g_unsetenv ("WL_LOG_FILE");
   g_unsetenv ("WYL_LOG_FILE");
   g_unsetenv ("WYL_LOG");
-  wyl_log_internal_reload_for_tests ();
+  wyl_log_internal_reconfigure ();
 
   g_autofree gchar *contents = NULL;
   gsize len = 0;
@@ -331,8 +331,8 @@ main (int argc, char **argv)
       test_file_sink_fallback_on_invalid_path);
   g_test_add_func ("/wyl-log/runtime/filter-end-to-end",
       test_runtime_filter_end_to_end);
-  g_test_add_func ("/wyl-log/runtime/same-path-coexistence-no-crash",
-      test_same_path_coexistence_no_crash);
+  g_test_add_func ("/wyl-log/runtime/file-sink-reopen-same-path-no-crash",
+      test_file_sink_reopen_same_path_no_crash);
 
   return g_test_run ();
 }

--- a/tests/test-log.c
+++ b/tests/test-log.c
@@ -3,6 +3,7 @@
 #include <unistd.h>
 
 #include <glib.h>
+#include <glib/gstdio.h>
 
 #include "wyrelog/wyl-log-private.h"
 
@@ -294,6 +295,86 @@ test_file_sink_reopen_same_path_no_crash (void)
   rmdir (tmpdir);
 }
 
+/* T7 — Thread-stress: sink_mutex serialises concurrent writes correctly.
+ *
+ * 8 threads each emit 1000 WARNING records into a shared file sink.
+ * After all threads join we verify:
+ *   - total line count == 8000 (no records lost)
+ *   - no line is empty (no torn mid-line interleave)
+ *
+ * Process-unique tmpdir (g_dir_make_tmp) avoids collisions with parallel
+ * meson test runs. */
+
+#define T7_THREAD_COUNT 8
+#define T7_RECORDS_PER_THREAD 1000
+
+typedef struct
+{
+  gint thread_id;
+} T7ThreadData;
+
+static gpointer
+t7_writer_thread (gpointer user_data)
+{
+  T7ThreadData *d = (T7ThreadData *) user_data;
+  for (gint i = 0; i < T7_RECORDS_PER_THREAD; i++) {
+    wyl_log_structured_at (WYL_LOG_SECTION_GENERAL, G_LOG_LEVEL_WARNING,
+        NULL, 0, NULL, "t7-thread-%d-record-%d", d->thread_id, i);
+  }
+  return NULL;
+}
+
+static void
+test_sink_mutex_concurrent_writes (void)
+{
+  GError *err = NULL;
+  g_autofree gchar *tmpdir = g_dir_make_tmp ("wyl-t7-XXXXXX", &err);
+  g_assert_no_error (err);
+  g_assert_nonnull (tmpdir);
+
+  g_autofree gchar *path = g_build_filename (tmpdir, "t7.log", NULL);
+
+  g_setenv ("WYL_LOG_FILE", path, TRUE);
+  g_setenv ("WYL_LOG", "*:2", TRUE);
+  wyl_log_internal_reconfigure ();
+
+  GThread *threads[T7_THREAD_COUNT];
+  T7ThreadData data[T7_THREAD_COUNT];
+  for (gint i = 0; i < T7_THREAD_COUNT; i++) {
+    data[i].thread_id = i;
+    threads[i] = g_thread_new ("t7-writer", t7_writer_thread, &data[i]);
+    g_assert_nonnull (threads[i]);
+  }
+  for (gint i = 0; i < T7_THREAD_COUNT; i++)
+    g_thread_join (threads[i]);
+
+  /* Flush: close the file by reconfiguring without WYL_LOG_FILE. */
+  g_unsetenv ("WYL_LOG_FILE");
+  g_unsetenv ("WYL_LOG");
+  wyl_log_internal_reconfigure ();
+
+  /* Read the log file and verify line count and integrity. */
+  g_autofree gchar *contents = NULL;
+  gsize len = 0;
+  gboolean ok = g_file_get_contents (path, &contents, &len, NULL);
+  g_assert_true (ok);
+  g_assert_nonnull (contents);
+
+  gchar **lines = g_strsplit (contents, "\n", -1);
+  gint line_count = 0;
+  for (gint i = 0; lines[i] != NULL; i++) {
+    /* g_strsplit produces a trailing empty token after the final newline. */
+    if (lines[i][0] != '\0')
+      line_count++;
+  }
+  g_strfreev (lines);
+
+  g_assert_cmpint (line_count, ==, T7_THREAD_COUNT * T7_RECORDS_PER_THREAD);
+
+  g_remove (path);
+  g_rmdir (tmpdir);
+}
+
 int
 main (int argc, char **argv)
 {
@@ -333,6 +414,8 @@ main (int argc, char **argv)
       test_runtime_filter_end_to_end);
   g_test_add_func ("/wyl-log/runtime/file-sink-reopen-same-path-no-crash",
       test_file_sink_reopen_same_path_no_crash);
+  g_test_add_func ("/wyl-log/runtime/sink-mutex-concurrent-writes",
+      test_sink_mutex_concurrent_writes);
 
   return g_test_run ();
 }

--- a/tests/test-log.c
+++ b/tests/test-log.c
@@ -1,0 +1,202 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <glib.h>
+
+#include "wyrelog/wyl-log-private.h"
+
+/* --- Spec parser tests ---------------------------------------------- */
+
+static void
+assert_all_at (const gint8 levels[WYL_LOG_SECTION_LAST_], gint expected)
+{
+  for (gint i = 0; i < WYL_LOG_SECTION_LAST_; i++)
+    g_assert_cmpint (levels[i], ==, expected);
+}
+
+static void
+test_parse_default (void)
+{
+  gint8 levels[WYL_LOG_SECTION_LAST_];
+  wyl_log_internal_parse_spec (NULL, levels);
+  assert_all_at (levels, WYL_LOG_LEVEL_WARN);
+}
+
+static void
+test_parse_empty (void)
+{
+  gint8 levels[WYL_LOG_SECTION_LAST_];
+  wyl_log_internal_parse_spec ("", levels);
+  assert_all_at (levels, WYL_LOG_LEVEL_WARN);
+}
+
+static void
+test_parse_wildcard_numeric (void)
+{
+  gint8 levels[WYL_LOG_SECTION_LAST_];
+  wyl_log_internal_parse_spec ("*:5", levels);
+  assert_all_at (levels, WYL_LOG_LEVEL_TRACE);
+}
+
+static void
+test_parse_wildcard_named (void)
+{
+  gint8 levels[WYL_LOG_SECTION_LAST_];
+  wyl_log_internal_parse_spec ("*:trace", levels);
+  assert_all_at (levels, WYL_LOG_LEVEL_TRACE);
+}
+
+static void
+test_parse_named_section (void)
+{
+  gint8 levels[WYL_LOG_SECTION_LAST_];
+  wyl_log_internal_parse_spec ("BOOT:debug", levels);
+  g_assert_cmpint (levels[WYL_LOG_SECTION_BOOT], ==, WYL_LOG_LEVEL_DEBUG);
+  /* Other sections retain the WARN default. */
+  g_assert_cmpint (levels[WYL_LOG_SECTION_POLICY], ==, WYL_LOG_LEVEL_WARN);
+  g_assert_cmpint (levels[WYL_LOG_SECTION_GENERAL], ==, WYL_LOG_LEVEL_WARN);
+}
+
+static void
+test_parse_section_case_insensitive (void)
+{
+  gint8 levels[WYL_LOG_SECTION_LAST_];
+  wyl_log_internal_parse_spec ("policy:info,Audit:Error", levels);
+  g_assert_cmpint (levels[WYL_LOG_SECTION_POLICY], ==, WYL_LOG_LEVEL_INFO);
+  g_assert_cmpint (levels[WYL_LOG_SECTION_AUDIT], ==, WYL_LOG_LEVEL_ERROR);
+}
+
+static void
+test_parse_override_later_wins (void)
+{
+  gint8 levels[WYL_LOG_SECTION_LAST_];
+  wyl_log_internal_parse_spec ("*:5,BOOT:0", levels);
+  /* All others start at trace, BOOT downgraded to none. */
+  g_assert_cmpint (levels[WYL_LOG_SECTION_BOOT], ==, WYL_LOG_LEVEL_NONE);
+  g_assert_cmpint (levels[WYL_LOG_SECTION_POLICY], ==, WYL_LOG_LEVEL_TRACE);
+  g_assert_cmpint (levels[WYL_LOG_SECTION_GENERAL], ==, WYL_LOG_LEVEL_TRACE);
+}
+
+static void
+test_parse_unknown_section_ignored (void)
+{
+  gint8 levels[WYL_LOG_SECTION_LAST_];
+  wyl_log_internal_parse_spec ("UNKNOWN:5,BOOT:debug", levels);
+  /* Unknown silently dropped, valid entry still applied. */
+  g_assert_cmpint (levels[WYL_LOG_SECTION_BOOT], ==, WYL_LOG_LEVEL_DEBUG);
+  g_assert_cmpint (levels[WYL_LOG_SECTION_POLICY], ==, WYL_LOG_LEVEL_WARN);
+}
+
+static void
+test_parse_unknown_level_ignored (void)
+{
+  gint8 levels[WYL_LOG_SECTION_LAST_];
+  wyl_log_internal_parse_spec ("BOOT:bogus,POLICY:info", levels);
+  /* Bogus level entry silently dropped, BOOT keeps default. */
+  g_assert_cmpint (levels[WYL_LOG_SECTION_BOOT], ==, WYL_LOG_LEVEL_WARN);
+  g_assert_cmpint (levels[WYL_LOG_SECTION_POLICY], ==, WYL_LOG_LEVEL_INFO);
+}
+
+static void
+test_parse_clamps_high_numeric (void)
+{
+  gint8 levels[WYL_LOG_SECTION_LAST_];
+  wyl_log_internal_parse_spec ("BOOT:9", levels);
+  g_assert_cmpint (levels[WYL_LOG_SECTION_BOOT], ==, WYL_LOG_LEVEL_TRACE);
+}
+
+static void
+test_parse_rejects_negative (void)
+{
+  gint8 levels[WYL_LOG_SECTION_LAST_];
+  wyl_log_internal_parse_spec ("BOOT:-1", levels);
+  /* Negative -> not a digit-leading token, parser falls into name
+   * matching, fails, entry dropped. */
+  g_assert_cmpint (levels[WYL_LOG_SECTION_BOOT], ==, WYL_LOG_LEVEL_WARN);
+}
+
+static void
+test_parse_malformed_skipped (void)
+{
+  gint8 levels[WYL_LOG_SECTION_LAST_];
+  wyl_log_internal_parse_spec ("BOOT,POLICY:info,:5,DECISION:debug", levels);
+  /* "BOOT" without ':' is dropped; ":5" without section is dropped. */
+  g_assert_cmpint (levels[WYL_LOG_SECTION_BOOT], ==, WYL_LOG_LEVEL_WARN);
+  g_assert_cmpint (levels[WYL_LOG_SECTION_POLICY], ==, WYL_LOG_LEVEL_INFO);
+  g_assert_cmpint (levels[WYL_LOG_SECTION_DECISION], ==, WYL_LOG_LEVEL_DEBUG);
+}
+
+static void
+test_parse_whitespace_tolerated (void)
+{
+  gint8 levels[WYL_LOG_SECTION_LAST_];
+  wyl_log_internal_parse_spec ("  BOOT : debug ,  POLICY:info  ", levels);
+  g_assert_cmpint (levels[WYL_LOG_SECTION_BOOT], ==, WYL_LOG_LEVEL_DEBUG);
+  g_assert_cmpint (levels[WYL_LOG_SECTION_POLICY], ==, WYL_LOG_LEVEL_INFO);
+}
+
+/* --- Section name table --------------------------------------------- */
+
+static void
+test_section_name_known (void)
+{
+  g_assert_cmpstr (wyl_log_section_name (WYL_LOG_SECTION_BOOT), ==, "BOOT");
+  g_assert_cmpstr (wyl_log_section_name (WYL_LOG_SECTION_POLICY), ==, "POLICY");
+  g_assert_cmpstr (wyl_log_section_name (WYL_LOG_SECTION_SESSION), ==,
+      "SESSION");
+  g_assert_cmpstr (wyl_log_section_name (WYL_LOG_SECTION_DECISION), ==,
+      "DECISION");
+  g_assert_cmpstr (wyl_log_section_name (WYL_LOG_SECTION_AUDIT), ==, "AUDIT");
+  g_assert_cmpstr (wyl_log_section_name (WYL_LOG_SECTION_IO), ==, "IO");
+  g_assert_cmpstr (wyl_log_section_name (WYL_LOG_SECTION_GENERAL), ==,
+      "GENERAL");
+}
+
+static void
+test_section_name_out_of_range (void)
+{
+  g_assert_null (wyl_log_section_name (WYL_LOG_SECTION_LAST_));
+  g_assert_null (wyl_log_section_name ((wyl_log_section_t) - 1));
+  g_assert_null (wyl_log_section_name ((wyl_log_section_t) 999));
+}
+
+static void
+test_section_count (void)
+{
+  /* Updating the enum requires updating the name table in lockstep;
+   * the count just confirms callers see the same cardinality. */
+  g_assert_cmpint (wyl_log_section_count (), ==, WYL_LOG_SECTION_LAST_);
+}
+
+int
+main (int argc, char **argv)
+{
+  g_test_init (&argc, &argv, NULL);
+
+  g_test_add_func ("/wyl-log/parse/default", test_parse_default);
+  g_test_add_func ("/wyl-log/parse/empty", test_parse_empty);
+  g_test_add_func ("/wyl-log/parse/wildcard-numeric",
+      test_parse_wildcard_numeric);
+  g_test_add_func ("/wyl-log/parse/wildcard-named", test_parse_wildcard_named);
+  g_test_add_func ("/wyl-log/parse/named-section", test_parse_named_section);
+  g_test_add_func ("/wyl-log/parse/section-case-insensitive",
+      test_parse_section_case_insensitive);
+  g_test_add_func ("/wyl-log/parse/override-later-wins",
+      test_parse_override_later_wins);
+  g_test_add_func ("/wyl-log/parse/unknown-section-ignored",
+      test_parse_unknown_section_ignored);
+  g_test_add_func ("/wyl-log/parse/unknown-level-ignored",
+      test_parse_unknown_level_ignored);
+  g_test_add_func ("/wyl-log/parse/clamps-high-numeric",
+      test_parse_clamps_high_numeric);
+  g_test_add_func ("/wyl-log/parse/rejects-negative",
+      test_parse_rejects_negative);
+  g_test_add_func ("/wyl-log/parse/malformed-skipped",
+      test_parse_malformed_skipped);
+  g_test_add_func ("/wyl-log/parse/whitespace-tolerated",
+      test_parse_whitespace_tolerated);
+  g_test_add_func ("/wyl-log/section/name-known", test_section_name_known);
+  g_test_add_func ("/wyl-log/section/name-out-of-range",
+      test_section_name_out_of_range);
+  g_test_add_func ("/wyl-log/section/count", test_section_count);
+
+  return g_test_run ();
+}

--- a/tests/test-log.c
+++ b/tests/test-log.c
@@ -1,6 +1,5 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #include <stdio.h>
-#include <unistd.h>
 
 #include <glib.h>
 #include <glib/gstdio.h>
@@ -201,7 +200,7 @@ test_file_sink_redirection (void)
           "redirect-test-marker 42"));
 
   remove (path);
-  rmdir (tmpdir);
+  g_rmdir (tmpdir);
 }
 
 static void
@@ -256,7 +255,7 @@ test_runtime_filter_end_to_end (void)
           "general-debug-should-not-appear"));
 
   remove (path);
-  rmdir (tmpdir);
+  g_rmdir (tmpdir);
 }
 
 static void
@@ -292,7 +291,7 @@ test_file_sink_reopen_same_path_no_crash (void)
           "coexistence-test-marker"));
 
   remove (path);
-  rmdir (tmpdir);
+  g_rmdir (tmpdir);
 }
 
 /* T7 — Thread-stress: sink_mutex serialises concurrent writes correctly.

--- a/tests/test-log.c
+++ b/tests/test-log.c
@@ -1,4 +1,7 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <stdio.h>
+#include <unistd.h>
+
 #include <glib.h>
 
 #include "wyrelog/wyl-log-private.h"
@@ -166,6 +169,131 @@ test_section_count (void)
   g_assert_cmpint (wyl_log_section_count (), ==, WYL_LOG_SECTION_LAST_);
 }
 
+/* --- File sink tests ------------------------------------------------ */
+
+static void
+test_file_sink_redirection (void)
+{
+  g_autofree gchar *tmpdir = g_dir_make_tmp ("wyrelog-test-XXXXXX", NULL);
+  g_assert_nonnull (tmpdir);
+  g_autofree gchar *path = g_build_filename (tmpdir, "wyl.log", NULL);
+
+  g_setenv ("WYL_LOG_FILE", path, TRUE);
+  g_setenv ("WYL_LOG", "*:5", TRUE);
+  wyl_log_internal_reload_for_tests ();
+
+  wyl_log_structured (WYL_LOG_SECTION_GENERAL, G_LOG_LEVEL_WARNING,
+      "redirect-test-marker %d", 42);
+
+  /* Flush any pending writes. */
+  wyl_log_internal_reload_for_tests (); /* closes the file */
+  g_unsetenv ("WYL_LOG_FILE");
+  g_unsetenv ("WYL_LOG");
+  wyl_log_internal_reload_for_tests ();
+
+  g_autofree gchar *contents = NULL;
+  gsize len = 0;
+  gboolean ok = g_file_get_contents (path, &contents, &len, NULL);
+  g_assert_true (ok);
+  g_assert_nonnull (contents);
+  g_assert_nonnull (g_strstr_len (contents, (gssize) len,
+          "redirect-test-marker 42"));
+
+  remove (path);
+  rmdir (tmpdir);
+}
+
+static void
+test_file_sink_fallback_on_invalid_path (void)
+{
+  g_setenv ("WYL_LOG_FILE", "/nonexistent-dir/xxx.log", TRUE);
+  g_setenv ("WYL_LOG", "*:5", TRUE);
+
+  /* Must not crash — stderr fallback applies (FC1: do not refuse to boot). */
+  wyl_log_internal_reload_for_tests ();
+  wyl_log_structured (WYL_LOG_SECTION_GENERAL, G_LOG_LEVEL_WARNING,
+      "fallback-test-marker");
+
+  g_unsetenv ("WYL_LOG_FILE");
+  g_unsetenv ("WYL_LOG");
+  wyl_log_internal_reload_for_tests ();
+}
+
+static void
+test_runtime_filter_end_to_end (void)
+{
+  g_autofree gchar *tmpdir = g_dir_make_tmp ("wyrelog-test-XXXXXX", NULL);
+  g_assert_nonnull (tmpdir);
+  g_autofree gchar *path = g_build_filename (tmpdir, "wyl.log", NULL);
+
+  g_setenv ("WYL_LOG_FILE", path, TRUE);
+  /* GENERAL threshold = ERROR (1); POLICY threshold = TRACE (5). */
+  g_setenv ("WYL_LOG", "GENERAL:1,POLICY:5", TRUE);
+  wyl_log_internal_reload_for_tests ();
+
+  /* DEBUG (wyl level 4) > GENERAL threshold (1) -> should be suppressed. */
+  wyl_log_structured (WYL_LOG_SECTION_GENERAL, G_LOG_LEVEL_DEBUG,
+      "general-debug-should-not-appear");
+  /* DEBUG (wyl level 4) <= POLICY threshold (5) -> should appear. */
+  wyl_log_structured (WYL_LOG_SECTION_POLICY, G_LOG_LEVEL_DEBUG,
+      "policy-debug-should-appear");
+
+  /* Close the file by reloading with no WYL_LOG_FILE. */
+  g_unsetenv ("WYL_LOG_FILE");
+  g_unsetenv ("WYL_LOG");
+  wyl_log_internal_reload_for_tests ();
+
+  g_autofree gchar *contents = NULL;
+  gsize len = 0;
+  gboolean ok = g_file_get_contents (path, &contents, &len, NULL);
+  g_assert_true (ok);
+  g_assert_nonnull (contents);
+
+  g_assert_nonnull (g_strstr_len (contents, (gssize) len,
+          "policy-debug-should-appear"));
+  g_assert_null (g_strstr_len (contents, (gssize) len,
+          "general-debug-should-not-appear"));
+
+  remove (path);
+  rmdir (tmpdir);
+}
+
+static void
+test_same_path_coexistence_no_crash (void)
+{
+  g_autofree gchar *tmpdir = g_dir_make_tmp ("wyrelog-test-XXXXXX", NULL);
+  g_assert_nonnull (tmpdir);
+  g_autofree gchar *path = g_build_filename (tmpdir, "shared.log", NULL);
+
+  /* WL_LOG_FILE is wirelog's env var. Both point at the same file.
+   * Interleaving with wirelog's writes is operator error and is not a
+   * wyrelog correctness contract; this test only asserts no crash and
+   * that wyrelog's own line is present. */
+  g_setenv ("WL_LOG_FILE", path, TRUE);
+  g_setenv ("WYL_LOG_FILE", path, TRUE);
+  g_setenv ("WYL_LOG", "*:5", TRUE);
+  wyl_log_internal_reload_for_tests ();
+
+  wyl_log_structured (WYL_LOG_SECTION_GENERAL, G_LOG_LEVEL_WARNING,
+      "coexistence-test-marker");
+
+  g_unsetenv ("WL_LOG_FILE");
+  g_unsetenv ("WYL_LOG_FILE");
+  g_unsetenv ("WYL_LOG");
+  wyl_log_internal_reload_for_tests ();
+
+  g_autofree gchar *contents = NULL;
+  gsize len = 0;
+  gboolean ok = g_file_get_contents (path, &contents, &len, NULL);
+  g_assert_true (ok);
+  g_assert_nonnull (contents);
+  g_assert_nonnull (g_strstr_len (contents, (gssize) len,
+          "coexistence-test-marker"));
+
+  remove (path);
+  rmdir (tmpdir);
+}
+
 int
 main (int argc, char **argv)
 {
@@ -197,6 +325,14 @@ main (int argc, char **argv)
   g_test_add_func ("/wyl-log/section/name-out-of-range",
       test_section_name_out_of_range);
   g_test_add_func ("/wyl-log/section/count", test_section_count);
+
+  g_test_add_func ("/wyl-log/file/redirection", test_file_sink_redirection);
+  g_test_add_func ("/wyl-log/file/fallback-on-invalid-path",
+      test_file_sink_fallback_on_invalid_path);
+  g_test_add_func ("/wyl-log/runtime/filter-end-to-end",
+      test_runtime_filter_end_to_end);
+  g_test_add_func ("/wyl-log/runtime/same-path-coexistence-no-crash",
+      test_same_path_coexistence_no_crash);
 
   return g_test_run ();
 }

--- a/tests/test-log.c
+++ b/tests/test-log.c
@@ -300,7 +300,10 @@ test_file_sink_reopen_same_path_no_crash (void)
  * 8 threads each emit 1000 WARNING records into a shared file sink.
  * After all threads join we verify:
  *   - total line count == 8000 (no records lost)
- *   - no line is empty (no torn mid-line interleave)
+ *   - every line matches the structured-record pattern exactly:
+ *       [wyrelog GENERAL] t7-thread-N-record-M
+ *     A torn write (partial line or interleaved prefix) would fail this
+ *     match, making torn-line detection explicit rather than implicit.
  *
  * Process-unique tmpdir (g_dir_make_tmp) avoids collisions with parallel
  * meson test runs. */
@@ -335,7 +338,7 @@ test_sink_mutex_concurrent_writes (void)
   g_autofree gchar *path = g_build_filename (tmpdir, "t7.log", NULL);
 
   g_setenv ("WYL_LOG_FILE", path, TRUE);
-  g_setenv ("WYL_LOG", "*:2", TRUE);
+  g_setenv ("WYL_LOG", "*:5", TRUE);
   wyl_log_internal_reconfigure ();
 
   GThread *threads[T7_THREAD_COUNT];
@@ -360,15 +363,36 @@ test_sink_mutex_concurrent_writes (void)
   g_assert_true (ok);
   g_assert_nonnull (contents);
 
+  /* Per-line structured-record pattern check.
+   * Each record must match: [wyrelog GENERAL] t7-thread-N-record-M
+   * A torn write (partial line or interleaved bytes) would produce a line
+   * that fails this pattern, making torn-line detection explicit. */
+  GError *re_err = NULL;
+  GRegex *record_re =
+      g_regex_new ("^\\[wyrelog GENERAL\\] t7-thread-[0-9]+-record-[0-9]+$",
+      G_REGEX_OPTIMIZE, 0, &re_err);
+  g_assert_no_error (re_err);
+  g_assert_nonnull (record_re);
+
   gchar **lines = g_strsplit (contents, "\n", -1);
   gint line_count = 0;
   for (gint i = 0; lines[i] != NULL; i++) {
     /* g_strsplit produces a trailing empty token after the final newline. */
-    if (lines[i][0] != '\0')
-      line_count++;
+    if (lines[i][0] == '\0')
+      continue;
+    line_count++;
+    gboolean matched = g_regex_match (record_re, lines[i], 0, NULL);
+    if (!matched) {
+      g_test_message
+          ("T7: line %d does not match structured-record pattern: %s", i,
+          lines[i]);
+    }
+    g_assert_true (matched);
   }
   g_strfreev (lines);
+  g_regex_unref (record_re);
 
+  /* Belt-and-suspenders: all 8000 records must be present. */
   g_assert_cmpint (line_count, ==, T7_THREAD_COUNT * T7_RECORDS_PER_THREAD);
 
   g_remove (path);

--- a/tools/check-private-headers-not-installed.sh
+++ b/tools/check-private-headers-not-installed.sh
@@ -8,18 +8,23 @@
 #
 # Strategy (two-tier):
 #
-#   1. If a builddir exists alongside the project root, use
-#      `meson introspect --installed builddir` to query the actual
-#      post-build install manifest.  This catches private headers
-#      included via multi-line files(...) blocks that a line-grep
-#      cannot see because the filename and the install_headers()
-#      call are on different lines.
+#   Tier 1 (authoritative, post-configure / CI after meson setup):
+#     If a builddir exists alongside the project root AND meson is on PATH,
+#     use `meson introspect --installed builddir` to query the actual
+#     post-build install manifest.  This catches private headers included
+#     via multi-line files(...) blocks that a line-grep cannot see because
+#     the filename and the install_headers() call are on different lines.
+#     A meson introspect failure (corrupt builddir, version mismatch) is
+#     treated as a hard error — it exits 1 so CI catches the problem rather
+#     than silently falling back to the weaker tier-2 check.
 #
-#   2. If no builddir exists (e.g. CI lint pass before first build),
-#      fall back to a line-grep over all meson.build files in the
-#      tree — the original heuristic.
+#   Tier 2 (fresh-checkout linting, no builddir available):
+#     Fall back to a line-grep over all meson.build files in the tree —
+#     the original heuristic.  Only used when meson is absent from PATH or
+#     no builddir exists; not a substitute for tier-1 in CI.
 #
-# Exit codes: 0 = clean, 1 = private header found in install set.
+# Exit codes: 0 = clean, 1 = private header found in install set or
+#             meson introspect error when builddir is present.
 
 set -eu
 
@@ -30,28 +35,33 @@ BUILDDIR="$PROJECT_ROOT/builddir"
 FOUND=0
 
 # -----------------------------------------------------------------------
-# Tier 1: meson introspect (authoritative, requires a configured builddir)
+# Tier 1: meson introspect (authoritative, post-configure CI mode)
 # -----------------------------------------------------------------------
 if [ -d "$BUILDDIR" ] && command -v meson >/dev/null 2>&1; then
-  introspect_out=$(meson introspect --installed "$BUILDDIR" 2>/dev/null) || true
-  if [ -n "$introspect_out" ]; then
-    # introspect --installed emits JSON: {"dest": "src", ...}
-    # Both keys and values can be install-destination paths.
-    # A -private.h in any path (key or value) is a violation.
-    if printf '%s\n' "$introspect_out" | grep -q -- '-private\.h'; then
-      echo "ERROR (introspect): private header found in install manifest:" >&2
-      printf '%s\n' "$introspect_out" | grep -- '-private\.h' >&2
-      FOUND=1
-    fi
-
-    if [ "$FOUND" -eq 1 ]; then
-      echo "FAIL: private header(s) would be installed. Aborting." >&2
-      exit 1
-    fi
-
-    echo "OK: no private headers found in install paths (introspect)."
-    exit 0
+  # Capture output and exit code separately so a meson failure is not
+  # silently swallowed.  An empty result from a successful introspect is
+  # valid (no installed files at all); a non-zero exit is a real error.
+  introspect_out=$(meson introspect --installed "$BUILDDIR" 2>&1)
+  introspect_rc=$?
+  if [ "$introspect_rc" -ne 0 ]; then
+    echo "ERROR: meson introspect failed (exit $introspect_rc) — builddir may be corrupt or stale." >&2
+    echo "$introspect_out" >&2
+    echo "Re-run 'meson setup builddir' and retry." >&2
+    exit 1
   fi
+
+  # introspect --installed emits JSON: {"dest": "src", ...}
+  # Both keys and values can be install-destination paths.
+  # A -private.h in any path (key or value) is a violation.
+  if printf '%s\n' "$introspect_out" | grep -q -- '-private\.h'; then
+    echo "ERROR (introspect): private header found in install manifest:" >&2
+    printf '%s\n' "$introspect_out" | grep -- '-private\.h' >&2
+    echo "FAIL: private header(s) would be installed. Aborting." >&2
+    exit 1
+  fi
+
+  echo "OK: no private headers found in install paths (introspect)."
+  exit 0
 fi
 
 # -----------------------------------------------------------------------

--- a/tools/check-private-headers-not-installed.sh
+++ b/tools/check-private-headers-not-installed.sh
@@ -38,17 +38,19 @@ FOUND=0
 # Tier 1: meson introspect (authoritative, post-configure CI mode)
 # -----------------------------------------------------------------------
 if [ -d "$BUILDDIR" ] && command -v meson >/dev/null 2>&1; then
-  # Capture output and exit code separately so a meson failure is not
-  # silently swallowed.  An empty result from a successful introspect is
-  # valid (no installed files at all); a non-zero exit is a real error.
-  introspect_out=$(meson introspect --installed "$BUILDDIR" 2>&1)
-  introspect_rc=$?
-  if [ "$introspect_rc" -ne 0 ]; then
+  # Use `if ! var=$(cmd)` — exempt from set -e early-exit — so a meson
+  # failure is captured and reported rather than silently terminating the
+  # shell before $? can be read.  An empty result from a successful
+  # introspect is valid (no installed files at all); non-zero is a hard error.
+  # Note: $? inside the then-branch reflects the negated test result, not the
+  # original exit code; store it via a subshell trick instead.
+  introspect_out=$(meson introspect --installed "$BUILDDIR" 2>&1) || {
+    introspect_rc=$?
     echo "ERROR: meson introspect failed (exit $introspect_rc) — builddir may be corrupt or stale." >&2
     echo "$introspect_out" >&2
     echo "Re-run 'meson setup builddir' and retry." >&2
     exit 1
-  fi
+  }
 
   # introspect --installed emits JSON: {"dest": "src", ...}
   # Both keys and values can be install-destination paths.

--- a/tools/check-private-headers-not-installed.sh
+++ b/tools/check-private-headers-not-installed.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# check-private-headers-not-installed.sh
+#
+# Verifies that no file matching *-private.h appears in any
+# install_headers() call or public header list in the meson build files.
+# Exits 1 if a private header is found in an install path; exits 0 otherwise.
+
+set -eu
+
+SCRIPT_DIR=$(dirname "$0")
+PROJECT_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+
+MESON_FILES="
+$PROJECT_ROOT/meson.build
+$PROJECT_ROOT/wyrelog/meson.build
+"
+
+FOUND=0
+
+for f in $MESON_FILES; do
+  if [ ! -f "$f" ]; then
+    continue
+  fi
+
+  # Look for lines that both mention install_headers or _public_headers
+  # and contain a *-private.h filename.
+  # We scan the file line by line; a private header on any install-related
+  # line is a violation.
+  while IFS= read -r line; do
+    case "$line" in
+      *install_headers*|*_public_headers*|*install_dir*)
+        case "$line" in
+          *-private.h*)
+            echo "ERROR: private header found in install context in $f:" >&2
+            echo "  $line" >&2
+            FOUND=1
+            ;;
+        esac
+        ;;
+    esac
+  done < "$f"
+done
+
+# Also do a direct grep for belt-and-suspenders coverage across the
+# entire wyrelog/ build subtree.
+if grep -r -- '-private\.h' \
+    "$PROJECT_ROOT/wyrelog/meson.build" \
+    "$PROJECT_ROOT/meson.build" \
+    2>/dev/null | grep -qE 'install_headers|_public_headers'; then
+  echo "ERROR: grep found private header reference in install context." >&2
+  FOUND=1
+fi
+
+if [ "$FOUND" -eq 1 ]; then
+  echo "FAIL: private header(s) would be installed. Aborting." >&2
+  exit 1
+fi
+
+echo "OK: no private headers found in install paths."
+exit 0

--- a/tools/check-private-headers-not-installed.sh
+++ b/tools/check-private-headers-not-installed.sh
@@ -3,31 +3,70 @@
 #
 # check-private-headers-not-installed.sh
 #
-# Verifies that no file matching *-private.h appears in any
-# install_headers() call or public header list in the meson build files.
-# Exits 1 if a private header is found in an install path; exits 0 otherwise.
+# Verifies that no file matching *-private.h appears in the installed
+# header set.
+#
+# Strategy (two-tier):
+#
+#   1. If a builddir exists alongside the project root, use
+#      `meson introspect --installed builddir` to query the actual
+#      post-build install manifest.  This catches private headers
+#      included via multi-line files(...) blocks that a line-grep
+#      cannot see because the filename and the install_headers()
+#      call are on different lines.
+#
+#   2. If no builddir exists (e.g. CI lint pass before first build),
+#      fall back to a line-grep over all meson.build files in the
+#      tree — the original heuristic.
+#
+# Exit codes: 0 = clean, 1 = private header found in install set.
 
 set -eu
 
 SCRIPT_DIR=$(dirname "$0")
 PROJECT_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+BUILDDIR="$PROJECT_ROOT/builddir"
 
+FOUND=0
+
+# -----------------------------------------------------------------------
+# Tier 1: meson introspect (authoritative, requires a configured builddir)
+# -----------------------------------------------------------------------
+if [ -d "$BUILDDIR" ] && command -v meson >/dev/null 2>&1; then
+  introspect_out=$(meson introspect --installed "$BUILDDIR" 2>/dev/null) || true
+  if [ -n "$introspect_out" ]; then
+    # introspect --installed emits JSON: {"dest": "src", ...}
+    # Both keys and values can be install-destination paths.
+    # A -private.h in any path (key or value) is a violation.
+    if printf '%s\n' "$introspect_out" | grep -q -- '-private\.h'; then
+      echo "ERROR (introspect): private header found in install manifest:" >&2
+      printf '%s\n' "$introspect_out" | grep -- '-private\.h' >&2
+      FOUND=1
+    fi
+
+    if [ "$FOUND" -eq 1 ]; then
+      echo "FAIL: private header(s) would be installed. Aborting." >&2
+      exit 1
+    fi
+
+    echo "OK: no private headers found in install paths (introspect)."
+    exit 0
+  fi
+fi
+
+# -----------------------------------------------------------------------
+# Tier 2: line-grep fallback (no builddir or meson not on PATH)
+# -----------------------------------------------------------------------
 MESON_FILES="
 $PROJECT_ROOT/meson.build
 $PROJECT_ROOT/wyrelog/meson.build
 "
-
-FOUND=0
 
 for f in $MESON_FILES; do
   if [ ! -f "$f" ]; then
     continue
   fi
 
-  # Look for lines that both mention install_headers or _public_headers
-  # and contain a *-private.h filename.
-  # We scan the file line by line; a private header on any install-related
-  # line is a violation.
   while IFS= read -r line; do
     case "$line" in
       *install_headers*|*_public_headers*|*install_dir*)
@@ -43,8 +82,7 @@ for f in $MESON_FILES; do
   done < "$f"
 done
 
-# Also do a direct grep for belt-and-suspenders coverage across the
-# entire wyrelog/ build subtree.
+# Belt-and-suspenders: grep across the full wyrelog build subtree.
 if grep -r -- '-private\.h' \
     "$PROJECT_ROOT/wyrelog/meson.build" \
     "$PROJECT_ROOT/meson.build" \
@@ -58,5 +96,5 @@ if [ "$FOUND" -eq 1 ]; then
   exit 1
 fi
 
-echo "OK: no private headers found in install paths."
+echo "OK: no private headers found in install paths (line-grep)."
 exit 0

--- a/wyrelog/meson.build
+++ b/wyrelog/meson.build
@@ -25,6 +25,7 @@ wyrelog_sources = files(
   'wyl-handle.c',
   'wyl-id.c',
   'wyl-keyprovider-dev.c',
+  'wyl-log.c',
   'wyl-perm.c',
   'wyl-permission-scope.c',
   'wyl-session.c',
@@ -33,7 +34,19 @@ wyrelog_sources = files(
 
 wyrelog_deps = [glib_dep, gio_dep, libchronoid_dep]
 
-wyrelog_c_args = []
+wyrelog_log_levels = {
+  'none' : 0,
+  'error' : 1,
+  'warn' : 2,
+  'info' : 3,
+  'debug' : 4,
+  'trace' : 5,
+}
+wyrelog_log_max = wyrelog_log_levels[get_option('wyrelog_log_max_level')]
+
+wyrelog_c_args = [
+  '-DWYL_LOG_MAX_LEVEL=' + wyrelog_log_max.to_string(),
+]
 
 if get_option('enable_audit').allowed()
   wyrelog_sources += files('audit/conn.c')

--- a/wyrelog/wyl-boot.c
+++ b/wyrelog/wyl-boot.c
@@ -18,7 +18,8 @@ wyl_boot_run (const boot_phase_t *seq, gsize n, gpointer ctx)
     if (phase->fn == NULL) {
       if (phase->fail_closed)
         return WYRELOG_E_INTERNAL;
-      WYL_LOG_WARN ("boot phase %d (%s) has no fn; skipping",
+      WYL_LOG_WARN (WYL_LOG_SECTION_BOOT,
+          "boot phase %d (%s) has no fn; skipping",
           phase->id, phase->name ? phase->name : "?");
       continue;
     }
@@ -26,11 +27,13 @@ wyl_boot_run (const boot_phase_t *seq, gsize n, gpointer ctx)
     rc = phase->fn (ctx);
     if (rc != WYRELOG_E_OK) {
       if (phase->fail_closed) {
-        WYL_LOG_ERROR ("boot phase %d (%s) failed; halting",
+        WYL_LOG_ERROR (WYL_LOG_SECTION_BOOT,
+            "boot phase %d (%s) failed; halting",
             phase->id, phase->name ? phase->name : "?");
         return rc;
       }
-      WYL_LOG_WARN ("boot phase %d (%s) failed (continuing)",
+      WYL_LOG_WARN (WYL_LOG_SECTION_BOOT,
+          "boot phase %d (%s) failed (continuing)",
           phase->id, phase->name ? phase->name : "?");
     }
   }

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -2,6 +2,7 @@
 #include "wyrelog/wyrelog.h"
 
 #include "wyl-id-private.h"
+#include "wyl-log-private.h"
 
 #ifdef WYL_HAS_AUDIT
 #include "audit/conn-private.h"
@@ -59,6 +60,11 @@ wyrelog_error_t
 wyl_init (const gchar *config_path, WylHandle **out_handle)
 {
   (void) config_path;
+
+  /* Eagerly initialise the log subsystem before any other library code
+   * runs so that log sites in boot phases see the correct thresholds
+   * and file sink from the very first message. */
+  wyl_log_internal_reconfigure ();
 
   if (out_handle == NULL)
     return WYRELOG_E_INVALID;

--- a/wyrelog/wyl-log-private.h
+++ b/wyrelog/wyl-log-private.h
@@ -175,18 +175,39 @@ G_GNUC_PRINTF (6, 7);
  *     held simultaneously.
  *   - NOT async-signal-safe: do NOT call from signal handlers. The
  *     function acquires mutexes and calls fopen/fclose.
- *   - NOT safe across fork(2). The FILE* sink is inherited along with
- *     its userspace stdio buffer, which is shared at the OS level with
- *     the parent. The child MUST NOT call fclose (flushes the shared
- *     buffer, corrupting parent's pending writes) and MUST NOT call
- *     freopen (which calls fclose internally — same hazard). The
- *     supported pattern is post-fork re-exec: the child re-executes
- *     itself so that inherited FILE* handles are closed by the C
- *     runtime before main() runs. If re-exec is not possible and the
- *     child must silence the inherited handle, call
- *     close(fileno(inherited_fp)) directly after ensuring no other
- *     code path in the child references it; do NOT call
- *     wyl_log_internal_reconfigure on a path that the parent also
- *     writes to, as this would open a shared output and interleave
- *     records. */
+ *   - NOT safe across fork(2) without exec. The FILE* sink is
+ *     inherited along with its userspace stdio buffer. At the OS level
+ *     both parent and child share the same open file description
+ *     (offset, flags). Hazards in the child after fork-without-exec:
+ *
+ *     (a) close(fileno(f)) caveat: if you want to silence the
+ *         inherited handle you may call close(fileno(log_file_sink))
+ *         directly, but ONLY before any other code in the child can
+ *         reach it. You MUST NOT subsequently call fclose() on the
+ *         same FILE* — fclose calls fflush which flushes the shared
+ *         userspace buffer back through the now-closed (or reassigned)
+ *         fd, causing EBADF or writing parent data to the wrong file.
+ *         Similarly, do NOT pass the inherited FILE* to
+ *         wyl_log_internal_reconfigure: the function calls
+ *         fclose(log_file_sink) internally before opening the new
+ *         path, so the same EBADF / UB hazard applies.
+ *
+ *     (b) Prefer _exit(2) over exit(3) after fork-without-exec. exit()
+ *         runs atexit handlers registered by the parent (including
+ *         stdio fflush of all open FILE* streams) and may corrupt the
+ *         parent's pending output. _exit() terminates immediately
+ *         without running those handlers.
+ *
+ *     (c) Multithreaded programs: fork-without-exec is inherently
+ *         unsafe when the parent has multiple threads. Only the calling
+ *         thread is duplicated in the child; any thread holding
+ *         log_mutex or sink_mutex at the moment of fork leaves those
+ *         mutexes permanently locked in the child. pthread_atfork
+ *         handlers can acquire and release known mutexes around the
+ *         fork, but this does not make arbitrary library state (e.g.
+ *         libsoup-3.0 worker pools, GLib thread pools) safe. The only
+ *         fully supported pattern in multithreaded code is
+ *         fork-then-exec; call execve(2) as soon as possible after
+ *         fork(2) and do not call wyl_log_internal_reconfigure or any
+ *         stdio function in the child before exec. */
      void wyl_log_internal_reconfigure (void);

--- a/wyrelog/wyl-log-private.h
+++ b/wyrelog/wyl-log-private.h
@@ -175,10 +175,11 @@ G_GNUC_PRINTF (6, 7);
  *     held simultaneously.
  *   - NOT async-signal-safe: do NOT call from signal handlers. The
  *     function acquires mutexes and calls fopen/fclose.
- *   - NOT fork-safe: after fork() the child inherits the open FILE*
- *     from the parent. Sharing a FILE* across a fork boundary leads
- *     to buffer aliasing and undefined behaviour. The child must not
- *     call wyl_log_structured* or wyl_log_internal_reconfigure without
- *     first calling wyl_log_internal_reconfigure to close and reopen
- *     the sink in the child's address space. */
+ *   - NOT safe across fork(2). The file FILE* is inherited along with
+ *     its userspace stdio buffer. The child MUST NOT call fclose on
+ *     the inherited handle (which would flush shared OS-level buffers
+ *     and potentially corrupt the parent's pending writes); instead
+ *     the child should construct a fresh log state from scratch (e.g.
+ *     via wyl_log_internal_reconfigure after the inherited FILE* has
+ *     been abandoned with freopen(/dev/null, ...) or by re-execing). */
      void wyl_log_internal_reconfigure (void);

--- a/wyrelog/wyl-log-private.h
+++ b/wyrelog/wyl-log-private.h
@@ -94,3 +94,4 @@ G_GNUC_PRINTF (3, 4);
      gint wyl_log_internal_get_section_level (wyl_log_section_t section);
      void wyl_log_internal_parse_spec (const char *spec,
     gint8 levels[WYL_LOG_SECTION_LAST_]);
+     void wyl_log_internal_reload_for_tests (void);

--- a/wyrelog/wyl-log-private.h
+++ b/wyrelog/wyl-log-private.h
@@ -35,3 +35,67 @@
   g_log (WYL_LOG_DOMAIN, G_LOG_LEVEL_CRITICAL, __VA_ARGS__)
 #define WYL_LOG_CRITICAL(...) \
   g_log (WYL_LOG_DOMAIN, G_LOG_LEVEL_ERROR, __VA_ARGS__)
+
+/* --- Section grammar -------------------------------------------------
+ *
+ * Sections are coarse functional buckets that operators filter on at
+ * runtime via WYL_LOG=SECTION:LEVEL[,...]. Adding a new section is
+ * load-bearing for the parser test suite: any new value before
+ * WYL_LOG_SECTION_LAST_ must also appear in the static name table in
+ * wyl-log.c.
+ *
+ * Section names are operator-visible (they appear in env-var input
+ * and in formatted log output). Names are deliberately neutral and
+ * do not advertise wyrelog-internal axioms.
+ */
+typedef enum
+{
+  WYL_LOG_SECTION_BOOT = 0,
+  WYL_LOG_SECTION_POLICY,
+  WYL_LOG_SECTION_SESSION,
+  WYL_LOG_SECTION_DECISION,
+  WYL_LOG_SECTION_AUDIT,
+  WYL_LOG_SECTION_IO,
+  WYL_LOG_SECTION_GENERAL,
+  WYL_LOG_SECTION_LAST_,
+} wyl_log_section_t;
+
+/* Numeric levels match the WYL_LOG=*:N grammar. The runtime threshold
+ * test is `wyl_level <= section_threshold`, so larger numbers are
+ * more verbose. */
+#define WYL_LOG_LEVEL_NONE   0
+#define WYL_LOG_LEVEL_ERROR  1
+#define WYL_LOG_LEVEL_WARN   2
+#define WYL_LOG_LEVEL_INFO   3
+#define WYL_LOG_LEVEL_DEBUG  4
+#define WYL_LOG_LEVEL_TRACE  5
+
+/* Compile-time ceiling supplied by meson via -DWYL_LOG_MAX_LEVEL=N.
+ * Defaults to TRACE if the build system did not set it (e.g. when
+ * compiling a single test file outside of meson). */
+#ifndef WYL_LOG_MAX_LEVEL
+#define WYL_LOG_MAX_LEVEL WYL_LOG_LEVEL_TRACE
+#endif
+
+/* Public-ish helpers (private header — intra-library only). */
+const char *wyl_log_section_name (wyl_log_section_t section);
+gint wyl_log_section_count (void);
+
+/* Structured log entry point. Carries a WYL_SECTION GLib log field so
+ * the wyrelog writer can route by section. Callers normally reach for
+ * the section-aware macros that arrive in a follow-up commit; this
+ * function is the single landing point those macros expand to. */
+void
+wyl_log_structured (wyl_log_section_t section, GLogLevelFlags level,
+    const char *fmt, ...)
+G_GNUC_PRINTF (3, 4);
+
+/*
+ * Internal hooks (suffix _internal_: not stable API). Exposed so the
+ * parser-test suite can drive the spec parser without mutating
+ * process-global env state, and so a future test can probe the
+ * active section threshold table without reaching into static
+ * storage.
+ */
+     void wyl_log_internal_parse_spec (const char *spec, gint8 *levels);
+     gint wyl_log_internal_get_section_level (wyl_log_section_t section);

--- a/wyrelog/wyl-log-private.h
+++ b/wyrelog/wyl-log-private.h
@@ -175,11 +175,18 @@ G_GNUC_PRINTF (6, 7);
  *     held simultaneously.
  *   - NOT async-signal-safe: do NOT call from signal handlers. The
  *     function acquires mutexes and calls fopen/fclose.
- *   - NOT safe across fork(2). The file FILE* is inherited along with
- *     its userspace stdio buffer. The child MUST NOT call fclose on
- *     the inherited handle (which would flush shared OS-level buffers
- *     and potentially corrupt the parent's pending writes); instead
- *     the child should construct a fresh log state from scratch (e.g.
- *     via wyl_log_internal_reconfigure after the inherited FILE* has
- *     been abandoned with freopen(/dev/null, ...) or by re-execing). */
+ *   - NOT safe across fork(2). The FILE* sink is inherited along with
+ *     its userspace stdio buffer, which is shared at the OS level with
+ *     the parent. The child MUST NOT call fclose (flushes the shared
+ *     buffer, corrupting parent's pending writes) and MUST NOT call
+ *     freopen (which calls fclose internally — same hazard). The
+ *     supported pattern is post-fork re-exec: the child re-executes
+ *     itself so that inherited FILE* handles are closed by the C
+ *     runtime before main() runs. If re-exec is not possible and the
+ *     child must silence the inherited handle, call
+ *     close(fileno(inherited_fp)) directly after ensuring no other
+ *     code path in the child references it; do NOT call
+ *     wyl_log_internal_reconfigure on a path that the parent also
+ *     writes to, as this would open a shared output and interleave
+ *     records. */
      void wyl_log_internal_reconfigure (void);

--- a/wyrelog/wyl-log-private.h
+++ b/wyrelog/wyl-log-private.h
@@ -90,12 +90,7 @@ wyl_log_structured (wyl_log_section_t section, GLogLevelFlags level,
     const char *fmt, ...)
 G_GNUC_PRINTF (3, 4);
 
-/*
- * Internal hooks (suffix _internal_: not stable API). Exposed so the
- * parser-test suite can drive the spec parser without mutating
- * process-global env state, and so a future test can probe the
- * active section threshold table without reaching into static
- * storage.
- */
-     void wyl_log_internal_parse_spec (const char *spec, gint8 *levels);
+/* Internal hooks (suffix _internal_: not stable API). */
      gint wyl_log_internal_get_section_level (wyl_log_section_t section);
+     void wyl_log_internal_parse_spec (const char *spec,
+    gint8 levels[WYL_LOG_SECTION_LAST_]);

--- a/wyrelog/wyl-log-private.h
+++ b/wyrelog/wyl-log-private.h
@@ -24,7 +24,7 @@
  *   WYL_LOG_ERROR(s,...)    -> WYL_LOG_LEVEL_ERROR  ceiling,
  *                              G_LOG_LEVEL_CRITICAL (recoverable;
  *                              program continues)
- *   WYL_LOG_CRITICAL(s,...) -> WYL_LOG_LEVEL_ERROR  ceiling,
+ *   WYL_LOG_CRITICAL(s,...) -> BYPASSES WYL_LOG_MAX_LEVEL ceiling,
  *                              G_LOG_LEVEL_ERROR    (invariant violation;
  *                              GLib calls abort() — program terminates)
  *
@@ -34,43 +34,57 @@
  * WYL_LOG_CRITICAL is reserved for unrecoverable invariant violations
  * and must NOT be used for errors that are expected to be handled.
  *
- * When WYL_LOG_MAX_LEVEL is below the macro's required level the macro
- * expands to G_STMT_START {} G_STMT_END so arguments are never
- * evaluated (compile-time dead-code elimination, no side-effects).
+ * WYL_LOG_DEBUG/INFO/WARN/ERROR are subject to WYL_LOG_MAX_LEVEL and
+ * may compile to no-ops (G_STMT_START {} G_STMT_END) when the ceiling
+ * is set below their required level — arguments are never evaluated in
+ * that case (compile-time dead-code elimination, no side-effects).
+ *
+ * WYL_LOG_CRITICAL bypasses WYL_LOG_MAX_LEVEL entirely because
+ * invariant violations must always abort, even under
+ * -Dwyrelog_log_max_level=none. Silencing an abort-class invariant
+ * violation is a safety defect, not a tuning option.
+ *
+ * All macros pass __FILE__, __LINE__, and G_STRFUNC to the internal
+ * entry point so the formatted output includes source location.
  */
 
 #define WYL_LOG_DEBUG(section, ...) \
   G_STMT_START { \
     if (WYL_LOG_LEVEL_DEBUG <= WYL_LOG_MAX_LEVEL) \
-      wyl_log_structured ((section), G_LOG_LEVEL_DEBUG, __VA_ARGS__); \
+      wyl_log_structured_at ((section), G_LOG_LEVEL_DEBUG, \
+          __FILE__, __LINE__, G_STRFUNC, __VA_ARGS__); \
   } G_STMT_END
 
 #define WYL_LOG_INFO(section, ...) \
   G_STMT_START { \
     if (WYL_LOG_LEVEL_INFO <= WYL_LOG_MAX_LEVEL) \
-      wyl_log_structured ((section), G_LOG_LEVEL_INFO, __VA_ARGS__); \
+      wyl_log_structured_at ((section), G_LOG_LEVEL_INFO, \
+          __FILE__, __LINE__, G_STRFUNC, __VA_ARGS__); \
   } G_STMT_END
 
 #define WYL_LOG_WARN(section, ...) \
   G_STMT_START { \
     if (WYL_LOG_LEVEL_WARN <= WYL_LOG_MAX_LEVEL) \
-      wyl_log_structured ((section), G_LOG_LEVEL_WARNING, __VA_ARGS__); \
+      wyl_log_structured_at ((section), G_LOG_LEVEL_WARNING, \
+          __FILE__, __LINE__, G_STRFUNC, __VA_ARGS__); \
   } G_STMT_END
 
 #define WYL_LOG_ERROR(section, ...) \
   G_STMT_START { \
     if (WYL_LOG_LEVEL_ERROR <= WYL_LOG_MAX_LEVEL) \
-      wyl_log_structured ((section), G_LOG_LEVEL_CRITICAL, __VA_ARGS__); \
+      wyl_log_structured_at ((section), G_LOG_LEVEL_CRITICAL, \
+          __FILE__, __LINE__, G_STRFUNC, __VA_ARGS__); \
   } G_STMT_END
 
-/* WYL_LOG_CRITICAL expands to G_LOG_LEVEL_ERROR which GLib treats as
- * always-fatal (calls abort()). Use ONLY for unrecoverable invariant
- * violations. Do NOT invoke for errors that callers are expected to
- * handle; use WYL_LOG_ERROR instead. */
+/* WYL_LOG_CRITICAL bypasses WYL_LOG_MAX_LEVEL because invariant
+ * violations must always abort. Setting -Dwyrelog_log_max_level=none
+ * still emits and aborts for CRITICAL. Use ONLY for unrecoverable
+ * invariant violations. Do NOT invoke for errors that callers are
+ * expected to handle; use WYL_LOG_ERROR instead. */
 #define WYL_LOG_CRITICAL(section, ...) \
   G_STMT_START { \
-    if (WYL_LOG_LEVEL_ERROR <= WYL_LOG_MAX_LEVEL) \
-      wyl_log_structured ((section), G_LOG_LEVEL_ERROR, __VA_ARGS__); \
+    wyl_log_structured_at ((section), G_LOG_LEVEL_ERROR, \
+        __FILE__, __LINE__, G_STRFUNC, __VA_ARGS__); \
   } G_STMT_END
 
 /* --- Section grammar -------------------------------------------------
@@ -84,6 +98,11 @@
  * Section names are operator-visible (they appear in env-var input
  * and in formatted log output). Names are deliberately neutral and
  * do not advertise wyrelog-internal axioms.
+ *
+ * Output routing note: the writer routes each record to the file sink
+ * (WYL_LOG_FILE) XOR stderr — tee-style logging to both is not
+ * supported in v0. fflush() errors are not currently propagated;
+ * persistent I/O errors silently drop records.
  */
 typedef enum
 {
@@ -118,17 +137,48 @@ typedef enum
 const char *wyl_log_section_name (wyl_log_section_t section);
 gint wyl_log_section_count (void);
 
-/* Structured log entry point. Carries a WYL_SECTION GLib log field so
- * the wyrelog writer can route by section. Callers normally reach for
- * the section-aware macros that arrive in a follow-up commit; this
- * function is the single landing point those macros expand to. */
+/* Primary structured log entry point. Accepts source location fields
+ * (file, line, func) that are emitted as CODE_FILE / CODE_LINE /
+ * CODE_FUNC GLib structured fields and included in the formatted
+ * output line. Callers use the WYL_LOG_* macros which supply
+ * __FILE__, __LINE__, G_STRFUNC automatically.
+ *
+ * wyl_log_structured is a thin wrapper that passes NULL / 0 / NULL for
+ * location fields; it exists for call sites (e.g. tests) that do not
+ * need source attribution. */
 void
-wyl_log_structured (wyl_log_section_t section, GLogLevelFlags level,
+wyl_log_structured_at (wyl_log_section_t section, GLogLevelFlags level,
+    const char *file, gint line, const char *func, const char *fmt, ...)
+G_GNUC_PRINTF (6, 7);
+
+     void wyl_log_structured (wyl_log_section_t section, GLogLevelFlags level,
     const char *fmt, ...)
-G_GNUC_PRINTF (3, 4);
+  G_GNUC_PRINTF (3, 4);
 
 /* Internal hooks (suffix _internal_: not stable API). */
      gint wyl_log_internal_get_section_level (wyl_log_section_t section);
      void wyl_log_internal_parse_spec (const char *spec,
     gint8 levels[WYL_LOG_SECTION_LAST_]);
+
+/* wyl_log_internal_reconfigure — reload log configuration from env vars.
+ *
+ * Re-reads WYL_LOG (section:level spec) and WYL_LOG_FILE (output path)
+ * on each call. If WYL_LOG_FILE changes, the prior file is closed and
+ * the new path opened in append mode.
+ *
+ * Properties:
+ *   - Idempotent: calling it multiple times with the same environment
+ *     is equivalent to calling it once; the prior sink is closed and
+ *     reopened on each call.
+ *   - Thread-safe: section levels are updated under log_mutex; the
+ *     file sink is swapped under sink_mutex. The two locks are never
+ *     held simultaneously.
+ *   - NOT async-signal-safe: do NOT call from signal handlers. The
+ *     function acquires mutexes and calls fopen/fclose.
+ *   - NOT fork-safe: after fork() the child inherits the open FILE*
+ *     from the parent. Sharing a FILE* across a fork boundary leads
+ *     to buffer aliasing and undefined behaviour. The child must not
+ *     call wyl_log_structured* or wyl_log_internal_reconfigure without
+ *     first calling wyl_log_internal_reconfigure to close and reopen
+ *     the sink in the child's address space. */
      void wyl_log_internal_reconfigure (void);

--- a/wyrelog/wyl-log-private.h
+++ b/wyrelog/wyl-log-private.h
@@ -8,33 +8,70 @@
 #endif
 
 /*
- * Severity macros mapped onto GLib log levels:
+ * Section-aware, compile-time-ceiling-aware severity macros.
  *
- *   WYL_LOG_DEBUG    -> G_LOG_LEVEL_DEBUG     (verbose)
- *   WYL_LOG_INFO     -> G_LOG_LEVEL_INFO      (informational)
- *   WYL_LOG_WARN     -> G_LOG_LEVEL_WARNING   (recoverable warning)
- *   WYL_LOG_ERROR    -> G_LOG_LEVEL_CRITICAL  (recoverable error;
- *                                              program continues)
- *   WYL_LOG_CRITICAL -> G_LOG_LEVEL_ERROR     (invariant violation;
- *                                              terminates the program)
+ * Every macro takes a WYL_LOG_SECTION_* constant as its first argument
+ * followed by a printf-style format and variadic arguments.
  *
- * The mapping for ERROR/CRITICAL is intentionally inverted relative to
- * the GLib level names because GLib treats G_LOG_LEVEL_ERROR as
- * always-fatal (it calls abort()) and G_LOG_LEVEL_CRITICAL as
- * non-fatal. Library code reaches for WYL_LOG_ERROR to record handled
- * but bad events; only WYL_LOG_CRITICAL is intended to terminate.
+ * Mapping onto GLib log levels (ERROR/CRITICAL intentionally inverted):
+ *
+ *   WYL_LOG_DEBUG(s,...)    -> WYL_LOG_LEVEL_DEBUG  ceiling,
+ *                              G_LOG_LEVEL_DEBUG
+ *   WYL_LOG_INFO(s,...)     -> WYL_LOG_LEVEL_INFO   ceiling,
+ *                              G_LOG_LEVEL_INFO
+ *   WYL_LOG_WARN(s,...)     -> WYL_LOG_LEVEL_WARN   ceiling,
+ *                              G_LOG_LEVEL_WARNING
+ *   WYL_LOG_ERROR(s,...)    -> WYL_LOG_LEVEL_ERROR  ceiling,
+ *                              G_LOG_LEVEL_CRITICAL (recoverable;
+ *                              program continues)
+ *   WYL_LOG_CRITICAL(s,...) -> WYL_LOG_LEVEL_ERROR  ceiling,
+ *                              G_LOG_LEVEL_ERROR    (invariant violation;
+ *                              GLib calls abort() — program terminates)
+ *
+ * The ERROR/CRITICAL inversion is deliberate: GLib treats
+ * G_LOG_LEVEL_ERROR as always-fatal (abort()) and G_LOG_LEVEL_CRITICAL
+ * as non-fatal. WYL_LOG_ERROR is for handled-but-bad events;
+ * WYL_LOG_CRITICAL is reserved for unrecoverable invariant violations
+ * and must NOT be used for errors that are expected to be handled.
+ *
+ * When WYL_LOG_MAX_LEVEL is below the macro's required level the macro
+ * expands to G_STMT_START {} G_STMT_END so arguments are never
+ * evaluated (compile-time dead-code elimination, no side-effects).
  */
 
-#define WYL_LOG_DEBUG(...) \
-  g_log (WYL_LOG_DOMAIN, G_LOG_LEVEL_DEBUG, __VA_ARGS__)
-#define WYL_LOG_INFO(...) \
-  g_log (WYL_LOG_DOMAIN, G_LOG_LEVEL_INFO, __VA_ARGS__)
-#define WYL_LOG_WARN(...) \
-  g_log (WYL_LOG_DOMAIN, G_LOG_LEVEL_WARNING, __VA_ARGS__)
-#define WYL_LOG_ERROR(...) \
-  g_log (WYL_LOG_DOMAIN, G_LOG_LEVEL_CRITICAL, __VA_ARGS__)
-#define WYL_LOG_CRITICAL(...) \
-  g_log (WYL_LOG_DOMAIN, G_LOG_LEVEL_ERROR, __VA_ARGS__)
+#define WYL_LOG_DEBUG(section, ...) \
+  G_STMT_START { \
+    if (WYL_LOG_LEVEL_DEBUG <= WYL_LOG_MAX_LEVEL) \
+      wyl_log_structured ((section), G_LOG_LEVEL_DEBUG, __VA_ARGS__); \
+  } G_STMT_END
+
+#define WYL_LOG_INFO(section, ...) \
+  G_STMT_START { \
+    if (WYL_LOG_LEVEL_INFO <= WYL_LOG_MAX_LEVEL) \
+      wyl_log_structured ((section), G_LOG_LEVEL_INFO, __VA_ARGS__); \
+  } G_STMT_END
+
+#define WYL_LOG_WARN(section, ...) \
+  G_STMT_START { \
+    if (WYL_LOG_LEVEL_WARN <= WYL_LOG_MAX_LEVEL) \
+      wyl_log_structured ((section), G_LOG_LEVEL_WARNING, __VA_ARGS__); \
+  } G_STMT_END
+
+#define WYL_LOG_ERROR(section, ...) \
+  G_STMT_START { \
+    if (WYL_LOG_LEVEL_ERROR <= WYL_LOG_MAX_LEVEL) \
+      wyl_log_structured ((section), G_LOG_LEVEL_CRITICAL, __VA_ARGS__); \
+  } G_STMT_END
+
+/* WYL_LOG_CRITICAL expands to G_LOG_LEVEL_ERROR which GLib treats as
+ * always-fatal (calls abort()). Use ONLY for unrecoverable invariant
+ * violations. Do NOT invoke for errors that callers are expected to
+ * handle; use WYL_LOG_ERROR instead. */
+#define WYL_LOG_CRITICAL(section, ...) \
+  G_STMT_START { \
+    if (WYL_LOG_LEVEL_ERROR <= WYL_LOG_MAX_LEVEL) \
+      wyl_log_structured ((section), G_LOG_LEVEL_ERROR, __VA_ARGS__); \
+  } G_STMT_END
 
 /* --- Section grammar -------------------------------------------------
  *
@@ -94,4 +131,4 @@ G_GNUC_PRINTF (3, 4);
      gint wyl_log_internal_get_section_level (wyl_log_section_t section);
      void wyl_log_internal_parse_spec (const char *spec,
     gint8 levels[WYL_LOG_SECTION_LAST_]);
-     void wyl_log_internal_reload_for_tests (void);
+     void wyl_log_internal_reconfigure (void);

--- a/wyrelog/wyl-log.c
+++ b/wyrelog/wyl-log.c
@@ -178,7 +178,10 @@ log_writer (GLogLevelFlags log_level,
   g_mutex_lock (&log_mutex);
   threshold = section_levels[section];
   g_mutex_unlock (&log_mutex);
-  if (wyl_level > threshold)
+  /* CRITICAL bypasses runtime threshold so that invariant
+   * violations are unconditionally visible, matching the
+   * compile-time bypass in WYL_LOG_CRITICAL. */
+  if (!(log_level & G_LOG_LEVEL_ERROR) && wyl_level > threshold)
     return G_LOG_WRITER_HANDLED;
 
   /* Route to WYL_LOG_FILE if open, else stderr. The mutex is

--- a/wyrelog/wyl-log.c
+++ b/wyrelog/wyl-log.c
@@ -1,0 +1,230 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "wyl-log-private.h"
+
+#include <glib.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* --- Section name table -------------------------------------------- */
+
+static const char *const section_names[WYL_LOG_SECTION_LAST_] = {
+  [WYL_LOG_SECTION_BOOT] = "BOOT",
+  [WYL_LOG_SECTION_POLICY] = "POLICY",
+  [WYL_LOG_SECTION_SESSION] = "SESSION",
+  [WYL_LOG_SECTION_DECISION] = "DECISION",
+  [WYL_LOG_SECTION_AUDIT] = "AUDIT",
+  [WYL_LOG_SECTION_IO] = "IO",
+  [WYL_LOG_SECTION_GENERAL] = "GENERAL",
+};
+
+const char *
+wyl_log_section_name (wyl_log_section_t section)
+{
+  if ((gint) section < 0 || (gint) section >= WYL_LOG_SECTION_LAST_)
+    return NULL;
+  return section_names[section];
+}
+
+gint
+wyl_log_section_count (void)
+{
+  return (gint) WYL_LOG_SECTION_LAST_;
+}
+
+/* --- Spec parser --------------------------------------------------- */
+
+static gint
+parse_level_token (const char *tok)
+{
+  if (g_ascii_isdigit ((guchar) tok[0])) {
+    gint n = atoi (tok);
+    if (n < 0)
+      return -1;
+    if (n > WYL_LOG_LEVEL_TRACE)
+      return WYL_LOG_LEVEL_TRACE;
+    return n;
+  }
+  if (g_ascii_strcasecmp (tok, "none") == 0)
+    return WYL_LOG_LEVEL_NONE;
+  if (g_ascii_strcasecmp (tok, "error") == 0)
+    return WYL_LOG_LEVEL_ERROR;
+  if (g_ascii_strcasecmp (tok, "warn") == 0)
+    return WYL_LOG_LEVEL_WARN;
+  if (g_ascii_strcasecmp (tok, "info") == 0)
+    return WYL_LOG_LEVEL_INFO;
+  if (g_ascii_strcasecmp (tok, "debug") == 0)
+    return WYL_LOG_LEVEL_DEBUG;
+  if (g_ascii_strcasecmp (tok, "trace") == 0)
+    return WYL_LOG_LEVEL_TRACE;
+  return -1;
+}
+
+static gint
+parse_section_token (const char *tok)
+{
+  if (strcmp (tok, "*") == 0)
+    return -2;
+  for (gint i = 0; i < WYL_LOG_SECTION_LAST_; i++) {
+    if (g_ascii_strcasecmp (tok, section_names[i]) == 0)
+      return i;
+  }
+  return -1;
+}
+
+void
+wyl_log_internal_parse_spec (const char *spec,
+    gint8 levels[WYL_LOG_SECTION_LAST_])
+{
+  for (gint i = 0; i < WYL_LOG_SECTION_LAST_; i++)
+    levels[i] = (gint8) WYL_LOG_LEVEL_WARN;
+
+  if (spec == NULL || spec[0] == '\0')
+    return;
+
+  g_auto (GStrv) entries = g_strsplit (spec, ",", -1);
+  for (gint i = 0; entries[i] != NULL; i++) {
+    g_autofree gchar *trimmed = g_strstrip (g_strdup (entries[i]));
+    if (trimmed[0] == '\0')
+      continue;
+    g_auto (GStrv) parts = g_strsplit (trimmed, ":", 2);
+    if (g_strv_length (parts) != 2)
+      continue;
+    const char *sec_tok = g_strstrip (parts[0]);
+    const char *lvl_tok = g_strstrip (parts[1]);
+    gint level = parse_level_token (lvl_tok);
+    if (level < 0)
+      continue;
+    gint sec = parse_section_token (sec_tok);
+    if (sec == -2) {
+      for (gint j = 0; j < WYL_LOG_SECTION_LAST_; j++)
+        levels[j] = (gint8) level;
+    } else if (sec >= 0) {
+      levels[sec] = (gint8) level;
+    }
+    /* Unknown section silently ignored: an operator typo should not
+     * destabilise the daemon. The price is silent miscalibration if a
+     * deployed config drifts; documented as such in the K4 design. */
+  }
+}
+
+/* --- Runtime threshold table + writer install --------------------- */
+
+static GMutex log_mutex;
+static gint8 section_levels[WYL_LOG_SECTION_LAST_];
+static gsize init_once = 0;
+
+static gint
+glib_level_to_wyl (GLogLevelFlags level)
+{
+  if (level & G_LOG_LEVEL_ERROR)
+    return WYL_LOG_LEVEL_ERROR;
+  if (level & G_LOG_LEVEL_CRITICAL)
+    return WYL_LOG_LEVEL_ERROR;
+  if (level & G_LOG_LEVEL_WARNING)
+    return WYL_LOG_LEVEL_WARN;
+  if (level & G_LOG_LEVEL_MESSAGE)
+    return WYL_LOG_LEVEL_INFO;
+  if (level & G_LOG_LEVEL_INFO)
+    return WYL_LOG_LEVEL_INFO;
+  if (level & G_LOG_LEVEL_DEBUG)
+    return WYL_LOG_LEVEL_DEBUG;
+  return WYL_LOG_LEVEL_INFO;
+}
+
+static GLogWriterOutput
+log_writer (GLogLevelFlags log_level,
+    const GLogField *fields, gsize n_fields, gpointer user_data)
+{
+  (void) user_data;
+
+  wyl_log_section_t section = WYL_LOG_SECTION_GENERAL;
+  const char *message = NULL;
+  const char *domain = NULL;
+  for (gsize i = 0; i < n_fields; i++) {
+    if (strcmp (fields[i].key, "WYL_SECTION") == 0) {
+      gint s = parse_section_token ((const char *) fields[i].value);
+      if (s >= 0)
+        section = (wyl_log_section_t) s;
+    } else if (strcmp (fields[i].key, "MESSAGE") == 0) {
+      message = (const char *) fields[i].value;
+    } else if (strcmp (fields[i].key, "GLIB_DOMAIN") == 0) {
+      domain = (const char *) fields[i].value;
+    }
+  }
+
+  /* If the record is not from our domain, defer to GLib's default
+   * writer. Embedders that link libwyrelog into a host with its own
+   * GLib logging keep their normal behaviour. */
+  if (domain == NULL || strcmp (domain, WYL_LOG_DOMAIN) != 0)
+    return g_log_writer_default (log_level, fields, n_fields, NULL);
+
+  gint wyl_level = glib_level_to_wyl (log_level);
+  gint8 threshold;
+  g_mutex_lock (&log_mutex);
+  threshold = section_levels[section];
+  g_mutex_unlock (&log_mutex);
+  if (wyl_level > threshold)
+    return G_LOG_WRITER_HANDLED;
+
+  /* Stderr sink for commit 1; file sink lands in a follow-up commit
+   * that wires WYL_LOG_FILE. The mutex around fputs is process-local
+   * (not async-signal-safe) — matches wirelog's stance. */
+  static GMutex sink_mutex;
+  g_mutex_lock (&sink_mutex);
+  fprintf (stderr, "[wyrelog %s] %s\n",
+      section_names[section], message != NULL ? message : "(no message)");
+  fflush (stderr);
+  g_mutex_unlock (&sink_mutex);
+
+  return G_LOG_WRITER_HANDLED;
+}
+
+static void
+ensure_init (void)
+{
+  if (g_once_init_enter (&init_once)) {
+    g_mutex_init (&log_mutex);
+    const char *spec = g_getenv ("WYL_LOG");
+    wyl_log_internal_parse_spec (spec, section_levels);
+    /* g_log_set_writer_func is set-once per process; subsequent calls
+     * trigger a one-line GLib warning and are ignored. Embedders that
+     * also call it lose to whichever caller wins the race. */
+    g_log_set_writer_func (log_writer, NULL, NULL);
+    g_once_init_leave (&init_once, 1);
+  }
+}
+
+gint
+wyl_log_internal_get_section_level (wyl_log_section_t section)
+{
+  if ((gint) section < 0 || (gint) section >= WYL_LOG_SECTION_LAST_)
+    return -1;
+  ensure_init ();
+  g_mutex_lock (&log_mutex);
+  gint level = section_levels[section];
+  g_mutex_unlock (&log_mutex);
+  return level;
+}
+
+void
+wyl_log_structured (wyl_log_section_t section,
+    GLogLevelFlags level, const char *fmt, ...)
+{
+  if ((gint) section < 0 || (gint) section >= WYL_LOG_SECTION_LAST_)
+    section = WYL_LOG_SECTION_GENERAL;
+
+  ensure_init ();
+
+  va_list ap;
+  va_start (ap, fmt);
+  g_autofree gchar *msg = g_strdup_vprintf (fmt, ap);
+  va_end (ap);
+
+  GLogField fields[3] = {
+    {"GLIB_DOMAIN", WYL_LOG_DOMAIN, -1},
+    {"WYL_SECTION", section_names[section], -1},
+    {"MESSAGE", msg, -1},
+  };
+  g_log_structured_array (level, fields, G_N_ELEMENTS (fields));
+}

--- a/wyrelog/wyl-log.c
+++ b/wyrelog/wyl-log.c
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #include "wyl-log-private.h"
 
+#include <errno.h>
 #include <glib.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -114,6 +115,10 @@ static GMutex log_mutex;
 static gint8 section_levels[WYL_LOG_SECTION_LAST_];
 static gsize init_once = 0;
 
+/* File sink state. Protected by sink_mutex; NULL means use stderr. */
+static GMutex sink_mutex;
+static FILE *log_file_sink = NULL;
+
 static gint
 glib_level_to_wyl (GLogLevelFlags level)
 {
@@ -167,14 +172,14 @@ log_writer (GLogLevelFlags log_level,
   if (wyl_level > threshold)
     return G_LOG_WRITER_HANDLED;
 
-  /* Stderr sink for commit 1; file sink lands in a follow-up commit
-   * that wires WYL_LOG_FILE. The mutex around fputs is process-local
-   * (not async-signal-safe) — matches wirelog's stance. */
-  static GMutex sink_mutex;
+  /* Route to WYL_LOG_FILE if open, else stderr. The mutex is
+   * module-scope (sink_mutex) so the reload path can swap the fd
+   * safely. Process-local only — not async-signal-safe. */
   g_mutex_lock (&sink_mutex);
-  fprintf (stderr, "[wyrelog %s] %s\n",
+  FILE *sink = log_file_sink != NULL ? log_file_sink : stderr;
+  fprintf (sink, "[wyrelog %s] %s\n",
       section_names[section], message != NULL ? message : "(no message)");
-  fflush (stderr);
+  fflush (sink);
   g_mutex_unlock (&sink_mutex);
 
   return G_LOG_WRITER_HANDLED;
@@ -185,14 +190,62 @@ ensure_init (void)
 {
   if (g_once_init_enter (&init_once)) {
     g_mutex_init (&log_mutex);
+    g_mutex_init (&sink_mutex);
     const char *spec = g_getenv ("WYL_LOG");
     wyl_log_internal_parse_spec (spec, section_levels);
+
+    const char *path = g_getenv ("WYL_LOG_FILE");
+    if (path != NULL && path[0] != '\0') {
+      FILE *f = fopen (path, "a");
+      if (f != NULL) {
+        setvbuf (f, NULL, _IOLBF, 0);
+        log_file_sink = f;
+      } else {
+        fprintf (stderr, "[wyrelog WARN] WYL_LOG_FILE=%s unwritable: %s\n",
+            path, g_strerror (errno));
+      }
+    }
+
     /* g_log_set_writer_func is set-once per process; subsequent calls
      * trigger a one-line GLib warning and are ignored. Embedders that
      * also call it lose to whichever caller wins the race. */
     g_log_set_writer_func (log_writer, NULL, NULL);
     g_once_init_leave (&init_once, 1);
   }
+}
+
+void
+wyl_log_internal_reload_for_tests (void)
+{
+  ensure_init ();
+
+  /* Re-read WYL_LOG spec under log_mutex. */
+  const char *spec = g_getenv ("WYL_LOG");
+  gint8 new_levels[WYL_LOG_SECTION_LAST_];
+  wyl_log_internal_parse_spec (spec, new_levels);
+  g_mutex_lock (&log_mutex);
+  for (gint i = 0; i < WYL_LOG_SECTION_LAST_; i++)
+    section_levels[i] = new_levels[i];
+  g_mutex_unlock (&log_mutex);
+
+  /* Re-open WYL_LOG_FILE under sink_mutex. */
+  const char *path = g_getenv ("WYL_LOG_FILE");
+  g_mutex_lock (&sink_mutex);
+  if (log_file_sink != NULL) {
+    fclose (log_file_sink);
+    log_file_sink = NULL;
+  }
+  if (path != NULL && path[0] != '\0') {
+    FILE *f = fopen (path, "a");
+    if (f != NULL) {
+      setvbuf (f, NULL, _IOLBF, 0);
+      log_file_sink = f;
+    } else {
+      fprintf (stderr, "[wyrelog WARN] WYL_LOG_FILE=%s unwritable: %s\n",
+          path, g_strerror (errno));
+    }
+  }
+  g_mutex_unlock (&sink_mutex);
 }
 
 gint

--- a/wyrelog/wyl-log.c
+++ b/wyrelog/wyl-log.c
@@ -198,7 +198,8 @@ ensure_init (void)
     if (path != NULL && path[0] != '\0') {
       FILE *f = fopen (path, "a");
       if (f != NULL) {
-        setvbuf (f, NULL, _IOLBF, 0);
+        /* fflush() per record in the writer handles ordering;
+         * setvbuf line-buffering is redundant and not used. */
         log_file_sink = f;
       } else {
         fprintf (stderr, "[wyrelog WARN] WYL_LOG_FILE=%s unwritable: %s\n",
@@ -215,7 +216,7 @@ ensure_init (void)
 }
 
 void
-wyl_log_internal_reload_for_tests (void)
+wyl_log_internal_reconfigure (void)
 {
   ensure_init ();
 
@@ -228,7 +229,9 @@ wyl_log_internal_reload_for_tests (void)
     section_levels[i] = new_levels[i];
   g_mutex_unlock (&log_mutex);
 
-  /* Re-open WYL_LOG_FILE under sink_mutex. */
+  /* Re-open WYL_LOG_FILE under sink_mutex. fflush() per record in the
+   * writer already handles ordering; setvbuf line-buffering is
+   * redundant and dropped here. */
   const char *path = g_getenv ("WYL_LOG_FILE");
   g_mutex_lock (&sink_mutex);
   if (log_file_sink != NULL) {
@@ -238,7 +241,6 @@ wyl_log_internal_reload_for_tests (void)
   if (path != NULL && path[0] != '\0') {
     FILE *f = fopen (path, "a");
     if (f != NULL) {
-      setvbuf (f, NULL, _IOLBF, 0);
       log_file_sink = f;
     } else {
       fprintf (stderr, "[wyrelog WARN] WYL_LOG_FILE=%s unwritable: %s\n",

--- a/wyrelog/wyl-log.c
+++ b/wyrelog/wyl-log.c
@@ -146,6 +146,9 @@ log_writer (GLogLevelFlags log_level,
   wyl_log_section_t section = WYL_LOG_SECTION_GENERAL;
   const char *message = NULL;
   const char *domain = NULL;
+  const char *code_file = NULL;
+  const char *code_line = NULL;
+  const char *code_func = NULL;
   for (gsize i = 0; i < n_fields; i++) {
     if (strcmp (fields[i].key, "WYL_SECTION") == 0) {
       gint s = parse_section_token ((const char *) fields[i].value);
@@ -155,6 +158,12 @@ log_writer (GLogLevelFlags log_level,
       message = (const char *) fields[i].value;
     } else if (strcmp (fields[i].key, "GLIB_DOMAIN") == 0) {
       domain = (const char *) fields[i].value;
+    } else if (strcmp (fields[i].key, "CODE_FILE") == 0) {
+      code_file = (const char *) fields[i].value;
+    } else if (strcmp (fields[i].key, "CODE_LINE") == 0) {
+      code_line = (const char *) fields[i].value;
+    } else if (strcmp (fields[i].key, "CODE_FUNC") == 0) {
+      code_func = (const char *) fields[i].value;
     }
   }
 
@@ -177,8 +186,15 @@ log_writer (GLogLevelFlags log_level,
    * safely. Process-local only — not async-signal-safe. */
   g_mutex_lock (&sink_mutex);
   FILE *sink = log_file_sink != NULL ? log_file_sink : stderr;
-  fprintf (sink, "[wyrelog %s] %s\n",
-      section_names[section], message != NULL ? message : "(no message)");
+  if (code_file != NULL && code_line != NULL) {
+    fprintf (sink, "[wyrelog %s %s:%s] %s\n",
+        section_names[section], code_file, code_line,
+        message != NULL ? message : "(no message)");
+  } else {
+    fprintf (sink, "[wyrelog %s] %s\n",
+        section_names[section], message != NULL ? message : "(no message)");
+  }
+  (void) code_func;
   fflush (sink);
   g_mutex_unlock (&sink_mutex);
 
@@ -260,6 +276,45 @@ wyl_log_internal_get_section_level (wyl_log_section_t section)
   gint level = section_levels[section];
   g_mutex_unlock (&log_mutex);
   return level;
+}
+
+void
+wyl_log_structured_at (wyl_log_section_t section,
+    GLogLevelFlags level, const char *file, gint line, const char *func,
+    const char *fmt, ...)
+{
+  if ((gint) section < 0 || (gint) section >= WYL_LOG_SECTION_LAST_)
+    section = WYL_LOG_SECTION_GENERAL;
+
+  ensure_init ();
+
+  va_list ap;
+  va_start (ap, fmt);
+  g_autofree gchar *msg = g_strdup_vprintf (fmt, ap);
+  va_end (ap);
+
+  /* Format CODE_LINE as a decimal string in a stack buffer. */
+  char line_buf[24];
+  g_snprintf (line_buf, sizeof (line_buf), "%d", line);
+
+  if (file != NULL && func != NULL) {
+    GLogField fields[6] = {
+      {"GLIB_DOMAIN", WYL_LOG_DOMAIN, -1},
+      {"WYL_SECTION", section_names[section], -1},
+      {"MESSAGE", msg, -1},
+      {"CODE_FILE", file, -1},
+      {"CODE_LINE", line_buf, -1},
+      {"CODE_FUNC", func, -1},
+    };
+    g_log_structured_array (level, fields, G_N_ELEMENTS (fields));
+  } else {
+    GLogField fields[3] = {
+      {"GLIB_DOMAIN", WYL_LOG_DOMAIN, -1},
+      {"WYL_SECTION", section_names[section], -1},
+      {"MESSAGE", msg, -1},
+    };
+    g_log_structured_array (level, fields, G_N_ELEMENTS (fields));
+  }
 }
 
 void


### PR DESCRIPTION
## Summary

Add the wyrelog WYL_LOG observability surface:

- **Section + level grammar** `WYL_LOG=SECTION:LEVEL[,...]` with `*` wildcard and later-wins override; seven sections (BOOT, POLICY, SESSION, DECISION, AUDIT, IO, GENERAL) and six levels (NONE/ERROR/WARN/INFO/DEBUG/TRACE = 0..5).
- **Custom `GLogWriterFunc`** installed once via `g_log_set_writer_func`, mutex-protected, stderr default sink with `WYL_LOG_FILE` redirection and stderr fallback on fopen failure.
- **Section-aware ceiling-aware macros** (`WYL_LOG_DEBUG/INFO/WARN/ERROR/CRITICAL`) consuming `-Dwyrelog_log_max_level` to strip disabled sites at compile time.
- **`WYL_LOG_CRITICAL` invariant**: bypasses both compile-time ceiling and runtime threshold so abort-class invariant violations are unconditionally visible. The `G_LOG_LEVEL_ERROR` inversion (CRITICAL → fatal) is documented.
- **Source-location fields** (`CODE_FILE`/`CODE_LINE`/`CODE_FUNC`) carried through `wyl_log_structured_at` and formatted into the human-readable line.
- **Eager init** at `wyl_init` so `wyl-boot.c` log sites reach the new writer without depending on lazy init.
- **`wyl_log_internal_reconfigure`** as the production entry point for re-reading env-driven config (idempotent, mutex-protected, NOT async-signal-safe, NOT fork-safe — fork doc explicitly forbids `fclose`/`freopen` on inherited handles and mandates post-fork re-exec).
- **Private-header CI guard** (`tools/check-private-headers-not-installed.sh`) with two-tier check: `meson introspect --installed builddir` (authoritative) + line-grep fallback.

## Concrete invariants tested

- Parser: 13 grammar tests cover wildcards, named sections, case insensitivity, override semantics, malformed entries silently dropped, numeric clamping, whitespace tolerance.
- Section name table: round-trip + count.
- File sink: redirection, fopen-failure stderr fallback, runtime end-to-end filter, same-path reopen no-crash.
- CRITICAL bypass: positive arg-evaluation test under `WYL_LOG_MAX_LEVEL=2` + `WYL_LOG=*:none` (subprocess trap with sentinel file).
- CRITICAL abort: subprocess trap death test asserts process termination + stderr contains the formatted message.
- sink_mutex: 8 threads × 1000 records → file-sink capture asserts 8000 lines AND each line matches `^\[wyrelog GENERAL\] t7-thread-N-record-M$` (per-line regex catches torn writes).
- Private-header guard: tier-1 introspect + tier-2 line-grep; tier-1 hard-fails on meson introspect error rather than silent fallback.

## Commit series (10 atomic commits, each builds and passes tests on its own)

1. `060b17c log: add section grammar parser and structured handler infrastructure`
2. `cffbf5e log: harmonise wyl_log_internal_parse_spec parameter form`
3. `b35bf8f log: route WYL_LOG_FILE sink with stderr fallback`
4. `93a8681 log: replace WYL_LOG_* macros with section-aware ceiling-aware form`
5. `e329462 log: restore CRITICAL abort and source-location fields`
6. `de06dfc log: bypass runtime threshold for WYL_LOG_CRITICAL`
7. `1c1b0c8 log: harden critical-bypass test path uniqueness and fork doc`
8. `3ed69b0 log: ship death test, thread-stress, robust private-header guard`
9. `e12f206 log: tighten T7 torn-line check and T7/CI-guard explicit-mode handling`
10. `9889664 log: avoid set -e early-exit in private-header guard introspect path`

Each commit cleared a per-commit reviewer + meta-review pass before the next started; some sev-2 issues surfaced mid-series and were closed by fixup commits in the same PR (this is reflected in the series shape — feature commits and fixup commits alternate by design).

## Out of scope (deferred follow-ups)

- ASan registration as a separate hygiene commit
- `WYL_LOG_TRACE` macro (currently TRACE routes via `G_LOG_LEVEL_DEBUG`)
- Public `wyrelog/log.h` umbrella header (currently `wyl-log-private.h` is internal-only)
- Tighter T6 stderr matcher (currently `*boom*`)
- Narrower private-header detection regex (`-private.h` substring is permissive)
- Explicit `pthread_atfork` ownership statement in fork doc
- Faulty-builddir + corrupt-introspect regression tests in the meson harness
- Compile-time `WYL_LOG_MAX_LEVEL` test variants beyond `=2`

## Test plan

- [x] `meson setup builddir --reconfigure` succeeds
- [x] `meson test -C builddir` reports 33/33 OK after every commit in the series
- [x] `ninja -C builddir` produces no `-W` warnings introduced by this branch
- [x] CI guard `./tools/check-private-headers-not-installed.sh` exits 0 with current install set
- [x] CI guard hard-fails (exit 1 + diagnostic banner) when `meson introspect` fails — empirically verified with a fake-meson stub that exits 2
- [x] T7 thread-stress asserts both 8000-line count AND per-line regex match
- [x] CRITICAL bypass + abort death test both pass under `WYL_LOG_MAX_LEVEL=2`