### PR TITLE
engine: add delta callback for incremental fact updates

### DIFF
--- a/tests/test-engine-io.c
+++ b/tests/test-engine-io.c
@@ -19,6 +19,18 @@ typedef struct
   guint seen;
 } SnapshotExpect;
 
+typedef struct
+{
+  const gchar *expected_relation;
+  const gint64 (*expected_rows)[3];
+  guint expected_row_count;
+  WylDeltaKind expected_kind;
+  guint invoked;
+  guint matching;
+  gchar *last_relation;
+  WylDeltaKind last_kind;
+} DeltaExpect;
+
 static WylEngine *
 open_engine_from_real_templates (void)
 {
@@ -96,6 +108,59 @@ build_snapshot_rows (WylEngine *engine, gint64 member_row[3],
 }
 
 static void
+build_delta_rows (WylEngine *engine, gint64 member_row[3],
+    gint64 expected_member_rows[1][3])
+{
+  gint64 user_id = -1;
+  gint64 role_id = -1;
+  gint64 scope_id = -1;
+  wyrelog_error_t rc;
+
+  rc = wyl_engine_intern_symbol (engine, "alice", &user_id);
+  g_assert_cmpint (rc, ==, WYRELOG_E_OK);
+  g_assert_cmpint (user_id, >=, 0);
+
+  rc = wyl_engine_intern_symbol (engine, "wr.viewer", &role_id);
+  g_assert_cmpint (rc, ==, WYRELOG_E_OK);
+  g_assert_cmpint (role_id, >=, 0);
+
+  rc = wyl_engine_intern_symbol (engine, "scope1", &scope_id);
+  g_assert_cmpint (rc, ==, WYRELOG_E_OK);
+  g_assert_cmpint (scope_id, >=, 0);
+
+  member_row[0] = user_id;
+  member_row[1] = role_id;
+  member_row[2] = scope_id;
+
+  expected_member_rows[0][0] = user_id;
+  expected_member_rows[0][1] = role_id;
+  expected_member_rows[0][2] = scope_id;
+}
+
+static gboolean
+delta_row_matches (const DeltaExpect *expect, const gint64 *row, guint ncols)
+{
+  if (ncols != 3)
+    return FALSE;
+
+  for (guint i = 0; i < expect->expected_row_count; i++) {
+    gboolean matches = TRUE;
+
+    for (guint j = 0; j < ncols; j++) {
+      if (row[j] != expect->expected_rows[i][j]) {
+        matches = FALSE;
+        break;
+      }
+    }
+
+    if (matches)
+      return TRUE;
+  }
+
+  return FALSE;
+}
+
+static void
 snapshot_expect_cb (const gchar *relation, const gint64 *row, guint ncols,
     gpointer user_data)
 {
@@ -120,6 +185,32 @@ snapshot_count_cb (const gchar *relation, const gint64 *row, guint ncols,
   (void) ncols;
 
   (*seen)++;
+}
+
+static void
+delta_expect_cb (const gchar *relation, const gint64 *row, guint ncols,
+    WylDeltaKind kind, gpointer user_data)
+{
+  DeltaExpect *expect = user_data;
+
+  expect->invoked++;
+  g_clear_pointer (&expect->last_relation, g_free);
+  expect->last_relation = g_strdup (relation);
+  expect->last_kind = kind;
+
+  if (g_strcmp0 (relation, expect->expected_relation) == 0
+      && kind == expect->expected_kind && delta_row_matches (expect, row,
+          ncols)) {
+    expect->matching++;
+  }
+}
+
+static void
+delta_expect_reset (DeltaExpect *expect)
+{
+  expect->invoked = 0;
+  expect->matching = 0;
+  g_clear_pointer (&expect->last_relation, g_free);
 }
 
 static void
@@ -250,6 +341,187 @@ test_snapshot_observes_removed_row (void)
   g_assert_cmpint (wyl_engine_snapshot (engine, "has_permission",
           snapshot_count_cb, &seen), ==, WYRELOG_E_OK);
   g_assert_cmpuint (seen, ==, 0);
+}
+
+static void
+test_delta_nominal (void)
+{
+  g_autoptr (WylEngine) engine = open_engine_from_real_templates ();
+  gint64 member_row[3];
+  gint64 expected_member_rows[1][3];
+  DeltaExpect expect = {
+    "effective_member",
+    expected_member_rows,
+    1,
+    WYL_DELTA_INSERT,
+    0,
+    0,
+    NULL,
+    0,
+  };
+
+  build_delta_rows (engine, member_row, expected_member_rows);
+
+  g_assert_cmpint (wyl_engine_set_delta_callback (engine, delta_expect_cb,
+          &expect), ==, WYRELOG_E_OK);
+  g_assert_cmpint (wyl_engine_insert (engine, "member_of", member_row, 3),
+      ==, WYRELOG_E_OK);
+  g_assert_cmpint (wyl_engine_step (engine), ==, WYRELOG_E_OK);
+
+  g_assert_cmpuint (expect.matching, >=, 1);
+  g_assert_cmpstr (expect.last_relation, !=, NULL);
+
+  g_clear_pointer (&expect.last_relation, g_free);
+}
+
+static void
+test_delta_remove (void)
+{
+  g_autoptr (WylEngine) engine = open_engine_from_real_templates ();
+  gint64 member_row[3];
+  gint64 expected_member_rows[1][3];
+  DeltaExpect expect = {
+    "effective_member",
+    expected_member_rows,
+    1,
+    WYL_DELTA_INSERT,
+    0,
+    0,
+    NULL,
+    0,
+  };
+
+  build_delta_rows (engine, member_row, expected_member_rows);
+
+  g_assert_cmpint (wyl_engine_set_delta_callback (engine, delta_expect_cb,
+          &expect), ==, WYRELOG_E_OK);
+  g_assert_cmpint (wyl_engine_insert (engine, "member_of", member_row, 3),
+      ==, WYRELOG_E_OK);
+  g_assert_cmpint (wyl_engine_step (engine), ==, WYRELOG_E_OK);
+  g_assert_cmpuint (expect.matching, >=, 1);
+
+  delta_expect_reset (&expect);
+  expect.expected_kind = WYL_DELTA_REMOVE;
+
+  g_assert_cmpint (wyl_engine_remove (engine, "member_of", member_row, 3),
+      ==, WYRELOG_E_OK);
+  g_assert_cmpint (wyl_engine_step (engine), ==, WYRELOG_E_OK);
+
+  g_assert_cmpuint (expect.matching, >=, 1);
+  g_assert_cmpstr (expect.last_relation, !=, NULL);
+
+  g_clear_pointer (&expect.last_relation, g_free);
+}
+
+static void
+test_delta_clear (void)
+{
+  g_autoptr (WylEngine) engine = open_engine_from_real_templates ();
+  gint64 member_row[3];
+  gint64 expected_member_rows[1][3];
+  DeltaExpect expect = {
+    "effective_member",
+    expected_member_rows,
+    1,
+    WYL_DELTA_INSERT,
+    0,
+    0,
+    NULL,
+    0,
+  };
+
+  build_delta_rows (engine, member_row, expected_member_rows);
+
+  g_assert_cmpint (wyl_engine_set_delta_callback (engine, delta_expect_cb,
+          &expect), ==, WYRELOG_E_OK);
+  g_assert_cmpint (wyl_engine_set_delta_callback (engine, NULL, NULL),
+      ==, WYRELOG_E_OK);
+  g_assert_cmpint (wyl_engine_insert (engine, "member_of", member_row, 3),
+      ==, WYRELOG_E_OK);
+  g_assert_cmpint (wyl_engine_step (engine), ==, WYRELOG_E_OK);
+
+  g_assert_cmpuint (expect.invoked, ==, 0);
+}
+
+static void
+test_delta_replace (void)
+{
+  g_autoptr (WylEngine) engine = open_engine_from_real_templates ();
+  gint64 member_row[3];
+  gint64 expected_member_rows[1][3];
+  DeltaExpect expect_a = {
+    "effective_member",
+    expected_member_rows,
+    1,
+    WYL_DELTA_INSERT,
+    0,
+    0,
+    NULL,
+    0,
+  };
+  DeltaExpect expect_b = {
+    "effective_member",
+    expected_member_rows,
+    1,
+    WYL_DELTA_INSERT,
+    0,
+    0,
+    NULL,
+    0,
+  };
+
+  build_delta_rows (engine, member_row, expected_member_rows);
+
+  g_assert_cmpint (wyl_engine_set_delta_callback (engine, delta_expect_cb,
+          &expect_a), ==, WYRELOG_E_OK);
+  g_assert_cmpint (wyl_engine_set_delta_callback (engine, delta_expect_cb,
+          &expect_b), ==, WYRELOG_E_OK);
+  g_assert_cmpint (wyl_engine_insert (engine, "member_of", member_row, 3),
+      ==, WYRELOG_E_OK);
+  g_assert_cmpint (wyl_engine_step (engine), ==, WYRELOG_E_OK);
+
+  g_assert_cmpuint (expect_a.invoked, ==, 0);
+  g_assert_cmpuint (expect_b.matching, >=, 1);
+
+  g_clear_pointer (&expect_a.last_relation, g_free);
+  g_clear_pointer (&expect_b.last_relation, g_free);
+}
+
+static void
+test_delta_after_snapshot_rejected (void)
+{
+  g_autoptr (WylEngine) engine = open_engine_from_real_templates ();
+  guint seen = 0;
+
+  g_assert_cmpint (wyl_engine_snapshot (engine, "member_of",
+          snapshot_count_cb, &seen), ==, WYRELOG_E_OK);
+  g_assert_cmpint (wyl_engine_set_delta_callback (engine, delta_expect_cb,
+          NULL), ==, WYRELOG_E_INVALID);
+}
+
+static void
+test_delta_null_self (void)
+{
+  g_assert_cmpint (wyl_engine_set_delta_callback (NULL, delta_expect_cb, NULL),
+      ==, WYRELOG_E_INVALID);
+}
+
+static void
+test_delta_after_close (void)
+{
+  WylEngine *engine = open_engine_from_real_templates ();
+
+  wl_easy_close (engine->session);
+  engine->session = NULL;
+
+  g_assert_cmpint (wyl_engine_set_delta_callback (engine, delta_expect_cb,
+          NULL), ==, WYRELOG_E_INVALID);
+
+  /* g_autoptr is intentionally not used: the test mutates engine->session via
+   * the private header, and that reach-in is incompatible with autoptr's
+   * blanket cleanup discipline.  On assertion failure the engine leaks until
+   * process exit, which is acceptable for a test-side fixture. */
+  g_object_unref (engine);
 }
 
 static void
@@ -455,6 +727,14 @@ main (int argc, char **argv)
       test_snapshot_observes_inserted_row);
   g_test_add_func ("/engine-io/snapshot-observes-removed-row",
       test_snapshot_observes_removed_row);
+  g_test_add_func ("/engine-io/delta-nominal", test_delta_nominal);
+  g_test_add_func ("/engine-io/delta-remove", test_delta_remove);
+  g_test_add_func ("/engine-io/delta-clear", test_delta_clear);
+  g_test_add_func ("/engine-io/delta-replace", test_delta_replace);
+  g_test_add_func ("/engine-io/delta-after-snapshot-rejected",
+      test_delta_after_snapshot_rejected);
+  g_test_add_func ("/engine-io/delta-null-self", test_delta_null_self);
+  g_test_add_func ("/engine-io/delta-after-close", test_delta_after_close);
   g_test_add_func ("/engine-io/insert-null-self", test_insert_null_self);
   g_test_add_func ("/engine-io/insert-null-relation",
       test_insert_null_relation);

--- a/wyrelog/engine.h
+++ b/wyrelog/engine.h
@@ -200,4 +200,64 @@ G_DECLARE_FINAL_TYPE (WylEngine, wyl_engine, WYL, ENGINE, GObject)
      wyrelog_error_t wyl_engine_snapshot (WylEngine *self,
     const gchar *relation, WylTupleCallback cb, gpointer user_data);
 
+/*
+ * WylDeltaKind:
+ * @WYL_DELTA_REMOVE: A tuple was removed.
+ * @WYL_DELTA_INSERT: A tuple was inserted.
+ *
+ * Typed tuple-change kind passed to WylDeltaCallback.
+ */
+     typedef enum
+     {
+       WYL_DELTA_REMOVE = -1,
+       WYL_DELTA_INSERT = 1,
+     } WylDeltaKind;
+
+/*
+ * WylDeltaCallback:
+ * @relation: The relation name for the delivered tuple change.  Borrowed
+ *   from the engine; valid only for the duration of this callback.
+ * @row: (array length=ncols): The integer row values.  Borrowed;
+ *   the array must not be retained beyond the callback's return.
+ * @ncols: The number of columns in @row.
+ * @kind: Whether the tuple was inserted or removed.
+ * @user_data: The user-data pointer passed to
+ *   wyl_engine_set_delta_callback().
+ *
+ * Invoked synchronously during wyl_engine_step() for tuple changes emitted
+ * by the engine.  The relation name and row pointer are owned by the engine
+ * and are only valid for the duration of the callback; copy them if they
+ * must be retained.  @user_data is forwarded unchanged.  The caller is
+ * responsible for the lifetime of @user_data: it must outlive the engine, or
+ * the callback must be cleared with wyl_engine_set_delta_callback(NULL)
+ * before @user_data is freed.
+ *
+ * Only wyl_engine_intern_symbol() may be called on the same engine instance
+ * from inside the callback.  All other public operations on that engine,
+ * including step, snapshot, insert, remove, setting this callback, close, and
+ * releasing the last reference, are undefined while the callback is running.
+ */
+     typedef void (*WylDeltaCallback) (const gchar *relation,
+    const gint64 *row, guint ncols, WylDeltaKind kind, gpointer user_data);
+
+/*
+ * wyl_engine_set_delta_callback:
+ * @self: A `WylEngine` instance.  Must not be NULL.
+ * @cb: Callback invoked during wyl_engine_step(), or NULL to clear the
+ *   current callback.
+ * @user_data: Opaque pointer passed through to @cb.
+ *
+ * Registers a callback for tuple changes emitted while stepping the engine.
+ * Passing NULL for @cb clears the callback; the underlying evaluator
+ * guarantees NULL-clear behavior.  This function is rejected with
+ * %WYRELOG_E_INVALID if @self has already entered snapshot mode.
+ *
+ * Returns: %WYRELOG_E_OK on success; %WYRELOG_E_INVALID if @self is NULL,
+ *   has no live session, or is in snapshot mode; %WYRELOG_E_POLICY,
+ *   %WYRELOG_E_EXEC, %WYRELOG_E_NOMEM, %WYRELOG_E_IO, or
+ *   %WYRELOG_E_INTERNAL if the underlying evaluator rejects setup.
+ */
+     wyrelog_error_t wyl_engine_set_delta_callback (WylEngine *self,
+    WylDeltaCallback cb, gpointer user_data);
+
 G_END_DECLS;

--- a/wyrelog/wyl-engine-private.h
+++ b/wyrelog/wyl-engine-private.h
@@ -21,6 +21,8 @@ typedef enum
   WYL_ENGINE_MODE_SNAPSHOT,
 } wyl_engine_mode_t;
 
+typedef struct _WylDeltaCookie WylDeltaCookie;
+
 struct _WylEngine
 {
   GObject parent_instance;
@@ -28,6 +30,7 @@ struct _WylEngine
   /* Logical path strings for diagnostic logging only; freed in finalize. */
   gchar *dl_src_logical_paths[WYL_ENGINE_TEMPLATE_COUNT];
   wyl_engine_mode_t mode;       /* Latched at first step or snapshot. */
+  WylDeltaCookie *delta_cookie; /* Heap-owned, NULL when no cb. */
 };
 
 /*

--- a/wyrelog/wyl-engine.c
+++ b/wyrelog/wyl-engine.c
@@ -6,6 +6,7 @@
 #include "wyl-common-private.h"
 
 G_STATIC_ASSERT (sizeof (gint64) == sizeof (int64_t));
+G_STATIC_ASSERT (sizeof (gint32) == sizeof (int32_t));
 
 /*
  * Fixed dependency order for policy template files.
@@ -29,6 +30,12 @@ typedef struct
   gpointer user_data;
 } wyl_engine_tuple_cookie_t;
 
+struct _WylDeltaCookie
+{
+  WylDeltaCallback callback;
+  gpointer user_data;
+};
+
 static void
 wyl_engine_tuple_trampoline (const char *relation, const int64_t *row,
     uint32_t ncols, void *user)
@@ -36,6 +43,27 @@ wyl_engine_tuple_trampoline (const char *relation, const int64_t *row,
   const wyl_engine_tuple_cookie_t *cookie = user;
 
   cookie->cb (relation, (const gint64 *) row, (guint) ncols, cookie->user_data);
+}
+
+static void
+wyl_engine_delta_trampoline (const char *relation, const int64_t *row,
+    uint32_t ncols, int32_t diff, void *user)
+{
+  const WylDeltaCookie *cookie = user;
+  WylDeltaKind kind;
+
+  if (diff == 1) {
+    kind = WYL_DELTA_INSERT;
+  } else if (diff == -1) {
+    kind = WYL_DELTA_REMOVE;
+  } else {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_POLICY,
+        "engine: unexpected delta diff value (skipping callback)");
+    return;
+  }
+
+  cookie->callback (relation, (const gint64 *) row, (guint) ncols, kind,
+      cookie->user_data);
 }
 
 /* --- GObject boilerplate ------------------------------------------- */
@@ -48,6 +76,7 @@ wyl_engine_finalize (GObject *object)
   WylEngine *self = WYL_ENGINE (object);
 
   g_clear_pointer (&self->session, wl_easy_close);
+  g_clear_pointer (&self->delta_cookie, g_free);
 
   for (gsize i = 0; i < WYL_ENGINE_TEMPLATE_COUNT; i++)
     g_clear_pointer (&self->dl_src_logical_paths[i], g_free);
@@ -310,6 +339,53 @@ wyl_engine_snapshot (WylEngine *self, const gchar *relation,
   }
 
   return rc;
+}
+
+wyrelog_error_t
+wyl_engine_set_delta_callback (WylEngine *self, WylDeltaCallback cb,
+    gpointer user_data)
+{
+  if (self == NULL || !WYL_IS_ENGINE (self))
+    return WYRELOG_E_INVALID;
+  if (self->session == NULL)
+    return WYRELOG_E_INVALID;
+  if (self->mode == WYL_ENGINE_MODE_SNAPSHOT)
+    return WYRELOG_E_INVALID;
+
+  if (cb == NULL) {
+    /* Clear the substrate hook before releasing the cookie it may reference. */
+    wirelog_error_t wl_rc = wl_easy_set_delta_cb (self->session, NULL, NULL);
+    wyrelog_error_t rc = wyl_engine_map_wirelog_error (wl_rc);
+    if (rc != WYRELOG_E_OK) {
+      WYL_LOG_ERROR (WYL_LOG_SECTION_POLICY,
+          "engine: clear delta callback failed (rc=%d)", (int) rc);
+      return rc;
+    }
+
+    g_clear_pointer (&self->delta_cookie, g_free);
+    return WYRELOG_E_OK;
+  }
+
+  WylDeltaCookie *new_cookie = g_new0 (WylDeltaCookie, 1);
+  new_cookie->callback = cb;
+  new_cookie->user_data = user_data;
+
+  wirelog_error_t wl_rc =
+      wl_easy_set_delta_cb (self->session, wyl_engine_delta_trampoline,
+      new_cookie);
+  wyrelog_error_t rc = wyl_engine_map_wirelog_error (wl_rc);
+  if (rc != WYRELOG_E_OK) {
+    g_free (new_cookie);
+    WYL_LOG_ERROR (WYL_LOG_SECTION_POLICY,
+        "engine: install delta callback failed (rc=%d)", (int) rc);
+    return rc;
+  }
+
+  WylDeltaCookie *old = self->delta_cookie;
+  self->delta_cookie = new_cookie;
+  g_free (old);
+
+  return WYRELOG_E_OK;
 }
 
 wyrelog_error_t


### PR DESCRIPTION
## Summary

Adds a public engine delta callback API for incremental fact updates emitted during `wyl_engine_step()`.

## Changes

- Add typed insert/remove delta callback surface in `wyrelog/engine.h`
- Wire the callback through the underlying evaluator with replace and clear support
- Keep callback cookie ownership inside `WylEngine`
- Add engine I/O tests for insert, remove, clear, replace, invalid self, and after-close cases

## Validation

- `./tools/gst-indent tests/test-engine-io.c wyrelog/engine.h wyrelog/wyl-engine-private.h wyrelog/wyl-engine.c`
- `git diff --check origin/main..HEAD`
- `meson test -C builddir --print-errorlogs` (`37/37 OK`)
