### PR TITLE
engine: add wirelog session adapter with hardened policy loader

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -233,6 +233,16 @@ test_session_logout = executable('test-session-logout',
 
 test('session-logout', test_session_logout)
 
+test_engine = executable('test-engine',
+  'test-engine.c',
+  c_args : [
+    '-DWYL_TEST_TEMPLATE_DIR="' + meson.project_source_root() / 'templates' / 'access' + '"',
+  ],
+  dependencies : [wyrelog_dep, wirelog_dep],
+)
+
+test('engine', test_engine)
+
 check_private_headers = find_program(
   '../tools/check-private-headers-not-installed.sh',
 )

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -233,6 +233,11 @@ test_session_logout = executable('test-session-logout',
 
 test('session-logout', test_session_logout)
 
+# NOTE: WYL_TEST_TEMPLATE_DIR points at the in-tree source layout
+# only. The installed layout (${datadir}/wyrelog/access) — produced
+# by install_subdir at the top-level meson.build — is not
+# exercised by these tests. Validation of the installed layout is
+# tracked as packaging-CI follow-up rather than unit-test concern.
 test_engine = executable('test-engine',
   'test-engine.c',
   c_args : [

--- a/tests/test-engine.c
+++ b/tests/test-engine.c
@@ -1,0 +1,417 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <glib.h>
+#include <glib/gstdio.h>
+#include <string.h>
+
+#include "wyrelog/engine.h"
+
+/* Allow direct access to internal helpers for unit testing. */
+#define WYL_ENGINE_INTERNAL 1
+#include "wyrelog/wyl-engine-private.h"
+
+#ifndef WYL_TEST_TEMPLATE_DIR
+#error "WYL_TEST_TEMPLATE_DIR must be defined by the build."
+#endif
+
+/* ------------------------------------------------------------------ */
+/* Helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+/*
+ * write_file_in_dir: writes @contents to @filename inside @dir.
+ * Returns FALSE on error.
+ */
+static gboolean
+write_file_in_dir (const gchar *dir, const gchar *filename,
+    const gchar *contents)
+{
+  g_autofree gchar *path = g_build_filename (dir, filename, NULL);
+  g_autoptr (GError) err = NULL;
+  return g_file_set_contents (path, contents, -1, &err);
+}
+
+/*
+ * make_tmpdir: creates a GLib temp directory; caller frees with g_free
+ * and removes with g_rmdir after clearing contents.
+ */
+static gchar *
+make_tmpdir (void)
+{
+  g_autoptr (GError) err = NULL;
+  gchar *dir = g_dir_make_tmp ("wyl-engine-test-XXXXXX", &err);
+  if (dir == NULL) {
+    g_printerr ("make_tmpdir: %s\n", err ? err->message : "?");
+    return NULL;
+  }
+  return dir;
+}
+
+/*
+ * copy_real_templates_to: copies the 5 real template files from the
+ * canonical template dir into dest_dir, creating fsm/ subdirectory.
+ * Returns FALSE on any error.
+ */
+static gboolean
+copy_real_templates_to (const gchar *dest_dir)
+{
+  static const char *files[] = {
+    "bootstrap.dl",
+    "fsm/principal.dl",
+    "fsm/session.dl",
+    "fsm/permission_scope.dl",
+    "decision.dl",
+  };
+
+  /* Create fsm/ subdir. */
+  g_autofree gchar *fsm_dir = g_build_filename (dest_dir, "fsm", NULL);
+  if (g_mkdir (fsm_dir, 0755) != 0) {
+    g_printerr ("copy_real_templates_to: mkdir %s failed\n", fsm_dir);
+    return FALSE;
+  }
+
+  for (gsize i = 0; i < G_N_ELEMENTS (files); i++) {
+    g_autofree gchar *src = g_build_filename (WYL_TEST_TEMPLATE_DIR,
+        files[i], NULL);
+    g_autofree gchar *dst = g_build_filename (dest_dir, files[i], NULL);
+    g_autofree gchar *contents = NULL;
+    gsize len = 0;
+    g_autoptr (GError) err = NULL;
+
+    if (!g_file_get_contents (src, &contents, &len, &err)) {
+      g_printerr ("copy_real_templates_to: cannot read %s: %s\n",
+          src, err ? err->message : "?");
+      return FALSE;
+    }
+    if (!g_file_set_contents (dst, contents, (gssize) len, &err)) {
+      g_printerr ("copy_real_templates_to: cannot write %s: %s\n",
+          dst, err ? err->message : "?");
+      return FALSE;
+    }
+  }
+  return TRUE;
+}
+
+/*
+ * rmdir_recursive: removes a directory and all its contents.
+ * Only goes one level deep (sufficient for our tmpdir layout).
+ */
+static void
+rmdir_recursive (const gchar *dir)
+{
+  g_autoptr (GDir) d = g_dir_open (dir, 0, NULL);
+  if (d == NULL) {
+    g_rmdir (dir);
+    return;
+  }
+
+  const gchar *name;
+  while ((name = g_dir_read_name (d)) != NULL) {
+    g_autofree gchar *path = g_build_filename (dir, name, NULL);
+    if (g_file_test (path, G_FILE_TEST_IS_DIR))
+      rmdir_recursive (path);
+    else
+      g_unlink (path);
+  }
+  g_rmdir (dir);
+}
+
+/* ------------------------------------------------------------------ */
+/* Test cases                                                          */
+/* ------------------------------------------------------------------ */
+
+static gint
+test_engine_open_canonical_smoke (void)
+{
+  WylEngine *engine = NULL;
+  wyrelog_error_t rc = wyl_engine_open (WYL_TEST_TEMPLATE_DIR, 1, &engine);
+  if (rc != WYRELOG_E_OK) {
+    g_printerr ("test_engine_open_canonical_smoke: expected WYRELOG_E_OK, "
+        "got %d\n", (int) rc);
+    return 1;
+  }
+  if (engine == NULL) {
+    g_printerr ("test_engine_open_canonical_smoke: engine is NULL\n");
+    return 2;
+  }
+  wyl_engine_close (engine);
+  return 0;
+}
+
+static gint
+test_engine_open_eager_build_surfaces_errors (void)
+{
+  g_autofree gchar *tmpdir = make_tmpdir ();
+  if (tmpdir == NULL)
+    return 10;
+
+  /* Create fsm/ subdir and copy 4 good files, then overwrite decision.dl
+   * with malformed content. */
+  gboolean ok = copy_real_templates_to (tmpdir);
+  if (!ok) {
+    rmdir_recursive (tmpdir);
+    return 11;
+  }
+
+  /* Overwrite decision.dl with deliberately malformed content. */
+  if (!write_file_in_dir (tmpdir, "decision.dl",
+          "this is not valid datalog ((((\n")) {
+    rmdir_recursive (tmpdir);
+    return 12;
+  }
+
+  WylEngine *engine = NULL;
+  wyrelog_error_t rc = wyl_engine_open (tmpdir, 1, &engine);
+
+  rmdir_recursive (tmpdir);
+
+  if (rc == WYRELOG_E_OK) {
+    g_printerr ("test_engine_open_eager_build_surfaces_errors: expected "
+        "non-OK, got WYRELOG_E_OK\n");
+    if (engine != NULL)
+      g_object_unref (engine);
+    return 13;
+  }
+  if (engine != NULL) {
+    g_printerr ("test_engine_open_eager_build_surfaces_errors: *out should "
+        "be NULL on failure\n");
+    g_object_unref (engine);
+    return 14;
+  }
+  return 0;
+}
+
+static gint
+test_engine_open_missing_decision_fail_closed (void)
+{
+  g_autofree gchar *tmpdir = make_tmpdir ();
+  if (tmpdir == NULL)
+    return 20;
+
+  /* Create fsm/ subdir and copy bootstrap + fsm files but omit decision.dl */
+  g_autofree gchar *fsm_dir = g_build_filename (tmpdir, "fsm", NULL);
+  if (g_mkdir (fsm_dir, 0755) != 0) {
+    rmdir_recursive (tmpdir);
+    return 21;
+  }
+
+  static const char *partial_files[] = {
+    "bootstrap.dl",
+    "fsm/principal.dl",
+    "fsm/session.dl",
+    "fsm/permission_scope.dl",
+    /* decision.dl intentionally omitted */
+  };
+
+  for (gsize i = 0; i < G_N_ELEMENTS (partial_files); i++) {
+    g_autofree gchar *src =
+        g_build_filename (WYL_TEST_TEMPLATE_DIR, partial_files[i], NULL);
+    g_autofree gchar *dst = g_build_filename (tmpdir, partial_files[i], NULL);
+    g_autofree gchar *contents = NULL;
+    gsize len = 0;
+    g_autoptr (GError) err = NULL;
+
+    if (!g_file_get_contents (src, &contents, &len, &err)) {
+      g_printerr ("test_engine_open_missing_decision_fail_closed: "
+          "cannot read %s: %s\n", src, err ? err->message : "?");
+      rmdir_recursive (tmpdir);
+      return 22;
+    }
+    if (!g_file_set_contents (dst, contents, (gssize) len, &err)) {
+      rmdir_recursive (tmpdir);
+      return 23;
+    }
+  }
+
+  WylEngine *engine = NULL;
+  wyrelog_error_t rc = wyl_engine_open (tmpdir, 1, &engine);
+
+  rmdir_recursive (tmpdir);
+
+  if (rc != WYRELOG_E_IO) {
+    g_printerr ("test_engine_open_missing_decision_fail_closed: "
+        "expected WYRELOG_E_IO, got %d\n", (int) rc);
+    if (engine != NULL)
+      g_object_unref (engine);
+    return 24;
+  }
+  if (engine != NULL) {
+    g_printerr ("test_engine_open_missing_decision_fail_closed: "
+        "*out should be NULL on failure\n");
+    g_object_unref (engine);
+    return 25;
+  }
+  return 0;
+}
+
+static gint
+test_engine_open_null_template_dir_rejects (void)
+{
+  WylEngine *engine = NULL;
+  wyrelog_error_t rc = wyl_engine_open (NULL, 1, &engine);
+  if (rc != WYRELOG_E_INVALID) {
+    g_printerr ("test_engine_open_null_template_dir_rejects: "
+        "expected WYRELOG_E_INVALID, got %d\n", (int) rc);
+    if (engine != NULL)
+      g_object_unref (engine);
+    return 30;
+  }
+  if (engine != NULL) {
+    g_printerr ("test_engine_open_null_template_dir_rejects: "
+        "*out should be NULL\n");
+    g_object_unref (engine);
+    return 31;
+  }
+  return 0;
+}
+
+static gint
+test_engine_open_null_out_rejects (void)
+{
+  wyrelog_error_t rc = wyl_engine_open (WYL_TEST_TEMPLATE_DIR, 1, NULL);
+  if (rc != WYRELOG_E_INVALID) {
+    g_printerr ("test_engine_open_null_out_rejects: "
+        "expected WYRELOG_E_INVALID, got %d\n", (int) rc);
+    return 40;
+  }
+  return 0;
+}
+
+static gint
+test_engine_close_then_finalize_safe (void)
+{
+  WylEngine *engine = NULL;
+  wyrelog_error_t rc = wyl_engine_open (WYL_TEST_TEMPLATE_DIR, 1, &engine);
+  if (rc != WYRELOG_E_OK || engine == NULL) {
+    g_printerr ("test_engine_close_then_finalize_safe: open failed: %d\n",
+        (int) rc);
+    return 50;
+  }
+  /* Explicit close followed by g_object_unref via g_autoptr-style:
+   * wyl_engine_close releases the underlying session; subsequent
+   * g_object_unref sees a NULL session in finalize — no crash expected. */
+  g_object_unref (engine);
+  return 0;
+}
+
+static gint
+test_engine_double_close_safe (void)
+{
+  WylEngine *engine = NULL;
+  wyrelog_error_t rc = wyl_engine_open (WYL_TEST_TEMPLATE_DIR, 1, &engine);
+  if (rc != WYRELOG_E_OK || engine == NULL) {
+    g_printerr ("test_engine_double_close_safe: open failed: %d\n", (int) rc);
+    return 60;
+  }
+  /* Demonstrate NULL-safe close: use g_clear_pointer so the pointer is
+   * nulled after the first close; the second call is a no-op on NULL. */
+  g_clear_pointer (&engine, wyl_engine_close);
+  g_clear_pointer (&engine, wyl_engine_close);
+  return 0;
+}
+
+static gint
+test_engine_concat_with_newline_helper (void)
+{
+  /* Test wyl_engine_load_templates indirectly: create a tmpdir with two
+   * files where the first lacks a trailing newline, verify the combined
+   * source has a newline boundary between them. */
+  g_autofree gchar *tmpdir = make_tmpdir ();
+  if (tmpdir == NULL)
+    return 70;
+
+  /* Create fsm/ subdir. */
+  g_autofree gchar *fsm_dir = g_build_filename (tmpdir, "fsm", NULL);
+  if (g_mkdir (fsm_dir, 0755) != 0) {
+    rmdir_recursive (tmpdir);
+    return 71;
+  }
+
+  /* Write a minimal but syntactically acceptable bootstrap.dl (no trailing
+   * newline). The actual content just needs to be parseable enough that
+   * the template loader can read it; we only test the newline stitching
+   * at the load_templates layer, not the wirelog parse layer. */
+  const gchar *bootstrap_content = "% bootstrap";       /* no trailing \n */
+
+  if (!write_file_in_dir (tmpdir, "bootstrap.dl", bootstrap_content)) {
+    rmdir_recursive (tmpdir);
+    return 72;
+  }
+
+  /* For the remaining 4 files, write minimal placeholder stubs. */
+  static const char *rest[] = {
+    "fsm/principal.dl",
+    "fsm/session.dl",
+    "fsm/permission_scope.dl",
+    "decision.dl",
+  };
+  for (gsize i = 0; i < G_N_ELEMENTS (rest); i++) {
+    g_autofree gchar *stub = g_strdup_printf ("%% stub for %s\n", rest[i]);
+    if (!write_file_in_dir (tmpdir, rest[i], stub)) {
+      rmdir_recursive (tmpdir);
+      return (gint) (73 + i);
+    }
+  }
+
+  gchar *dl_src = NULL;
+  wyrelog_error_t rc = wyl_engine_load_templates (tmpdir, &dl_src);
+
+  if (rc != WYRELOG_E_OK) {
+    g_printerr ("test_engine_concat_with_newline_helper: "
+        "load_templates failed: %d\n", (int) rc);
+    rmdir_recursive (tmpdir);
+    return 78;
+  }
+
+  /* Verify that "% bootstrap" is immediately followed by '\n' and then
+   * the next file's content — confirming newline insertion between files. */
+  const gchar *boundary = strstr (dl_src, "% bootstrap");
+  gboolean has_newline = (boundary != NULL)
+      && (*(boundary + strlen ("% bootstrap")) == '\n');
+
+  memset (dl_src, 0, strlen (dl_src));
+  g_free (dl_src);
+  rmdir_recursive (tmpdir);
+
+  if (!has_newline) {
+    g_printerr ("test_engine_concat_with_newline_helper: "
+        "expected '\\n' after first file content\n");
+    return 79;
+  }
+  return 0;
+}
+
+/* ------------------------------------------------------------------ */
+/* main                                                                */
+/* ------------------------------------------------------------------ */
+
+int
+main (void)
+{
+  gint rc;
+
+  if ((rc = test_engine_open_canonical_smoke ()) != 0)
+    return rc;
+
+  if ((rc = test_engine_open_eager_build_surfaces_errors ()) != 0)
+    return rc;
+
+  if ((rc = test_engine_open_missing_decision_fail_closed ()) != 0)
+    return rc;
+
+  if ((rc = test_engine_open_null_template_dir_rejects ()) != 0)
+    return rc;
+
+  if ((rc = test_engine_open_null_out_rejects ()) != 0)
+    return rc;
+
+  if ((rc = test_engine_close_then_finalize_safe ()) != 0)
+    return rc;
+
+  if ((rc = test_engine_double_close_safe ()) != 0)
+    return rc;
+
+  if ((rc = test_engine_concat_with_newline_helper ()) != 0)
+    return rc;
+
+  return 0;
+}

--- a/tests/test-engine.c
+++ b/tests/test-engine.c
@@ -312,9 +312,10 @@ test_engine_double_close_safe (void)
 static gint
 test_engine_concat_with_newline_helper (void)
 {
-  /* Test wyl_engine_load_templates indirectly: create a tmpdir with two
-   * files where the first lacks a trailing newline, verify the combined
-   * source has a newline boundary between them. */
+  /* Test wyl_engine_load_templates directly via the internal helper exposed
+   * by wyl-engine-private.h: create a tmpdir with two files where the first
+   * lacks a trailing newline, verify the combined source has a newline
+   * boundary between them. */
   g_autofree gchar *tmpdir = make_tmpdir ();
   if (tmpdir == NULL)
     return 70;
@@ -353,7 +354,8 @@ test_engine_concat_with_newline_helper (void)
   }
 
   gchar *dl_src = NULL;
-  wyrelog_error_t rc = wyl_engine_load_templates (tmpdir, &dl_src);
+  gsize dl_src_len = 0;
+  wyrelog_error_t rc = wyl_engine_load_templates (tmpdir, &dl_src, &dl_src_len);
 
   if (rc != WYRELOG_E_OK) {
     g_printerr ("test_engine_concat_with_newline_helper: "
@@ -368,7 +370,9 @@ test_engine_concat_with_newline_helper (void)
   gboolean has_newline = (boundary != NULL)
       && (*(boundary + strlen ("% bootstrap")) == '\n');
 
-  memset (dl_src, 0, strlen (dl_src));
+  /* Use the tracked length (not strlen) for the zero-fill to ensure the full
+   * buffer is overwritten regardless of any embedded NUL bytes. */
+  memset (dl_src, 0, dl_src_len);
   g_free (dl_src);
   rmdir_recursive (tmpdir);
 

--- a/tests/test-engine.c
+++ b/tests/test-engine.c
@@ -384,6 +384,60 @@ test_engine_concat_with_newline_helper (void)
   return 0;
 }
 
+static gint
+test_engine_open_empty_templates (void)
+{
+  g_autofree gchar *tmpdir = make_tmpdir ();
+  if (tmpdir == NULL)
+    return 80;
+
+  /* Create fsm/ subdir. */
+  g_autofree gchar *fsm_dir = g_build_filename (tmpdir, "fsm", NULL);
+  if (g_mkdir (fsm_dir, 0755) != 0) {
+    rmdir_recursive (tmpdir);
+    return 81;
+  }
+
+  /* Write all 5 template files as zero-byte files. */
+  static const char *all_files[] = {
+    "bootstrap.dl",
+    "fsm/principal.dl",
+    "fsm/session.dl",
+    "fsm/permission_scope.dl",
+    "decision.dl",
+  };
+  for (gsize i = 0; i < G_N_ELEMENTS (all_files); i++) {
+    g_autofree gchar *path = g_build_filename (tmpdir, all_files[i], NULL);
+    g_autoptr (GError) err = NULL;
+    if (!g_file_set_contents (path, "", 0, &err)) {
+      g_printerr ("test_engine_open_empty_templates: "
+          "cannot create %s: %s\n", all_files[i], err ? err->message : "?");
+      rmdir_recursive (tmpdir);
+      return 82;
+    }
+  }
+
+  WylEngine *engine = NULL;
+  wyrelog_error_t rc = wyl_engine_open (tmpdir, 1, &engine);
+
+  rmdir_recursive (tmpdir);
+
+  if (rc != WYRELOG_E_INTERNAL) {
+    g_printerr ("test_engine_open_empty_templates: "
+        "expected WYRELOG_E_INTERNAL, got %d\n", (int) rc);
+    if (engine != NULL)
+      g_object_unref (engine);
+    return 83;
+  }
+  if (engine != NULL) {
+    g_printerr ("test_engine_open_empty_templates: "
+        "*out should be NULL on failure\n");
+    g_object_unref (engine);
+    return 84;
+  }
+  return 0;
+}
+
 /* ------------------------------------------------------------------ */
 /* main                                                                */
 /* ------------------------------------------------------------------ */
@@ -415,6 +469,9 @@ main (void)
     return rc;
 
   if ((rc = test_engine_concat_with_newline_helper ()) != 0)
+    return rc;
+
+  if ((rc = test_engine_open_empty_templates ()) != 0)
     return rc;
 
   return 0;

--- a/wyrelog/engine.h
+++ b/wyrelog/engine.h
@@ -1,0 +1,59 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+
+#include <glib.h>
+#include <glib-object.h>
+
+#include "wyrelog/error.h"
+
+G_BEGIN_DECLS;
+
+/*
+ * WylEngine - evaluator session handle.
+ *
+ * Loads access-control policy templates and opens an evaluator session.
+ * Created with wyl_engine_open, shut down with wyl_engine_close,
+ * released with g_object_unref (or g_autoptr(WylEngine) in scoped form).
+ *
+ * Thread safety: a WylEngine is NOT thread-safe. Callers must serialize
+ * all access to a given instance. Independent instances may be used on
+ * separate threads without coordination.
+ */
+typedef struct _WylEngine WylEngine;
+
+#define WYL_TYPE_ENGINE (wyl_engine_get_type ())
+G_DECLARE_FINAL_TYPE (WylEngine, wyl_engine, WYL, ENGINE, GObject)
+/*
+ * wyl_engine_open:
+ * @template_dir: Path to the directory containing the policy template files.
+ *                Must not be NULL.
+ * @num_workers:  Number of worker threads for the underlying session. Pass 1
+ *                for single-threaded use; 0 is internally clamped to 1.
+ * @out:          (out) Receives the new engine handle on success.
+ *                Set to NULL at function entry; left NULL on any failure.
+ *
+ * Reads the policy templates from @template_dir in a fixed dependency order,
+ * concatenates them with explicit newline separators, and opens the underlying
+ * evaluator session with eager build enabled — so any policy parse or plan
+ * failure surfaces synchronously here rather than at first use.
+ *
+ * Returns: WYRELOG_E_OK on success. On failure, *out is NULL and the return
+ * value describes the failure class: WYRELOG_E_INVALID for NULL arguments,
+ * WYRELOG_E_IO for missing or unreadable templates, WYRELOG_E_POLICY for
+ * policy parse or plan errors, WYRELOG_E_NOMEM for allocation failures,
+ * WYRELOG_E_INTERNAL for unexpected evaluator errors.
+ */
+     wyrelog_error_t wyl_engine_open (const gchar *template_dir,
+    guint32 num_workers, WylEngine **out);
+
+/*
+ * wyl_engine_close:
+ * @engine: Engine to close (NULL-safe).
+ *
+ * Releases the engine and its underlying evaluator session. Equivalent to
+ * g_clear_object when called on a g_autoptr-managed variable, but available
+ * as an explicit close site for callers that do not use autoptr.
+ */
+     void wyl_engine_close (WylEngine *engine);
+
+G_END_DECLS;

--- a/wyrelog/meson.build
+++ b/wyrelog/meson.build
@@ -3,6 +3,7 @@ wyrelog_inc = include_directories('..')
 wyrelog_public_headers = files(
   'audit.h',
   'decide.h',
+  'engine.h',
   'error.h',
   'events.h',
   'handle.h',
@@ -18,6 +19,7 @@ wyrelog_sources = files(
   'wyl-boot.c',
   'wyl-decide.c',
   'wyl-dl-static.c',
+  'wyl-engine.c',
   'wyl-error.c',
   'wyl-events.c',
   'wyl-fsm-principal.c',
@@ -33,7 +35,7 @@ wyrelog_sources = files(
   'wyl-version.c',
 )
 
-wyrelog_deps = [glib_dep, gio_dep, libchronoid_dep]
+wyrelog_deps = [glib_dep, gio_dep, libchronoid_dep, wirelog_dep]
 
 wyrelog_log_levels = {
   'none' : 0,

--- a/wyrelog/wyl-engine-private.h
+++ b/wyrelog/wyl-engine-private.h
@@ -42,7 +42,7 @@ wyrelog_error_t wyl_engine_map_wirelog_error (wirelog_error_t wl_err);
  *                   pointed to by *@dl_src_out, not including the NUL
  *                   terminator. Use this value — not strlen() — for memset to
  *                   ensure every byte is overwritten regardless of embedded
- *                   NUL bytes.
+ *                   NUL bytes. Must not be NULL.
  *
  * Reads the policy templates in a fixed dependency order and concatenates
  * them into a single source string suitable for passing to the evaluator.

--- a/wyrelog/wyl-engine-private.h
+++ b/wyrelog/wyl-engine-private.h
@@ -32,11 +32,17 @@ wyrelog_error_t wyl_engine_map_wirelog_error (wirelog_error_t wl_err);
 
 /*
  * wyl_engine_load_templates:
- * @template_dir: Directory containing the policy template files.
- * @dl_src_out:   (out) On success, receives a newly-allocated gchar* containing
- *                all template file contents concatenated with '\n' between
- *                files. Caller is responsible for zeroing and freeing the
- *                buffer via memset + g_free.
+ * @template_dir:    Directory containing the policy template files.
+ * @dl_src_out:      (out) On success, receives a newly-allocated gchar*
+ *                   containing all template file contents concatenated with
+ *                   '\n' between files. Caller is responsible for zeroing and
+ *                   freeing the buffer via memset(@dl_src_len_out bytes) +
+ *                   g_free.
+ * @dl_src_len_out:  (out) On success, receives the byte length of the buffer
+ *                   pointed to by *@dl_src_out, not including the NUL
+ *                   terminator. Use this value — not strlen() — for memset to
+ *                   ensure every byte is overwritten regardless of embedded
+ *                   NUL bytes.
  *
  * Reads the policy templates in a fixed dependency order and concatenates
  * them into a single source string suitable for passing to the evaluator.
@@ -45,6 +51,6 @@ wyrelog_error_t wyl_engine_map_wirelog_error (wirelog_error_t wl_err);
  * unreadable, WYRELOG_E_NOMEM on allocation failure.
  */
 wyrelog_error_t wyl_engine_load_templates (const gchar * template_dir,
-    gchar ** dl_src_out);
+    gchar ** dl_src_out, gsize * dl_src_len_out);
 
 G_END_DECLS;

--- a/wyrelog/wyl-engine-private.h
+++ b/wyrelog/wyl-engine-private.h
@@ -1,0 +1,50 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+
+#include <glib.h>
+#include <glib-object.h>
+
+#include <wirelog/wl_easy.h>
+
+#include "wyrelog/engine.h"
+#include "wyrelog/error.h"
+
+G_BEGIN_DECLS;
+
+/* Number of policy template files loaded at open time. */
+#define WYL_ENGINE_TEMPLATE_COUNT 5
+
+struct _WylEngine
+{
+  GObject parent_instance;
+  wl_easy_session_t *session;
+  /* Logical path strings for diagnostic logging only; freed in finalize. */
+  gchar *dl_src_logical_paths[WYL_ENGINE_TEMPLATE_COUNT];
+};
+
+/*
+ * wyl_engine_map_wirelog_error:
+ *
+ * Maps a wirelog_error_t value from the underlying evaluator into the
+ * project's wyrelog_error_t taxonomy.
+ */
+wyrelog_error_t wyl_engine_map_wirelog_error (wirelog_error_t wl_err);
+
+/*
+ * wyl_engine_load_templates:
+ * @template_dir: Directory containing the policy template files.
+ * @dl_src_out:   (out) On success, receives a newly-allocated gchar* containing
+ *                all template file contents concatenated with '\n' between
+ *                files. Caller is responsible for zeroing and freeing the
+ *                buffer via memset + g_free.
+ *
+ * Reads the policy templates in a fixed dependency order and concatenates
+ * them into a single source string suitable for passing to the evaluator.
+ *
+ * Returns: WYRELOG_E_OK on success, WYRELOG_E_IO if any file is missing or
+ * unreadable, WYRELOG_E_NOMEM on allocation failure.
+ */
+wyrelog_error_t wyl_engine_load_templates (const gchar * template_dir,
+    gchar ** dl_src_out);
+
+G_END_DECLS;

--- a/wyrelog/wyl-engine-private.h
+++ b/wyrelog/wyl-engine-private.h
@@ -37,7 +37,7 @@ wyrelog_error_t wyl_engine_map_wirelog_error (wirelog_error_t wl_err);
  *                   containing all template file contents concatenated with
  *                   '\n' between files. Caller is responsible for zeroing and
  *                   freeing the buffer via memset(@dl_src_len_out bytes) +
- *                   g_free.
+ *                   g_free. Must not be NULL.
  * @dl_src_len_out:  (out) On success, receives the byte length of the buffer
  *                   pointed to by *@dl_src_out, not including the NUL
  *                   terminator. Use this value — not strlen() — for memset to

--- a/wyrelog/wyl-engine.c
+++ b/wyrelog/wyl-engine.c
@@ -1,0 +1,173 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <string.h>
+
+#include "wyrelog/wyrelog.h"
+#include "wyl-engine-private.h"
+#include "wyl-common-private.h"
+
+/*
+ * Fixed dependency order for policy template files.
+ *
+ * The order is load-bearing: later files may reference relations declared
+ * in earlier files. Do not reorder without updating the dependency analysis.
+ */
+static const char *const TEMPLATE_FILES[] = {
+  "bootstrap.dl",
+  "fsm/principal.dl",
+  "fsm/session.dl",
+  "fsm/permission_scope.dl",
+  "decision.dl",
+};
+
+G_STATIC_ASSERT (G_N_ELEMENTS (TEMPLATE_FILES) == WYL_ENGINE_TEMPLATE_COUNT);
+
+/* --- GObject boilerplate ------------------------------------------- */
+
+G_DEFINE_FINAL_TYPE (WylEngine, wyl_engine, G_TYPE_OBJECT);
+
+static void
+wyl_engine_finalize (GObject *object)
+{
+  WylEngine *self = WYL_ENGINE (object);
+
+  g_clear_pointer (&self->session, wl_easy_close);
+
+  for (gsize i = 0; i < WYL_ENGINE_TEMPLATE_COUNT; i++)
+    g_clear_pointer (&self->dl_src_logical_paths[i], g_free);
+
+  G_OBJECT_CLASS (wyl_engine_parent_class)->finalize (object);
+}
+
+static void
+wyl_engine_class_init (WylEngineClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->finalize = wyl_engine_finalize;
+}
+
+static void
+wyl_engine_init (WylEngine *self)
+{
+  self->session = NULL;
+  for (gsize i = 0; i < WYL_ENGINE_TEMPLATE_COUNT; i++)
+    self->dl_src_logical_paths[i] = NULL;
+}
+
+/* --- Internal helpers --------------------------------------------- */
+
+wyrelog_error_t
+wyl_engine_map_wirelog_error (wirelog_error_t wl_err)
+{
+  switch (wl_err) {
+    case WIRELOG_OK:
+      return WYRELOG_E_OK;
+    case WIRELOG_ERR_PARSE:
+    case WIRELOG_ERR_INVALID_IR:
+      return WYRELOG_E_POLICY;
+    case WIRELOG_ERR_EXEC:
+      return WYRELOG_E_EXEC;
+    case WIRELOG_ERR_MEMORY:
+      return WYRELOG_E_NOMEM;
+    case WIRELOG_ERR_IO:
+      return WYRELOG_E_IO;
+    case WIRELOG_ERR_UNKNOWN:
+      return WYRELOG_E_INTERNAL;
+    default:
+      return WYRELOG_E_INTERNAL;
+  }
+}
+
+wyrelog_error_t
+wyl_engine_load_templates (const gchar *template_dir, gchar **dl_src_out)
+{
+  g_autoptr (GString) combined = g_string_new (NULL);
+
+  for (gsize i = 0; i < G_N_ELEMENTS (TEMPLATE_FILES); i++) {
+    g_autofree gchar *path =
+        g_build_filename (template_dir, TEMPLATE_FILES[i], NULL);
+    g_autofree gchar *contents = NULL;
+    gsize len = 0;
+    g_autoptr (GError) err = NULL;
+
+    if (!g_file_get_contents (path, &contents, &len, &err)) {
+      WYL_LOG_ERROR (WYL_LOG_SECTION_BOOT,
+          "missing or unreadable template: %s", TEMPLATE_FILES[i]);
+      return WYRELOG_E_IO;
+    }
+
+    /* Insert newline between files unconditionally for concat-boundary safety. */
+    if (i > 0)
+      g_string_append_c (combined, '\n');
+
+    g_string_append_len (combined, contents, (gssize) len);
+  }
+
+  *dl_src_out = g_string_free (g_steal_pointer (&combined), FALSE);
+  return WYRELOG_E_OK;
+}
+
+/* --- Public API ---------------------------------------------------- */
+
+wyrelog_error_t
+wyl_engine_open (const gchar *template_dir, guint32 num_workers,
+    WylEngine **out)
+{
+  /* Set out-param to NULL at entry; every failure path leaves it NULL. */
+  if (out != NULL)
+    *out = NULL;
+
+  if (out == NULL)
+    return WYRELOG_E_INVALID;
+
+  if (template_dir == NULL)
+    return WYRELOG_E_INVALID;
+
+  gchar *dl_src = NULL;
+  wyrelog_error_t rc = wyl_engine_load_templates (template_dir, &dl_src);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  wl_easy_open_opts_t opts = {
+    .size = sizeof (opts),
+    .num_workers = num_workers,
+    .eager_build = true,
+    ._reserved = NULL,
+  };
+
+  wl_easy_session_t *session = NULL;
+  wirelog_error_t wl_rc = wl_easy_open_opts (dl_src, &opts, &session);
+
+  /* FC4: zero-fill the policy source buffer before freeing to avoid
+   * leaving policy text in core dumps or swap. */
+  memset (dl_src, 0, strlen (dl_src));
+  g_free (dl_src);
+  dl_src = NULL;
+
+  if (wl_rc != WIRELOG_OK) {
+    /* wl_easy_open_opts sets *out to NULL on error per its contract,
+     * but be defensive: close any partial session that may have been
+     * returned despite the error. */
+    if (session != NULL)
+      wl_easy_close (session);
+    return wyl_engine_map_wirelog_error (wl_rc);
+  }
+
+  WylEngine *engine = g_object_new (WYL_TYPE_ENGINE, NULL);
+  engine->session = session;
+
+  /* Store logical paths for diagnostic logging. */
+  for (gsize i = 0; i < WYL_ENGINE_TEMPLATE_COUNT; i++)
+    engine->dl_src_logical_paths[i] = g_strdup (TEMPLATE_FILES[i]);
+
+  *out = engine;
+  return WYRELOG_E_OK;
+}
+
+void
+wyl_engine_close (WylEngine *engine)
+{
+  if (engine == NULL)
+    return;
+  g_object_unref (engine);
+}

--- a/wyrelog/wyl-engine.c
+++ b/wyrelog/wyl-engine.c
@@ -83,6 +83,7 @@ wyl_engine_load_templates (const gchar *template_dir, gchar **dl_src_out,
     gsize *dl_src_len_out)
 {
   g_autoptr (GString) combined = g_string_new (NULL);
+  gsize total_content_bytes = 0;
 
   for (gsize i = 0; i < G_N_ELEMENTS (TEMPLATE_FILES); i++) {
     g_autofree gchar *path =
@@ -102,6 +103,17 @@ wyl_engine_load_templates (const gchar *template_dir, gchar **dl_src_out,
       g_string_append_c (combined, '\n');
 
     g_string_append_len (combined, contents, (gssize) len);
+    total_content_bytes += len;
+  }
+
+  /* In-tree invariant: the 5 template files must collectively contain at
+   * least one byte of policy content.  A zero total means all files are
+   * empty, which is a wyrelog-side invariant violation (not operator-authored
+   * bad policy).  Separator newlines inserted above are not counted. */
+  if (total_content_bytes == 0) {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_BOOT,
+        "engine: invariant violated — in-tree templates produced zero bytes");
+    return WYRELOG_E_INTERNAL;
   }
 
   /* Capture the authoritative byte count before transferring ownership of the
@@ -134,17 +146,6 @@ wyl_engine_open (const gchar *template_dir, guint32 num_workers,
       wyl_engine_load_templates (template_dir, &dl_src, &dl_src_len);
   if (rc != WYRELOG_E_OK)
     return rc;
-
-  /* Defense-in-depth: reject a zero-byte policy source before it reaches the
-   * evaluator.  Under normal operation the TEMPLATE_FILES array always
-   * produces content, but guard against a future refactor that mistakenly
-   * empties it or produces only empty files. */
-  if (dl_src_len == 0) {
-    WYL_LOG_ERROR (WYL_LOG_SECTION_BOOT,
-        "engine: empty policy source (zero bytes loaded)");
-    g_free (dl_src);
-    return WYRELOG_E_POLICY;
-  }
 
   wl_easy_open_opts_t opts = {
     .size = sizeof (opts),

--- a/wyrelog/wyl-engine.c
+++ b/wyrelog/wyl-engine.c
@@ -79,7 +79,8 @@ wyl_engine_map_wirelog_error (wirelog_error_t wl_err)
 }
 
 wyrelog_error_t
-wyl_engine_load_templates (const gchar *template_dir, gchar **dl_src_out)
+wyl_engine_load_templates (const gchar *template_dir, gchar **dl_src_out,
+    gsize *dl_src_len_out)
 {
   g_autoptr (GString) combined = g_string_new (NULL);
 
@@ -103,6 +104,10 @@ wyl_engine_load_templates (const gchar *template_dir, gchar **dl_src_out)
     g_string_append_len (combined, contents, (gssize) len);
   }
 
+  /* Capture the authoritative byte count before transferring ownership of the
+   * underlying buffer.  strlen() must not be used for the subsequent memset
+   * because it short-circuits at the first embedded NUL byte. */
+  *dl_src_len_out = combined->len;
   *dl_src_out = g_string_free (g_steal_pointer (&combined), FALSE);
   return WYRELOG_E_OK;
 }
@@ -124,9 +129,22 @@ wyl_engine_open (const gchar *template_dir, guint32 num_workers,
     return WYRELOG_E_INVALID;
 
   gchar *dl_src = NULL;
-  wyrelog_error_t rc = wyl_engine_load_templates (template_dir, &dl_src);
+  gsize dl_src_len = 0;
+  wyrelog_error_t rc =
+      wyl_engine_load_templates (template_dir, &dl_src, &dl_src_len);
   if (rc != WYRELOG_E_OK)
     return rc;
+
+  /* Defense-in-depth: reject a zero-byte policy source before it reaches the
+   * evaluator.  Under normal operation the TEMPLATE_FILES array always
+   * produces content, but guard against a future refactor that mistakenly
+   * empties it or produces only empty files. */
+  if (dl_src_len == 0) {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_BOOT,
+        "engine: empty policy source (zero bytes loaded)");
+    g_free (dl_src);
+    return WYRELOG_E_POLICY;
+  }
 
   wl_easy_open_opts_t opts = {
     .size = sizeof (opts),
@@ -138,9 +156,11 @@ wyl_engine_open (const gchar *template_dir, guint32 num_workers,
   wl_easy_session_t *session = NULL;
   wirelog_error_t wl_rc = wl_easy_open_opts (dl_src, &opts, &session);
 
-  /* FC4: zero-fill the policy source buffer before freeing to avoid
-   * leaving policy text in core dumps or swap. */
-  memset (dl_src, 0, strlen (dl_src));
+  /* FC4: zero-fill the policy source buffer before freeing to avoid leaving
+   * policy text in core dumps or swap.  Use the tracked length rather than
+   * strlen() to ensure every byte — including any tail past an embedded NUL —
+   * is overwritten. */
+  memset (dl_src, 0, dl_src_len);
   g_free (dl_src);
   dl_src = NULL;
 


### PR DESCRIPTION
## Summary

Introduces the wyrelog policy engine adapter over the wirelog substrate
with an eager-build session lifecycle, plus three correctness hardenings
on the policy template loader.

## Commits

- `a547166` engine: add wirelog session adapter with eager-build lifecycle
- `2216a6f` engine: track policy buffer length for safe zero-fill
- `1644f26` engine: classify empty policy source as internal invariant
- `2460b56` engine: tighten policy loader output-pointer doc

## Details

- **Adapter + lifecycle.** Eager session build at open time so policy
  template errors surface synchronously rather than at first evaluation.
  The wirelog session is private to the engine; nothing in the public
  surface couples to wirelog types.
- **Safe buffer cleanup.** The loader tracks the authoritative byte
  length of the concatenated template buffer so secure zero-fill on
  teardown overwrites every byte regardless of embedded NULs. `strlen()`
  is no longer used for the cleanup memset size.
- **Invariant classification.** An empty in-tree template concatenation
  is now reported as `WYRELOG_E_INTERNAL` rather than a policy/IO error,
  since reaching the loader implies the templates exist; an empty
  concatenation is a wyrelog-side invariant violation, not operator
  authoring.
- **Loader contract docs.** The private loader's output-pointer
  preconditions now match the unconditional dereference at the call
  site.

## Test plan

- [x] `meson compile -C builddir` clean
- [x] `meson test -C builddir` 35/35 OK (includes `wyrelog:engine`)
- [x] `./tools/gst-indent` idempotent on touched sources
- [x] `tools/check-public-headers-no-novelty-tokens.sh` green
- [x] `tools/check-private-headers-not-installed.sh` green