### PR TITLE
session: reject login without handle

### DIFF
--- a/tests/test-session-id.c
+++ b/tests/test-session-id.c
@@ -87,6 +87,18 @@ check_accessor_null_safety (void)
   return 0;
 }
 
+static gint
+check_login_rejects_null_handle (void)
+{
+  WylSession *session = (WylSession *) 0x1;
+
+  if (wyl_session_login (NULL, NULL, &session) != WYRELOG_E_INVALID)
+    return 60;
+  if (session != NULL)
+    return 61;
+  return 0;
+}
+
 int
 main (void)
 {
@@ -101,6 +113,8 @@ main (void)
   if ((rc = check_created_at_is_recent ()) != 0)
     return rc;
   if ((rc = check_accessor_null_safety ()) != 0)
+    return rc;
+  if ((rc = check_login_rejects_null_handle ()) != 0)
     return rc;
 
   return 0;

--- a/wyrelog/wyl-session.c
+++ b/wyrelog/wyl-session.c
@@ -55,6 +55,8 @@ wyl_session_login (WylHandle *handle, const wyl_login_req_t *req,
   if (out_session == NULL)
     return WYRELOG_E_INVALID;
   *out_session = NULL;
+  if (handle == NULL)
+    return WYRELOG_E_INVALID;
 
   WylSession *session = g_object_new (WYL_TYPE_SESSION, NULL);
   const gchar *username = NULL;
@@ -63,8 +65,7 @@ wyl_session_login (WylHandle *handle, const wyl_login_req_t *req,
     session->username = g_strdup (username);
   }
 
-  if (handle != NULL && username != NULL
-      && wyl_handle_get_read_engine (handle) != NULL) {
+  if (username != NULL && wyl_handle_get_read_engine (handle) != NULL) {
     gint64 row[2];
     wyrelog_error_t rc =
         wyl_handle_intern_engine_symbol (handle, username, &row[0]);


### PR DESCRIPTION
## Summary
- reject `wyl_session_login()` calls with a null handle
- clear the output session before returning invalid for that path
- add session id coverage for the null-handle login contract

## Tests
- meson test -C builddir --print-errorlogs