### PR TITLE
engine: add policy I/O wrapper (intern, insert/remove, step/snapshot)

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -258,6 +258,16 @@ test_engine_intern = executable('test-engine-intern',
 
 test('engine-intern', test_engine_intern)
 
+test_engine_io = executable('test-engine-io',
+  'test-engine-io.c',
+  c_args : [
+    '-DWYL_TEST_TEMPLATE_DIR="' + meson.project_source_root() / 'templates' / 'access' + '"',
+  ],
+  dependencies : [wyrelog_dep, wirelog_dep],
+)
+
+test('engine-io', test_engine_io)
+
 check_private_headers = find_program(
   '../tools/check-private-headers-not-installed.sh',
 )

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -248,6 +248,16 @@ test_engine = executable('test-engine',
 
 test('engine', test_engine)
 
+test_engine_intern = executable('test-engine-intern',
+  'test-engine-intern.c',
+  c_args : [
+    '-DWYL_TEST_TEMPLATE_DIR="' + meson.project_source_root() / 'templates' / 'access' + '"',
+  ],
+  dependencies : [wyrelog_dep, wirelog_dep],
+)
+
+test('engine-intern', test_engine_intern)
+
 check_private_headers = find_program(
   '../tools/check-private-headers-not-installed.sh',
 )

--- a/tests/test-engine-intern.c
+++ b/tests/test-engine-intern.c
@@ -1,0 +1,301 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <glib.h>
+#include <string.h>
+
+#include "wyrelog/engine.h"
+
+/* Allow direct access to internal struct fields for test_intern_after_close. */
+#define WYL_ENGINE_INTERNAL 1
+#include "wyrelog/wyl-engine-private.h"
+
+#ifndef WYL_TEST_TEMPLATE_DIR
+#error "WYL_TEST_TEMPLATE_DIR must be defined by the build."
+#endif
+
+/* ------------------------------------------------------------------ */
+/* Fixture helpers                                                     */
+/* ------------------------------------------------------------------ */
+
+/*
+ * open_engine_from_real_templates:
+ *
+ * Opens a WylEngine backed by the canonical in-tree templates.
+ * Returns WYRELOG_E_OK and sets *out on success.
+ */
+static wyrelog_error_t
+open_engine_from_real_templates (WylEngine **out)
+{
+  return wyl_engine_open (WYL_TEST_TEMPLATE_DIR, 1, out);
+}
+
+/* ------------------------------------------------------------------ */
+/* Test cases                                                          */
+/* ------------------------------------------------------------------ */
+
+/*
+ * test_intern_nominal:
+ *
+ * Intern "alice", expect OK and a non-negative id.
+ * Intern "alice" again; expect the same id (stable within a session).
+ */
+static gint
+test_intern_nominal (void)
+{
+  WylEngine *engine = NULL;
+  wyrelog_error_t rc = open_engine_from_real_templates (&engine);
+  if (rc != WYRELOG_E_OK || engine == NULL) {
+    g_printerr ("test_intern_nominal: open failed: %d\n", (int) rc);
+    return 1;
+  }
+
+  gint64 id1 = -999;
+  rc = wyl_engine_intern_symbol (engine, "alice", &id1);
+  if (rc != WYRELOG_E_OK) {
+    g_printerr ("test_intern_nominal: first intern failed: %d\n", (int) rc);
+    wyl_engine_close (engine);
+    return 2;
+  }
+  if (id1 < 0) {
+    g_printerr ("test_intern_nominal: id1 is negative: %" G_GINT64_FORMAT "\n",
+        id1);
+    wyl_engine_close (engine);
+    return 3;
+  }
+
+  gint64 id2 = -999;
+  rc = wyl_engine_intern_symbol (engine, "alice", &id2);
+  if (rc != WYRELOG_E_OK) {
+    g_printerr ("test_intern_nominal: second intern failed: %d\n", (int) rc);
+    wyl_engine_close (engine);
+    return 4;
+  }
+  if (id1 != id2) {
+    g_printerr ("test_intern_nominal: ids differ: %" G_GINT64_FORMAT
+        " vs %" G_GINT64_FORMAT "\n", id1, id2);
+    wyl_engine_close (engine);
+    return 5;
+  }
+
+  wyl_engine_close (engine);
+  return 0;
+}
+
+/*
+ * test_intern_distinct:
+ *
+ * Intern "alice" and "bob"; their ids must differ.
+ */
+static gint
+test_intern_distinct (void)
+{
+  WylEngine *engine = NULL;
+  wyrelog_error_t rc = open_engine_from_real_templates (&engine);
+  if (rc != WYRELOG_E_OK || engine == NULL) {
+    g_printerr ("test_intern_distinct: open failed: %d\n", (int) rc);
+    return 10;
+  }
+
+  gint64 id_alice = -999;
+  rc = wyl_engine_intern_symbol (engine, "alice", &id_alice);
+  if (rc != WYRELOG_E_OK) {
+    g_printerr ("test_intern_distinct: intern alice failed: %d\n", (int) rc);
+    wyl_engine_close (engine);
+    return 11;
+  }
+
+  gint64 id_bob = -999;
+  rc = wyl_engine_intern_symbol (engine, "bob", &id_bob);
+  if (rc != WYRELOG_E_OK) {
+    g_printerr ("test_intern_distinct: intern bob failed: %d\n", (int) rc);
+    wyl_engine_close (engine);
+    return 12;
+  }
+
+  if (id_alice == id_bob) {
+    g_printerr ("test_intern_distinct: alice and bob share the same id: %"
+        G_GINT64_FORMAT "\n", id_alice);
+    wyl_engine_close (engine);
+    return 13;
+  }
+
+  wyl_engine_close (engine);
+  return 0;
+}
+
+/*
+ * test_intern_null_self:
+ *
+ * Pass NULL as self; expect WYRELOG_E_INVALID.
+ */
+static gint
+test_intern_null_self (void)
+{
+  gint64 id = -999;
+  wyrelog_error_t rc = wyl_engine_intern_symbol (NULL, "alice", &id);
+  if (rc != WYRELOG_E_INVALID) {
+    g_printerr ("test_intern_null_self: expected WYRELOG_E_INVALID, got %d\n",
+        (int) rc);
+    return 20;
+  }
+  return 0;
+}
+
+/*
+ * test_intern_null_symbol:
+ *
+ * Open engine, pass NULL symbol; expect WYRELOG_E_INVALID, no crash.
+ */
+static gint
+test_intern_null_symbol (void)
+{
+  WylEngine *engine = NULL;
+  wyrelog_error_t rc = open_engine_from_real_templates (&engine);
+  if (rc != WYRELOG_E_OK || engine == NULL) {
+    g_printerr ("test_intern_null_symbol: open failed: %d\n", (int) rc);
+    return 30;
+  }
+
+  gint64 id = -999;
+  rc = wyl_engine_intern_symbol (engine, NULL, &id);
+  if (rc != WYRELOG_E_INVALID) {
+    g_printerr ("test_intern_null_symbol: expected WYRELOG_E_INVALID, got %d\n",
+        (int) rc);
+    wyl_engine_close (engine);
+    return 31;
+  }
+
+  wyl_engine_close (engine);
+  return 0;
+}
+
+/*
+ * test_intern_null_out:
+ *
+ * Open engine, pass NULL out; expect WYRELOG_E_INVALID, no crash.
+ */
+static gint
+test_intern_null_out (void)
+{
+  WylEngine *engine = NULL;
+  wyrelog_error_t rc = open_engine_from_real_templates (&engine);
+  if (rc != WYRELOG_E_OK || engine == NULL) {
+    g_printerr ("test_intern_null_out: open failed: %d\n", (int) rc);
+    return 40;
+  }
+
+  rc = wyl_engine_intern_symbol (engine, "alice", NULL);
+  if (rc != WYRELOG_E_INVALID) {
+    g_printerr ("test_intern_null_out: expected WYRELOG_E_INVALID, got %d\n",
+        (int) rc);
+    wyl_engine_close (engine);
+    return 41;
+  }
+
+  wyl_engine_close (engine);
+  return 0;
+}
+
+/*
+ * test_intern_empty_symbol:
+ *
+ * Intern the empty string ""; wirelog accepts it per contract.
+ * Expect OK and a valid (non-negative) id.
+ */
+static gint
+test_intern_empty_symbol (void)
+{
+  WylEngine *engine = NULL;
+  wyrelog_error_t rc = open_engine_from_real_templates (&engine);
+  if (rc != WYRELOG_E_OK || engine == NULL) {
+    g_printerr ("test_intern_empty_symbol: open failed: %d\n", (int) rc);
+    return 50;
+  }
+
+  gint64 id = -999;
+  rc = wyl_engine_intern_symbol (engine, "", &id);
+  if (rc != WYRELOG_E_OK) {
+    g_printerr ("test_intern_empty_symbol: expected WYRELOG_E_OK, got %d\n",
+        (int) rc);
+    wyl_engine_close (engine);
+    return 51;
+  }
+  if (id < 0) {
+    g_printerr ("test_intern_empty_symbol: id is negative: %"
+        G_GINT64_FORMAT "\n", id);
+    wyl_engine_close (engine);
+    return 52;
+  }
+
+  wyl_engine_close (engine);
+  return 0;
+}
+
+/*
+ * test_intern_after_close:
+ *
+ * Simulate a "closed" engine by directly nulling the session pointer via
+ * the private struct (WYL_ENGINE_INTERNAL). The implementation checks
+ * self->session == NULL and must return WYRELOG_E_INVALID.
+ */
+static gint
+test_intern_after_close (void)
+{
+  WylEngine *engine = NULL;
+  wyrelog_error_t rc = open_engine_from_real_templates (&engine);
+  if (rc != WYRELOG_E_OK || engine == NULL) {
+    g_printerr ("test_intern_after_close: open failed: %d\n", (int) rc);
+    return 60;
+  }
+
+  /* Simulate a closed engine: close the underlying session directly and
+   * null the pointer so the engine object remains alive but sessionless. */
+  wl_easy_close (engine->session);
+  engine->session = NULL;
+
+  gint64 id = -999;
+  rc = wyl_engine_intern_symbol (engine, "alice", &id);
+
+  /* Release the engine. finalize will see session == NULL and skip
+   * wl_easy_close (g_clear_pointer is a no-op on NULL). */
+  g_object_unref (engine);
+
+  if (rc != WYRELOG_E_INVALID) {
+    g_printerr ("test_intern_after_close: expected WYRELOG_E_INVALID, "
+        "got %d\n", (int) rc);
+    return 61;
+  }
+  return 0;
+}
+
+/* ------------------------------------------------------------------ */
+/* main                                                                */
+/* ------------------------------------------------------------------ */
+
+int
+main (void)
+{
+  gint rc;
+
+  if ((rc = test_intern_nominal ()) != 0)
+    return rc;
+
+  if ((rc = test_intern_distinct ()) != 0)
+    return rc;
+
+  if ((rc = test_intern_null_self ()) != 0)
+    return rc;
+
+  if ((rc = test_intern_null_symbol ()) != 0)
+    return rc;
+
+  if ((rc = test_intern_null_out ()) != 0)
+    return rc;
+
+  if ((rc = test_intern_empty_symbol ()) != 0)
+    return rc;
+
+  if ((rc = test_intern_after_close ()) != 0)
+    return rc;
+
+  return 0;
+}

--- a/tests/test-engine-io.c
+++ b/tests/test-engine-io.c
@@ -160,6 +160,9 @@ test_insert_remove_idempotent_remove (void)
       ==, WYRELOG_E_OK);
   g_assert_cmpint (wyl_engine_remove (engine, "member_of", row, 3),
       ==, WYRELOG_E_OK);
+  /* Pin: the wirelog substrate currently treats removing a never-inserted row
+   * as a no-op update.  This test exists to detect a future upstream change
+   * that promotes the case to an error. */
   g_assert_cmpint (wyl_engine_remove (engine, "member_of", row, 3),
       ==, WYRELOG_E_OK);
 }
@@ -299,6 +302,10 @@ test_insert_after_close (void)
   g_assert_cmpint (wyl_engine_insert (engine, "member_of", row, 3),
       ==, WYRELOG_E_INVALID);
 
+  /* g_autoptr is intentionally not used: the test mutates engine->session via
+   * the private header, and that reach-in is incompatible with autoptr's
+   * blanket cleanup discipline.  On assertion failure the engine leaks until
+   * process exit, which is acceptable for a test-side fixture. */
   g_object_unref (engine);
 }
 
@@ -318,6 +325,10 @@ test_step_after_close (void)
 
   g_assert_cmpint (wyl_engine_step (engine), ==, WYRELOG_E_INVALID);
 
+  /* g_autoptr is intentionally not used: the test mutates engine->session via
+   * the private header, and that reach-in is incompatible with autoptr's
+   * blanket cleanup discipline.  On assertion failure the engine leaks until
+   * process exit, which is acceptable for a test-side fixture. */
   g_object_unref (engine);
 }
 
@@ -362,6 +373,10 @@ test_snapshot_after_close (void)
   g_assert_cmpint (wyl_engine_snapshot (engine, "member_of",
           snapshot_count_cb, &seen), ==, WYRELOG_E_INVALID);
 
+  /* g_autoptr is intentionally not used: the test mutates engine->session via
+   * the private header, and that reach-in is incompatible with autoptr's
+   * blanket cleanup discipline.  On assertion failure the engine leaks until
+   * process exit, which is acceptable for a test-side fixture. */
   g_object_unref (engine);
 }
 
@@ -415,6 +430,10 @@ test_remove_after_close (void)
   g_assert_cmpint (wyl_engine_remove (engine, "member_of", row, 3),
       ==, WYRELOG_E_INVALID);
 
+  /* g_autoptr is intentionally not used: the test mutates engine->session via
+   * the private header, and that reach-in is incompatible with autoptr's
+   * blanket cleanup discipline.  On assertion failure the engine leaks until
+   * process exit, which is acceptable for a test-side fixture. */
   g_object_unref (engine);
 }
 

--- a/tests/test-engine-io.c
+++ b/tests/test-engine-io.c
@@ -1,0 +1,217 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <glib.h>
+
+#include "wyrelog/engine.h"
+
+/* Allow direct access to internal struct fields for after-close tests. */
+#define WYL_ENGINE_INTERNAL 1
+#include "wyrelog/wyl-engine-private.h"
+
+#ifndef WYL_TEST_TEMPLATE_DIR
+#error "WYL_TEST_TEMPLATE_DIR must be defined by the build."
+#endif
+
+static WylEngine *
+open_engine_from_real_templates (void)
+{
+  WylEngine *engine = NULL;
+  wyrelog_error_t rc = wyl_engine_open (WYL_TEST_TEMPLATE_DIR, 1, &engine);
+
+  g_assert_cmpint (rc, ==, WYRELOG_E_OK);
+  g_assert_nonnull (engine);
+
+  return engine;
+}
+
+static void
+build_member_of_row (WylEngine *engine, gint64 row[3])
+{
+  gint64 role_id = -1;
+  gint64 resource_id = -1;
+  wyrelog_error_t rc;
+
+  rc = wyl_engine_intern_symbol (engine, "wr.viewer", &role_id);
+  g_assert_cmpint (rc, ==, WYRELOG_E_OK);
+  g_assert_cmpint (role_id, >=, 0);
+
+  rc = wyl_engine_intern_symbol (engine, "resource-a", &resource_id);
+  g_assert_cmpint (rc, ==, WYRELOG_E_OK);
+  g_assert_cmpint (resource_id, >=, 0);
+
+  row[0] = 7;
+  row[1] = role_id;
+  row[2] = resource_id;
+}
+
+static void
+test_insert_nominal (void)
+{
+  g_autoptr (WylEngine) engine = open_engine_from_real_templates ();
+  gint64 row[3];
+
+  build_member_of_row (engine, row);
+
+  g_assert_cmpint (wyl_engine_insert (engine, "member_of", row, 3),
+      ==, WYRELOG_E_OK);
+}
+
+static void
+test_remove_nominal (void)
+{
+  g_autoptr (WylEngine) engine = open_engine_from_real_templates ();
+  gint64 row[3];
+
+  build_member_of_row (engine, row);
+
+  g_assert_cmpint (wyl_engine_insert (engine, "member_of", row, 3),
+      ==, WYRELOG_E_OK);
+  g_assert_cmpint (wyl_engine_remove (engine, "member_of", row, 3),
+      ==, WYRELOG_E_OK);
+}
+
+static void
+test_insert_remove_idempotent_remove (void)
+{
+  g_autoptr (WylEngine) engine = open_engine_from_real_templates ();
+  gint64 row[3];
+
+  build_member_of_row (engine, row);
+
+  g_assert_cmpint (wyl_engine_insert (engine, "member_of", row, 3),
+      ==, WYRELOG_E_OK);
+  g_assert_cmpint (wyl_engine_remove (engine, "member_of", row, 3),
+      ==, WYRELOG_E_OK);
+  g_assert_cmpint (wyl_engine_remove (engine, "member_of", row, 3),
+      ==, WYRELOG_E_OK);
+}
+
+static void
+test_insert_null_self (void)
+{
+  gint64 row[3] = { 1, 2, 3 };
+
+  g_assert_cmpint (wyl_engine_insert (NULL, "member_of", row, 3),
+      ==, WYRELOG_E_INVALID);
+}
+
+static void
+test_insert_null_relation (void)
+{
+  g_autoptr (WylEngine) engine = open_engine_from_real_templates ();
+  gint64 row[3] = { 1, 2, 3 };
+
+  g_assert_cmpint (wyl_engine_insert (engine, NULL, row, 3),
+      ==, WYRELOG_E_INVALID);
+}
+
+static void
+test_insert_null_row (void)
+{
+  g_autoptr (WylEngine) engine = open_engine_from_real_templates ();
+
+  g_assert_cmpint (wyl_engine_insert (engine, "member_of", NULL, 3),
+      ==, WYRELOG_E_INVALID);
+}
+
+static void
+test_insert_zero_ncols (void)
+{
+  g_autoptr (WylEngine) engine = open_engine_from_real_templates ();
+  gint64 row[3] = { 1, 2, 3 };
+
+  g_assert_cmpint (wyl_engine_insert (engine, "member_of", row, 0),
+      ==, WYRELOG_E_INVALID);
+}
+
+static void
+test_insert_after_close (void)
+{
+  WylEngine *engine = open_engine_from_real_templates ();
+  gint64 row[3] = { 1, 2, 3 };
+
+  wl_easy_close (engine->session);
+  engine->session = NULL;
+
+  g_assert_cmpint (wyl_engine_insert (engine, "member_of", row, 3),
+      ==, WYRELOG_E_INVALID);
+
+  g_object_unref (engine);
+}
+
+static void
+test_remove_null_self (void)
+{
+  gint64 row[3] = { 1, 2, 3 };
+
+  g_assert_cmpint (wyl_engine_remove (NULL, "member_of", row, 3),
+      ==, WYRELOG_E_INVALID);
+}
+
+static void
+test_remove_null_relation (void)
+{
+  g_autoptr (WylEngine) engine = open_engine_from_real_templates ();
+  gint64 row[3] = { 1, 2, 3 };
+
+  g_assert_cmpint (wyl_engine_remove (engine, NULL, row, 3),
+      ==, WYRELOG_E_INVALID);
+}
+
+static void
+test_remove_null_row (void)
+{
+  g_autoptr (WylEngine) engine = open_engine_from_real_templates ();
+
+  g_assert_cmpint (wyl_engine_remove (engine, "member_of", NULL, 3),
+      ==, WYRELOG_E_INVALID);
+}
+
+static void
+test_remove_zero_ncols (void)
+{
+  g_autoptr (WylEngine) engine = open_engine_from_real_templates ();
+  gint64 row[3] = { 1, 2, 3 };
+
+  g_assert_cmpint (wyl_engine_remove (engine, "member_of", row, 0),
+      ==, WYRELOG_E_INVALID);
+}
+
+static void
+test_remove_after_close (void)
+{
+  WylEngine *engine = open_engine_from_real_templates ();
+  gint64 row[3] = { 1, 2, 3 };
+
+  wl_easy_close (engine->session);
+  engine->session = NULL;
+
+  g_assert_cmpint (wyl_engine_remove (engine, "member_of", row, 3),
+      ==, WYRELOG_E_INVALID);
+
+  g_object_unref (engine);
+}
+
+int
+main (int argc, char **argv)
+{
+  g_test_init (&argc, &argv, NULL);
+
+  g_test_add_func ("/engine-io/insert-nominal", test_insert_nominal);
+  g_test_add_func ("/engine-io/remove-nominal", test_remove_nominal);
+  g_test_add_func ("/engine-io/insert-remove-idempotent-remove",
+      test_insert_remove_idempotent_remove);
+  g_test_add_func ("/engine-io/insert-null-self", test_insert_null_self);
+  g_test_add_func ("/engine-io/insert-null-relation",
+      test_insert_null_relation);
+  g_test_add_func ("/engine-io/insert-null-row", test_insert_null_row);
+  g_test_add_func ("/engine-io/insert-zero-ncols", test_insert_zero_ncols);
+  g_test_add_func ("/engine-io/insert-after-close", test_insert_after_close);
+  g_test_add_func ("/engine-io/remove-null-self", test_remove_null_self);
+  g_test_add_func ("/engine-io/remove-null-relation",
+      test_remove_null_relation);
+  g_test_add_func ("/engine-io/remove-null-row", test_remove_null_row);
+  g_test_add_func ("/engine-io/remove-zero-ncols", test_remove_zero_ncols);
+  g_test_add_func ("/engine-io/remove-after-close", test_remove_after_close);
+
+  return g_test_run ();
+}

--- a/tests/test-engine-io.c
+++ b/tests/test-engine-io.c
@@ -11,6 +11,14 @@
 #error "WYL_TEST_TEMPLATE_DIR must be defined by the build."
 #endif
 
+typedef struct
+{
+  const gchar *relation;
+  const gint64 *expected_row;
+  guint expected_ncols;
+  guint seen;
+} SnapshotExpect;
+
 static WylEngine *
 open_engine_from_real_templates (void)
 {
@@ -26,9 +34,14 @@ open_engine_from_real_templates (void)
 static void
 build_member_of_row (WylEngine *engine, gint64 row[3])
 {
+  gint64 user_id = -1;
   gint64 role_id = -1;
   gint64 resource_id = -1;
   wyrelog_error_t rc;
+
+  rc = wyl_engine_intern_symbol (engine, "user-a", &user_id);
+  g_assert_cmpint (rc, ==, WYRELOG_E_OK);
+  g_assert_cmpint (user_id, >=, 0);
 
   rc = wyl_engine_intern_symbol (engine, "wr.viewer", &role_id);
   g_assert_cmpint (rc, ==, WYRELOG_E_OK);
@@ -38,9 +51,75 @@ build_member_of_row (WylEngine *engine, gint64 row[3])
   g_assert_cmpint (rc, ==, WYRELOG_E_OK);
   g_assert_cmpint (resource_id, >=, 0);
 
-  row[0] = 7;
+  row[0] = user_id;
   row[1] = role_id;
   row[2] = resource_id;
+}
+
+static void
+build_snapshot_rows (WylEngine *engine, gint64 member_row[3],
+    gint64 role_permission_row[2], gint64 expected_permission_row[3])
+{
+  gint64 user_id = -1;
+  gint64 role_id = -1;
+  gint64 permission_id = -1;
+  gint64 resource_id = -1;
+  wyrelog_error_t rc;
+
+  rc = wyl_engine_intern_symbol (engine, "snapshot-user-a", &user_id);
+  g_assert_cmpint (rc, ==, WYRELOG_E_OK);
+  g_assert_cmpint (user_id, >=, 0);
+
+  rc = wyl_engine_intern_symbol (engine, "wr.snapshot-role-a", &role_id);
+  g_assert_cmpint (rc, ==, WYRELOG_E_OK);
+  g_assert_cmpint (role_id, >=, 0);
+
+  rc = wyl_engine_intern_symbol (engine, "wr.snapshot-permission-a",
+      &permission_id);
+  g_assert_cmpint (rc, ==, WYRELOG_E_OK);
+  g_assert_cmpint (permission_id, >=, 0);
+
+  rc = wyl_engine_intern_symbol (engine, "snapshot-resource-a", &resource_id);
+  g_assert_cmpint (rc, ==, WYRELOG_E_OK);
+  g_assert_cmpint (resource_id, >=, 0);
+
+  member_row[0] = user_id;
+  member_row[1] = role_id;
+  member_row[2] = resource_id;
+
+  role_permission_row[0] = role_id;
+  role_permission_row[1] = permission_id;
+
+  expected_permission_row[0] = user_id;
+  expected_permission_row[1] = permission_id;
+  expected_permission_row[2] = resource_id;
+}
+
+static void
+snapshot_expect_cb (const gchar *relation, const gint64 *row, guint ncols,
+    gpointer user_data)
+{
+  SnapshotExpect *expect = user_data;
+
+  g_assert_cmpstr (relation, ==, expect->relation);
+  g_assert_cmpuint (ncols, ==, expect->expected_ncols);
+  for (guint i = 0; i < ncols; i++)
+    g_assert_cmpint (row[i], ==, expect->expected_row[i]);
+
+  expect->seen++;
+}
+
+static void
+snapshot_count_cb (const gchar *relation, const gint64 *row, guint ncols,
+    gpointer user_data)
+{
+  guint *seen = user_data;
+
+  (void) relation;
+  (void) row;
+  (void) ncols;
+
+  (*seen)++;
 }
 
 static void
@@ -83,6 +162,91 @@ test_insert_remove_idempotent_remove (void)
       ==, WYRELOG_E_OK);
   g_assert_cmpint (wyl_engine_remove (engine, "member_of", row, 3),
       ==, WYRELOG_E_OK);
+}
+
+static void
+test_step_nominal (void)
+{
+  g_autoptr (WylEngine) engine = open_engine_from_real_templates ();
+  gint64 row[3];
+
+  build_member_of_row (engine, row);
+
+  g_assert_cmpint (wyl_engine_insert (engine, "member_of", row, 3),
+      ==, WYRELOG_E_OK);
+  g_assert_cmpint (wyl_engine_step (engine), ==, WYRELOG_E_OK);
+}
+
+static void
+test_step_after_snapshot_rejected (void)
+{
+  g_autoptr (WylEngine) engine = open_engine_from_real_templates ();
+  guint seen = 0;
+
+  g_assert_cmpint (wyl_engine_snapshot (engine, "member_of",
+          snapshot_count_cb, &seen), ==, WYRELOG_E_OK);
+  g_assert_cmpint (wyl_engine_step (engine), ==, WYRELOG_E_INVALID);
+}
+
+static void
+test_snapshot_after_step_rejected (void)
+{
+  g_autoptr (WylEngine) engine = open_engine_from_real_templates ();
+  guint seen = 0;
+
+  g_assert_cmpint (wyl_engine_step (engine), ==, WYRELOG_E_OK);
+  g_assert_cmpint (wyl_engine_snapshot (engine, "member_of",
+          snapshot_count_cb, &seen), ==, WYRELOG_E_INVALID);
+}
+
+static void
+test_snapshot_observes_inserted_row (void)
+{
+  g_autoptr (WylEngine) engine = open_engine_from_real_templates ();
+  gint64 member_row[3];
+  gint64 role_permission_row[2];
+  gint64 expected_permission_row[3];
+  SnapshotExpect expect;
+
+  build_snapshot_rows (engine, member_row, role_permission_row,
+      expected_permission_row);
+
+  g_assert_cmpint (wyl_engine_insert (engine, "role_permission",
+          role_permission_row, 2), ==, WYRELOG_E_OK);
+  g_assert_cmpint (wyl_engine_insert (engine, "member_of", member_row, 3),
+      ==, WYRELOG_E_OK);
+
+  expect.relation = "has_permission";
+  expect.expected_row = expected_permission_row;
+  expect.expected_ncols = 3;
+  expect.seen = 0;
+
+  g_assert_cmpint (wyl_engine_snapshot (engine, "has_permission",
+          snapshot_expect_cb, &expect), ==, WYRELOG_E_OK);
+  g_assert_cmpuint (expect.seen, ==, 1);
+}
+
+static void
+test_snapshot_observes_removed_row (void)
+{
+  g_autoptr (WylEngine) engine = open_engine_from_real_templates ();
+  gint64 member_row[3];
+  gint64 role_permission_row[2];
+  gint64 expected_permission_row[3];
+  guint seen = 0;
+
+  build_snapshot_rows (engine, member_row, role_permission_row,
+      expected_permission_row);
+
+  g_assert_cmpint (wyl_engine_insert (engine, "role_permission",
+          role_permission_row, 2), ==, WYRELOG_E_OK);
+  g_assert_cmpint (wyl_engine_insert (engine, "member_of", member_row, 3),
+      ==, WYRELOG_E_OK);
+  g_assert_cmpint (wyl_engine_remove (engine, "member_of", member_row, 3),
+      ==, WYRELOG_E_OK);
+  g_assert_cmpint (wyl_engine_snapshot (engine, "has_permission",
+          snapshot_count_cb, &seen), ==, WYRELOG_E_OK);
+  g_assert_cmpuint (seen, ==, 0);
 }
 
 static void
@@ -134,6 +298,69 @@ test_insert_after_close (void)
 
   g_assert_cmpint (wyl_engine_insert (engine, "member_of", row, 3),
       ==, WYRELOG_E_INVALID);
+
+  g_object_unref (engine);
+}
+
+static void
+test_step_null_self (void)
+{
+  g_assert_cmpint (wyl_engine_step (NULL), ==, WYRELOG_E_INVALID);
+}
+
+static void
+test_step_after_close (void)
+{
+  WylEngine *engine = open_engine_from_real_templates ();
+
+  wl_easy_close (engine->session);
+  engine->session = NULL;
+
+  g_assert_cmpint (wyl_engine_step (engine), ==, WYRELOG_E_INVALID);
+
+  g_object_unref (engine);
+}
+
+static void
+test_snapshot_null_self (void)
+{
+  guint seen = 0;
+
+  g_assert_cmpint (wyl_engine_snapshot (NULL, "member_of", snapshot_count_cb,
+          &seen), ==, WYRELOG_E_INVALID);
+}
+
+static void
+test_snapshot_null_relation (void)
+{
+  g_autoptr (WylEngine) engine = open_engine_from_real_templates ();
+  guint seen = 0;
+
+  g_assert_cmpint (wyl_engine_snapshot (engine, NULL, snapshot_count_cb,
+          &seen), ==, WYRELOG_E_INVALID);
+}
+
+static void
+test_snapshot_null_cb (void)
+{
+  g_autoptr (WylEngine) engine = open_engine_from_real_templates ();
+  guint seen = 0;
+
+  g_assert_cmpint (wyl_engine_snapshot (engine, "member_of", NULL, &seen),
+      ==, WYRELOG_E_INVALID);
+}
+
+static void
+test_snapshot_after_close (void)
+{
+  WylEngine *engine = open_engine_from_real_templates ();
+  guint seen = 0;
+
+  wl_easy_close (engine->session);
+  engine->session = NULL;
+
+  g_assert_cmpint (wyl_engine_snapshot (engine, "member_of",
+          snapshot_count_cb, &seen), ==, WYRELOG_E_INVALID);
 
   g_object_unref (engine);
 }
@@ -200,12 +427,29 @@ main (int argc, char **argv)
   g_test_add_func ("/engine-io/remove-nominal", test_remove_nominal);
   g_test_add_func ("/engine-io/insert-remove-idempotent-remove",
       test_insert_remove_idempotent_remove);
+  g_test_add_func ("/engine-io/step-nominal", test_step_nominal);
+  g_test_add_func ("/engine-io/step-after-snapshot-rejected",
+      test_step_after_snapshot_rejected);
+  g_test_add_func ("/engine-io/snapshot-after-step-rejected",
+      test_snapshot_after_step_rejected);
+  g_test_add_func ("/engine-io/snapshot-observes-inserted-row",
+      test_snapshot_observes_inserted_row);
+  g_test_add_func ("/engine-io/snapshot-observes-removed-row",
+      test_snapshot_observes_removed_row);
   g_test_add_func ("/engine-io/insert-null-self", test_insert_null_self);
   g_test_add_func ("/engine-io/insert-null-relation",
       test_insert_null_relation);
   g_test_add_func ("/engine-io/insert-null-row", test_insert_null_row);
   g_test_add_func ("/engine-io/insert-zero-ncols", test_insert_zero_ncols);
   g_test_add_func ("/engine-io/insert-after-close", test_insert_after_close);
+  g_test_add_func ("/engine-io/step-null-self", test_step_null_self);
+  g_test_add_func ("/engine-io/step-after-close", test_step_after_close);
+  g_test_add_func ("/engine-io/snapshot-null-self", test_snapshot_null_self);
+  g_test_add_func ("/engine-io/snapshot-null-relation",
+      test_snapshot_null_relation);
+  g_test_add_func ("/engine-io/snapshot-null-cb", test_snapshot_null_cb);
+  g_test_add_func ("/engine-io/snapshot-after-close",
+      test_snapshot_after_close);
   g_test_add_func ("/engine-io/remove-null-self", test_remove_null_self);
   g_test_add_func ("/engine-io/remove-null-relation",
       test_remove_null_relation);

--- a/wyrelog/engine.h
+++ b/wyrelog/engine.h
@@ -52,9 +52,11 @@ G_DECLARE_FINAL_TYPE (WylEngine, wyl_engine, WYL, ENGINE, GObject)
  *
  * Releases the engine and its underlying evaluator session. Equivalent to
  * g_clear_object when called on a g_autoptr-managed variable, but available
- * as an explicit close site for callers that do not use autoptr.  This call
- * releases and invalidates the handle; callers must not dereference @engine
- * after it returns.
+ * as an explicit close site for callers that do not use autoptr.  Drops one
+ * reference on @engine.  If this was the last reference, the underlying
+ * evaluator session is closed and @engine is finalized and must not be
+ * dereferenced.  If the caller holds additional references via g_object_ref(),
+ * @engine remains valid and those references must be released separately.
  */
      void wyl_engine_close (WylEngine *engine);
 
@@ -137,8 +139,11 @@ G_DECLARE_FINAL_TYPE (WylEngine, wyl_engine, WYL, ENGINE, GObject)
  * either, it must copy them.  @user_data is the same opaque pointer
  * passed to wyl_engine_snapshot() and is forwarded unchanged to each
  * callback invocation.  The callback is invoked synchronously while the
- * engine is mid-evaluation; the callback MUST NOT re-enter the same
- * `WylEngine` instance via any of its public functions.
+ * engine is mid-evaluation; the callback MUST NOT call wyl_engine_step(),
+ * wyl_engine_snapshot(), wyl_engine_insert(), or wyl_engine_remove() on @self
+ * while the callback is running; recursing into those evaluating or mutating
+ * operations on the same engine while it is mid-evaluation is undefined.
+ * wyl_engine_intern_symbol() is safe to call from inside the callback.
  */
      typedef void (*WylTupleCallback) (const gchar *relation,
     const gint64 *row, guint ncols, gpointer user_data);

--- a/wyrelog/engine.h
+++ b/wyrelog/engine.h
@@ -52,7 +52,9 @@ G_DECLARE_FINAL_TYPE (WylEngine, wyl_engine, WYL, ENGINE, GObject)
  *
  * Releases the engine and its underlying evaluator session. Equivalent to
  * g_clear_object when called on a g_autoptr-managed variable, but available
- * as an explicit close site for callers that do not use autoptr.
+ * as an explicit close site for callers that do not use autoptr.  This call
+ * releases and invalidates the handle; callers must not dereference @engine
+ * after it returns.
  */
      void wyl_engine_close (WylEngine *engine);
 
@@ -71,8 +73,9 @@ G_DECLARE_FINAL_TYPE (WylEngine, wyl_engine, WYL, ENGINE, GObject)
  * engine instances are not interchangeable.
  *
  * Returns: %WYRELOG_E_OK on success; %WYRELOG_E_INVALID if any
- *   argument is NULL or @self has been closed; %WYRELOG_E_INTERNAL
- *   if the engine cannot register the symbol.
+ *   argument is NULL or @self is in an uninitialized or partially-finalized
+ *   state; %WYRELOG_E_INTERNAL if the underlying wirelog engine fails to
+ *   intern the symbol.
  */
      wyrelog_error_t wyl_engine_intern_symbol (WylEngine *self,
     const gchar *symbol, gint64 *out_id);
@@ -88,12 +91,13 @@ G_DECLARE_FINAL_TYPE (WylEngine, wyl_engine, WYL, ENGINE, GObject)
  *
  * Inserts a single row into the named relation. The evaluator accepts
  * the row as fact data; if the loaded program declares the relation
- * with a different arity, the insert fails with %WYRELOG_E_EXEC.
+ * with a different arity, or the underlying engine rejects the row for
+ * any other evaluator-side reason, the call fails with %WYRELOG_E_EXEC.
  *
  * Returns: %WYRELOG_E_OK on success; %WYRELOG_E_INVALID if any
  *   argument fails its precondition or @self has no live session;
  *   %WYRELOG_E_EXEC if the underlying engine rejects the row;
- *   other %WYRELOG_E_* codes on internal failure.
+ *   %WYRELOG_E_INTERNAL on a wyrelog-side invariant violation.
  */
      wyrelog_error_t wyl_engine_insert (WylEngine *self,
     const gchar *relation, const gint64 *row, gsize ncols);
@@ -113,7 +117,7 @@ G_DECLARE_FINAL_TYPE (WylEngine, wyl_engine, WYL, ENGINE, GObject)
  * Returns: %WYRELOG_E_OK on success; %WYRELOG_E_INVALID if any
  *   argument fails its precondition or @self has no live session;
  *   %WYRELOG_E_EXEC if the underlying engine rejects the row;
- *   other %WYRELOG_E_* codes on internal failure.
+ *   %WYRELOG_E_INTERNAL on a wyrelog-side invariant violation.
  */
      wyrelog_error_t wyl_engine_remove (WylEngine *self,
     const gchar *relation, const gint64 *row, gsize ncols);
@@ -130,7 +134,11 @@ G_DECLARE_FINAL_TYPE (WylEngine, wyl_engine, WYL, ENGINE, GObject)
  * Invoked once per tuple during a snapshot.  The relation name
  * and row pointer are owned by the engine and are only valid for
  * the duration of the callback; if the caller wishes to retain
- * either, it must copy them.
+ * either, it must copy them.  @user_data is the same opaque pointer
+ * passed to wyl_engine_snapshot() and is forwarded unchanged to each
+ * callback invocation.  The callback is invoked synchronously while the
+ * engine is mid-evaluation; the callback MUST NOT re-enter the same
+ * `WylEngine` instance via any of its public functions.
  */
      typedef void (*WylTupleCallback) (const gchar *relation,
     const gint64 *row, guint ncols, gpointer user_data);
@@ -149,8 +157,14 @@ G_DECLARE_FINAL_TYPE (WylEngine, wyl_engine, WYL, ENGINE, GObject)
  * not allow mixing step advancement and snapshot probing on the same batch.
  *
  * Returns: %WYRELOG_E_OK on success; %WYRELOG_E_INVALID if @self is NULL,
- *   has no live session, or has already been used in snapshot mode; other
- *   %WYRELOG_E_* codes on internal failure.
+ *   has no live session, or has already been used in snapshot mode;
+ *   %WYRELOG_E_EXEC on a wirelog evaluator failure; %WYRELOG_E_INTERNAL on
+ *   a wyrelog-side invariant violation.  On %WYRELOG_E_EXEC, the engine is
+ *   not latched into incremental mode by this wrapper; callers should not
+ *   assume the underlying session state was rolled back unless the underlying
+ *   engine documents that guarantee.  Treat a step failure as terminal for
+ *   this engine instance unless the underlying engine explicitly supports
+ *   retry.
  */
      wyrelog_error_t wyl_engine_step (WylEngine *self);
 
@@ -174,7 +188,8 @@ G_DECLARE_FINAL_TYPE (WylEngine, wyl_engine, WYL, ENGINE, GObject)
  *
  * Returns: %WYRELOG_E_OK on success; %WYRELOG_E_INVALID if any argument is
  *   NULL, @self has no live session, or the engine has already been used in
- *   step mode; other %WYRELOG_E_* codes on internal failure.
+ *   step mode; %WYRELOG_E_EXEC on a wirelog evaluator failure;
+ *   %WYRELOG_E_INTERNAL on a wyrelog-side invariant violation.
  */
      wyrelog_error_t wyl_engine_snapshot (WylEngine *self,
     const gchar *relation, WylTupleCallback cb, gpointer user_data);

--- a/wyrelog/engine.h
+++ b/wyrelog/engine.h
@@ -56,4 +56,25 @@ G_DECLARE_FINAL_TYPE (WylEngine, wyl_engine, WYL, ENGINE, GObject)
  */
      void wyl_engine_close (WylEngine *engine);
 
+/*
+ * wyl_engine_intern_symbol:
+ * @self: A `WylEngine` instance.
+ * @symbol: A symbolic string to be assigned a stable identifier.
+ *   Must not be NULL.
+ * @out_id: (out) On success, receives the integer identifier
+ *   that the engine has registered for @symbol. Must not be NULL.
+ *
+ * Registers @symbol with the engine and returns its stable
+ * integer identifier. Subsequent calls on the same engine with
+ * the same @symbol return the same identifier. Identifiers are
+ * stable for the lifetime of @self; identifiers from different
+ * engine instances are not interchangeable.
+ *
+ * Returns: %WYRELOG_E_OK on success; %WYRELOG_E_INVALID if any
+ *   argument is NULL or @self has been closed; %WYRELOG_E_INTERNAL
+ *   if the engine cannot register the symbol.
+ */
+     wyrelog_error_t wyl_engine_intern_symbol (WylEngine *self,
+    const gchar *symbol, gint64 *out_id);
+
 G_END_DECLS;

--- a/wyrelog/engine.h
+++ b/wyrelog/engine.h
@@ -54,9 +54,10 @@ G_DECLARE_FINAL_TYPE (WylEngine, wyl_engine, WYL, ENGINE, GObject)
  * g_clear_object when called on a g_autoptr-managed variable, but available
  * as an explicit close site for callers that do not use autoptr.  Drops one
  * reference on @engine.  If this was the last reference, the underlying
- * evaluator session is closed and @engine is finalized and must not be
- * dereferenced.  If the caller holds additional references via g_object_ref(),
- * @engine remains valid and those references must be released separately.
+ * evaluator session is closed and @engine is finalized; @engine must not be
+ * dereferenced after this call returns.  If the caller holds additional
+ * references via g_object_ref(), @engine remains valid and those references
+ * must be released separately.
  */
      void wyl_engine_close (WylEngine *engine);
 
@@ -139,12 +140,12 @@ G_DECLARE_FINAL_TYPE (WylEngine, wyl_engine, WYL, ENGINE, GObject)
  * either, it must copy them.  @user_data is the same opaque pointer
  * passed to wyl_engine_snapshot() and is forwarded unchanged to each
  * callback invocation.  The callback is invoked synchronously while the
- * engine is mid-evaluation; the callback MUST NOT call wyl_engine_step(),
- * wyl_engine_snapshot(), wyl_engine_insert(), or wyl_engine_remove() on @self
- * while the callback is running; recursing into those evaluating or mutating
- * operations on the same engine while it is mid-evaluation is undefined.
- * wyl_engine_intern_symbol() is safe to call from inside the callback.
- */
+ * engine is mid-evaluation.  Only wyl_engine_intern_symbol() may be called on
+ * the same engine instance that was passed to wyl_engine_snapshot() from
+ * inside the callback; all other public operations on that engine, including
+ * releasing the last reference (e.g. wyl_engine_close, g_object_unref), are
+ * undefined while the callback is running.
+*/
      typedef void (*WylTupleCallback) (const gchar *relation,
     const gint64 *row, guint ncols, gpointer user_data);
 

--- a/wyrelog/engine.h
+++ b/wyrelog/engine.h
@@ -118,4 +118,65 @@ G_DECLARE_FINAL_TYPE (WylEngine, wyl_engine, WYL, ENGINE, GObject)
      wyrelog_error_t wyl_engine_remove (WylEngine *self,
     const gchar *relation, const gint64 *row, gsize ncols);
 
+/*
+ * WylTupleCallback:
+ * @relation: The relation name for the delivered tuple.  Borrowed
+ *   from the engine; valid only for the duration of this callback.
+ * @row: (array length=ncols): The integer row values.  Borrowed;
+ *   the array must not be retained beyond the callback's return.
+ * @ncols: The number of columns in @row.
+ * @user_data: The user-data pointer passed to wyl_engine_snapshot().
+ *
+ * Invoked once per tuple during a snapshot.  The relation name
+ * and row pointer are owned by the engine and are only valid for
+ * the duration of the callback; if the caller wishes to retain
+ * either, it must copy them.
+ */
+     typedef void (*WylTupleCallback) (const gchar *relation,
+    const gint64 *row, guint ncols, gpointer user_data);
+
+/*
+ * wyl_engine_step:
+ * @self: A `WylEngine` instance.  Must not be NULL.
+ *
+ * Advances the engine's queued evaluation work by one logical step,
+ * processing any pending fact changes accumulated via wyl_engine_insert() /
+ * wyl_engine_remove() since the last step.
+ *
+ * Calling wyl_engine_step() commits this engine to step mode for the rest of
+ * its lifetime.  After a successful step call, wyl_engine_snapshot() returns
+ * %WYRELOG_E_INVALID.  This is intentional: the underlying evaluator does
+ * not allow mixing step advancement and snapshot probing on the same batch.
+ *
+ * Returns: %WYRELOG_E_OK on success; %WYRELOG_E_INVALID if @self is NULL,
+ *   has no live session, or has already been used in snapshot mode; other
+ *   %WYRELOG_E_* codes on internal failure.
+ */
+     wyrelog_error_t wyl_engine_step (WylEngine *self);
+
+/*
+ * wyl_engine_snapshot:
+ * @self: A `WylEngine` instance.  Must not be NULL.
+ * @relation: The relation name to probe.  Must not be NULL.
+ * @cb: A callback invoked once per tuple of the relation.  Must
+ *   not be NULL.
+ * @user_data: Opaque pointer passed through to @cb.
+ *
+ * Probes the named relation and invokes @cb once per tuple in the relation's
+ * current state.  Tuples are delivered in an unspecified order; do not rely
+ * on a particular ordering.
+ *
+ * Calling wyl_engine_snapshot() commits this engine to snapshot mode for the
+ * rest of its lifetime.  After a successful snapshot call, wyl_engine_step()
+ * returns %WYRELOG_E_INVALID.  This is intentional: the underlying evaluator
+ * does not allow mixing snapshot probing and step advancement on the same
+ * batch.
+ *
+ * Returns: %WYRELOG_E_OK on success; %WYRELOG_E_INVALID if any argument is
+ *   NULL, @self has no live session, or the engine has already been used in
+ *   step mode; other %WYRELOG_E_* codes on internal failure.
+ */
+     wyrelog_error_t wyl_engine_snapshot (WylEngine *self,
+    const gchar *relation, WylTupleCallback cb, gpointer user_data);
+
 G_END_DECLS;

--- a/wyrelog/engine.h
+++ b/wyrelog/engine.h
@@ -77,4 +77,45 @@ G_DECLARE_FINAL_TYPE (WylEngine, wyl_engine, WYL, ENGINE, GObject)
      wyrelog_error_t wyl_engine_intern_symbol (WylEngine *self,
     const gchar *symbol, gint64 *out_id);
 
+/*
+ * wyl_engine_insert:
+ * @self: A `WylEngine` instance. Must not be NULL.
+ * @relation: The relation name to insert into. Must not be NULL.
+ * @row: (array length=ncols): The integer row values. Must not be
+ *   NULL when @ncols > 0. Each value is either a raw integer or
+ *   the stable identifier returned by wyl_engine_intern_symbol().
+ * @ncols: The number of columns in @row. Must be > 0.
+ *
+ * Inserts a single row into the named relation. The evaluator accepts
+ * the row as fact data; if the loaded program declares the relation
+ * with a different arity, the insert fails with %WYRELOG_E_EXEC.
+ *
+ * Returns: %WYRELOG_E_OK on success; %WYRELOG_E_INVALID if any
+ *   argument fails its precondition or @self has no live session;
+ *   %WYRELOG_E_EXEC if the underlying engine rejects the row;
+ *   other %WYRELOG_E_* codes on internal failure.
+ */
+     wyrelog_error_t wyl_engine_insert (WylEngine *self,
+    const gchar *relation, const gint64 *row, gsize ncols);
+
+/*
+ * wyl_engine_remove:
+ * @self: A `WylEngine` instance. Must not be NULL.
+ * @relation: The relation name to retract from. Must not be NULL.
+ * @row: (array length=ncols): The integer row values to retract.
+ *   Must not be NULL when @ncols > 0.
+ * @ncols: The number of columns in @row. Must be > 0.
+ *
+ * Retracts a single previously-inserted row from the named relation.
+ * Removing a row that was never inserted is not an error; the engine
+ * treats it as a no-op.
+ *
+ * Returns: %WYRELOG_E_OK on success; %WYRELOG_E_INVALID if any
+ *   argument fails its precondition or @self has no live session;
+ *   %WYRELOG_E_EXEC if the underlying engine rejects the row;
+ *   other %WYRELOG_E_* codes on internal failure.
+ */
+     wyrelog_error_t wyl_engine_remove (WylEngine *self,
+    const gchar *relation, const gint64 *row, gsize ncols);
+
 G_END_DECLS;

--- a/wyrelog/wyl-engine-private.h
+++ b/wyrelog/wyl-engine-private.h
@@ -14,12 +14,20 @@ G_BEGIN_DECLS;
 /* Number of policy template files loaded at open time. */
 #define WYL_ENGINE_TEMPLATE_COUNT 5
 
+typedef enum
+{
+  WYL_ENGINE_MODE_NONE = 0,
+  WYL_ENGINE_MODE_STEP,
+  WYL_ENGINE_MODE_SNAPSHOT,
+} wyl_engine_mode_t;
+
 struct _WylEngine
 {
   GObject parent_instance;
   wl_easy_session_t *session;
   /* Logical path strings for diagnostic logging only; freed in finalize. */
   gchar *dl_src_logical_paths[WYL_ENGINE_TEMPLATE_COUNT];
+  wyl_engine_mode_t mode;       /* Latched at first step or snapshot. */
 };
 
 /*

--- a/wyrelog/wyl-engine.c
+++ b/wyrelog/wyl-engine.c
@@ -214,3 +214,55 @@ wyl_engine_intern_symbol (WylEngine *self, const gchar *symbol, gint64 *out_id)
   *out_id = id;
   return WYRELOG_E_OK;
 }
+
+wyrelog_error_t
+wyl_engine_insert (WylEngine *self, const gchar *relation, const gint64 *row,
+    gsize ncols)
+{
+  if (self == NULL || !WYL_IS_ENGINE (self))
+    return WYRELOG_E_INVALID;
+  if (relation == NULL || ncols == 0 || ncols > G_MAXUINT32)
+    return WYRELOG_E_INVALID;
+  if (row == NULL)
+    return WYRELOG_E_INVALID;
+  if (self->session == NULL)
+    return WYRELOG_E_INVALID;
+
+  wirelog_error_t wl_rc =
+      wl_easy_insert (self->session, relation, (const int64_t *) row,
+      (uint32_t) ncols);
+  wyrelog_error_t rc = wyl_engine_map_wirelog_error (wl_rc);
+  if (rc != WYRELOG_E_OK) {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_POLICY,
+        "engine: insert failed for relation '%s' with %" G_GSIZE_FORMAT
+        " columns", relation, ncols);
+  }
+
+  return rc;
+}
+
+wyrelog_error_t
+wyl_engine_remove (WylEngine *self, const gchar *relation, const gint64 *row,
+    gsize ncols)
+{
+  if (self == NULL || !WYL_IS_ENGINE (self))
+    return WYRELOG_E_INVALID;
+  if (relation == NULL || ncols == 0 || ncols > G_MAXUINT32)
+    return WYRELOG_E_INVALID;
+  if (row == NULL)
+    return WYRELOG_E_INVALID;
+  if (self->session == NULL)
+    return WYRELOG_E_INVALID;
+
+  wirelog_error_t wl_rc =
+      wl_easy_remove (self->session, relation, (const int64_t *) row,
+      (uint32_t) ncols);
+  wyrelog_error_t rc = wyl_engine_map_wirelog_error (wl_rc);
+  if (rc != WYRELOG_E_OK) {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_POLICY,
+        "engine: remove failed for relation '%s' with %" G_GSIZE_FORMAT
+        " columns", relation, ncols);
+  }
+
+  return rc;
+}

--- a/wyrelog/wyl-engine.c
+++ b/wyrelog/wyl-engine.c
@@ -192,3 +192,25 @@ wyl_engine_close (WylEngine *engine)
     return;
   g_object_unref (engine);
 }
+
+wyrelog_error_t
+wyl_engine_intern_symbol (WylEngine *self, const gchar *symbol, gint64 *out_id)
+{
+  if (self == NULL || !WYL_IS_ENGINE (self))
+    return WYRELOG_E_INVALID;
+  if (symbol == NULL || out_id == NULL)
+    return WYRELOG_E_INVALID;
+  if (self->session == NULL)
+    return WYRELOG_E_INVALID;
+
+  int64_t id = wl_easy_intern (self->session, symbol);
+  if (id < 0) {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_POLICY,
+        "engine: symbol interning failed for symbol of length %zu",
+        strlen (symbol));
+    return WYRELOG_E_INTERNAL;
+  }
+
+  *out_id = id;
+  return WYRELOG_E_OK;
+}

--- a/wyrelog/wyl-engine.c
+++ b/wyrelog/wyl-engine.c
@@ -5,6 +5,8 @@
 #include "wyl-engine-private.h"
 #include "wyl-common-private.h"
 
+G_STATIC_ASSERT (sizeof (gint64) == sizeof (int64_t));
+
 /*
  * Fixed dependency order for policy template files.
  *
@@ -20,6 +22,21 @@ static const char *const TEMPLATE_FILES[] = {
 };
 
 G_STATIC_ASSERT (G_N_ELEMENTS (TEMPLATE_FILES) == WYL_ENGINE_TEMPLATE_COUNT);
+
+typedef struct
+{
+  WylTupleCallback cb;
+  gpointer user_data;
+} wyl_engine_tuple_cookie_t;
+
+static void
+wyl_engine_tuple_trampoline (const char *relation, const int64_t *row,
+    uint32_t ncols, void *user)
+{
+  const wyl_engine_tuple_cookie_t *cookie = user;
+
+  cookie->cb (relation, (const gint64 *) row, (guint) ncols, cookie->user_data);
+}
 
 /* --- GObject boilerplate ------------------------------------------- */
 
@@ -50,6 +67,7 @@ static void
 wyl_engine_init (WylEngine *self)
 {
   self->session = NULL;
+  self->mode = WYL_ENGINE_MODE_NONE;
   for (gsize i = 0; i < WYL_ENGINE_TEMPLATE_COUNT; i++)
     self->dl_src_logical_paths[i] = NULL;
 }
@@ -176,6 +194,8 @@ wyl_engine_open (const gchar *template_dir, guint32 num_workers,
 
   WylEngine *engine = g_object_new (WYL_TYPE_ENGINE, NULL);
   engine->session = session;
+  /* Keep the initial mode explicit instead of relying on zero-fill. */
+  engine->mode = WYL_ENGINE_MODE_NONE;
 
   /* Store logical paths for diagnostic logging. */
   for (gsize i = 0; i < WYL_ENGINE_TEMPLATE_COUNT; i++)
@@ -236,6 +256,57 @@ wyl_engine_insert (WylEngine *self, const gchar *relation, const gint64 *row,
     WYL_LOG_ERROR (WYL_LOG_SECTION_POLICY,
         "engine: insert failed for relation '%s' with %" G_GSIZE_FORMAT
         " columns", relation, ncols);
+  }
+
+  return rc;
+}
+
+wyrelog_error_t
+wyl_engine_step (WylEngine *self)
+{
+  if (self == NULL || !WYL_IS_ENGINE (self))
+    return WYRELOG_E_INVALID;
+  if (self->session == NULL)
+    return WYRELOG_E_INVALID;
+  if (self->mode == WYL_ENGINE_MODE_SNAPSHOT)
+    return WYRELOG_E_INVALID;
+
+  wirelog_error_t wl_rc = wl_easy_step (self->session);
+  wyrelog_error_t rc = wyl_engine_map_wirelog_error (wl_rc);
+  if (rc == WYRELOG_E_OK) {
+    self->mode = WYL_ENGINE_MODE_STEP;
+  } else {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_POLICY,
+        "engine: step failed (rc=%d)", (int) rc);
+  }
+
+  return rc;
+}
+
+wyrelog_error_t
+wyl_engine_snapshot (WylEngine *self, const gchar *relation,
+    WylTupleCallback cb, gpointer user_data)
+{
+  if (self == NULL || !WYL_IS_ENGINE (self))
+    return WYRELOG_E_INVALID;
+  if (relation == NULL || cb == NULL)
+    return WYRELOG_E_INVALID;
+  if (self->session == NULL)
+    return WYRELOG_E_INVALID;
+  if (self->mode == WYL_ENGINE_MODE_STEP)
+    return WYRELOG_E_INVALID;
+
+  wyl_engine_tuple_cookie_t cookie = { cb, user_data };
+  wirelog_error_t wl_rc =
+      wl_easy_snapshot (self->session, relation, wyl_engine_tuple_trampoline,
+      &cookie);
+  wyrelog_error_t rc = wyl_engine_map_wirelog_error (wl_rc);
+  if (rc == WYRELOG_E_OK) {
+    self->mode = WYL_ENGINE_MODE_SNAPSHOT;
+  } else {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_POLICY,
+        "engine: snapshot failed for relation '%s' (rc=%d)", relation,
+        (int) rc);
   }
 
   return rc;


### PR DESCRIPTION
## Summary

Adds the wyrelog policy I/O wrapper on top of the previously-merged
`WylEngine` lifecycle. The wrapper exposes symbolic identifier
encoding, row-shape fact insertion and retraction, and the two
mutually-exclusive evaluation modes (incremental advance vs.
relation snapshot) of the underlying timely-differential engine.

## Commits

- `9b50dbb` engine: add symbol intern entrypoint
- `58c5360` engine: add row insert and remove on relation
- `26516a4` engine: add step and snapshot with mode latch
- `438e357` engine: tighten policy I/O public-API documentation
- `9b82018` engine: narrow close and callback reentrancy contracts
- `6c0bedb` engine: refine close lifetime and callback whitelist wording

## Details

- **Symbol interning.** `wyl_engine_intern_symbol` registers a
  symbolic string with the engine and returns a stable integer
  identifier. Identifiers stay valid for the lifetime of the
  engine; cross-engine usage is undefined. The error log records
  only the symbol length, never the value, since interned symbols
  may carry operator-supplied PII.
- **Row-shape insert/remove.** `wyl_engine_insert` and
  `wyl_engine_remove` accept `(relation, row, ncols)` arrays of
  `gint64`. Rows can carry raw integers or interned identifiers.
  The array form was chosen over a varargs convenience layer to
  avoid the `int`-promoted-to-`int64_t` undefined-behavior
  footgun when callers pass literal values through `va_arg`.
- **Step / snapshot with mode latch.** `wyl_engine_step` advances
  incremental evaluation; `wyl_engine_snapshot` probes a named
  relation. The two are mutually exclusive over an engine's
  lifetime: a successful first call latches the engine into that
  mode, and the opposite call subsequently returns
  `WYRELOG_E_INVALID`. The latch turns a documented
  evaluator-side hazard (mixing the two on one insert batch
  produces duplicate tuples) into a deterministic refusal at
  the wyrelog seam.
- **Callback contract.** `WylTupleCallback` is invoked
  synchronously while the engine is mid-evaluation; only
  `wyl_engine_intern_symbol` may be called on the same engine
  from inside the callback. Releasing the last reference from
  inside the callback is undefined.
- **Reference-count semantics.** `wyl_engine_close` documents
  drop-one-reference behavior and the temporal contract on
  dereference after the call returns.
- A `G_STATIC_ASSERT(sizeof(gint64) == sizeof(int64_t))` pins
  the pointer-cast assumption at the wirelog seam.

## Test plan

- [x] `meson compile -C builddir` clean
- [x] `meson test -C builddir` 37/37 OK (24 subtests in `engine-io`)
- [x] `./tools/gst-indent` idempotent on touched sources
- [x] `tools/check-public-headers-no-novelty-tokens.sh` green
- [x] `tools/check-private-headers-not-installed.sh` green