### PR TITLE
handle: add policy engine pair lifecycle

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -163,6 +163,16 @@ test_handle_id = executable('test-handle-id',
 
 test('handle-id', test_handle_id)
 
+test_handle_engine_pair = executable('test-handle-engine-pair',
+  'test-handle-engine-pair.c',
+  c_args : [
+    '-DWYL_TEST_TEMPLATE_DIR="' + meson.project_source_root() / 'templates' / 'access' + '"',
+  ],
+  dependencies : [wyrelog_dep, wirelog_dep],
+)
+
+test('handle-engine-pair', test_handle_engine_pair)
+
 test_session_id = executable('test-session-id',
   'test-session-id.c',
   dependencies : [wyrelog_dep],

--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -1,0 +1,115 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <glib.h>
+
+#include "wyrelog/wyrelog.h"
+#include "wyrelog/wyl-handle-private.h"
+
+#ifndef WYL_TEST_TEMPLATE_DIR
+#error "WYL_TEST_TEMPLATE_DIR must be defined by the build."
+#endif
+
+static gint
+check_init_keeps_engines_absent (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 10;
+  if (wyl_handle_get_read_engine (handle) != NULL)
+    return 11;
+  if (wyl_handle_get_delta_engine (handle) != NULL)
+    return 12;
+  return 0;
+}
+
+static gint
+check_open_pair_creates_distinct_engines (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 20;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 21;
+  WylEngine *read_engine = wyl_handle_get_read_engine (handle);
+  WylEngine *delta_engine = wyl_handle_get_delta_engine (handle);
+  if (read_engine == NULL)
+    return 22;
+  if (delta_engine == NULL)
+    return 23;
+  if (read_engine == delta_engine)
+    return 24;
+  return 0;
+}
+
+static gint
+check_invalid_template_pair_open_fails_closed (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 30;
+  if (wyl_handle_open_engine_pair (handle,
+          "/definitely/not/a/wyrelog/template-dir")
+      != WYRELOG_E_IO)
+    return 31;
+  if (wyl_handle_get_read_engine (handle) != NULL)
+    return 32;
+  if (wyl_handle_get_delta_engine (handle) != NULL)
+    return 33;
+  return 0;
+}
+
+static gint
+check_shutdown_clears_engine_pair (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 40;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 41;
+  wyl_shutdown (handle);
+  if (wyl_handle_get_read_engine (handle) != NULL)
+    return 42;
+  if (wyl_handle_get_delta_engine (handle) != NULL)
+    return 43;
+  return 0;
+}
+
+static gint
+check_second_open_is_rejected (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 50;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 51;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_INVALID)
+    return 52;
+  return 0;
+}
+
+int
+main (void)
+{
+  gint rc;
+
+  if ((rc = check_init_keeps_engines_absent ()) != 0)
+    return rc;
+  if ((rc = check_open_pair_creates_distinct_engines ()) != 0)
+    return rc;
+  if ((rc = check_invalid_template_pair_open_fails_closed ()) != 0)
+    return rc;
+  if ((rc = check_shutdown_clears_engine_pair ()) != 0)
+    return rc;
+  if ((rc = check_second_open_is_rejected ()) != 0)
+    return rc;
+
+  return 0;
+}

--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -8,6 +8,76 @@
 #error "WYL_TEST_TEMPLATE_DIR must be defined by the build."
 #endif
 
+typedef struct
+{
+  const gint64 *expected_row;
+  guint seen;
+} SnapshotExpect;
+
+typedef struct
+{
+  const gchar *expected_relation;
+  const gint64 *expected_row;
+  WylDeltaKind expected_kind;
+  guint matching;
+} DeltaExpect;
+
+static void
+snapshot_expect_cb (const gchar *relation, const gint64 *row, guint ncols,
+    gpointer user_data)
+{
+  SnapshotExpect *expect = user_data;
+
+  if (g_strcmp0 (relation, "has_permission") != 0 || ncols != 3)
+    return;
+  if (row[0] == expect->expected_row[0] && row[1] == expect->expected_row[1]
+      && row[2] == expect->expected_row[2]) {
+    expect->seen++;
+  }
+}
+
+static void
+snapshot_count_cb (const gchar *relation, const gint64 *row, guint ncols,
+    gpointer user_data)
+{
+  guint *seen = user_data;
+
+  (void) relation;
+  (void) row;
+  (void) ncols;
+
+  (*seen)++;
+}
+
+static void
+delta_expect_cb (const gchar *relation, const gint64 *row, guint ncols,
+    WylDeltaKind kind, gpointer user_data)
+{
+  DeltaExpect *expect = user_data;
+
+  if (g_strcmp0 (relation, expect->expected_relation) != 0 || ncols != 3)
+    return;
+  if (kind != expect->expected_kind)
+    return;
+  if (row[0] == expect->expected_row[0] && row[1] == expect->expected_row[1]
+      && row[2] == expect->expected_row[2]) {
+    expect->matching++;
+  }
+}
+
+static wyrelog_error_t
+intern3 (WylHandle *handle, const gchar *a, const gchar *b, const gchar *c,
+    gint64 row[3])
+{
+  wyrelog_error_t rc = wyl_handle_intern_engine_symbol (handle, a, &row[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, b, &row[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_intern_engine_symbol (handle, c, &row[2]);
+}
+
 static gint
 check_init_keeps_engines_absent (void)
 {
@@ -165,6 +235,124 @@ check_symbol_intern_rejects_missing_pair (void)
   return 0;
 }
 
+static gint
+check_insert_fanout_reaches_read_engine (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  gint64 member_row[3];
+  gint64 role_permission_row[2];
+  gint64 expected_row[3];
+  SnapshotExpect expect = { expected_row, 0 };
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 90;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 91;
+  if (intern3 (handle, "fanout-user-a", "wr.fanout-role-a", "fanout-scope-a",
+          member_row) != WYRELOG_E_OK)
+    return 92;
+  expected_row[0] = member_row[0];
+  role_permission_row[0] = member_row[1];
+  if (wyl_handle_intern_engine_symbol (handle, "wr.fanout-permission-a",
+          &expected_row[1]) != WYRELOG_E_OK)
+    return 93;
+  role_permission_row[1] = expected_row[1];
+  expected_row[2] = member_row[2];
+
+  if (wyl_handle_engine_insert (handle, "role_permission",
+          role_permission_row, 2) != WYRELOG_E_OK)
+    return 94;
+  if (wyl_handle_engine_insert (handle, "member_of", member_row, 3)
+      != WYRELOG_E_OK)
+    return 95;
+  if (wyl_engine_snapshot (wyl_handle_get_read_engine (handle),
+          "has_permission", snapshot_expect_cb, &expect) != WYRELOG_E_OK)
+    return 96;
+  if (expect.seen != 1)
+    return 97;
+  return 0;
+}
+
+static gint
+check_insert_fanout_reaches_delta_engine (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  gint64 member_row[3];
+  DeltaExpect expect = {
+    "effective_member",
+    member_row,
+    WYL_DELTA_INSERT,
+    0,
+  };
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 100;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 101;
+  if (intern3 (handle, "fanout-user-b", "wr.viewer", "fanout-scope-b",
+          member_row) != WYRELOG_E_OK)
+    return 102;
+  if (wyl_engine_set_delta_callback (wyl_handle_get_delta_engine (handle),
+          delta_expect_cb, &expect) != WYRELOG_E_OK)
+    return 103;
+  if (wyl_handle_engine_insert (handle, "member_of", member_row, 3)
+      != WYRELOG_E_OK)
+    return 104;
+  if (wyl_engine_step (wyl_handle_get_delta_engine (handle)) != WYRELOG_E_OK)
+    return 105;
+  if (expect.matching == 0)
+    return 106;
+  return 0;
+}
+
+static gint
+check_remove_fanout_reaches_read_engine (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  gint64 member_row[3];
+  guint seen = 0;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 110;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 111;
+  if (intern3 (handle, "fanout-user-c", "wr.viewer", "fanout-scope-c",
+          member_row) != WYRELOG_E_OK)
+    return 112;
+  if (wyl_handle_engine_insert (handle, "member_of", member_row, 3)
+      != WYRELOG_E_OK)
+    return 113;
+  if (wyl_handle_engine_remove (handle, "member_of", member_row, 3)
+      != WYRELOG_E_OK)
+    return 114;
+  if (wyl_engine_snapshot (wyl_handle_get_read_engine (handle),
+          "effective_member", snapshot_count_cb, &seen) != WYRELOG_E_OK)
+    return 115;
+  if (seen != 0)
+    return 116;
+  return 0;
+}
+
+static gint
+check_insert_fanout_rejects_missing_pair (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  gint64 row[3] = { 1, 2, 3 };
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 120;
+  if (wyl_handle_engine_insert (handle, "member_of", row, 3)
+      != WYRELOG_E_INVALID)
+    return 121;
+  if (wyl_handle_engine_remove (handle, "member_of", row, 3)
+      != WYRELOG_E_INVALID)
+    return 122;
+  return 0;
+}
+
 int
 main (void)
 {
@@ -185,6 +373,14 @@ main (void)
   if ((rc = check_symbol_intern_is_stable ()) != 0)
     return rc;
   if ((rc = check_symbol_intern_rejects_missing_pair ()) != 0)
+    return rc;
+  if ((rc = check_insert_fanout_reaches_read_engine ()) != 0)
+    return rc;
+  if ((rc = check_insert_fanout_reaches_delta_engine ()) != 0)
+    return rc;
+  if ((rc = check_remove_fanout_reaches_read_engine ()) != 0)
+    return rc;
+  if ((rc = check_insert_fanout_rejects_missing_pair ()) != 0)
     return rc;
 
   return 0;

--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -95,6 +95,76 @@ check_second_open_is_rejected (void)
   return 0;
 }
 
+static gint
+check_symbol_intern_reaches_both_engines (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  gint64 pair_id = -1;
+  gint64 read_id = -1;
+  gint64 delta_id = -1;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 60;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 61;
+  if (wyl_handle_intern_engine_symbol (handle, "pair-symbol-a", &pair_id)
+      != WYRELOG_E_OK)
+    return 62;
+  if (pair_id < 0)
+    return 63;
+  if (wyl_engine_intern_symbol (wyl_handle_get_read_engine (handle),
+          "pair-symbol-a", &read_id) != WYRELOG_E_OK)
+    return 64;
+  if (wyl_engine_intern_symbol (wyl_handle_get_delta_engine (handle),
+          "pair-symbol-a", &delta_id) != WYRELOG_E_OK)
+    return 65;
+  if (pair_id != read_id)
+    return 66;
+  if (pair_id != delta_id)
+    return 67;
+  return 0;
+}
+
+static gint
+check_symbol_intern_is_stable (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  gint64 first = -1;
+  gint64 second = -1;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 70;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 71;
+  if (wyl_handle_intern_engine_symbol (handle, "pair-symbol-b", &first)
+      != WYRELOG_E_OK)
+    return 72;
+  if (wyl_handle_intern_engine_symbol (handle, "pair-symbol-b", &second)
+      != WYRELOG_E_OK)
+    return 73;
+  if (first != second)
+    return 74;
+  return 0;
+}
+
+static gint
+check_symbol_intern_rejects_missing_pair (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  gint64 id = -1;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 80;
+  if (wyl_handle_intern_engine_symbol (handle, "pair-symbol-c", &id)
+      != WYRELOG_E_INVALID)
+    return 81;
+  if (id != -1)
+    return 82;
+  return 0;
+}
+
 int
 main (void)
 {
@@ -109,6 +179,12 @@ main (void)
   if ((rc = check_shutdown_clears_engine_pair ()) != 0)
     return rc;
   if ((rc = check_second_open_is_rejected ()) != 0)
+    return rc;
+  if ((rc = check_symbol_intern_reaches_both_engines ()) != 0)
+    return rc;
+  if ((rc = check_symbol_intern_is_stable ()) != 0)
+    return rc;
+  if ((rc = check_symbol_intern_rejects_missing_pair ()) != 0)
     return rc;
 
   return 0;

--- a/wyrelog/wyl-handle-private.h
+++ b/wyrelog/wyl-handle-private.h
@@ -4,6 +4,7 @@
 #include <glib.h>
 
 #include "wyrelog/handle.h"
+#include "wyrelog/engine.h"
 
 #ifdef WYL_HAS_AUDIT
 #include "audit/conn-private.h"
@@ -21,5 +22,22 @@ G_BEGIN_DECLS;
  */
 wyl_audit_conn_t *wyl_handle_get_audit_conn (WylHandle * self);
 #endif
+
+/*
+ * Opens the handle-owned policy engine pair from @template_dir.
+ * Rejected if the pair is already present. On failure the handle is left
+ * without policy engines.
+ */
+wyrelog_error_t wyl_handle_open_engine_pair (WylHandle * self,
+    const gchar * template_dir);
+
+/*
+ * Borrowed policy engine sessions owned by |self|. These are NULL when
+ * no policy engine pair has been opened. The read engine is reserved for
+ * snapshot-style reads; the delta engine is reserved for step/delta
+ * processing.
+ */
+WylEngine *wyl_handle_get_read_engine (WylHandle * self);
+WylEngine *wyl_handle_get_delta_engine (WylHandle * self);
 
 G_END_DECLS;

--- a/wyrelog/wyl-handle-private.h
+++ b/wyrelog/wyl-handle-private.h
@@ -39,6 +39,17 @@ wyrelog_error_t wyl_handle_intern_engine_symbol (WylHandle * self,
     const gchar * symbol, gint64 * out_id);
 
 /*
+ * Applies an EDB row update to both handle-owned policy engines. Rejected
+ * unless the engine pair is already open. This helper is not transactional
+ * across the two engines; callers must treat a non-OK return as terminal for
+ * the pair.
+ */
+wyrelog_error_t wyl_handle_engine_insert (WylHandle * self,
+    const gchar * relation, const gint64 * row, gsize ncols);
+wyrelog_error_t wyl_handle_engine_remove (WylHandle * self,
+    const gchar * relation, const gint64 * row, gsize ncols);
+
+/*
  * Borrowed policy engine sessions owned by |self|. These are NULL when
  * no policy engine pair has been opened. The read engine is reserved for
  * snapshot-style reads; the delta engine is reserved for step/delta

--- a/wyrelog/wyl-handle-private.h
+++ b/wyrelog/wyl-handle-private.h
@@ -32,6 +32,13 @@ wyrelog_error_t wyl_handle_open_engine_pair (WylHandle * self,
     const gchar * template_dir);
 
 /*
+ * Interns @symbol into both handle-owned policy engines and returns the shared
+ * integer id. Rejected unless the engine pair is already open.
+ */
+wyrelog_error_t wyl_handle_intern_engine_symbol (WylHandle * self,
+    const gchar * symbol, gint64 * out_id);
+
+/*
  * Borrowed policy engine sessions owned by |self|. These are NULL when
  * no policy engine pair has been opened. The read engine is reserved for
  * snapshot-style reads; the delta engine is reserved for step/delta

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -197,6 +197,40 @@ wyl_handle_intern_engine_symbol (WylHandle *self, const gchar *symbol,
   return WYRELOG_E_OK;
 }
 
+wyrelog_error_t
+wyl_handle_engine_insert (WylHandle *self, const gchar *relation,
+    const gint64 *row, gsize ncols)
+{
+  if (self == NULL || !WYL_IS_HANDLE (self))
+    return WYRELOG_E_INVALID;
+  if (self->read_engine == NULL || self->delta_engine == NULL)
+    return WYRELOG_E_INVALID;
+
+  wyrelog_error_t rc =
+      wyl_engine_insert (self->read_engine, relation, row, ncols);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  return wyl_engine_insert (self->delta_engine, relation, row, ncols);
+}
+
+wyrelog_error_t
+wyl_handle_engine_remove (WylHandle *self, const gchar *relation,
+    const gint64 *row, gsize ncols)
+{
+  if (self == NULL || !WYL_IS_HANDLE (self))
+    return WYRELOG_E_INVALID;
+  if (self->read_engine == NULL || self->delta_engine == NULL)
+    return WYRELOG_E_INVALID;
+
+  wyrelog_error_t rc =
+      wyl_engine_remove (self->read_engine, relation, row, ncols);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  return wyl_engine_remove (self->delta_engine, relation, row, ncols);
+}
+
 WylEngine *
 wyl_handle_get_read_engine (WylHandle *self)
 {

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #include "wyrelog/wyrelog.h"
 
+#include "wyrelog/engine.h"
 #include "wyl-id-private.h"
 #include "wyl-log-private.h"
 
@@ -13,6 +14,8 @@ struct _WylHandle
   GObject parent_instance;
   wyl_id_t id;
   gint64 created_at_us;
+  WylEngine *read_engine;
+  WylEngine *delta_engine;
 #ifdef WYL_HAS_AUDIT
   wyl_audit_conn_t *audit_conn;
 #endif
@@ -23,8 +26,11 @@ G_DEFINE_FINAL_TYPE (WylHandle, wyl_handle, G_TYPE_OBJECT);
 static void
 wyl_handle_finalize (GObject *object)
 {
-#ifdef WYL_HAS_AUDIT
   WylHandle *self = WYL_HANDLE (object);
+
+  g_clear_object (&self->read_engine);
+  g_clear_object (&self->delta_engine);
+#ifdef WYL_HAS_AUDIT
   /* NULL-safe: if wyl_shutdown already closed the conn the pointer
    * was reset to NULL there; otherwise this is the only close site
    * and the audit log file (if any) is released here. */
@@ -59,8 +65,6 @@ wyl_handle_init (WylHandle *self)
 wyrelog_error_t
 wyl_init (const gchar *config_path, WylHandle **out_handle)
 {
-  (void) config_path;
-
   /* Eagerly initialise the log subsystem before any other library code
    * runs so that log sites in boot phases see the correct thresholds
    * and file sink from the very first message. */
@@ -89,6 +93,7 @@ wyl_init (const gchar *config_path, WylHandle **out_handle)
 #endif
 
   *out_handle = self;
+  (void) config_path;
   return WYRELOG_E_OK;
 }
 
@@ -104,6 +109,8 @@ wyl_shutdown (WylHandle *handle)
    * will not double-close. */
   g_clear_pointer (&handle->audit_conn, wyl_audit_conn_close);
 #endif
+  g_clear_object (&handle->read_engine);
+  g_clear_object (&handle->delta_engine);
 }
 
 gchar *
@@ -133,3 +140,44 @@ wyl_handle_get_audit_conn (WylHandle *self)
   return self->audit_conn;
 }
 #endif
+
+wyrelog_error_t
+wyl_handle_open_engine_pair (WylHandle *self, const gchar *template_dir)
+{
+  if (self == NULL || !WYL_IS_HANDLE (self))
+    return WYRELOG_E_INVALID;
+  if (template_dir == NULL)
+    return WYRELOG_E_INVALID;
+  if (self->read_engine != NULL || self->delta_engine != NULL)
+    return WYRELOG_E_INVALID;
+
+  WylEngine *read_engine = NULL;
+  wyrelog_error_t rc = wyl_engine_open (template_dir, 1, &read_engine);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  WylEngine *delta_engine = NULL;
+  rc = wyl_engine_open (template_dir, 1, &delta_engine);
+  if (rc != WYRELOG_E_OK) {
+    g_object_unref (read_engine);
+    return rc;
+  }
+
+  self->read_engine = read_engine;
+  self->delta_engine = delta_engine;
+  return WYRELOG_E_OK;
+}
+
+WylEngine *
+wyl_handle_get_read_engine (WylHandle *self)
+{
+  g_return_val_if_fail (WYL_IS_HANDLE (self), NULL);
+  return self->read_engine;
+}
+
+WylEngine *
+wyl_handle_get_delta_engine (WylHandle *self)
+{
+  g_return_val_if_fail (WYL_IS_HANDLE (self), NULL);
+  return self->delta_engine;
+}

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -168,6 +168,35 @@ wyl_handle_open_engine_pair (WylHandle *self, const gchar *template_dir)
   return WYRELOG_E_OK;
 }
 
+wyrelog_error_t
+wyl_handle_intern_engine_symbol (WylHandle *self, const gchar *symbol,
+    gint64 *out_id)
+{
+  if (self == NULL || !WYL_IS_HANDLE (self))
+    return WYRELOG_E_INVALID;
+  if (symbol == NULL || out_id == NULL)
+    return WYRELOG_E_INVALID;
+  if (self->read_engine == NULL || self->delta_engine == NULL)
+    return WYRELOG_E_INVALID;
+
+  gint64 read_id = -1;
+  wyrelog_error_t rc =
+      wyl_engine_intern_symbol (self->read_engine, symbol, &read_id);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  gint64 delta_id = -1;
+  rc = wyl_engine_intern_symbol (self->delta_engine, symbol, &delta_id);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  if (read_id != delta_id)
+    return WYRELOG_E_INTERNAL;
+
+  *out_id = read_id;
+  return WYRELOG_E_OK;
+}
+
 WylEngine *
 wyl_handle_get_read_engine (WylHandle *self)
 {


### PR DESCRIPTION
## Summary

Adds private handle-owned policy engine pair lifecycle helpers and the first paired update helpers used by higher-level access wiring.

## Changes

- Add a private helper to open distinct read and delta engine sessions for a handle
- Add private accessors for the borrowed read and delta engines
- Add paired symbol interning with id consistency checks
- Add paired insert/remove helpers for engine fact updates
- Add handle-level tests covering lifecycle, symbol pairing, read snapshots, delta callbacks, removal, and invalid states

## Validation

- `./tools/gst-indent wyrelog/wyl-handle.c wyrelog/wyl-handle-private.h tests/test-handle-engine-pair.c`
- `git diff --check main..HEAD`
- `meson test -C builddir --print-errorlogs` (`38/38 OK`)
