### PR TITLE
session: authenticate principal in policy engine

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -189,7 +189,10 @@ test('login-req', test_login_req)
 
 test_session_username = executable('test-session-username',
   'test-session-username.c',
-  dependencies : [wyrelog_dep],
+  c_args : [
+    '-DWYL_TEST_TEMPLATE_DIR="' + meson.project_source_root() / 'templates' / 'access' + '"',
+  ],
+  dependencies : [wyrelog_dep, wirelog_dep],
 )
 
 test('session-username', test_session_username)

--- a/tests/test-session-username.c
+++ b/tests/test-session-username.c
@@ -3,6 +3,59 @@
 #include <string.h>
 
 #include "wyrelog/wyrelog.h"
+#include "wyrelog/wyl-handle-private.h"
+
+#ifndef WYL_TEST_TEMPLATE_DIR
+#error "WYL_TEST_TEMPLATE_DIR must be defined by the build."
+#endif
+
+static wyrelog_error_t
+intern_symbol (WylHandle *handle, const gchar *symbol, gint64 *out_id)
+{
+  return wyl_handle_intern_engine_symbol (handle, symbol, out_id);
+}
+
+static wyrelog_error_t
+insert_symbol_row1 (WylHandle *handle, const gchar *relation,
+    const gchar *value)
+{
+  gint64 row[1];
+  wyrelog_error_t rc = intern_symbol (handle, value, &row[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_engine_insert (handle, relation, row, 1);
+}
+
+static wyrelog_error_t
+insert_symbol_row2 (WylHandle *handle, const gchar *relation,
+    const gchar *a, const gchar *b)
+{
+  gint64 row[2];
+  wyrelog_error_t rc = intern_symbol (handle, a, &row[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = intern_symbol (handle, b, &row[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_engine_insert (handle, relation, row, 2);
+}
+
+static wyrelog_error_t
+insert_symbol_row3 (WylHandle *handle, const gchar *relation,
+    const gchar *a, const gchar *b, const gchar *c)
+{
+  gint64 row[3];
+  wyrelog_error_t rc = intern_symbol (handle, a, &row[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = intern_symbol (handle, b, &row[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = intern_symbol (handle, c, &row[2]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_engine_insert (handle, relation, row, 3);
+}
 
 static WylSession *
 login_with_username (const gchar *username)
@@ -115,6 +168,46 @@ check_dup_null_session (void)
   return 0;
 }
 
+static gint
+check_login_authenticates_engine_principal (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 70;
+
+  if (insert_symbol_row2 (handle, "role_permission", "wr.login-role",
+          "wr.login-permission") != WYRELOG_E_OK)
+    return 71;
+  if (insert_symbol_row3 (handle, "member_of", "login-user",
+          "wr.login-role", "login-scope") != WYRELOG_E_OK)
+    return 72;
+  if (insert_symbol_row2 (handle, "session_state", "login-scope", "active")
+      != WYRELOG_E_OK)
+    return 73;
+  if (insert_symbol_row1 (handle, "session_active", "active") != WYRELOG_E_OK)
+    return 74;
+
+  g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
+  wyl_login_req_set_username (login, "login-user");
+  g_autoptr (WylSession) session = NULL;
+  if (wyl_session_login (handle, login, &session) != WYRELOG_E_OK)
+    return 75;
+  if (session == NULL)
+    return 76;
+
+  g_autoptr (wyl_decide_req_t) decide = wyl_decide_req_new ();
+  wyl_decide_req_set_subject_id (decide, "login-user");
+  wyl_decide_req_set_action (decide, "wr.login-permission");
+  wyl_decide_req_set_resource_id (decide, "login-scope");
+
+  g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
+  if (wyl_decide (handle, decide, resp) != WYRELOG_E_OK)
+    return 77;
+  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_ALLOW)
+    return 78;
+  return 0;
+}
+
 int
 main (void)
 {
@@ -131,6 +224,8 @@ main (void)
   if ((rc = check_dup_returns_distinct_buffers ()) != 0)
     return rc;
   if ((rc = check_dup_null_session ()) != 0)
+    return rc;
+  if ((rc = check_login_authenticates_engine_principal ()) != 0)
     return rc;
 
   return 0;

--- a/wyrelog/wyl-session.c
+++ b/wyrelog/wyl-session.c
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #include "wyrelog/wyrelog.h"
 
+#include "wyl-handle-private.h"
 #include "wyl-id-private.h"
 
 struct _WylSession
@@ -51,14 +52,37 @@ wyrelog_error_t
 wyl_session_login (WylHandle *handle, const wyl_login_req_t *req,
     WylSession **out_session)
 {
-  (void) handle;
-
   if (out_session == NULL)
     return WYRELOG_E_INVALID;
+  *out_session = NULL;
 
   WylSession *session = g_object_new (WYL_TYPE_SESSION, NULL);
-  if (req != NULL)
-    session->username = g_strdup (wyl_login_req_get_username (req));
+  const gchar *username = NULL;
+  if (req != NULL) {
+    username = wyl_login_req_get_username (req);
+    session->username = g_strdup (username);
+  }
+
+  if (handle != NULL && username != NULL
+      && wyl_handle_get_read_engine (handle) != NULL) {
+    gint64 row[2];
+    wyrelog_error_t rc =
+        wyl_handle_intern_engine_symbol (handle, username, &row[0]);
+    if (rc != WYRELOG_E_OK) {
+      g_object_unref (session);
+      return rc;
+    }
+    rc = wyl_handle_intern_engine_symbol (handle, "authenticated", &row[1]);
+    if (rc != WYRELOG_E_OK) {
+      g_object_unref (session);
+      return rc;
+    }
+    rc = wyl_handle_engine_insert (handle, "principal_state", row, 2);
+    if (rc != WYRELOG_E_OK) {
+      g_object_unref (session);
+      return rc;
+    }
+  }
 
   *out_session = session;
   return WYRELOG_E_OK;


### PR DESCRIPTION
## Summary
- insert a `principal_state(user, "authenticated")` fact during username login when a policy engine pair is attached
- preserve the existing lightweight behavior for handles without policy engines and for unset usernames
- add an engine-backed login-to-decision test that verifies the login fact participates in `allow_bool`

## Tests
- meson test -C builddir --print-errorlogs