### PR TITLE
decide: apply guard context to catalogue perms

### DIFF
--- a/templates/access/decision.dl
+++ b/templates/access/decision.dl
@@ -38,21 +38,25 @@
     witness: symbol)
 
 .decl allow(user: symbol, perm: symbol, scope: symbol)
+.decl allow_guard_base(user: symbol, perm: symbol, scope: symbol)
 .decl allow_bool(user: symbol, perm: symbol, scope: symbol)
 .decl deny_reason(user: symbol, perm: symbol, scope: symbol,
     code: symbol, origin: symbol)
 
 // --- allow / allow_bool ----------------------------------------------
 
-allow(U, P, S) :-
+allow_guard_base(U, P, S) :-
     has_permission(U, P, S),
     principal_state(U, "authenticated"),
     session_state(S, ST),
     session_active(ST),
-    armed(U, P, S),
     !frozen(S),
     !disabled_role_for(U, P),
     !policy_violation("sod", U, P, _).
+
+allow(U, P, S) :-
+    allow_guard_base(U, P, S),
+    armed(U, P, S).
 
 allow_bool(U, P, S) :- allow(U, P, S).
 

--- a/tests/test-decide.c
+++ b/tests/test-decide.c
@@ -82,8 +82,8 @@ insert_symbol_row4 (WylHandle *handle, const gchar *relation,
 }
 
 static wyrelog_error_t
-insert_allow_fixture (WylHandle *handle, const gchar *subject,
-    const gchar *action, const gchar *resource)
+insert_allow_fixture_state (WylHandle *handle, const gchar *subject,
+    const gchar *action, const gchar *resource, gboolean armed)
 {
   wyrelog_error_t rc =
       insert_symbol_row2 (handle, "role_permission", "wr.decide-role",
@@ -103,8 +103,17 @@ insert_allow_fixture (WylHandle *handle, const gchar *subject,
   rc = insert_symbol_row1 (handle, "session_active", "active");
   if (rc != WYRELOG_E_OK)
     return rc;
+  if (!armed)
+    return WYRELOG_E_OK;
   return insert_symbol_row4 (handle, "perm_state", subject, action, resource,
       "armed");
+}
+
+static wyrelog_error_t
+insert_allow_fixture (WylHandle *handle, const gchar *subject,
+    const gchar *action, const gchar *resource)
+{
+  return insert_allow_fixture_state (handle, subject, action, resource, TRUE);
 }
 
 static gint
@@ -220,6 +229,70 @@ check_decide_denies_engine_miss (void)
   return 0;
 }
 
+static gint
+check_decide_allows_guarded_permission_with_context (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 60;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 61;
+  if (insert_allow_fixture_state (handle, "decide-user-c", "wr.audit.read",
+          "decide-resource-c", FALSE) != WYRELOG_E_OK)
+    return 62;
+
+  g_autoptr (wyl_decide_req_t) req = wyl_decide_req_new ();
+  wyl_decide_req_set_subject_id (req, "decide-user-c");
+  wyl_decide_req_set_action (req, "wr.audit.read");
+  wyl_decide_req_set_resource_id (req, "decide-resource-c");
+  wyl_decide_req_set_guard_context (req, 123, "public", 69);
+
+  g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
+  if (wyl_decide (handle, req, resp) != WYRELOG_E_OK)
+    return 63;
+  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_ALLOW)
+    return 64;
+
+  wyl_decide_req_clear_guard_context (req);
+  wyl_decide_resp_set_decision (resp, WYL_DECISION_ALLOW);
+  if (wyl_decide (handle, req, resp) != WYRELOG_E_OK)
+    return 65;
+  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_DENY)
+    return 66;
+
+  return 0;
+}
+
+static gint
+check_decide_denies_guarded_permission_on_context_miss (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 70;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 71;
+  if (insert_allow_fixture_state (handle, "decide-user-d", "wr.audit.read",
+          "decide-resource-d", TRUE) != WYRELOG_E_OK)
+    return 72;
+
+  g_autoptr (wyl_decide_req_t) req = wyl_decide_req_new ();
+  wyl_decide_req_set_subject_id (req, "decide-user-d");
+  wyl_decide_req_set_action (req, "wr.audit.read");
+  wyl_decide_req_set_resource_id (req, "decide-resource-d");
+  wyl_decide_req_set_guard_context (req, 123, "public", 70);
+
+  g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
+  wyl_decide_resp_set_decision (resp, WYL_DECISION_ALLOW);
+  if (wyl_decide (handle, req, resp) != WYRELOG_E_OK)
+    return 73;
+  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_DENY)
+    return 74;
+
+  return 0;
+}
+
 int
 main (void)
 {
@@ -233,6 +306,10 @@ main (void)
   if ((rc = check_decide_allows_engine_tuple ()) != 0)
     return rc;
   if ((rc = check_decide_denies_engine_miss ()) != 0)
+    return rc;
+  if ((rc = check_decide_allows_guarded_permission_with_context ()) != 0)
+    return rc;
+  if ((rc = check_decide_denies_guarded_permission_on_context_miss ()) != 0)
     return rc;
   return 0;
 }

--- a/wyrelog/decide.h
+++ b/wyrelog/decide.h
@@ -52,6 +52,15 @@ void wyl_decide_req_set_resource_id (wyl_decide_req_t * req,
     const gchar * resource_id);
 const gchar *wyl_decide_req_get_resource_id (const wyl_decide_req_t * req);
 
+/*
+ * Sets or clears request-time attributes used by guarded catalogue
+ * permissions. When no guard context is set, guarded permissions remain
+ * fail-closed. The location class string is duplicated by the request.
+ */
+void wyl_decide_req_set_guard_context (wyl_decide_req_t * req,
+    gint64 timestamp, const gchar * loc_class, gint64 risk);
+void wyl_decide_req_clear_guard_context (wyl_decide_req_t * req);
+
 wyl_decide_resp_t *wyl_decide_resp_new (void);
 void wyl_decide_resp_free (wyl_decide_resp_t * resp);
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (wyl_decide_resp_t, wyl_decide_resp_free);

--- a/wyrelog/wyl-decide.c
+++ b/wyrelog/wyl-decide.c
@@ -2,12 +2,17 @@
 #include "wyrelog/wyrelog.h"
 
 #include "wyl-handle-private.h"
+#include "wyl-permission-scope-private.h"
 
 struct _wyl_decide_req
 {
   gchar *subject_id;
   gchar *action;
   gchar *resource_id;
+  gboolean has_guard_context;
+  gint64 guard_timestamp;
+  gchar *guard_loc_class;
+  gint64 guard_risk;
 };
 
 struct _wyl_decide_resp
@@ -29,6 +34,7 @@ wyl_decide_req_free (wyl_decide_req_t *req)
   g_free (req->subject_id);
   g_free (req->action);
   g_free (req->resource_id);
+  g_free (req->guard_loc_class);
   g_free (req);
 }
 
@@ -77,6 +83,28 @@ wyl_decide_req_get_resource_id (const wyl_decide_req_t *req)
   return req->resource_id;
 }
 
+void
+wyl_decide_req_set_guard_context (wyl_decide_req_t *req, gint64 timestamp,
+    const gchar *loc_class, gint64 risk)
+{
+  g_return_if_fail (req != NULL);
+  req->has_guard_context = TRUE;
+  req->guard_timestamp = timestamp;
+  g_free (req->guard_loc_class);
+  req->guard_loc_class = g_strdup (loc_class);
+  req->guard_risk = risk;
+}
+
+void
+wyl_decide_req_clear_guard_context (wyl_decide_req_t *req)
+{
+  g_return_if_fail (req != NULL);
+  req->has_guard_context = FALSE;
+  req->guard_timestamp = 0;
+  g_clear_pointer (&req->guard_loc_class, g_free);
+  req->guard_risk = 0;
+}
+
 wyl_decide_resp_t *
 wyl_decide_resp_new (void)
 {
@@ -104,6 +132,29 @@ wyl_decide_resp_get_decision (const wyl_decide_resp_t *resp)
    * response must not silently observe an ALLOW. */
   g_return_val_if_fail (resp != NULL, WYL_DECISION_DENY);
   return resp->decision;
+}
+
+static wyrelog_error_t
+guard_base_decide_if_satisfied (WylHandle *handle,
+    const wyl_guard_expr_t *guard, const wyl_decide_req_t *req,
+    const gint64 row[3], gboolean *out_allowed)
+{
+  *out_allowed = FALSE;
+
+  if (guard == NULL || !req->has_guard_context)
+    return WYRELOG_E_OK;
+
+  wyl_scope_t scope = {
+    .user = wyl_decide_req_get_subject_id (req),
+    .timestamp = req->guard_timestamp,
+    .loc_class = req->guard_loc_class,
+    .risk = req->guard_risk,
+  };
+  if (!wyl_eval_guard (guard, &scope))
+    return WYRELOG_E_OK;
+
+  return wyl_handle_engine_contains (handle, "allow_guard_base", row, 3,
+      out_allowed);
 }
 
 wyrelog_error_t
@@ -135,9 +186,17 @@ wyl_decide (WylHandle *handle, const wyl_decide_req_t *req,
       return rc;
 
     gboolean allowed = FALSE;
-    rc = wyl_handle_engine_decide (handle, row, &allowed);
-    if (rc != WYRELOG_E_OK)
-      return rc;
+    const wyl_guard_expr_t *guard =
+        wyl_perm_arm_rule_lookup (wyl_decide_req_get_action (req));
+    if (guard != NULL) {
+      rc = guard_base_decide_if_satisfied (handle, guard, req, row, &allowed);
+      if (rc != WYRELOG_E_OK)
+        return rc;
+    } else {
+      rc = wyl_handle_engine_decide (handle, row, &allowed);
+      if (rc != WYRELOG_E_OK)
+        return rc;
+    }
     if (allowed)
       wyl_decide_resp_set_decision (resp, WYL_DECISION_ALLOW);
   }

--- a/wyrelog/wyl-handle-private.h
+++ b/wyrelog/wyl-handle-private.h
@@ -50,6 +50,14 @@ wyrelog_error_t wyl_handle_engine_remove (WylHandle * self,
     const gchar * relation, const gint64 * row, gsize ncols);
 
 /*
+ * Probes the read engine for an exact EDB/IDB row match. Rejected unless the
+ * engine pair is already open.
+ */
+wyrelog_error_t wyl_handle_engine_contains (WylHandle * self,
+    const gchar * relation, const gint64 * row, gsize ncols,
+    gboolean * out_contains);
+
+/*
  * Reads allow_bool/3 from the handle-owned read engine for @row
  * (user, permission, scope). Rejected unless the engine pair is already open.
  */

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -239,24 +239,48 @@ wyl_handle_engine_remove (WylHandle *self, const gchar *relation,
 
 typedef struct
 {
+  const gchar *relation;
   const gint64 *row;
+  gsize ncols;
   gboolean matched;
-} WylDecisionProbe;
+} WylRowProbe;
 
 static void
-wyl_handle_decide_snapshot_cb (const gchar *relation, const gint64 *row,
+wyl_handle_row_snapshot_cb (const gchar *relation, const gint64 *row,
     guint ncols, gpointer user_data)
 {
-  WylDecisionProbe *probe = user_data;
+  WylRowProbe *probe = user_data;
 
-  (void) relation;
-
-  if (ncols != 3)
+  if (g_strcmp0 (relation, probe->relation) != 0)
     return;
-  if (row[0] == probe->row[0] && row[1] == probe->row[1]
-      && row[2] == probe->row[2]) {
-    probe->matched = TRUE;
+  if (ncols != probe->ncols)
+    return;
+  for (gsize i = 0; i < probe->ncols; i++) {
+    if (row[i] != probe->row[i])
+      return;
   }
+  probe->matched = TRUE;
+}
+
+wyrelog_error_t
+wyl_handle_engine_contains (WylHandle *self, const gchar *relation,
+    const gint64 *row, gsize ncols, gboolean *out_contains)
+{
+  if (self == NULL || !WYL_IS_HANDLE (self))
+    return WYRELOG_E_INVALID;
+  if (relation == NULL || row == NULL || ncols == 0 || out_contains == NULL)
+    return WYRELOG_E_INVALID;
+  if (self->read_engine == NULL || self->delta_engine == NULL)
+    return WYRELOG_E_INVALID;
+
+  WylRowProbe probe = { relation, row, ncols, FALSE };
+  wyrelog_error_t rc = wyl_engine_snapshot (self->read_engine,
+      relation, wyl_handle_row_snapshot_cb, &probe);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  *out_contains = probe.matched;
+  return WYRELOG_E_OK;
 }
 
 wyrelog_error_t
@@ -270,14 +294,7 @@ wyl_handle_engine_decide (WylHandle *self, const gint64 row[3],
   if (self->read_engine == NULL || self->delta_engine == NULL)
     return WYRELOG_E_INVALID;
 
-  WylDecisionProbe probe = { row, FALSE };
-  wyrelog_error_t rc = wyl_engine_snapshot (self->read_engine,
-      "allow_bool", wyl_handle_decide_snapshot_cb, &probe);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-
-  *out_allowed = probe.matched;
-  return WYRELOG_E_OK;
+  return wyl_handle_engine_contains (self, "allow_bool", row, 3, out_allowed);
 }
 
 WylEngine *


### PR DESCRIPTION
## Summary
- add request guard context for guarded catalogue permissions
- split the policy decision into `allow_guard_base` and `allow_bool` projections
- require guarded actions to pass request-time guard evaluation before allow
- reuse exact row snapshot probing for policy engine checks

## Tests
- meson test -C builddir --print-errorlogs