### PR TITLE
decide: query policy engine when available

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -224,7 +224,10 @@ test('revoke-req', test_revoke_req)
 
 test_decide = executable('test-decide',
   'test-decide.c',
-  dependencies : [wyrelog_dep],
+  c_args : [
+    '-DWYL_TEST_TEMPLATE_DIR="' + meson.project_source_root() / 'templates' / 'access' + '"',
+  ],
+  dependencies : [wyrelog_dep, wirelog_dep],
 )
 
 test('decide', test_decide)

--- a/tests/test-decide.c
+++ b/tests/test-decide.c
@@ -2,13 +2,86 @@
 #include <glib.h>
 
 #include "wyrelog/wyrelog.h"
+#include "wyrelog/wyl-handle-private.h"
 
 /*
- * wyl_decide v0 contract: every decide call returns WYRELOG_E_OK
- * with a DENY verdict (the policy decision point is not yet wired
- * to a configured allow-list). Validates argument-handling and the
- * fail-closed default.
+ * wyl_decide returns a fail-closed DENY when no policy engine pair is wired.
+ * When a handle-owned engine pair is present, it queries allow_bool/3.
  */
+
+#ifndef WYL_TEST_TEMPLATE_DIR
+#error "WYL_TEST_TEMPLATE_DIR must be defined by the build."
+#endif
+
+static wyrelog_error_t
+intern_symbol (WylHandle *handle, const gchar *symbol, gint64 *out_id)
+{
+  return wyl_handle_intern_engine_symbol (handle, symbol, out_id);
+}
+
+static wyrelog_error_t
+insert_symbol_row1 (WylHandle *handle, const gchar *relation,
+    const gchar *value)
+{
+  gint64 row[1];
+  wyrelog_error_t rc = intern_symbol (handle, value, &row[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_engine_insert (handle, relation, row, 1);
+}
+
+static wyrelog_error_t
+insert_symbol_row2 (WylHandle *handle, const gchar *relation,
+    const gchar *a, const gchar *b)
+{
+  gint64 row[2];
+  wyrelog_error_t rc = intern_symbol (handle, a, &row[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = intern_symbol (handle, b, &row[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_engine_insert (handle, relation, row, 2);
+}
+
+static wyrelog_error_t
+insert_symbol_row3 (WylHandle *handle, const gchar *relation,
+    const gchar *a, const gchar *b, const gchar *c)
+{
+  gint64 row[3];
+  wyrelog_error_t rc = intern_symbol (handle, a, &row[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = intern_symbol (handle, b, &row[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = intern_symbol (handle, c, &row[2]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_engine_insert (handle, relation, row, 3);
+}
+
+static wyrelog_error_t
+insert_allow_fixture (WylHandle *handle, const gchar *subject,
+    const gchar *action, const gchar *resource)
+{
+  wyrelog_error_t rc =
+      insert_symbol_row2 (handle, "role_permission", "wr.decide-role",
+      action);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = insert_symbol_row3 (handle, "member_of", subject, "wr.decide-role",
+      resource);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = insert_symbol_row2 (handle, "principal_state", subject, "authenticated");
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = insert_symbol_row2 (handle, "session_state", resource, "active");
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return insert_symbol_row1 (handle, "session_active", "active");
+}
 
 static gint
 check_decide_returns_ok_and_deny (void)
@@ -67,6 +140,58 @@ check_decide_default_resp_stays_deny (void)
   return 0;
 }
 
+static gint
+check_decide_allows_engine_tuple (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 40;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 41;
+  if (insert_allow_fixture (handle, "decide-user-a",
+          "wr.decide-permission-a", "decide-resource-a") != WYRELOG_E_OK)
+    return 42;
+
+  g_autoptr (wyl_decide_req_t) req = wyl_decide_req_new ();
+  wyl_decide_req_set_subject_id (req, "decide-user-a");
+  wyl_decide_req_set_action (req, "wr.decide-permission-a");
+  wyl_decide_req_set_resource_id (req, "decide-resource-a");
+
+  g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
+  if (wyl_decide (handle, req, resp) != WYRELOG_E_OK)
+    return 43;
+  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_ALLOW)
+    return 44;
+  return 0;
+}
+
+static gint
+check_decide_denies_engine_miss (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 50;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 51;
+  if (insert_allow_fixture (handle, "decide-user-b",
+          "wr.decide-permission-b", "decide-resource-b") != WYRELOG_E_OK)
+    return 52;
+
+  g_autoptr (wyl_decide_req_t) req = wyl_decide_req_new ();
+  wyl_decide_req_set_subject_id (req, "decide-user-b");
+  wyl_decide_req_set_action (req, "wr.decide-permission-b");
+  wyl_decide_req_set_resource_id (req, "other-resource-b");
+
+  g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
+  if (wyl_decide (handle, req, resp) != WYRELOG_E_OK)
+    return 53;
+  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_DENY)
+    return 54;
+  return 0;
+}
+
 int
 main (void)
 {
@@ -76,6 +201,10 @@ main (void)
   if ((rc = check_decide_rejects_null_args ()) != 0)
     return rc;
   if ((rc = check_decide_default_resp_stays_deny ()) != 0)
+    return rc;
+  if ((rc = check_decide_allows_engine_tuple ()) != 0)
+    return rc;
+  if ((rc = check_decide_denies_engine_miss ()) != 0)
     return rc;
   return 0;
 }

--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -78,6 +78,72 @@ intern3 (WylHandle *handle, const gchar *a, const gchar *b, const gchar *c,
   return wyl_handle_intern_engine_symbol (handle, c, &row[2]);
 }
 
+static wyrelog_error_t
+insert1_symbol (WylHandle *handle, const gchar *relation, const gchar *a)
+{
+  gint64 row[1];
+
+  wyrelog_error_t rc = wyl_handle_intern_engine_symbol (handle, a, &row[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_engine_insert (handle, relation, row, 1);
+}
+
+static wyrelog_error_t
+insert_decision_fixture (WylHandle *handle, const gchar *user,
+    const gchar *role, const gchar *permission, const gchar *scope,
+    const gchar *principal_state, const gchar *session_state,
+    gint64 decision_row[3])
+{
+  gint64 member_row[3];
+  gint64 principal_state_row[2];
+  gint64 session_state_row[2];
+  wyrelog_error_t rc = intern3 (handle, user, role, scope, member_row);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  gint64 role_permission_row[2] = { member_row[1], -1 };
+  rc = wyl_handle_intern_engine_symbol (handle, permission,
+      &role_permission_row[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_engine_insert (handle, "role_permission",
+      role_permission_row, 2);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_engine_insert (handle, "member_of", member_row, 3);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  principal_state_row[0] = member_row[0];
+  rc = wyl_handle_intern_engine_symbol (handle, principal_state,
+      &principal_state_row[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_engine_insert (handle, "principal_state",
+      principal_state_row, 2);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  session_state_row[0] = member_row[2];
+  rc = wyl_handle_intern_engine_symbol (handle, session_state,
+      &session_state_row[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_engine_insert (handle, "session_state", session_state_row, 2);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  rc = insert1_symbol (handle, "session_active", session_state);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  decision_row[0] = member_row[0];
+  decision_row[1] = role_permission_row[1];
+  decision_row[2] = member_row[2];
+  return WYRELOG_E_OK;
+}
+
 static gint
 check_init_keeps_engines_absent (void)
 {
@@ -353,6 +419,72 @@ check_insert_fanout_rejects_missing_pair (void)
   return 0;
 }
 
+static gint
+check_decision_query_allows_matching_tuple (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  gint64 decision_row[3];
+  gboolean allowed = FALSE;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 130;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 131;
+  if (insert_decision_fixture (handle, "decision-user-a",
+          "wr.decision-role-a", "wr.decision-permission-a",
+          "decision-scope-a", "authenticated", "active", decision_row)
+      != WYRELOG_E_OK)
+    return 132;
+  if (wyl_handle_engine_decide (handle, decision_row, &allowed)
+      != WYRELOG_E_OK)
+    return 133;
+  if (!allowed)
+    return 134;
+  return 0;
+}
+
+static gint
+check_decision_query_denies_missing_tuple (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  gint64 decision_row[3];
+  gboolean allowed = TRUE;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 140;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 141;
+  if (insert_decision_fixture (handle, "decision-user-b",
+          "wr.decision-role-b", "wr.decision-permission-b",
+          "decision-scope-b", "unverified", "active", decision_row)
+      != WYRELOG_E_OK)
+    return 142;
+  if (wyl_handle_engine_decide (handle, decision_row, &allowed)
+      != WYRELOG_E_OK)
+    return 143;
+  if (allowed)
+    return 144;
+  return 0;
+}
+
+static gint
+check_decision_query_rejects_missing_pair (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  gint64 row[3] = { 1, 2, 3 };
+  gboolean allowed = TRUE;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 150;
+  if (wyl_handle_engine_decide (handle, row, &allowed) != WYRELOG_E_INVALID)
+    return 151;
+  if (!allowed)
+    return 152;
+  return 0;
+}
+
 int
 main (void)
 {
@@ -381,6 +513,12 @@ main (void)
   if ((rc = check_remove_fanout_reaches_read_engine ()) != 0)
     return rc;
   if ((rc = check_insert_fanout_rejects_missing_pair ()) != 0)
+    return rc;
+  if ((rc = check_decision_query_allows_matching_tuple ()) != 0)
+    return rc;
+  if ((rc = check_decision_query_denies_missing_tuple ()) != 0)
+    return rc;
+  if ((rc = check_decision_query_rejects_missing_pair ()) != 0)
     return rc;
 
   return 0;

--- a/wyrelog/wyl-decide.c
+++ b/wyrelog/wyl-decide.c
@@ -1,6 +1,8 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #include "wyrelog/wyrelog.h"
 
+#include "wyl-handle-private.h"
+
 struct _wyl_decide_req
 {
   gchar *subject_id;
@@ -111,13 +113,30 @@ wyl_decide (WylHandle *handle, const wyl_decide_req_t *req,
   if (handle == NULL || req == NULL || resp == NULL)
     return WYRELOG_E_INVALID;
 
-  /* The policy decision point is not yet wired to the principal /
-   * session FSMs or to a configured allow-list, so every decide
-   * call returns DENY. This keeps the public contract fail-closed
-   * by default; a future commit will replace this with the actual
-   * Datalog evaluation. */
   wyl_decide_resp_set_decision (resp, WYL_DECISION_DENY);
 
+  if (wyl_handle_get_read_engine (handle) != NULL) {
+    gint64 row[3];
+    wyrelog_error_t rc = wyl_handle_intern_engine_symbol (handle,
+        wyl_decide_req_get_subject_id (req), &row[0]);
+    if (rc != WYRELOG_E_OK)
+      return rc;
+    rc = wyl_handle_intern_engine_symbol (handle, wyl_decide_req_get_action
+        (req), &row[1]);
+    if (rc != WYRELOG_E_OK)
+      return rc;
+    rc = wyl_handle_intern_engine_symbol (handle,
+        wyl_decide_req_get_resource_id (req), &row[2]);
+    if (rc != WYRELOG_E_OK)
+      return rc;
+
+    gboolean allowed = FALSE;
+    rc = wyl_handle_engine_decide (handle, row, &allowed);
+    if (rc != WYRELOG_E_OK)
+      return rc;
+    if (allowed)
+      wyl_decide_resp_set_decision (resp, WYL_DECISION_ALLOW);
+  }
 #ifdef WYL_HAS_AUDIT
   /* Mirror the decision into the audit log so every decide call
    * leaves a row regardless of whether downstream callers also

--- a/wyrelog/wyl-handle-private.h
+++ b/wyrelog/wyl-handle-private.h
@@ -50,6 +50,13 @@ wyrelog_error_t wyl_handle_engine_remove (WylHandle * self,
     const gchar * relation, const gint64 * row, gsize ncols);
 
 /*
+ * Reads allow_bool/3 from the handle-owned read engine for @row
+ * (user, permission, scope). Rejected unless the engine pair is already open.
+ */
+wyrelog_error_t wyl_handle_engine_decide (WylHandle * self,
+    const gint64 row[3], gboolean * out_allowed);
+
+/*
  * Borrowed policy engine sessions owned by |self|. These are NULL when
  * no policy engine pair has been opened. The read engine is reserved for
  * snapshot-style reads; the delta engine is reserved for step/delta

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -231,6 +231,49 @@ wyl_handle_engine_remove (WylHandle *self, const gchar *relation,
   return wyl_engine_remove (self->delta_engine, relation, row, ncols);
 }
 
+typedef struct
+{
+  const gint64 *row;
+  gboolean matched;
+} WylDecisionProbe;
+
+static void
+wyl_handle_decide_snapshot_cb (const gchar *relation, const gint64 *row,
+    guint ncols, gpointer user_data)
+{
+  WylDecisionProbe *probe = user_data;
+
+  (void) relation;
+
+  if (ncols != 3)
+    return;
+  if (row[0] == probe->row[0] && row[1] == probe->row[1]
+      && row[2] == probe->row[2]) {
+    probe->matched = TRUE;
+  }
+}
+
+wyrelog_error_t
+wyl_handle_engine_decide (WylHandle *self, const gint64 row[3],
+    gboolean *out_allowed)
+{
+  if (self == NULL || !WYL_IS_HANDLE (self))
+    return WYRELOG_E_INVALID;
+  if (row == NULL || out_allowed == NULL)
+    return WYRELOG_E_INVALID;
+  if (self->read_engine == NULL || self->delta_engine == NULL)
+    return WYRELOG_E_INVALID;
+
+  WylDecisionProbe probe = { row, FALSE };
+  wyrelog_error_t rc = wyl_engine_snapshot (self->read_engine,
+      "allow_bool", wyl_handle_decide_snapshot_cb, &probe);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  *out_allowed = probe.matched;
+  return WYRELOG_E_OK;
+}
+
 WylEngine *
 wyl_handle_get_read_engine (WylHandle *self)
 {


### PR DESCRIPTION
## Summary

Wires the handle-owned read engine into the decision path behind private helpers.

## Changes

- Add a private helper that snapshots `allow_bool/3` for a single decision tuple
- Keep the helper internal and scoped to the handle-owned engine pair
- Update `wyl_decide()` to query the read engine when a pair is available
- Preserve the existing fail-closed DENY behavior for handles without an engine pair
- Add tests for allow, deny, and no-engine fallback paths

## Validation

- `./tools/gst-indent wyrelog/wyl-decide.c tests/test-decide.c wyrelog/wyl-handle.c wyrelog/wyl-handle-private.h tests/test-handle-engine-pair.c`
- `git diff --check main..HEAD`
- `meson test -C builddir --print-errorlogs` (`38/38 OK`)
