### PR TITLE
handle: open engine pair from config path

### DIFF
--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -180,6 +180,23 @@ check_open_pair_creates_distinct_engines (void)
 }
 
 static gint
+check_init_config_opens_engine_pair (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 25;
+  if (wyl_handle_get_read_engine (handle) == NULL)
+    return 26;
+  if (wyl_handle_get_delta_engine (handle) == NULL)
+    return 27;
+  if (wyl_handle_get_read_engine (handle) == wyl_handle_get_delta_engine
+      (handle))
+    return 28;
+  return 0;
+}
+
+static gint
 check_invalid_template_pair_open_fails_closed (void)
 {
   g_autoptr (WylHandle) handle = NULL;
@@ -194,6 +211,19 @@ check_invalid_template_pair_open_fails_closed (void)
     return 32;
   if (wyl_handle_get_delta_engine (handle) != NULL)
     return 33;
+  return 0;
+}
+
+static gint
+check_invalid_config_init_fails_closed (void)
+{
+  WylHandle *handle = (WylHandle *) 0x1;
+
+  if (wyl_init ("/definitely/not/a/wyrelog/template-dir", &handle)
+      != WYRELOG_E_IO)
+    return 35;
+  if (handle != NULL)
+    return 36;
   return 0;
 }
 
@@ -494,7 +524,11 @@ main (void)
     return rc;
   if ((rc = check_open_pair_creates_distinct_engines ()) != 0)
     return rc;
+  if ((rc = check_init_config_opens_engine_pair ()) != 0)
+    return rc;
   if ((rc = check_invalid_template_pair_open_fails_closed ()) != 0)
+    return rc;
+  if ((rc = check_invalid_config_init_fails_closed ()) != 0)
     return rc;
   if ((rc = check_shutdown_clears_engine_pair ()) != 0)
     return rc;

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -2,6 +2,7 @@
 #include "wyrelog/wyrelog.h"
 
 #include "wyrelog/engine.h"
+#include "wyl-handle-private.h"
 #include "wyl-id-private.h"
 #include "wyl-log-private.h"
 
@@ -72,14 +73,20 @@ wyl_init (const gchar *config_path, WylHandle **out_handle)
 
   if (out_handle == NULL)
     return WYRELOG_E_INVALID;
+  *out_handle = NULL;
 
   WylHandle *self = g_object_new (WYL_TYPE_HANDLE, NULL);
 
+  if (config_path != NULL) {
+    wyrelog_error_t rc = wyl_handle_open_engine_pair (self, config_path);
+    if (rc != WYRELOG_E_OK) {
+      g_object_unref (self);
+      return rc;
+    }
+  }
 #ifdef WYL_HAS_AUDIT
   /* Open an in-memory audit database and create the audit_events
-   * schema. config_path will eventually direct this at a persistent
-   * location; for now the in-memory store is enough to exercise the
-   * full lifecycle. */
+   * schema. Audit persistence is not wired to config_path yet. */
   wyrelog_error_t rc = wyl_audit_conn_open (NULL, &self->audit_conn);
   if (rc != WYRELOG_E_OK) {
     g_object_unref (self);
@@ -93,7 +100,6 @@ wyl_init (const gchar *config_path, WylHandle **out_handle)
 #endif
 
   *out_handle = self;
-  (void) config_path;
   return WYRELOG_E_OK;
 }
 


### PR DESCRIPTION
## Summary
- open the handle-owned policy engine pair when `wyl_init()` receives a config path
- keep the NULL-config initialization path lightweight
- fail closed and clear the output handle when engine setup fails
- update handle engine-pair coverage for config-backed initialization

## Tests
- meson test -C builddir --print-errorlogs