### PR TITLE
perm: mirror direct grants into policy engine

### DIFF
--- a/templates/access/bootstrap.dl
+++ b/templates/access/bootstrap.dl
@@ -37,6 +37,7 @@
 .decl ttl(key: symbol, seconds: int32)
 
 // EDB injected by the host at runtime
+.decl direct_permission(user: symbol, perm: symbol, scope: symbol)
 .decl member_of(user: symbol, role: symbol, scope: symbol)
 .decl now(ts: int64)
 .decl break_glass_used(ts: int64)
@@ -192,6 +193,7 @@ effective_permission(R, P) :- role_permission(R, P).
 effective_permission(R, P) :- inherits(R, R2), effective_permission(R2, P).
 
 has_permission(U, P, S) :- effective_member(U, R, S), effective_permission(R, P).
+has_permission(U, P, S) :- direct_permission(U, P, S).
 
 is_admin(U) :- has_permission(U, "wr.sys.admin", _).
 is_admin(U) :- has_permission(U, "wr.svc.admin", _).

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -237,7 +237,10 @@ test('decide', test_decide)
 
 test_perm = executable('test-perm',
   'test-perm.c',
-  dependencies : [wyrelog_dep],
+  c_args : [
+    '-DWYL_TEST_TEMPLATE_DIR="' + meson.project_source_root() / 'templates' / 'access' + '"',
+  ],
+  dependencies : [wyrelog_dep, wirelog_dep],
 )
 
 test('perm', test_perm)

--- a/tests/test-engine-io.c
+++ b/tests/test-engine-io.c
@@ -321,6 +321,32 @@ test_snapshot_observes_inserted_row (void)
 }
 
 static void
+test_snapshot_observes_direct_permission (void)
+{
+  g_autoptr (WylEngine) engine = open_engine_from_real_templates ();
+  gint64 row[3];
+  SnapshotExpect expect;
+
+  g_assert_cmpint (wyl_engine_intern_symbol (engine,
+          "direct-permission-user", &row[0]), ==, WYRELOG_E_OK);
+  g_assert_cmpint (wyl_engine_intern_symbol (engine,
+          "wr.direct-permission", &row[1]), ==, WYRELOG_E_OK);
+  g_assert_cmpint (wyl_engine_intern_symbol (engine,
+          "direct-permission-scope", &row[2]), ==, WYRELOG_E_OK);
+  g_assert_cmpint (wyl_engine_insert (engine, "direct_permission", row, 3),
+      ==, WYRELOG_E_OK);
+
+  expect.relation = "has_permission";
+  expect.expected_row = row;
+  expect.expected_ncols = 3;
+  expect.seen = 0;
+
+  g_assert_cmpint (wyl_engine_snapshot (engine, "has_permission",
+          snapshot_expect_cb, &expect), ==, WYRELOG_E_OK);
+  g_assert_cmpuint (expect.seen, ==, 1);
+}
+
+static void
 test_snapshot_observes_removed_row (void)
 {
   g_autoptr (WylEngine) engine = open_engine_from_real_templates ();
@@ -725,6 +751,8 @@ main (int argc, char **argv)
       test_snapshot_after_step_rejected);
   g_test_add_func ("/engine-io/snapshot-observes-inserted-row",
       test_snapshot_observes_inserted_row);
+  g_test_add_func ("/engine-io/snapshot-observes-direct-permission",
+      test_snapshot_observes_direct_permission);
   g_test_add_func ("/engine-io/snapshot-observes-removed-row",
       test_snapshot_observes_removed_row);
   g_test_add_func ("/engine-io/delta-nominal", test_delta_nominal);

--- a/tests/test-perm.c
+++ b/tests/test-perm.c
@@ -2,11 +2,17 @@
 #include <glib.h>
 
 #include "wyrelog/wyrelog.h"
+#include "wyrelog/wyl-handle-private.h"
+
+#ifndef WYL_TEST_TEMPLATE_DIR
+#error "WYL_TEST_TEMPLATE_DIR must be defined by the build."
+#endif
 
 /*
  * v0 contract for wyl_perm_grant / wyl_perm_revoke: validate
- * arguments, record the admin operation in the audit log when
- * audit is enabled, and return WYRELOG_E_OK without touching a
+ * arguments, mirror the direct permission fact into any attached
+ * policy engine pair, record the admin operation in the audit log
+ * when audit is enabled, and return WYRELOG_E_OK without touching a
  * durable permission store. The store wiring is a follow-up.
  */
 
@@ -61,6 +67,23 @@ check_grant_rejects_null_args (void)
 }
 
 static gint
+check_grant_rejects_incomplete_req (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 35;
+
+  g_autoptr (wyl_grant_req_t) req = wyl_grant_req_new ();
+  if (wyl_perm_grant (handle, req) != WYRELOG_E_INVALID)
+    return 36;
+  wyl_grant_req_set_subject_id (req, "alice");
+  wyl_grant_req_set_action (req, "read");
+  if (wyl_perm_grant (handle, req) != WYRELOG_E_INVALID)
+    return 37;
+  return 0;
+}
+
+static gint
 check_revoke_rejects_null_args (void)
 {
   g_autoptr (WylHandle) handle = NULL;
@@ -76,6 +99,110 @@ check_revoke_rejects_null_args (void)
   return 0;
 }
 
+static gint
+check_revoke_rejects_incomplete_req (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 45;
+
+  g_autoptr (wyl_revoke_req_t) req = wyl_revoke_req_new ();
+  if (wyl_perm_revoke (handle, req) != WYRELOG_E_INVALID)
+    return 46;
+  wyl_revoke_req_set_subject_id (req, "alice");
+  wyl_revoke_req_set_action (req, "read");
+  if (wyl_perm_revoke (handle, req) != WYRELOG_E_INVALID)
+    return 47;
+  return 0;
+}
+
+static gint
+check_grant_allows_engine_decide (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 50;
+
+  g_autoptr (wyl_grant_req_t) grant = wyl_grant_req_new ();
+  wyl_grant_req_set_subject_id (grant, "grant-user");
+  wyl_grant_req_set_action (grant, "wr.grant-permission");
+  wyl_grant_req_set_resource_id (grant, "grant-scope");
+  if (wyl_perm_grant (handle, grant) != WYRELOG_E_OK)
+    return 51;
+
+  g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
+  wyl_login_req_set_username (login, "grant-user");
+  g_autoptr (WylSession) session = NULL;
+  if (wyl_session_login (handle, login, &session) != WYRELOG_E_OK)
+    return 52;
+
+  gint64 active_row[1];
+  if (wyl_handle_intern_engine_symbol (handle, "active", &active_row[0])
+      != WYRELOG_E_OK)
+    return 53;
+  if (wyl_handle_engine_insert (handle, "session_active", active_row, 1)
+      != WYRELOG_E_OK)
+    return 54;
+  gint64 session_row[2];
+  if (wyl_handle_intern_engine_symbol (handle, "grant-scope",
+          &session_row[0]) != WYRELOG_E_OK)
+    return 55;
+  session_row[1] = active_row[0];
+  if (wyl_handle_engine_insert (handle, "session_state", session_row, 2)
+      != WYRELOG_E_OK)
+    return 56;
+
+  g_autoptr (wyl_decide_req_t) decide = wyl_decide_req_new ();
+  wyl_decide_req_set_subject_id (decide, "grant-user");
+  wyl_decide_req_set_action (decide, "wr.grant-permission");
+  wyl_decide_req_set_resource_id (decide, "grant-scope");
+  g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
+  if (wyl_decide (handle, decide, resp) != WYRELOG_E_OK)
+    return 57;
+  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_ALLOW)
+    return 58;
+  return 0;
+}
+
+static gint
+check_revoke_removes_engine_grant (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 60;
+
+  g_autoptr (wyl_grant_req_t) grant = wyl_grant_req_new ();
+  wyl_grant_req_set_subject_id (grant, "revoke-user");
+  wyl_grant_req_set_action (grant, "wr.revoke-permission");
+  wyl_grant_req_set_resource_id (grant, "revoke-scope");
+  if (wyl_perm_grant (handle, grant) != WYRELOG_E_OK)
+    return 61;
+
+  g_autoptr (wyl_revoke_req_t) revoke = wyl_revoke_req_new ();
+  wyl_revoke_req_set_subject_id (revoke, "revoke-user");
+  wyl_revoke_req_set_action (revoke, "wr.revoke-permission");
+  wyl_revoke_req_set_resource_id (revoke, "revoke-scope");
+  if (wyl_perm_revoke (handle, revoke) != WYRELOG_E_OK)
+    return 62;
+
+  gint64 row[3];
+  if (wyl_handle_intern_engine_symbol (handle, "revoke-user", &row[0])
+      != WYRELOG_E_OK)
+    return 63;
+  if (wyl_handle_intern_engine_symbol (handle, "wr.revoke-permission",
+          &row[1]) != WYRELOG_E_OK)
+    return 64;
+  if (wyl_handle_intern_engine_symbol (handle, "revoke-scope", &row[2])
+      != WYRELOG_E_OK)
+    return 65;
+  gboolean allowed = TRUE;
+  if (wyl_handle_engine_decide (handle, row, &allowed) != WYRELOG_E_OK)
+    return 66;
+  if (allowed)
+    return 67;
+  return 0;
+}
+
 int
 main (void)
 {
@@ -86,7 +213,15 @@ main (void)
     return rc;
   if ((rc = check_grant_rejects_null_args ()) != 0)
     return rc;
+  if ((rc = check_grant_rejects_incomplete_req ()) != 0)
+    return rc;
   if ((rc = check_revoke_rejects_null_args ()) != 0)
+    return rc;
+  if ((rc = check_revoke_rejects_incomplete_req ()) != 0)
+    return rc;
+  if ((rc = check_grant_allows_engine_decide ()) != 0)
+    return rc;
+  if ((rc = check_revoke_removes_engine_grant ()) != 0)
     return rc;
   return 0;
 }

--- a/wyrelog/wyl-perm.c
+++ b/wyrelog/wyl-perm.c
@@ -1,6 +1,8 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #include "wyrelog/wyrelog.h"
 
+#include "wyl-handle-private.h"
+
 struct _wyl_login_req
 {
   gchar *username;
@@ -174,11 +176,45 @@ wyl_revoke_req_get_resource_id (const wyl_revoke_req_t *req)
   return req->resource_id;
 }
 
+static wyrelog_error_t
+update_direct_permission (WylHandle *handle, const gchar *subject_id,
+    const gchar *action, const gchar *resource_id, gboolean insert)
+{
+  if (wyl_handle_get_read_engine (handle) == NULL)
+    return WYRELOG_E_OK;
+
+  gint64 row[3];
+  wyrelog_error_t rc =
+      wyl_handle_intern_engine_symbol (handle, subject_id, &row[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, action, &row[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, resource_id, &row[2]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  if (insert)
+    return wyl_handle_engine_insert (handle, "direct_permission", row, 3);
+  return wyl_handle_engine_remove (handle, "direct_permission", row, 3);
+}
+
 wyrelog_error_t
 wyl_perm_grant (WylHandle *handle, const wyl_grant_req_t *req)
 {
   if (handle == NULL || req == NULL)
     return WYRELOG_E_INVALID;
+  if (wyl_grant_req_get_subject_id (req) == NULL
+      || wyl_grant_req_get_action (req) == NULL
+      || wyl_grant_req_get_resource_id (req) == NULL)
+    return WYRELOG_E_INVALID;
+
+  wyrelog_error_t rc = update_direct_permission (handle,
+      wyl_grant_req_get_subject_id (req), wyl_grant_req_get_action (req),
+      wyl_grant_req_get_resource_id (req), TRUE);
+  if (rc != WYRELOG_E_OK)
+    return rc;
 
 #ifdef WYL_HAS_AUDIT
   /* Record the grant attempt in the audit log so admin operations
@@ -196,9 +232,9 @@ wyl_perm_grant (WylHandle *handle, const wyl_grant_req_t *req)
   (void) wyl_audit_emit (handle, ev);
 #endif
 
-  /* Real persistence into a durable permission store lands in a
-   * follow-up; v0 returns E_OK after validating the request and
-   * recording it in the audit log. */
+  /* Durable permission-store persistence lands in a follow-up; v0
+   * mirrors the direct fact into the attached engine pair and records
+   * the accepted operation in the audit log. */
   return WYRELOG_E_OK;
 }
 
@@ -207,6 +243,16 @@ wyl_perm_revoke (WylHandle *handle, const wyl_revoke_req_t *req)
 {
   if (handle == NULL || req == NULL)
     return WYRELOG_E_INVALID;
+  if (wyl_revoke_req_get_subject_id (req) == NULL
+      || wyl_revoke_req_get_action (req) == NULL
+      || wyl_revoke_req_get_resource_id (req) == NULL)
+    return WYRELOG_E_INVALID;
+
+  wyrelog_error_t rc = update_direct_permission (handle,
+      wyl_revoke_req_get_subject_id (req), wyl_revoke_req_get_action (req),
+      wyl_revoke_req_get_resource_id (req), FALSE);
+  if (rc != WYRELOG_E_OK)
+    return rc;
 
 #ifdef WYL_HAS_AUDIT
   /* Mirror revoke in audit alongside grant (see wyl_perm_grant for


### PR DESCRIPTION
## Summary
- add a host-populated `direct_permission` policy relation
- derive `has_permission` from direct permission facts
- mirror public grant and revoke requests into the handle policy engine pair
- validate incomplete grant and revoke requests before accepting them

## Tests
- meson test -C builddir --print-errorlogs