### PR TITLE
policy: require explicit armed state

### DIFF
--- a/templates/access/fsm/permission_scope.dl
+++ b/templates/access/fsm/permission_scope.dl
@@ -5,10 +5,11 @@
 // commercial license; see LICENSE.md at the project root.
 //
 // Stateless armed/3 derivation. The version-0 perm-scope is a pure
-// IDB rule set with no transition lifecycle: a permission is either
-// ungated (no perm_arm_rule entry, in which case it is always
-// armed when the principal holds it) or, in a future commit, gated
-// by a guard expression evaluated against the request scope.
+// IDB rule set with no transition lifecycle: the host must inject
+// perm_state(user, perm, scope, "armed") for permissions that are
+// ready to participate in allow/3. Guard-derived arming lands in a
+// future commit when compound guard payloads are bridged into the
+// engine.
 //
 // EDB schemas (host-populated, no clauses below):
 //   perm_state(user, perm, scope, state)        -- v0 row count = 0
@@ -58,14 +59,6 @@ perm_arm_rule("wr.audit.explain",    "_v0_deferred").
 // rule-1: state-driven path. perm_state is host-populated; an
 // "armed" entry directly arms the (user, perm, scope) tuple.
 armed(U, P, S) :- perm_state(U, P, S, "armed").
-
-// rule-2: ungated permission -- no perm_arm_rule entry means the
-// permission is always armed when held. With the v0 catalogue above
-// populated for every gated perm, rule-2 is reserved for permissions
-// outside the catalogue (e.g. host-issued operational perms).
-armed(U, P, S) :-
-    has_permission(U, P, S),
-    !perm_arm_rule(P, _).
 
 // rule-3: gated permission with compound-term guard payload.
 // Deferred: the embedded Datalog engine supports compound terms

--- a/tests/test-decide.c
+++ b/tests/test-decide.c
@@ -62,6 +62,26 @@ insert_symbol_row3 (WylHandle *handle, const gchar *relation,
 }
 
 static wyrelog_error_t
+insert_symbol_row4 (WylHandle *handle, const gchar *relation,
+    const gchar *a, const gchar *b, const gchar *c, const gchar *d)
+{
+  gint64 row[4];
+  wyrelog_error_t rc = intern_symbol (handle, a, &row[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = intern_symbol (handle, b, &row[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = intern_symbol (handle, c, &row[2]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = intern_symbol (handle, d, &row[3]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_engine_insert (handle, relation, row, 4);
+}
+
+static wyrelog_error_t
 insert_allow_fixture (WylHandle *handle, const gchar *subject,
     const gchar *action, const gchar *resource)
 {
@@ -80,7 +100,11 @@ insert_allow_fixture (WylHandle *handle, const gchar *subject,
   rc = insert_symbol_row2 (handle, "session_state", resource, "active");
   if (rc != WYRELOG_E_OK)
     return rc;
-  return insert_symbol_row1 (handle, "session_active", "active");
+  rc = insert_symbol_row1 (handle, "session_active", "active");
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return insert_symbol_row4 (handle, "perm_state", subject, action, resource,
+      "armed");
 }
 
 static gint

--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -90,10 +90,44 @@ insert1_symbol (WylHandle *handle, const gchar *relation, const gchar *a)
 }
 
 static wyrelog_error_t
-insert_decision_fixture (WylHandle *handle, const gchar *user,
+insert2_symbol (WylHandle *handle, const gchar *relation, const gchar *a,
+    const gchar *b)
+{
+  gint64 row[2];
+  wyrelog_error_t rc = wyl_handle_intern_engine_symbol (handle, a, &row[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, b, &row[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_engine_insert (handle, relation, row, 2);
+}
+
+static wyrelog_error_t
+insert4_symbol (WylHandle *handle, const gchar *relation, const gchar *a,
+    const gchar *b, const gchar *c, const gchar *d)
+{
+  gint64 row[4];
+  wyrelog_error_t rc = wyl_handle_intern_engine_symbol (handle, a, &row[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, b, &row[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, c, &row[2]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, d, &row[3]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_engine_insert (handle, relation, row, 4);
+}
+
+static wyrelog_error_t
+insert_decision_fixture_state (WylHandle *handle, const gchar *user,
     const gchar *role, const gchar *permission, const gchar *scope,
     const gchar *principal_state, const gchar *session_state,
-    gint64 decision_row[3])
+    gboolean armed, gint64 decision_row[3])
 {
   gint64 member_row[3];
   gint64 principal_state_row[2];
@@ -137,11 +171,27 @@ insert_decision_fixture (WylHandle *handle, const gchar *user,
   rc = insert1_symbol (handle, "session_active", session_state);
   if (rc != WYRELOG_E_OK)
     return rc;
+  if (armed) {
+    rc = insert4_symbol (handle, "perm_state", user, permission, scope,
+        "armed");
+    if (rc != WYRELOG_E_OK)
+      return rc;
+  }
 
   decision_row[0] = member_row[0];
   decision_row[1] = role_permission_row[1];
   decision_row[2] = member_row[2];
   return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+insert_decision_fixture (WylHandle *handle, const gchar *user,
+    const gchar *role, const gchar *permission, const gchar *scope,
+    const gchar *principal_state, const gchar *session_state,
+    gint64 decision_row[3])
+{
+  return insert_decision_fixture_state (handle, user, role, permission, scope,
+      principal_state, session_state, TRUE, decision_row);
 }
 
 static gint
@@ -500,6 +550,113 @@ check_decision_query_denies_missing_tuple (void)
 }
 
 static gint
+check_decision_query_denies_frozen_scope (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  gint64 decision_row[3];
+  gboolean allowed = TRUE;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 145;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 146;
+  if (insert_decision_fixture (handle, "decision-user-c",
+          "wr.decision-role-c", "wr.decision-permission-c",
+          "decision-scope-c", "authenticated", "active", decision_row)
+      != WYRELOG_E_OK)
+    return 147;
+  if (insert1_symbol (handle, "frozen", "decision-scope-c") != WYRELOG_E_OK)
+    return 148;
+  if (wyl_handle_engine_decide (handle, decision_row, &allowed)
+      != WYRELOG_E_OK)
+    return 149;
+  if (allowed)
+    return 150;
+  return 0;
+}
+
+static gint
+check_decision_query_denies_disabled_role (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  gint64 decision_row[3];
+  gboolean allowed = TRUE;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 155;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 156;
+  if (insert_decision_fixture (handle, "decision-user-d",
+          "wr.decision-role-d", "wr.decision-permission-d",
+          "decision-scope-d", "authenticated", "active", decision_row)
+      != WYRELOG_E_OK)
+    return 157;
+  if (insert2_symbol (handle, "disabled_role_for", "decision-user-d",
+          "wr.decision-permission-d") != WYRELOG_E_OK)
+    return 158;
+  if (wyl_handle_engine_decide (handle, decision_row, &allowed)
+      != WYRELOG_E_OK)
+    return 159;
+  if (allowed)
+    return 160;
+  return 0;
+}
+
+static gint
+check_decision_query_denies_sod_violation (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  gint64 decision_row[3];
+  gboolean allowed = TRUE;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 165;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 166;
+  if (insert_decision_fixture (handle, "decision-user-e",
+          "wr.decision-role-e", "wr.decision-permission-e",
+          "decision-scope-e", "authenticated", "active", decision_row)
+      != WYRELOG_E_OK)
+    return 167;
+  if (insert4_symbol (handle, "policy_violation", "sod", "decision-user-e",
+          "wr.decision-permission-e", "witness-e") != WYRELOG_E_OK)
+    return 168;
+  if (wyl_handle_engine_decide (handle, decision_row, &allowed)
+      != WYRELOG_E_OK)
+    return 169;
+  if (allowed)
+    return 170;
+  return 0;
+}
+
+static gint
+check_decision_query_denies_unarmed_catalogue_permission (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  gint64 decision_row[3];
+  gboolean allowed = TRUE;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 171;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 172;
+  if (insert_decision_fixture_state (handle, "decision-user-f",
+          "wr.decision-role-f", "wr.audit.read", "decision-scope-f",
+          "authenticated", "active", FALSE, decision_row) != WYRELOG_E_OK)
+    return 173;
+  if (wyl_handle_engine_decide (handle, decision_row, &allowed)
+      != WYRELOG_E_OK)
+    return 174;
+  if (allowed)
+    return 175;
+  return 0;
+}
+
+static gint
 check_decision_query_rejects_missing_pair (void)
 {
   g_autoptr (WylHandle) handle = NULL;
@@ -551,6 +708,14 @@ main (void)
   if ((rc = check_decision_query_allows_matching_tuple ()) != 0)
     return rc;
   if ((rc = check_decision_query_denies_missing_tuple ()) != 0)
+    return rc;
+  if ((rc = check_decision_query_denies_frozen_scope ()) != 0)
+    return rc;
+  if ((rc = check_decision_query_denies_disabled_role ()) != 0)
+    return rc;
+  if ((rc = check_decision_query_denies_sod_violation ()) != 0)
+    return rc;
+  if ((rc = check_decision_query_denies_unarmed_catalogue_permission ()) != 0)
     return rc;
   if ((rc = check_decision_query_rejects_missing_pair ()) != 0)
     return rc;

--- a/tests/test-perm.c
+++ b/tests/test-perm.c
@@ -10,10 +10,11 @@
 
 /*
  * v0 contract for wyl_perm_grant / wyl_perm_revoke: validate
- * arguments, mirror the direct permission fact into any attached
- * policy engine pair, record the admin operation in the audit log
- * when audit is enabled, and return WYRELOG_E_OK without touching a
- * durable permission store. The store wiring is a follow-up.
+ * arguments, mirror direct permission plus armed-state facts into
+ * any attached policy engine pair, record the admin operation in
+ * the audit log when audit is enabled, and return WYRELOG_E_OK
+ * without touching a durable permission store. The store wiring is
+ * a follow-up.
  */
 
 static gint

--- a/tests/test-session-username.c
+++ b/tests/test-session-username.c
@@ -57,6 +57,26 @@ insert_symbol_row3 (WylHandle *handle, const gchar *relation,
   return wyl_handle_engine_insert (handle, relation, row, 3);
 }
 
+static wyrelog_error_t
+insert_symbol_row4 (WylHandle *handle, const gchar *relation,
+    const gchar *a, const gchar *b, const gchar *c, const gchar *d)
+{
+  gint64 row[4];
+  wyrelog_error_t rc = intern_symbol (handle, a, &row[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = intern_symbol (handle, b, &row[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = intern_symbol (handle, c, &row[2]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = intern_symbol (handle, d, &row[3]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_engine_insert (handle, relation, row, 4);
+}
+
 static WylSession *
 login_with_username (const gchar *username)
 {
@@ -186,14 +206,17 @@ check_login_authenticates_engine_principal (void)
     return 73;
   if (insert_symbol_row1 (handle, "session_active", "active") != WYRELOG_E_OK)
     return 74;
+  if (insert_symbol_row4 (handle, "perm_state", "login-user",
+          "wr.login-permission", "login-scope", "armed") != WYRELOG_E_OK)
+    return 75;
 
   g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
   wyl_login_req_set_username (login, "login-user");
   g_autoptr (WylSession) session = NULL;
   if (wyl_session_login (handle, login, &session) != WYRELOG_E_OK)
-    return 75;
-  if (session == NULL)
     return 76;
+  if (session == NULL)
+    return 77;
 
   g_autoptr (wyl_decide_req_t) decide = wyl_decide_req_new ();
   wyl_decide_req_set_subject_id (decide, "login-user");
@@ -202,9 +225,9 @@ check_login_authenticates_engine_principal (void)
 
   g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
   if (wyl_decide (handle, decide, resp) != WYRELOG_E_OK)
-    return 77;
-  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_ALLOW)
     return 78;
+  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_ALLOW)
+    return 79;
   return 0;
 }
 

--- a/wyrelog/wyl-perm.c
+++ b/wyrelog/wyl-perm.c
@@ -198,9 +198,22 @@ update_direct_permission (WylHandle *handle, const gchar *subject_id,
   if (rc != WYRELOG_E_OK)
     return rc;
 
-  if (insert)
-    return wyl_handle_engine_insert (handle, "direct_permission", row, 3);
-  return wyl_handle_engine_remove (handle, "direct_permission", row, 3);
+  gint64 state_row[4] = { row[0], row[1], row[2], -1 };
+  rc = wyl_handle_intern_engine_symbol (handle, "armed", &state_row[3]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  if (insert) {
+    rc = wyl_handle_engine_insert (handle, "direct_permission", row, 3);
+    if (rc != WYRELOG_E_OK)
+      return rc;
+    return wyl_handle_engine_insert (handle, "perm_state", state_row, 4);
+  }
+
+  rc = wyl_handle_engine_remove (handle, "direct_permission", row, 3);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_engine_remove (handle, "perm_state", state_row, 4);
 }
 
 wyrelog_error_t


### PR DESCRIPTION
## Summary
- require explicit `perm_state(..., "armed")` before allow decisions can pass
- mirror custom direct grants into both `direct_permission` and `perm_state`
- remove mirrored facts on revoke
- add engine-backed deny and unarmed catalogue permission coverage

## Tests
- meson test -C builddir --print-errorlogs