### PR TITLE
events: introduce opaque access event API

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -239,6 +239,12 @@ check_private_headers = find_program(
 
 test('check-private-headers-not-installed', check_private_headers)
 
+check_public_headers = find_program(
+  '../tools/check-public-headers-no-novelty-tokens.sh',
+)
+
+test('check-public-headers-no-novelty-tokens', check_public_headers)
+
 if get_option('enable_audit').allowed()
   audit_conn_test_env = environment()
   if host_machine.system() == 'windows' \

--- a/tests/test-events.c
+++ b/tests/test-events.c
@@ -1,14 +1,19 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #include <glib.h>
+#include <string.h>
 
 #include "wyrelog/wyl-events-private.h"
+
+/* -----------------------------------------------------------------------
+ * Legacy flat-struct tests (preserved exactly)
+ * --------------------------------------------------------------------- */
 
 /* --- Domain name round-trip ------------------------------------- */
 
 static gint
 check_domain_names (void)
 {
-  for (guint d = 0; d < WYL_ACCESS_EVENT_DOMAIN_LAST_; d++) {
+  for (guint d = 0; d < (guint) WYL_ACCESS_EVENT_DOMAIN_LAST_; d++) {
     const gchar *name =
         wyl_access_event_domain_name ((wyl_access_event_domain_t) d);
     if (name == NULL || name[0] == '\0')
@@ -125,10 +130,375 @@ check_zero_init (void)
   return 0;
 }
 
+/* -----------------------------------------------------------------------
+ * Helpers for GObject-based tests
+ * --------------------------------------------------------------------- */
+
+/* Mint a non-NIL id for testing by filling bytes with a fixed pattern. */
+static wyl_id_t
+make_test_id (guint8 seed)
+{
+  wyl_id_t id;
+  memset (id.bytes, seed, WYL_ID_BYTES);
+  /* Force version=7 (nibble at byte 6 high) and variant=10 (byte 8)
+   * so id_is_nil() does not match WYL_ID_NIL (all zeros).
+   * For test purposes we just need non-NIL; the ID need not be
+   * a valid UUIDv7 for constructor acceptance. */
+  id.bytes[6] = (guint8) ((id.bytes[6] & 0x0f) | 0x70);
+  id.bytes[8] = (guint8) ((id.bytes[8] & 0x3f) | 0x80);
+  return id;
+}
+
+/* -----------------------------------------------------------------------
+ * GObject ctor tests - PRINCIPAL domain
+ * --------------------------------------------------------------------- */
+
+static gint
+test_event_ctor_principal_valid (void)
+{
+  wyl_id_t eid = make_test_id (1);
+  wyl_id_t pid = make_test_id (2);
+  WylAccessEvent *e = NULL;
+  wyrelog_error_t rc;
+
+  rc = wyl_access_event_new_principal (eid, pid,
+      WYL_PRINCIPAL_EVENT_LOGIN_OK,
+      "password", "10.0.0.1", "TestAgent/1.0",
+      G_GINT64_CONSTANT (123456789), NULL, &e);
+
+  if (rc != WYRELOG_E_OK)
+    return 100;
+  if (e == NULL)
+    return 101;
+  if (wyl_access_event_get_domain (e) != WYL_ACCESS_EVENT_DOMAIN_PRINCIPAL)
+    return 102;
+  if (!wyl_id_equal (&eid, &(wyl_id_t) {
+            .bytes = { 0 }
+          }
+      )){
+    wyl_id_t got = wyl_access_event_get_event_id (e);
+    if (!wyl_id_equal (&got, &eid))
+      return 103;
+  }
+  {
+    wyl_id_t got_eid = wyl_access_event_get_event_id (e);
+    if (!wyl_id_equal (&got_eid, &eid))
+      return 103;
+  }
+  if (wyl_access_event_get_timestamp_us (e) != G_GINT64_CONSTANT (123456789))
+    return 104;
+  {
+    wyl_id_t got_pid = wyl_access_event_get_principal_id (e);
+    if (!wyl_id_equal (&got_pid, &pid))
+      return 105;
+  }
+  if (wyl_access_event_get_principal_fsm_event (e) !=
+      WYL_PRINCIPAL_EVENT_LOGIN_OK)
+    return 106;
+  if (g_strcmp0 (wyl_access_event_get_auth_method (e), "password") != 0)
+    return 107;
+  if (g_strcmp0 (wyl_access_event_get_principal_source_ip (e), "10.0.0.1") != 0)
+    return 108;
+  if (g_strcmp0 (wyl_access_event_get_principal_user_agent (e),
+          "TestAgent/1.0") != 0)
+    return 109;
+  if (wyl_access_event_get_context (e) != NULL)
+    return 110;
+
+  g_object_unref (e);
+  return 0;
+}
+
+static gint
+test_event_ctor_principal_nil_event_id_rejects (void)
+{
+  wyl_id_t pid = make_test_id (3);
+  WylAccessEvent *e = NULL;
+  wyrelog_error_t rc;
+
+  rc = wyl_access_event_new_principal (WYL_ID_NIL, pid,
+      WYL_PRINCIPAL_EVENT_LOGIN_OK, "password", NULL, NULL, 0, NULL, &e);
+
+  if (rc != WYRELOG_E_INVALID)
+    return 120;
+  if (e != NULL)
+    return 121;
+  return 0;
+}
+
+static gint
+test_event_ctor_principal_nil_principal_id_rejects (void)
+{
+  wyl_id_t eid = make_test_id (4);
+  WylAccessEvent *e = NULL;
+  wyrelog_error_t rc;
+
+  rc = wyl_access_event_new_principal (eid, WYL_ID_NIL,
+      WYL_PRINCIPAL_EVENT_LOGIN_OK, "password", NULL, NULL, 0, NULL, &e);
+
+  if (rc != WYRELOG_E_INVALID)
+    return 130;
+  if (e != NULL)
+    return 131;
+  return 0;
+}
+
+static gint
+test_event_ctor_principal_null_auth_method_rejects (void)
+{
+  wyl_id_t eid = make_test_id (5);
+  wyl_id_t pid = make_test_id (6);
+  WylAccessEvent *e = NULL;
+  wyrelog_error_t rc;
+
+  rc = wyl_access_event_new_principal (eid, pid,
+      WYL_PRINCIPAL_EVENT_LOGIN_OK, NULL, NULL, NULL, 0, NULL, &e);
+
+  if (rc != WYRELOG_E_INVALID)
+    return 140;
+  if (e != NULL)
+    return 141;
+  return 0;
+}
+
+static gint
+test_event_ctor_principal_null_out_rejects (void)
+{
+  wyl_id_t eid = make_test_id (7);
+  wyl_id_t pid = make_test_id (8);
+  wyrelog_error_t rc;
+
+  rc = wyl_access_event_new_principal (eid, pid,
+      WYL_PRINCIPAL_EVENT_LOGIN_OK, "password", NULL, NULL, 0, NULL, NULL);
+
+  if (rc != WYRELOG_E_INVALID)
+    return 150;
+  return 0;
+}
+
+static gint
+test_event_ctor_principal_sentinel_fsm_rejects (void)
+{
+  wyl_id_t eid = make_test_id (9);
+  wyl_id_t pid = make_test_id (10);
+  WylAccessEvent *e = NULL;
+  wyrelog_error_t rc;
+
+  rc = wyl_access_event_new_principal (eid, pid,
+      WYL_PRINCIPAL_EVENT_LAST_, "password", NULL, NULL, 0, NULL, &e);
+
+  if (rc != WYRELOG_E_INVALID)
+    return 160;
+  if (e != NULL)
+    return 161;
+  return 0;
+}
+
+/* -----------------------------------------------------------------------
+ * GObject ctor tests - SESSION domain
+ * --------------------------------------------------------------------- */
+
+static gint
+test_event_ctor_session_valid (void)
+{
+  wyl_id_t eid = make_test_id (11);
+  wyl_id_t sid = make_test_id (12);
+  WylAccessEvent *e = NULL;
+  wyrelog_error_t rc;
+
+  rc = wyl_access_event_new_session (eid, sid,
+      WYL_SESSION_EVENT_REQUEST,
+      "192.168.1.1", "Browser/2.0", G_GINT64_CONSTANT (987654321), NULL, &e);
+
+  if (rc != WYRELOG_E_OK)
+    return 200;
+  if (e == NULL)
+    return 201;
+  if (wyl_access_event_get_domain (e) != WYL_ACCESS_EVENT_DOMAIN_SESSION)
+    return 202;
+  {
+    wyl_id_t got_eid = wyl_access_event_get_event_id (e);
+    if (!wyl_id_equal (&got_eid, &eid))
+      return 203;
+  }
+  if (wyl_access_event_get_timestamp_us (e) != G_GINT64_CONSTANT (987654321))
+    return 204;
+  {
+    wyl_id_t got_sid = wyl_access_event_get_session_id (e);
+    if (!wyl_id_equal (&got_sid, &sid))
+      return 205;
+  }
+  if (wyl_access_event_get_session_fsm_event (e) != WYL_SESSION_EVENT_REQUEST)
+    return 206;
+  if (g_strcmp0 (wyl_access_event_get_session_source_ip (e),
+          "192.168.1.1") != 0)
+    return 207;
+  if (g_strcmp0 (wyl_access_event_get_session_user_agent (e),
+          "Browser/2.0") != 0)
+    return 208;
+
+  g_object_unref (e);
+  return 0;
+}
+
+static gint
+test_event_ctor_session_sentinel_fsm_rejects (void)
+{
+  wyl_id_t eid = make_test_id (13);
+  wyl_id_t sid = make_test_id (14);
+  WylAccessEvent *e = NULL;
+  wyrelog_error_t rc;
+
+  rc = wyl_access_event_new_session (eid, sid,
+      WYL_SESSION_EVENT_LAST_, NULL, NULL, 0, NULL, &e);
+
+  if (rc != WYRELOG_E_INVALID)
+    return 210;
+  if (e != NULL)
+    return 211;
+  return 0;
+}
+
+/* -----------------------------------------------------------------------
+ * Autoptr cleanup (build-level: no crash = pass)
+ * --------------------------------------------------------------------- */
+
+static gint
+test_event_autoptr_cleanup (void)
+{
+  wyl_id_t eid = make_test_id (15);
+  wyl_id_t pid = make_test_id (16);
+
+  {
+    g_autoptr (WylAccessEvent) e = NULL;
+    wyrelog_error_t rc = wyl_access_event_new_principal (eid, pid,
+        WYL_PRINCIPAL_EVENT_MFA_OK,
+        "totp", NULL, NULL, 0, NULL, &e);
+    if (rc != WYRELOG_E_OK || e == NULL)
+      return 220;
+    /* e is released by g_autoptr at end of block */
+  }
+  return 0;
+}
+
+/* -----------------------------------------------------------------------
+ * Cross-domain accessor isolation
+ * --------------------------------------------------------------------- */
+
+static gint
+test_event_cross_domain_accessor_isolation (void)
+{
+  wyl_id_t eid = make_test_id (17);
+  wyl_id_t pid = make_test_id (18);
+  WylAccessEvent *e = NULL;
+
+  wyrelog_error_t rc = wyl_access_event_new_principal (eid, pid,
+      WYL_PRINCIPAL_EVENT_LOGIN_OK,
+      "password", NULL, NULL, 0, NULL, &e);
+  if (rc != WYRELOG_E_OK)
+    return 230;
+
+  /* Calling session accessor on a principal event returns NIL sentinel */
+  wyl_id_t result = wyl_access_event_get_session_id (e);
+  if (!wyl_id_equal (&result, &WYL_ID_NIL))
+    return 231;
+
+  g_object_unref (e);
+  return 0;
+}
+
+/* -----------------------------------------------------------------------
+ * Context attachment
+ * --------------------------------------------------------------------- */
+
+static gint
+test_event_context_attachment (void)
+{
+  wyl_id_t eid = make_test_id (19);
+  wyl_id_t pid = make_test_id (20);
+  WylAccessContext *ctx = NULL;
+  WylAccessEvent *e = NULL;
+
+  wyrelog_error_t rc =
+      wyl_access_context_new (G_GINT64_CONSTANT (111222333), "1.2.3.4", "UA/1",
+      "req-abc", &ctx);
+  if (rc != WYRELOG_E_OK || ctx == NULL)
+    return 240;
+
+  rc = wyl_access_event_new_principal (eid, pid,
+      WYL_PRINCIPAL_EVENT_LOGIN_OK, "password", NULL, NULL, 0, ctx, &e);
+  if (rc != WYRELOG_E_OK)
+    return 241;
+
+  /* Accessor must return the attached context */
+  WylAccessContext *got = wyl_access_event_get_context (e);
+  if (got == NULL)
+    return 242;
+  if (wyl_access_context_get_timestamp_us (got) !=
+      G_GINT64_CONSTANT (111222333))
+    return 243;
+  if (g_strcmp0 (wyl_access_context_get_source_ip (got), "1.2.3.4") != 0)
+    return 244;
+
+  /* Release the caller's reference; event still holds its own */
+  g_object_unref (ctx);
+  /* Now release the event; its dispose releases the context ref */
+  g_object_unref (e);
+  return 0;
+}
+
+/* -----------------------------------------------------------------------
+ * Owned strings: caller mutation after ctor must not affect stored value
+ * --------------------------------------------------------------------- */
+
+static gint
+test_event_owned_strings (void)
+{
+  wyl_id_t eid = make_test_id (21);
+  wyl_id_t pid = make_test_id (22);
+  WylAccessEvent *e = NULL;
+
+  gchar method_buf[] = "original";
+
+  wyrelog_error_t rc = wyl_access_event_new_principal (eid, pid,
+      WYL_PRINCIPAL_EVENT_LOGIN_OK,
+      method_buf, NULL, NULL, 0, NULL, &e);
+  if (rc != WYRELOG_E_OK)
+    return 250;
+
+  /* Mutate the caller's buffer */
+  method_buf[0] = 'X';
+
+  /* Event must still carry the original string */
+  if (g_strcmp0 (wyl_access_event_get_auth_method (e), "original") != 0)
+    return 251;
+
+  g_object_unref (e);
+  return 0;
+}
+
+/* -----------------------------------------------------------------------
+ * Total kinds preserved (existing contract)
+ * --------------------------------------------------------------------- */
+
+static gint
+test_event_total_kinds_preserved (void)
+{
+  if (wyl_access_event_total_kinds () != 13)
+    return 260;
+  return 0;
+}
+
+/* -----------------------------------------------------------------------
+ * main
+ * --------------------------------------------------------------------- */
+
 int
 main (void)
 {
   gint rc;
+
+  /* Legacy flat-struct tests */
   if ((rc = check_domain_names ()) != 0)
     return rc;
   if ((rc = check_total_kinds ()) != 0)
@@ -139,5 +509,40 @@ main (void)
     return rc;
   if ((rc = check_zero_init ()) != 0)
     return rc;
+
+  /* GObject ctor tests - PRINCIPAL */
+  if ((rc = test_event_ctor_principal_valid ()) != 0)
+    return rc;
+  if ((rc = test_event_ctor_principal_nil_event_id_rejects ()) != 0)
+    return rc;
+  if ((rc = test_event_ctor_principal_nil_principal_id_rejects ()) != 0)
+    return rc;
+  if ((rc = test_event_ctor_principal_null_auth_method_rejects ()) != 0)
+    return rc;
+  if ((rc = test_event_ctor_principal_null_out_rejects ()) != 0)
+    return rc;
+  if ((rc = test_event_ctor_principal_sentinel_fsm_rejects ()) != 0)
+    return rc;
+
+  /* GObject ctor tests - SESSION */
+  if ((rc = test_event_ctor_session_valid ()) != 0)
+    return rc;
+  if ((rc = test_event_ctor_session_sentinel_fsm_rejects ()) != 0)
+    return rc;
+
+  /* Autoptr, cross-domain, context, owned strings */
+  if ((rc = test_event_autoptr_cleanup ()) != 0)
+    return rc;
+  if ((rc = test_event_cross_domain_accessor_isolation ()) != 0)
+    return rc;
+  if ((rc = test_event_context_attachment ()) != 0)
+    return rc;
+  if ((rc = test_event_owned_strings ()) != 0)
+    return rc;
+
+  /* Preserved total-kinds contract */
+  if ((rc = test_event_total_kinds_preserved ()) != 0)
+    return rc;
+
   return 0;
 }

--- a/tests/test-events.c
+++ b/tests/test-events.c
@@ -359,6 +359,152 @@ test_event_ctor_session_sentinel_fsm_rejects (void)
   return 0;
 }
 
+static gint
+test_event_ctor_session_nil_event_id_rejects (void)
+{
+  wyl_id_t sid = make_test_id (23);
+  WylAccessEvent *sentinel = (WylAccessEvent *) (gpointer) 0xdeadbeef;
+  WylAccessEvent *e = sentinel;
+  wyrelog_error_t rc;
+
+  rc = wyl_access_event_new_session (WYL_ID_NIL, sid,
+      WYL_SESSION_EVENT_REQUEST, NULL, NULL, 0, NULL, &e);
+
+  if (rc != WYRELOG_E_INVALID)
+    return 270;
+  if (e != NULL)
+    return 271;
+  return 0;
+}
+
+static gint
+test_event_ctor_session_nil_session_id_rejects (void)
+{
+  wyl_id_t eid = make_test_id (24);
+  WylAccessEvent *sentinel = (WylAccessEvent *) (gpointer) 0xdeadbeef;
+  WylAccessEvent *e = sentinel;
+  wyrelog_error_t rc;
+
+  rc = wyl_access_event_new_session (eid, WYL_ID_NIL,
+      WYL_SESSION_EVENT_REQUEST, NULL, NULL, 0, NULL, &e);
+
+  if (rc != WYRELOG_E_INVALID)
+    return 280;
+  if (e != NULL)
+    return 281;
+  return 0;
+}
+
+static gint
+test_event_ctor_session_null_out_rejects (void)
+{
+  wyl_id_t eid = make_test_id (25);
+  wyl_id_t sid = make_test_id (26);
+  wyrelog_error_t rc;
+
+  rc = wyl_access_event_new_session (eid, sid,
+      WYL_SESSION_EVENT_REQUEST, NULL, NULL, 0, NULL, NULL);
+
+  if (rc != WYRELOG_E_INVALID)
+    return 290;
+  return 0;
+}
+
+static gint
+test_event_cross_domain_accessor_isolation_full (void)
+{
+  wyl_id_t p_eid = make_test_id (27);
+  wyl_id_t pid = make_test_id (28);
+  wyl_id_t s_eid = make_test_id (29);
+  wyl_id_t sid = make_test_id (30);
+  WylAccessEvent *pe = NULL;
+  WylAccessEvent *se = NULL;
+  wyrelog_error_t rc;
+
+  rc = wyl_access_event_new_principal (p_eid, pid,
+      WYL_PRINCIPAL_EVENT_LOGIN_OK,
+      "password", "10.0.0.1", "UA/1", 0, NULL, &pe);
+  if (rc != WYRELOG_E_OK)
+    return 300;
+
+  rc = wyl_access_event_new_session (s_eid, sid,
+      WYL_SESSION_EVENT_REQUEST, "10.0.0.2", "UA/2", 0, NULL, &se);
+  if (rc != WYRELOG_E_OK) {
+    g_object_unref (pe);
+    return 301;
+  }
+
+  /* --- Principal accessors on a SESSION event must return sentinels --- */
+  {
+    wyl_id_t r = wyl_access_event_get_principal_id (se);
+    if (!wyl_id_equal (&r, &WYL_ID_NIL))
+      goto fail_302;
+  }
+  if (wyl_access_event_get_principal_fsm_event (se) !=
+      WYL_PRINCIPAL_EVENT_LAST_)
+    goto fail_303;
+  if (wyl_access_event_get_auth_method (se) != NULL)
+    goto fail_304;
+  if (wyl_access_event_get_principal_source_ip (se) != NULL)
+    goto fail_305;
+  if (wyl_access_event_get_principal_user_agent (se) != NULL)
+    goto fail_306;
+
+  /* --- Session accessors on a PRINCIPAL event must return sentinels --- */
+  {
+    wyl_id_t r = wyl_access_event_get_session_id (pe);
+    if (!wyl_id_equal (&r, &WYL_ID_NIL))
+      goto fail_307;
+  }
+  if (wyl_access_event_get_session_fsm_event (pe) != WYL_SESSION_EVENT_LAST_)
+    goto fail_308;
+  if (wyl_access_event_get_session_source_ip (pe) != NULL)
+    goto fail_309;
+  if (wyl_access_event_get_session_user_agent (pe) != NULL)
+    goto fail_310;
+
+  g_object_unref (pe);
+  g_object_unref (se);
+  return 0;
+
+fail_302:
+  g_object_unref (pe);
+  g_object_unref (se);
+  return 302;
+fail_303:
+  g_object_unref (pe);
+  g_object_unref (se);
+  return 303;
+fail_304:
+  g_object_unref (pe);
+  g_object_unref (se);
+  return 304;
+fail_305:
+  g_object_unref (pe);
+  g_object_unref (se);
+  return 305;
+fail_306:
+  g_object_unref (pe);
+  g_object_unref (se);
+  return 306;
+fail_307:
+  g_object_unref (pe);
+  g_object_unref (se);
+  return 307;
+fail_308:
+  g_object_unref (pe);
+  g_object_unref (se);
+  return 308;
+fail_309:
+  g_object_unref (pe);
+  g_object_unref (se);
+  return 309;
+fail_310:
+  g_object_unref (pe);
+  g_object_unref (se);
+  return 310;
+}
+
 /* -----------------------------------------------------------------------
  * Autoptr cleanup (build-level: no crash = pass)
  * --------------------------------------------------------------------- */
@@ -529,11 +675,19 @@ main (void)
     return rc;
   if ((rc = test_event_ctor_session_sentinel_fsm_rejects ()) != 0)
     return rc;
+  if ((rc = test_event_ctor_session_nil_event_id_rejects ()) != 0)
+    return rc;
+  if ((rc = test_event_ctor_session_nil_session_id_rejects ()) != 0)
+    return rc;
+  if ((rc = test_event_ctor_session_null_out_rejects ()) != 0)
+    return rc;
 
   /* Autoptr, cross-domain, context, owned strings */
   if ((rc = test_event_autoptr_cleanup ()) != 0)
     return rc;
   if ((rc = test_event_cross_domain_accessor_isolation ()) != 0)
+    return rc;
+  if ((rc = test_event_cross_domain_accessor_isolation_full ()) != 0)
     return rc;
   if ((rc = test_event_context_attachment ()) != 0)
     return rc;

--- a/tools/check-public-headers-no-novelty-tokens.sh
+++ b/tools/check-public-headers-no-novelty-tokens.sh
@@ -1,0 +1,166 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# check-public-headers-no-novelty-tokens.sh
+#
+# CI gate: verifies that installed public headers contain no forbidden
+# internal-vocabulary tokens, no raw chronoid type references, and no
+# bare struct declarations for WylAccess-prefixed GObject types.
+#
+# Strategy (two-tier):
+#
+#   Tier 1 (authoritative, post-configure / CI after meson setup):
+#     If a builddir exists alongside the project root AND meson is on
+#     PATH, use `meson introspect --installed builddir` to extract the
+#     actual installed header paths from the build manifest, then grep
+#     those files.  A meson introspect failure is a hard error.
+#
+#   Tier 2 (fresh-checkout linting, no builddir available):
+#     Fall back to grepping the files listed in wyrelog_public_headers
+#     in wyrelog/meson.build directly.
+#
+# Forbidden token regex (case-insensitive, word-bounded):
+#   \b(armed|arm_rule|compound_scope|scope_term|differential|
+#      delta_propag|fsm_gated|lobac|compound)\b
+#
+# Also forbidden:
+#   - chronoid_uuidv7_t or <chronoid/ (vendored chronoid type leak)
+#   - bare struct declarations of WylAccess-prefixed GObject types
+#     (T7 bare-struct ABI lock-in guard)
+#
+# Exit codes: 0 = clean, 1 = violation found or introspect error.
+
+set -eu
+
+SCRIPT_DIR=$(dirname "$0")
+PROJECT_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+BUILDDIR="$PROJECT_ROOT/builddir"
+
+# Forbidden token pattern (word-bounded, case-insensitive)
+TOKEN_RE='\b(armed|arm_rule|compound_scope|scope_term|differential|delta_propag|fsm_gated|lobac|compound)\b'
+
+FOUND=0
+
+check_file () {
+  f="$1"
+
+  if [ ! -f "$f" ]; then
+    return
+  fi
+
+  # Tier check: forbidden internal vocabulary tokens
+  if grep -Ei "$TOKEN_RE" "$f" >/dev/null 2>&1; then
+    echo "ERROR: forbidden token found in public header: $f" >&2
+    grep -Eni "$TOKEN_RE" "$f" >&2
+    FOUND=1
+  fi
+
+  # Check: no chronoid_uuidv7_t in public headers
+  if grep -E 'chronoid_uuidv7_t' "$f" >/dev/null 2>&1; then
+    echo "ERROR: chronoid_uuidv7_t found in public header: $f" >&2
+    grep -En 'chronoid_uuidv7_t' "$f" >&2
+    FOUND=1
+  fi
+
+  # Check: no <chronoid/ include in public headers
+  if grep -E '<chronoid/' "$f" >/dev/null 2>&1; then
+    echo "ERROR: <chronoid/ include found in public header: $f" >&2
+    grep -En '<chronoid/' "$f" >&2
+    FOUND=1
+  fi
+
+  # T7 bare-struct guard: no bare struct declarations for WylAccess types.
+  # Matches lines like:
+  #   struct _WylAccessEvent { ...
+  #   struct WylAccessContext { ...
+  # (The typedef alias "typedef struct _WylAccessEvent wyl_access_event_t;"
+  #  is intentional and is NOT matched by this pattern.)
+  if grep -E '^struct[[:space:]]+_?[Ww][Yy][Ll][Aa]ccess' "$f" >/dev/null 2>&1; then
+    echo "ERROR: bare WylAccess struct body declaration in public header: $f" >&2
+    grep -En '^struct[[:space:]]+_?[Ww][Yy][Ll][Aa]ccess' "$f" >&2
+    FOUND=1
+  fi
+}
+
+# -----------------------------------------------------------------------
+# Tier 1: meson introspect (authoritative, post-configure CI mode)
+# -----------------------------------------------------------------------
+if [ -d "$BUILDDIR" ] && command -v meson >/dev/null 2>&1; then
+  introspect_out=$(meson introspect --installed "$BUILDDIR" 2>&1) || {
+    introspect_rc=$?
+    echo "ERROR: meson introspect failed (exit $introspect_rc) -- builddir may be corrupt or stale." >&2
+    echo "$introspect_out" >&2
+    echo "Re-run 'meson setup builddir' and retry." >&2
+    exit 1
+  }
+
+  # Extract installed header paths: source-side values in the JSON map that
+  # live directly under $PROJECT_ROOT/wyrelog/ (the library source dir).
+  # The introspect JSON maps install-destination -> source-path.
+  # We want source paths that are the project's own public headers, i.e.
+  # files under "$PROJECT_ROOT/wyrelog/" but NOT under
+  # "$PROJECT_ROOT/subprojects/" or "$PROJECT_ROOT/builddir/".
+  header_paths=$(printf '%s\n' "$introspect_out" \
+    | grep -o "\"$PROJECT_ROOT/wyrelog/[^\"]*\\.h\"" \
+    | sed 's/"//g') || true
+
+  if [ -z "$header_paths" ]; then
+    echo "OK: no wyrelog public headers in install manifest (introspect)."
+    exit 0
+  fi
+
+  for h in $header_paths; do
+    check_file "$h"
+  done
+
+  if [ "$FOUND" -eq 1 ]; then
+    echo "FAIL: public header violation(s) found (introspect). Aborting." >&2
+    exit 1
+  fi
+
+  echo "OK: no forbidden tokens in public headers (introspect)."
+  exit 0
+fi
+
+# -----------------------------------------------------------------------
+# Tier 2: line-grep fallback (no builddir or meson not on PATH)
+# -----------------------------------------------------------------------
+MESON_BUILD="$PROJECT_ROOT/wyrelog/meson.build"
+
+if [ ! -f "$MESON_BUILD" ]; then
+  echo "ERROR: cannot find $MESON_BUILD for tier-2 fallback." >&2
+  exit 1
+fi
+
+# Extract filenames listed in wyrelog_public_headers = files(...).
+# Read lines between the opening files( and the closing ).
+in_block=0
+while IFS= read -r line; do
+  case "$line" in
+    *wyrelog_public_headers*files*)
+      in_block=1
+      ;;
+  esac
+  if [ "$in_block" -eq 1 ]; then
+    # Extract a quoted filename from the line, e.g. '  '\''audit.h'\'','
+    fname=$(printf '%s' "$line" \
+      | grep -o "'[^']*\.h'" \
+      | sed "s/'//g") || true
+    if [ -n "$fname" ]; then
+      check_file "$PROJECT_ROOT/wyrelog/$fname"
+    fi
+    case "$line" in
+      *\)*)
+        in_block=0
+        ;;
+    esac
+  fi
+done < "$MESON_BUILD"
+
+if [ "$FOUND" -eq 1 ]; then
+  echo "FAIL: public header violation(s) found (line-grep). Aborting." >&2
+  exit 1
+fi
+
+echo "OK: no forbidden tokens in public headers (line-grep)."
+exit 0

--- a/wyrelog/events.h
+++ b/wyrelog/events.h
@@ -1,0 +1,347 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+
+#include <glib.h>
+#include <glib-object.h>
+
+#include "wyrelog/error.h"
+
+G_BEGIN_DECLS;
+
+/*
+ * WylAccessEvent - opaque access event carrier.
+ *
+ * Records a single access-related occurrence for one of two domains:
+ * a principal authentication event or a session lifecycle event.
+ * Each event carries a caller-issued identifier, a domain-specific
+ * FSM event, optional string metadata, a microsecond-precision
+ * timestamp, and an optional context attachment.
+ *
+ * Immutable post-construction. Not thread-safe; ownership must be
+ * transferred explicitly before handing off to another thread.
+ * Strings supplied at construction time are duplicated; modifying
+ * the caller's buffer after construction does not affect the stored
+ * value.
+ *
+ * Released with g_object_unref or g_autoptr(WylAccessEvent).
+ */
+G_DECLARE_FINAL_TYPE (WylAccessEvent, wyl_access_event, WYL, ACCESS_EVENT,
+    GObject);
+#define WYL_TYPE_ACCESS_EVENT (wyl_access_event_get_type ())
+
+/*
+ * WylAccessContext - opaque request context carrier.
+ *
+ * Provides a domain-neutral surface for ingress code to attach
+ * per-request metadata (timestamp, source address, user-agent string,
+ * and similar request-scoped fields) alongside an access event
+ * payload. Context objects are reference-counted; attaching a context
+ * to an event increments the reference count, and the event releases
+ * its reference when finalized.
+ *
+ * Released with g_object_unref or g_autoptr(WylAccessContext).
+ */
+G_DECLARE_FINAL_TYPE (WylAccessContext, wyl_access_context, WYL,
+    ACCESS_CONTEXT, GObject);
+#define WYL_TYPE_ACCESS_CONTEXT (wyl_access_context_get_type ())
+
+/*
+ * Domain discriminator: selects which FSM vocabulary the event
+ * carries and which accessor family is valid.
+ */
+typedef enum wyl_access_event_domain_t
+{
+  WYL_ACCESS_EVENT_DOMAIN_PRINCIPAL = 0,
+  WYL_ACCESS_EVENT_DOMAIN_SESSION,
+} wyl_access_event_domain_t;
+
+/*
+ * Time-ordered identifier: 16-byte value type backed by a UUIDv7-shaped
+ * generator. Bytewise lexicographic order tracks creation order at
+ * millisecond granularity.
+ *
+ * The all-zero value WYL_ID_NIL is reserved for "no identifier" slots.
+ * Constructors reject WYL_ID_NIL inputs for mandatory identifier fields.
+ *
+ * Guard: wyl-id-private.h defines WYL_ID_BYTES and is the authoritative
+ * definition site for library-internal code. This block is guarded so
+ * that whichever header is included first wins; the two definitions are
+ * identical and the guard prevents a redefinition error.
+ */
+#ifndef WYL_ID_BYTES
+#define WYL_ID_BYTES 16
+
+typedef struct wyl_id_t
+{
+  guint8 bytes[WYL_ID_BYTES];
+} wyl_id_t;
+
+G_STATIC_ASSERT (sizeof (wyl_id_t) == WYL_ID_BYTES);
+
+extern const wyl_id_t WYL_ID_NIL;
+
+/*
+ * Bytewise equality. Returns FALSE when either pointer is NULL.
+ */
+gboolean wyl_id_equal (const wyl_id_t * a, const wyl_id_t * b);
+
+#endif /* WYL_ID_BYTES */
+
+/*
+ * Principal FSM event vocabulary (input to the authentication FSM).
+ *
+ * Guard: wyl-fsm-principal-private.h is the authoritative definition
+ * site for library-internal code. This block is guarded so that
+ * whichever header is included first wins.
+ */
+#ifndef WYL_PRINCIPAL_EVENT_T_DEFINED
+#define WYL_PRINCIPAL_EVENT_T_DEFINED
+
+typedef enum wyl_principal_event_t
+{
+  WYL_PRINCIPAL_EVENT_LOGIN_OK = 0,
+  WYL_PRINCIPAL_EVENT_LOGIN_SKIP_MFA,
+  WYL_PRINCIPAL_EVENT_MFA_OK,
+  WYL_PRINCIPAL_EVENT_FAILED_ATTEMPT,
+  WYL_PRINCIPAL_EVENT_LOCK,
+  WYL_PRINCIPAL_EVENT_UNLOCK,
+  WYL_PRINCIPAL_EVENT_REVOKE,
+  WYL_PRINCIPAL_EVENT_LAST_,
+} wyl_principal_event_t;
+
+#endif /* WYL_PRINCIPAL_EVENT_T_DEFINED */
+
+/*
+ * Session lifecycle FSM event vocabulary.
+ *
+ * Guard: wyl-fsm-session-private.h is the authoritative definition
+ * site for library-internal code. This block is guarded so that
+ * whichever header is included first wins.
+ */
+#ifndef WYL_SESSION_EVENT_T_DEFINED
+#define WYL_SESSION_EVENT_T_DEFINED
+
+typedef enum wyl_session_event_t
+{
+  WYL_SESSION_EVENT_REQUEST = 0,
+  WYL_SESSION_EVENT_IDLE_TIMEOUT,
+  WYL_SESSION_EVENT_EXPIRY,
+  WYL_SESSION_EVENT_ELEVATE_GRANT,
+  WYL_SESSION_EVENT_ELEVATE_DROP,
+  WYL_SESSION_EVENT_LOGOUT,
+  WYL_SESSION_EVENT_LAST_,
+} wyl_session_event_t;
+
+#endif /* WYL_SESSION_EVENT_T_DEFINED */
+
+/* -----------------------------------------------------------------------
+ * WylAccessContext constructors and accessors
+ * --------------------------------------------------------------------- */
+
+/*
+ * Construct a new WylAccessContext carrying per-request metadata.
+ *
+ * @timestamp_us:  wall-clock time of the originating request in
+ *                 microseconds since the Unix epoch.
+ * @source_ip:     NUL-terminated source IP address string, or NULL.
+ * @user_agent:    NUL-terminated user-agent string, or NULL.
+ * @request_id:    NUL-terminated opaque request identifier, or NULL.
+ *
+ * On success sets *out to the new context and returns WYRELOG_E_OK.
+ * Returns WYRELOG_E_INVALID when out is NULL.
+ *
+ * Caller releases with g_object_unref or g_autoptr(WylAccessContext).
+ */
+wyrelog_error_t wyl_access_context_new (gint64 timestamp_us,
+    const gchar * source_ip, const gchar * user_agent,
+    const gchar * request_id, WylAccessContext ** out);
+
+/*
+ * Returns the timestamp recorded in the context, in microseconds
+ * since the Unix epoch. Returns 0 when ctx is NULL.
+ */
+gint64 wyl_access_context_get_timestamp_us (const WylAccessContext * ctx);
+
+/*
+ * Returns the borrowed source IP string, or NULL when absent or
+ * when ctx is NULL. Pointer is valid for the lifetime of ctx.
+ */
+const gchar *wyl_access_context_get_source_ip (const WylAccessContext * ctx);
+
+/*
+ * Returns the borrowed user-agent string, or NULL when absent or
+ * when ctx is NULL. Pointer is valid for the lifetime of ctx.
+ */
+const gchar *wyl_access_context_get_user_agent (const WylAccessContext * ctx);
+
+/*
+ * Returns the borrowed request identifier string, or NULL when
+ * absent or when ctx is NULL. Pointer is valid for the lifetime
+ * of ctx.
+ */
+const gchar *wyl_access_context_get_request_id (const WylAccessContext * ctx);
+
+/* -----------------------------------------------------------------------
+ * WylAccessEvent constructors
+ * --------------------------------------------------------------------- */
+
+/*
+ * Construct a new access event for the principal authentication domain.
+ *
+ * @event_id:     caller-issued identifier for this event; MUST NOT be
+ *                WYL_ID_NIL.
+ * @principal_id: identifier of the principal; MUST NOT be WYL_ID_NIL.
+ * @fsm_event:    the FSM event being recorded; MUST NOT be
+ *                WYL_PRINCIPAL_EVENT_LAST_.
+ * @auth_method:  NUL-terminated authentication method string; MUST NOT
+ *                be NULL.
+ * @source_ip:    NUL-terminated source IP address string, or NULL.
+ * @user_agent:   NUL-terminated user-agent string, or NULL.
+ * @timestamp_us: event timestamp in microseconds since the Unix epoch.
+ * @context:      optional context attachment; may be NULL. When
+ *                non-NULL the event holds a reference for its lifetime.
+ * @out:          MUST NOT be NULL; receives the new event on success.
+ *
+ * Returns WYRELOG_E_OK on success.
+ * Returns WYRELOG_E_INVALID when any mandatory argument is absent or
+ * out-of-range (event_id is NIL, principal_id is NIL, auth_method is
+ * NULL, fsm_event is LAST_, or out is NULL).
+ *
+ * Strings are duplicated at construction; the event is immutable
+ * post-construction. Caller releases with g_object_unref or
+ * g_autoptr(WylAccessEvent).
+ */
+wyrelog_error_t wyl_access_event_new_principal (wyl_id_t event_id,
+    wyl_id_t principal_id, wyl_principal_event_t fsm_event,
+    const gchar * auth_method, const gchar * source_ip,
+    const gchar * user_agent, gint64 timestamp_us,
+    WylAccessContext * context, WylAccessEvent ** out);
+
+/*
+ * Construct a new access event for the session lifecycle domain.
+ *
+ * @event_id:    caller-issued identifier for this event; MUST NOT be
+ *               WYL_ID_NIL.
+ * @session_id:  identifier of the session; MUST NOT be WYL_ID_NIL.
+ * @fsm_event:   the session FSM event being recorded; MUST NOT be
+ *               WYL_SESSION_EVENT_LAST_.
+ * @source_ip:   NUL-terminated source IP address string, or NULL.
+ * @user_agent:  NUL-terminated user-agent string, or NULL.
+ * @timestamp_us: event timestamp in microseconds since the Unix epoch.
+ * @context:     optional context attachment; may be NULL.
+ * @out:         MUST NOT be NULL; receives the new event on success.
+ *
+ * Returns WYRELOG_E_OK on success.
+ * Returns WYRELOG_E_INVALID on any mandatory-argument violation.
+ */
+wyrelog_error_t wyl_access_event_new_session (wyl_id_t event_id,
+    wyl_id_t session_id, wyl_session_event_t fsm_event,
+    const gchar * source_ip, const gchar * user_agent,
+    gint64 timestamp_us, WylAccessContext * context, WylAccessEvent ** out);
+
+/* -----------------------------------------------------------------------
+ * WylAccessEvent common accessors
+ * --------------------------------------------------------------------- */
+
+/*
+ * Returns the domain discriminator of the event.
+ * Returns WYL_ACCESS_EVENT_DOMAIN_PRINCIPAL when e is NULL.
+ */
+wyl_access_event_domain_t wyl_access_event_get_domain (const WylAccessEvent
+    * e);
+
+/*
+ * Returns the caller-issued event identifier.
+ * Returns WYL_ID_NIL when e is NULL.
+ */
+wyl_id_t wyl_access_event_get_event_id (const WylAccessEvent * e);
+
+/*
+ * Returns the event timestamp in microseconds since the Unix epoch.
+ * Returns 0 when e is NULL.
+ */
+gint64 wyl_access_event_get_timestamp_us (const WylAccessEvent * e);
+
+/*
+ * Returns the context attached at construction time, or NULL when no
+ * context was provided or when e is NULL.
+ * The returned pointer is borrowed from the event; do not unref.
+ */
+WylAccessContext *wyl_access_event_get_context (const WylAccessEvent * e);
+
+/* -----------------------------------------------------------------------
+ * WylAccessEvent domain-gated accessors
+ *
+ * Accessors in the PRINCIPAL family return a sentinel (WYL_ID_NIL or
+ * NULL) and log a recoverable error when called on a SESSION event,
+ * and vice versa.
+ * --------------------------------------------------------------------- */
+
+/*
+ * Returns the principal identifier carried by a PRINCIPAL-domain
+ * event. Returns WYL_ID_NIL and logs an error when e is NULL or when
+ * e is a SESSION-domain event.
+ */
+wyl_id_t wyl_access_event_get_principal_id (const WylAccessEvent * e);
+
+/*
+ * Returns the FSM event ordinal carried by a PRINCIPAL-domain event.
+ * Returns WYL_PRINCIPAL_EVENT_LAST_ and logs an error when e is NULL
+ * or when e is a SESSION-domain event.
+ */
+wyl_principal_event_t wyl_access_event_get_principal_fsm_event (const
+    WylAccessEvent * e);
+
+/*
+ * Returns the borrowed authentication method string from a
+ * PRINCIPAL-domain event. Returns NULL and logs an error when e is
+ * NULL or when e is a SESSION-domain event.
+ */
+const gchar *wyl_access_event_get_auth_method (const WylAccessEvent * e);
+
+/*
+ * Returns the borrowed source IP string from a PRINCIPAL-domain
+ * event. Returns NULL and logs an error when e is NULL or when e is
+ * a SESSION-domain event.
+ */
+const gchar *wyl_access_event_get_principal_source_ip (const WylAccessEvent
+    * e);
+
+/*
+ * Returns the borrowed user-agent string from a PRINCIPAL-domain
+ * event. Returns NULL and logs an error when e is NULL or when e is
+ * a SESSION-domain event.
+ */
+const gchar *wyl_access_event_get_principal_user_agent (const WylAccessEvent
+    * e);
+
+/*
+ * Returns the session identifier carried by a SESSION-domain event.
+ * Returns WYL_ID_NIL and logs an error when e is NULL or when e is a
+ * PRINCIPAL-domain event.
+ */
+wyl_id_t wyl_access_event_get_session_id (const WylAccessEvent * e);
+
+/*
+ * Returns the FSM event ordinal carried by a SESSION-domain event.
+ * Returns WYL_SESSION_EVENT_LAST_ and logs an error when e is NULL
+ * or when e is a PRINCIPAL-domain event.
+ */
+wyl_session_event_t wyl_access_event_get_session_fsm_event (const
+    WylAccessEvent * e);
+
+/*
+ * Returns the borrowed source IP string from a SESSION-domain event.
+ * Returns NULL and logs an error when e is NULL or when e is a
+ * PRINCIPAL-domain event.
+ */
+const gchar *wyl_access_event_get_session_source_ip (const WylAccessEvent * e);
+
+/*
+ * Returns the borrowed user-agent string from a SESSION-domain event.
+ * Returns NULL and logs an error when e is NULL or when e is a
+ * PRINCIPAL-domain event.
+ */
+const gchar *wyl_access_event_get_session_user_agent (const WylAccessEvent * e);
+
+G_END_DECLS;

--- a/wyrelog/events.h
+++ b/wyrelog/events.h
@@ -191,8 +191,8 @@ const gchar *wyl_access_context_get_request_id (const WylAccessContext * ctx);
  * @event_id:     caller-issued identifier for this event; MUST NOT be
  *                WYL_ID_NIL.
  * @principal_id: identifier of the principal; MUST NOT be WYL_ID_NIL.
- * @fsm_event:    the FSM event being recorded; MUST NOT be
- *                WYL_PRINCIPAL_EVENT_LAST_.
+ * @fsm_event:    the FSM event being recorded; MUST be a valid ordinal
+ *                less than WYL_PRINCIPAL_EVENT_LAST_.
  * @auth_method:  NUL-terminated authentication method string; MUST NOT
  *                be NULL.
  * @source_ip:    NUL-terminated source IP address string, or NULL.
@@ -205,7 +205,8 @@ const gchar *wyl_access_context_get_request_id (const WylAccessContext * ctx);
  * Returns WYRELOG_E_OK on success.
  * Returns WYRELOG_E_INVALID when any mandatory argument is absent or
  * out-of-range (event_id is NIL, principal_id is NIL, auth_method is
- * NULL, fsm_event is LAST_, or out is NULL).
+ * NULL, fsm_event is at or beyond WYL_PRINCIPAL_EVENT_LAST_, or out
+ * is NULL).
  *
  * Strings are duplicated at construction; the event is immutable
  * post-construction. Caller releases with g_object_unref or
@@ -223,8 +224,8 @@ wyrelog_error_t wyl_access_event_new_principal (wyl_id_t event_id,
  * @event_id:    caller-issued identifier for this event; MUST NOT be
  *               WYL_ID_NIL.
  * @session_id:  identifier of the session; MUST NOT be WYL_ID_NIL.
- * @fsm_event:   the session FSM event being recorded; MUST NOT be
- *               WYL_SESSION_EVENT_LAST_.
+ * @fsm_event:   the session FSM event being recorded; MUST be a valid
+ *               ordinal less than WYL_SESSION_EVENT_LAST_.
  * @source_ip:   NUL-terminated source IP address string, or NULL.
  * @user_agent:  NUL-terminated user-agent string, or NULL.
  * @timestamp_us: event timestamp in microseconds since the Unix epoch.

--- a/wyrelog/meson.build
+++ b/wyrelog/meson.build
@@ -4,6 +4,7 @@ wyrelog_public_headers = files(
   'audit.h',
   'decide.h',
   'error.h',
+  'events.h',
   'handle.h',
   'perm.h',
   'session.h',

--- a/wyrelog/wyl-events-private.h
+++ b/wyrelog/wyl-events-private.h
@@ -2,10 +2,31 @@
 #pragma once
 
 #include <glib.h>
+#include <glib-object.h>
 
 #include "wyrelog/error.h"
+
+/*
+ * Include the FSM and ID private headers first so their type
+ * definitions are established before events.h sees the guard macros.
+ * events.h declares the same types under #ifndef guards so that
+ * external callers (who cannot include the private headers) still get
+ * the definitions; internal code gets them here instead.
+ */
 #include "wyl-fsm-principal-private.h"
 #include "wyl-fsm-session-private.h"
+#include "wyl-id-private.h"
+
+/*
+ * Inform events.h that wyl_principal_event_t, wyl_session_event_t,
+ * and wyl_id_t are already defined so it skips its guarded copies.
+ */
+#define WYL_PRINCIPAL_EVENT_T_DEFINED
+#define WYL_SESSION_EVENT_T_DEFINED
+/* WYL_ID_BYTES is already defined by wyl-id-private.h above */
+
+#include "wyrelog/events.h"
+#include "wyl-log-private.h"
 
 G_BEGIN_DECLS;
 
@@ -35,12 +56,8 @@ G_BEGIN_DECLS;
  * transition is orphaned at the ingress boundary.
  */
 
-typedef enum wyl_access_event_domain_t
-{
-  WYL_ACCESS_EVENT_DOMAIN_PRINCIPAL = 0,
-  WYL_ACCESS_EVENT_DOMAIN_SESSION,
-  WYL_ACCESS_EVENT_DOMAIN_LAST_,
-} wyl_access_event_domain_t;
+/* Internal LAST_ sentinel for the domain enum (not in public header). */
+#define WYL_ACCESS_EVENT_DOMAIN_LAST_ ((wyl_access_event_domain_t) 2)
 
 typedef struct wyl_access_event_t
 {
@@ -54,6 +71,60 @@ typedef struct wyl_access_event_t
   const gchar *user_id;
   const gchar *session_id;
 } wyl_access_event_t;
+
+/*
+ * Private layout of the PRINCIPAL-domain payload union arm.
+ */
+typedef struct _WylPrincipalPayload
+{
+  wyl_id_t principal_id;
+  wyl_principal_event_t fsm_event;
+  gchar *auth_method;
+  gchar *source_ip;
+  gchar *user_agent;
+} _WylPrincipalPayload;
+
+/*
+ * Private layout of the SESSION-domain payload union arm.
+ */
+typedef struct _WylSessionPayload
+{
+  wyl_id_t session_id;
+  wyl_session_event_t fsm_event;
+  gchar *source_ip;
+  gchar *user_agent;
+} _WylSessionPayload;
+
+G_STATIC_ASSERT (sizeof (gint64) == 8);
+
+/*
+ * Private struct layout for WylAccessContext (GObject).
+ */
+struct _WylAccessContext
+{
+  GObject parent_instance;
+  gint64 timestamp_us;
+  gchar *source_ip;
+  gchar *user_agent;
+  gchar *request_id;
+};
+
+/*
+ * Private struct layout for WylAccessEvent (GObject).
+ */
+struct _WylAccessEvent
+{
+  GObject parent_instance;
+  wyl_access_event_domain_t domain;
+  wyl_id_t event_id;
+  union
+  {
+    _WylPrincipalPayload principal;
+    _WylSessionPayload session;
+  } payload;
+  gint64 timestamp_us;
+  WylAccessContext *context;
+};
 
 /*
  * Lexical name of the domain ordinal. NULL on out-of-range input.

--- a/wyrelog/wyl-events-private.h
+++ b/wyrelog/wyl-events-private.h
@@ -56,8 +56,13 @@ G_BEGIN_DECLS;
  * transition is orphaned at the ingress boundary.
  */
 
-/* Internal LAST_ sentinel for the domain enum (not in public header). */
+/* Internal LAST_ sentinel for the domain enum (not in public header).
+ * This constant MUST be updated atomically whenever the public
+ * wyl_access_event_domain_t enum gains a new domain value; the
+ * static assertion below locks it to the actual public cardinality
+ * so that silent bounds drift is caught at compile time. */
 #define WYL_ACCESS_EVENT_DOMAIN_LAST_ ((wyl_access_event_domain_t) 2)
+G_STATIC_ASSERT (WYL_ACCESS_EVENT_DOMAIN_LAST_ == 2);
 
 typedef struct wyl_access_event_t
 {

--- a/wyrelog/wyl-events.c
+++ b/wyrelog/wyl-events.c
@@ -1,17 +1,21 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #include "wyl-events-private.h"
 
+/* -----------------------------------------------------------------------
+ * Legacy flat-struct helpers (preserved; used by existing tests)
+ * --------------------------------------------------------------------- */
+
 static const gchar *const domain_names[] = {
   "principal",
   "session",
 };
 
-G_STATIC_ASSERT (G_N_ELEMENTS (domain_names) == WYL_ACCESS_EVENT_DOMAIN_LAST_);
+G_STATIC_ASSERT (G_N_ELEMENTS (domain_names) == 2);
 
 const gchar *
 wyl_access_event_domain_name (wyl_access_event_domain_t domain)
 {
-  if ((guint) domain >= WYL_ACCESS_EVENT_DOMAIN_LAST_)
+  if ((guint) domain >= (guint) WYL_ACCESS_EVENT_DOMAIN_LAST_)
     return NULL;
   return domain_names[domain];
 }
@@ -26,7 +30,6 @@ wyl_access_event_kind_name (const wyl_access_event_t *event)
       return wyl_principal_event_name (event->event.principal);
     case WYL_ACCESS_EVENT_DOMAIN_SESSION:
       return wyl_session_event_name (event->event.session);
-    case WYL_ACCESS_EVENT_DOMAIN_LAST_:
     default:
       return NULL;
   }
@@ -36,4 +39,414 @@ gsize
 wyl_access_event_total_kinds (void)
 {
   return (gsize) WYL_PRINCIPAL_EVENT_LAST_ + (gsize) WYL_SESSION_EVENT_LAST_;
+}
+
+/* -----------------------------------------------------------------------
+ * WylAccessContext GObject implementation
+ * --------------------------------------------------------------------- */
+
+G_DEFINE_FINAL_TYPE (WylAccessContext, wyl_access_context, G_TYPE_OBJECT);
+
+static void
+wyl_access_context_finalize (GObject *object)
+{
+  WylAccessContext *self = WYL_ACCESS_CONTEXT (object);
+
+  g_clear_pointer (&self->source_ip, g_free);
+  g_clear_pointer (&self->user_agent, g_free);
+  g_clear_pointer (&self->request_id, g_free);
+
+  G_OBJECT_CLASS (wyl_access_context_parent_class)->finalize (object);
+}
+
+static void
+wyl_access_context_class_init (WylAccessContextClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->finalize = wyl_access_context_finalize;
+}
+
+static void
+wyl_access_context_init (WylAccessContext *self)
+{
+  self->timestamp_us = 0;
+  self->source_ip = NULL;
+  self->user_agent = NULL;
+  self->request_id = NULL;
+}
+
+wyrelog_error_t
+wyl_access_context_new (gint64 timestamp_us, const gchar *source_ip,
+    const gchar *user_agent, const gchar *request_id, WylAccessContext **out)
+{
+  if (out == NULL)
+    return WYRELOG_E_INVALID;
+
+  WylAccessContext *ctx = g_object_new (WYL_TYPE_ACCESS_CONTEXT, NULL);
+  ctx->timestamp_us = timestamp_us;
+  ctx->source_ip = g_strdup (source_ip);
+  ctx->user_agent = g_strdup (user_agent);
+  ctx->request_id = g_strdup (request_id);
+
+  *out = ctx;
+  return WYRELOG_E_OK;
+}
+
+gint64
+wyl_access_context_get_timestamp_us (const WylAccessContext *ctx)
+{
+  if (ctx == NULL)
+    return 0;
+  return ctx->timestamp_us;
+}
+
+const gchar *
+wyl_access_context_get_source_ip (const WylAccessContext *ctx)
+{
+  if (ctx == NULL)
+    return NULL;
+  return ctx->source_ip;
+}
+
+const gchar *
+wyl_access_context_get_user_agent (const WylAccessContext *ctx)
+{
+  if (ctx == NULL)
+    return NULL;
+  return ctx->user_agent;
+}
+
+const gchar *
+wyl_access_context_get_request_id (const WylAccessContext *ctx)
+{
+  if (ctx == NULL)
+    return NULL;
+  return ctx->request_id;
+}
+
+/* -----------------------------------------------------------------------
+ * WylAccessEvent GObject implementation
+ * --------------------------------------------------------------------- */
+
+G_DEFINE_FINAL_TYPE (WylAccessEvent, wyl_access_event, G_TYPE_OBJECT);
+
+static void
+wyl_access_event_finalize (GObject *object)
+{
+  WylAccessEvent *self = WYL_ACCESS_EVENT (object);
+
+  switch (self->domain) {
+    case WYL_ACCESS_EVENT_DOMAIN_PRINCIPAL:
+      g_clear_pointer (&self->payload.principal.auth_method, g_free);
+      g_clear_pointer (&self->payload.principal.source_ip, g_free);
+      g_clear_pointer (&self->payload.principal.user_agent, g_free);
+      break;
+    case WYL_ACCESS_EVENT_DOMAIN_SESSION:
+      g_clear_pointer (&self->payload.session.source_ip, g_free);
+      g_clear_pointer (&self->payload.session.user_agent, g_free);
+      break;
+    default:
+      break;
+  }
+
+  G_OBJECT_CLASS (wyl_access_event_parent_class)->finalize (object);
+}
+
+static void
+wyl_access_event_dispose (GObject *object)
+{
+  WylAccessEvent *self = WYL_ACCESS_EVENT (object);
+
+  g_clear_object (&self->context);
+
+  G_OBJECT_CLASS (wyl_access_event_parent_class)->dispose (object);
+}
+
+static void
+wyl_access_event_class_init (WylAccessEventClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->finalize = wyl_access_event_finalize;
+  object_class->dispose = wyl_access_event_dispose;
+}
+
+static void
+wyl_access_event_init (WylAccessEvent *self)
+{
+  self->domain = WYL_ACCESS_EVENT_DOMAIN_PRINCIPAL;
+  self->timestamp_us = 0;
+  self->context = NULL;
+}
+
+/* --- Helper: compare two wyl_id_t values against WYL_ID_NIL ---------- */
+
+static gboolean
+id_is_nil (const wyl_id_t *id)
+{
+  return wyl_id_equal (id, &WYL_ID_NIL);
+}
+
+/* -----------------------------------------------------------------------
+ * Constructors
+ * --------------------------------------------------------------------- */
+
+wyrelog_error_t
+wyl_access_event_new_principal (wyl_id_t event_id, wyl_id_t principal_id,
+    wyl_principal_event_t fsm_event, const gchar *auth_method,
+    const gchar *source_ip, const gchar *user_agent,
+    gint64 timestamp_us, WylAccessContext *context, WylAccessEvent **out)
+{
+  if (out == NULL)
+    return WYRELOG_E_INVALID;
+  if (id_is_nil (&event_id))
+    return WYRELOG_E_INVALID;
+  if (id_is_nil (&principal_id))
+    return WYRELOG_E_INVALID;
+  if (auth_method == NULL)
+    return WYRELOG_E_INVALID;
+  if (fsm_event == WYL_PRINCIPAL_EVENT_LAST_ ||
+      (guint) fsm_event >= (guint) WYL_PRINCIPAL_EVENT_LAST_)
+    return WYRELOG_E_INVALID;
+
+  WylAccessEvent *self = g_object_new (WYL_TYPE_ACCESS_EVENT, NULL);
+  self->domain = WYL_ACCESS_EVENT_DOMAIN_PRINCIPAL;
+  self->event_id = event_id;
+  self->timestamp_us = timestamp_us;
+  self->payload.principal.principal_id = principal_id;
+  self->payload.principal.fsm_event = fsm_event;
+  self->payload.principal.auth_method = g_strdup (auth_method);
+  self->payload.principal.source_ip = g_strdup (source_ip);
+  self->payload.principal.user_agent = g_strdup (user_agent);
+  if (context != NULL)
+    self->context = g_object_ref (context);
+
+  *out = self;
+  return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
+wyl_access_event_new_session (wyl_id_t event_id, wyl_id_t session_id,
+    wyl_session_event_t fsm_event, const gchar *source_ip,
+    const gchar *user_agent, gint64 timestamp_us,
+    WylAccessContext *context, WylAccessEvent **out)
+{
+  if (out == NULL)
+    return WYRELOG_E_INVALID;
+  if (id_is_nil (&event_id))
+    return WYRELOG_E_INVALID;
+  if (id_is_nil (&session_id))
+    return WYRELOG_E_INVALID;
+  if (fsm_event == WYL_SESSION_EVENT_LAST_ ||
+      (guint) fsm_event >= (guint) WYL_SESSION_EVENT_LAST_)
+    return WYRELOG_E_INVALID;
+
+  WylAccessEvent *self = g_object_new (WYL_TYPE_ACCESS_EVENT, NULL);
+  self->domain = WYL_ACCESS_EVENT_DOMAIN_SESSION;
+  self->event_id = event_id;
+  self->timestamp_us = timestamp_us;
+  self->payload.session.session_id = session_id;
+  self->payload.session.fsm_event = fsm_event;
+  self->payload.session.source_ip = g_strdup (source_ip);
+  self->payload.session.user_agent = g_strdup (user_agent);
+  if (context != NULL)
+    self->context = g_object_ref (context);
+
+  *out = self;
+  return WYRELOG_E_OK;
+}
+
+/* -----------------------------------------------------------------------
+ * Common accessors
+ * --------------------------------------------------------------------- */
+
+wyl_access_event_domain_t
+wyl_access_event_get_domain (const WylAccessEvent *e)
+{
+  if (e == NULL)
+    return WYL_ACCESS_EVENT_DOMAIN_PRINCIPAL;
+  return e->domain;
+}
+
+wyl_id_t
+wyl_access_event_get_event_id (const WylAccessEvent *e)
+{
+  if (e == NULL)
+    return WYL_ID_NIL;
+  return e->event_id;
+}
+
+gint64
+wyl_access_event_get_timestamp_us (const WylAccessEvent *e)
+{
+  if (e == NULL)
+    return 0;
+  return e->timestamp_us;
+}
+
+WylAccessContext *
+wyl_access_event_get_context (const WylAccessEvent *e)
+{
+  if (e == NULL)
+    return NULL;
+  return e->context;
+}
+
+/* -----------------------------------------------------------------------
+ * Domain-gated PRINCIPAL accessors
+ * --------------------------------------------------------------------- */
+
+wyl_id_t
+wyl_access_event_get_principal_id (const WylAccessEvent *e)
+{
+  if (e == NULL) {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_GENERAL,
+        "wyl_access_event_get_principal_id: NULL event");
+    return WYL_ID_NIL;
+  }
+  if (e->domain != WYL_ACCESS_EVENT_DOMAIN_PRINCIPAL) {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_GENERAL,
+        "wyl_access_event_get_principal_id: called on session-domain event");
+    return WYL_ID_NIL;
+  }
+  return e->payload.principal.principal_id;
+}
+
+wyl_principal_event_t
+wyl_access_event_get_principal_fsm_event (const WylAccessEvent *e)
+{
+  if (e == NULL) {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_GENERAL,
+        "wyl_access_event_get_principal_fsm_event: NULL event");
+    return WYL_PRINCIPAL_EVENT_LAST_;
+  }
+  if (e->domain != WYL_ACCESS_EVENT_DOMAIN_PRINCIPAL) {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_GENERAL,
+        "wyl_access_event_get_principal_fsm_event: called on session-domain "
+        "event");
+    return WYL_PRINCIPAL_EVENT_LAST_;
+  }
+  return e->payload.principal.fsm_event;
+}
+
+const gchar *
+wyl_access_event_get_auth_method (const WylAccessEvent *e)
+{
+  if (e == NULL) {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_GENERAL,
+        "wyl_access_event_get_auth_method: NULL event");
+    return NULL;
+  }
+  if (e->domain != WYL_ACCESS_EVENT_DOMAIN_PRINCIPAL) {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_GENERAL,
+        "wyl_access_event_get_auth_method: called on session-domain event");
+    return NULL;
+  }
+  return e->payload.principal.auth_method;
+}
+
+const gchar *
+wyl_access_event_get_principal_source_ip (const WylAccessEvent *e)
+{
+  if (e == NULL) {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_GENERAL,
+        "wyl_access_event_get_principal_source_ip: NULL event");
+    return NULL;
+  }
+  if (e->domain != WYL_ACCESS_EVENT_DOMAIN_PRINCIPAL) {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_GENERAL,
+        "wyl_access_event_get_principal_source_ip: called on session-domain "
+        "event");
+    return NULL;
+  }
+  return e->payload.principal.source_ip;
+}
+
+const gchar *
+wyl_access_event_get_principal_user_agent (const WylAccessEvent *e)
+{
+  if (e == NULL) {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_GENERAL,
+        "wyl_access_event_get_principal_user_agent: NULL event");
+    return NULL;
+  }
+  if (e->domain != WYL_ACCESS_EVENT_DOMAIN_PRINCIPAL) {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_GENERAL,
+        "wyl_access_event_get_principal_user_agent: called on session-domain "
+        "event");
+    return NULL;
+  }
+  return e->payload.principal.user_agent;
+}
+
+/* -----------------------------------------------------------------------
+ * Domain-gated SESSION accessors
+ * --------------------------------------------------------------------- */
+
+wyl_id_t
+wyl_access_event_get_session_id (const WylAccessEvent *e)
+{
+  if (e == NULL) {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_GENERAL,
+        "wyl_access_event_get_session_id: NULL event");
+    return WYL_ID_NIL;
+  }
+  if (e->domain != WYL_ACCESS_EVENT_DOMAIN_SESSION) {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_GENERAL,
+        "wyl_access_event_get_session_id: called on principal-domain event");
+    return WYL_ID_NIL;
+  }
+  return e->payload.session.session_id;
+}
+
+wyl_session_event_t
+wyl_access_event_get_session_fsm_event (const WylAccessEvent *e)
+{
+  if (e == NULL) {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_GENERAL,
+        "wyl_access_event_get_session_fsm_event: NULL event");
+    return WYL_SESSION_EVENT_LAST_;
+  }
+  if (e->domain != WYL_ACCESS_EVENT_DOMAIN_SESSION) {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_GENERAL,
+        "wyl_access_event_get_session_fsm_event: called on principal-domain "
+        "event");
+    return WYL_SESSION_EVENT_LAST_;
+  }
+  return e->payload.session.fsm_event;
+}
+
+const gchar *
+wyl_access_event_get_session_source_ip (const WylAccessEvent *e)
+{
+  if (e == NULL) {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_GENERAL,
+        "wyl_access_event_get_session_source_ip: NULL event");
+    return NULL;
+  }
+  if (e->domain != WYL_ACCESS_EVENT_DOMAIN_SESSION) {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_GENERAL,
+        "wyl_access_event_get_session_source_ip: called on principal-domain "
+        "event");
+    return NULL;
+  }
+  return e->payload.session.source_ip;
+}
+
+const gchar *
+wyl_access_event_get_session_user_agent (const WylAccessEvent *e)
+{
+  if (e == NULL) {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_GENERAL,
+        "wyl_access_event_get_session_user_agent: NULL event");
+    return NULL;
+  }
+  if (e->domain != WYL_ACCESS_EVENT_DOMAIN_SESSION) {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_GENERAL,
+        "wyl_access_event_get_session_user_agent: called on principal-domain "
+        "event");
+    return NULL;
+  }
+  return e->payload.session.user_agent;
 }

--- a/wyrelog/wyl-events.c
+++ b/wyrelog/wyl-events.c
@@ -200,14 +200,14 @@ wyl_access_event_new_principal (wyl_id_t event_id, wyl_id_t principal_id,
 {
   if (out == NULL)
     return WYRELOG_E_INVALID;
+  *out = NULL;
   if (id_is_nil (&event_id))
     return WYRELOG_E_INVALID;
   if (id_is_nil (&principal_id))
     return WYRELOG_E_INVALID;
   if (auth_method == NULL)
     return WYRELOG_E_INVALID;
-  if (fsm_event == WYL_PRINCIPAL_EVENT_LAST_ ||
-      (guint) fsm_event >= (guint) WYL_PRINCIPAL_EVENT_LAST_)
+  if ((guint) fsm_event >= (guint) WYL_PRINCIPAL_EVENT_LAST_)
     return WYRELOG_E_INVALID;
 
   WylAccessEvent *self = g_object_new (WYL_TYPE_ACCESS_EVENT, NULL);
@@ -234,12 +234,12 @@ wyl_access_event_new_session (wyl_id_t event_id, wyl_id_t session_id,
 {
   if (out == NULL)
     return WYRELOG_E_INVALID;
+  *out = NULL;
   if (id_is_nil (&event_id))
     return WYRELOG_E_INVALID;
   if (id_is_nil (&session_id))
     return WYRELOG_E_INVALID;
-  if (fsm_event == WYL_SESSION_EVENT_LAST_ ||
-      (guint) fsm_event >= (guint) WYL_SESSION_EVENT_LAST_)
+  if ((guint) fsm_event >= (guint) WYL_SESSION_EVENT_LAST_)
     return WYRELOG_E_INVALID;
 
   WylAccessEvent *self = g_object_new (WYL_TYPE_ACCESS_EVENT, NULL);

--- a/wyrelog/wyl-id-private.h
+++ b/wyrelog/wyl-id-private.h
@@ -34,9 +34,18 @@ G_BEGIN_DECLS;
  * cleanup function.
  */
 
-#define WYL_ID_BYTES        16
 #define WYL_ID_STRING_LEN   36
 #define WYL_ID_STRING_BUF   37
+
+/*
+ * Guard: wyrelog/events.h is the authoritative public definition site
+ * for wyl_id_t, WYL_ID_BYTES, WYL_ID_NIL, and wyl_id_equal. This
+ * block is guarded so that whichever header is included first wins;
+ * the two definitions are identical and the guard prevents a
+ * redefinition error.
+ */
+#ifndef WYL_ID_BYTES
+#define WYL_ID_BYTES        16
 
 typedef struct wyl_id_t
 {
@@ -46,6 +55,13 @@ typedef struct wyl_id_t
 G_STATIC_ASSERT (sizeof (wyl_id_t) == WYL_ID_BYTES);
 
 extern const wyl_id_t WYL_ID_NIL;
+
+/*
+ * Bytewise equality. NULL on either side returns FALSE.
+ */
+gboolean wyl_id_equal (const wyl_id_t * a, const wyl_id_t * b);
+
+#endif /* WYL_ID_BYTES */
 
 /*
  * Generate a fresh time-ordered id stamped with the current wall-
@@ -79,11 +95,6 @@ wyrelog_error_t wyl_id_format (const wyl_id_t * id, gchar * buf, gsize buf_len);
  * guaranteed to round-trip through wyl_id_format.
  */
 wyrelog_error_t wyl_id_parse (const gchar * str, wyl_id_t * out);
-
-/*
- * Bytewise equality. NULL on either side returns FALSE.
- */
-gboolean wyl_id_equal (const wyl_id_t * a, const wyl_id_t * b);
 
 /*
  * Bytewise total order: returns <0, 0, >0 in memcmp fashion. NULL

--- a/wyrelog/wyrelog.h
+++ b/wyrelog/wyrelog.h
@@ -11,6 +11,7 @@
  */
 
 #include "wyrelog/error.h"
+#include "wyrelog/events.h"
 #include "wyrelog/handle.h"
 #include "wyrelog/session.h"
 #include "wyrelog/audit.h"


### PR DESCRIPTION
## Summary

Introduce a new public API surface for access events flowing through the wyrelog ingress layer:

- `WylAccessEvent` — opaque GObject final type representing an event from a single principal- or session-domain.
- `WylAccessContext` — opaque GObject carrying request metadata (timestamp, location/source, etc.) attached to an event.
- Two-domain enum: `WYL_ACCESS_EVENT_DOMAIN_PRINCIPAL`, `WYL_ACCESS_EVENT_DOMAIN_SESSION`.
- Per-domain ctors with caller-issued `wyl_id_t` IDs (UUIDv7), owned strings (constructed via `g_strdup`, freed at finalize), optional context attachment (refcounted via GObject).
- Domain-gated accessors that return sentinel values (`WYL_ID_NIL`, `NULL`, per-FSM `*_LAST_`) on cross-domain misuse without reading foreign-arm bytes.
- ctor validation: `WYL_ID_NIL` rejection on required IDs, NULL rejection on required strings, FSM-event range check, `*out = NULL` on every error path so callers do not observe stale pointers post-failure.

Plus a CI guard (`tools/check-public-headers-no-novelty-tokens.sh`) that fails the build if the install-set headers acquire bare-struct declarations of `WylAccess*` types or any of a documented vocabulary token list, preventing accidental ABI lock-in or unintended internal-vocabulary disclosure on the public surface.

## Concrete invariants tested

- Each ctor validates required inputs and returns `WYRELOG_E_INVALID` with `*out = NULL` on failure (sentinel-pre-set test confirms active nulling).
- ctor accepts `WYL_ACCESS_EVENT_DOMAIN_*` values; rejects FSM ordinals at or beyond the per-domain `*_LAST_` sentinel.
- Strings handed to ctor are duplicated into the event; mutating the caller's buffer afterwards does not change accessor return values.
- Context attachment refcounts correctly (caller can `g_object_unref` after handoff; event holds its own reference until finalize).
- Cross-domain accessor isolation: every domain-gated getter (9 paths) returns its sentinel when called against the wrong domain; no foreign-arm union read.
- Existing 13-event-kind contract preserved (`wyl_access_event_total_kinds() == 13`).
- A compile-time assertion locks the private domain-enum cardinality constant to the public enum.
- The umbrella header includes the new public header so consumers using `<wyrelog/wyrelog.h>` see the new types.
- Build clean, full test suite green, both header guards (private-not-installed + public-no-novelty-tokens) green, `gst-indent` idempotent on every modified file.

## Out of scope (deferred follow-up issues)

- Permission-scope domain (no consumer in tree yet).
- Multi-tenant slot in the event payload.
- Constructor ergonomics — current shape uses positional args; a builder/options-struct refactor may revisit before further domains.
- Session+context attachment dedicated test (current attachment test only exercises principal events).
- ASan/TSan registration as a CI lane.
- Consolidating the dual `wyl_id_t` definition site (currently guarded by `#ifndef WYL_ID_BYTES` so first-include-wins; works but couples two header blocks that must remain byte-identical).

## Test plan

- [x] `meson setup builddir --reconfigure` succeeds
- [x] `meson test -C builddir` reports 34/34 OK
- [x] `ninja -C builddir` produces no `-W` warnings introduced by this branch
- [x] `tools/check-private-headers-not-installed.sh` exits 0
- [x] `tools/check-public-headers-no-novelty-tokens.sh` exits 0
- [x] `gst-indent` idempotent on all modified C/H files
- [x] ctor failure path test (sentinel `0xdeadbeef` pre-set on `*out`) confirms post-failure `*out == NULL`
- [x] Cross-domain accessor coverage exercises all 9 domain-gated getters in the wrong direction