### PR TITLE
perm: reject gated direct grants

### DIFF
--- a/tests/test-perm.c
+++ b/tests/test-perm.c
@@ -165,6 +165,22 @@ check_grant_allows_engine_decide (void)
 }
 
 static gint
+check_gated_grant_is_rejected_by_engine_path (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 59;
+
+  g_autoptr (wyl_grant_req_t) grant = wyl_grant_req_new ();
+  wyl_grant_req_set_subject_id (grant, "gated-grant-user");
+  wyl_grant_req_set_action (grant, "wr.audit.read");
+  wyl_grant_req_set_resource_id (grant, "gated-grant-scope");
+  if (wyl_perm_grant (handle, grant) != WYRELOG_E_POLICY)
+    return 68;
+  return 0;
+}
+
+static gint
 check_revoke_removes_engine_grant (void)
 {
   g_autoptr (WylHandle) handle = NULL;
@@ -220,6 +236,8 @@ main (void)
   if ((rc = check_revoke_rejects_incomplete_req ()) != 0)
     return rc;
   if ((rc = check_grant_allows_engine_decide ()) != 0)
+    return rc;
+  if ((rc = check_gated_grant_is_rejected_by_engine_path ()) != 0)
     return rc;
   if ((rc = check_revoke_removes_engine_grant ()) != 0)
     return rc;

--- a/wyrelog/wyl-perm.c
+++ b/wyrelog/wyl-perm.c
@@ -2,6 +2,7 @@
 #include "wyrelog/wyrelog.h"
 
 #include "wyl-handle-private.h"
+#include "wyl-permission-scope-private.h"
 
 struct _wyl_login_req
 {
@@ -182,6 +183,8 @@ update_direct_permission (WylHandle *handle, const gchar *subject_id,
 {
   if (wyl_handle_get_read_engine (handle) == NULL)
     return WYRELOG_E_OK;
+  if (insert && wyl_perm_arm_rule_lookup (action) != NULL)
+    return WYRELOG_E_POLICY;
 
   gint64 row[3];
   wyrelog_error_t rc =


### PR DESCRIPTION
## Summary
- reject engine-backed direct grants for permissions with guard catalogue entries
- prevent direct permission facts from bypassing gated permission semantics
- add public grant coverage for the guarded permission path

## Tests
- meson test -C builddir --print-errorlogs