### PR TITLE
policy: keep guarded perms on host path

### DIFF
--- a/templates/access/decision.dl
+++ b/templates/access/decision.dl
@@ -39,6 +39,7 @@
 
 .decl allow(user: symbol, perm: symbol, scope: symbol)
 .decl allow_guard_base(user: symbol, perm: symbol, scope: symbol)
+.decl guarded_perm(perm: symbol)
 .decl allow_bool(user: symbol, perm: symbol, scope: symbol)
 .decl deny_reason(user: symbol, perm: symbol, scope: symbol,
     code: symbol, origin: symbol)
@@ -54,9 +55,12 @@ allow_guard_base(U, P, S) :-
     !disabled_role_for(U, P),
     !policy_violation("sod", U, P, _).
 
+guarded_perm(P) :- perm_arm_rule(P, G).
+
 allow(U, P, S) :-
     allow_guard_base(U, P, S),
-    armed(U, P, S).
+    armed(U, P, S),
+    !guarded_perm(P).
 
 allow_bool(U, P, S) :- allow(U, P, S).
 

--- a/tests/test-access-decision.c
+++ b/tests/test-access-decision.c
@@ -13,7 +13,7 @@
 /* --- Stratification self-check ---------------------------------- */
 
 /*
- * Lifts the eight rule heads introduced by decision.dl into
+ * Lifts the rule heads introduced by decision.dl into
  * wyl_dl_rule_t form and asserts the program is stratified. Every
  * negation edge from these rules lands on either an EDB predicate
  * (frozen, disabled_role_for, policy_violation, principal_state,
@@ -24,15 +24,22 @@
 static gint
 check_stratification (void)
 {
-  static const wyl_dl_body_atom_t allow_body[] = {
+  static const wyl_dl_body_atom_t allow_guard_base_body[] = {
     {.predicate = "has_permission",.negated = FALSE},
     {.predicate = "principal_state",.negated = FALSE},
     {.predicate = "session_state",.negated = FALSE},
     {.predicate = "session_active",.negated = FALSE},
-    {.predicate = "armed",.negated = FALSE},
     {.predicate = "frozen",.negated = TRUE},
     {.predicate = "disabled_role_for",.negated = TRUE},
     {.predicate = "policy_violation",.negated = TRUE},
+  };
+  static const wyl_dl_body_atom_t allow_body[] = {
+    {.predicate = "allow_guard_base",.negated = FALSE},
+    {.predicate = "armed",.negated = FALSE},
+    {.predicate = "guarded_perm",.negated = TRUE},
+  };
+  static const wyl_dl_body_atom_t guarded_perm_body[] = {
+    {.predicate = "perm_arm_rule",.negated = FALSE},
   };
   static const wyl_dl_body_atom_t allow_bool_body[] = {
     {.predicate = "allow",.negated = FALSE},
@@ -67,6 +74,10 @@ check_stratification (void)
     {.predicate = "armed",.negated = TRUE},
   };
   wyl_dl_rule_t rules[] = {
+    {.head = "allow_guard_base",.body = allow_guard_base_body,
+        .body_len = G_N_ELEMENTS (allow_guard_base_body)},
+    {.head = "guarded_perm",.body = guarded_perm_body,
+        .body_len = G_N_ELEMENTS (guarded_perm_body)},
     {.head = "allow",.body = allow_body,.body_len = G_N_ELEMENTS (allow_body)},
     {.head = "allow_bool",.body = allow_bool_body,
         .body_len = G_N_ELEMENTS (allow_bool_body)},

--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -657,6 +657,36 @@ check_decision_query_denies_unarmed_catalogue_permission (void)
 }
 
 static gint
+check_decision_query_denies_armed_catalogue_permission (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  gint64 decision_row[3];
+  gboolean allowed = TRUE;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 176;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 177;
+  if (insert_decision_fixture_state (handle, "decision-user-g",
+          "wr.decision-role-g", "wr.audit.read", "decision-scope-g",
+          "authenticated", "active", TRUE, decision_row) != WYRELOG_E_OK)
+    return 178;
+  gboolean guarded = FALSE;
+  if (wyl_handle_engine_contains (handle, "guarded_perm", &decision_row[1], 1,
+          &guarded) != WYRELOG_E_OK)
+    return 179;
+  if (!guarded)
+    return 180;
+  if (wyl_handle_engine_decide (handle, decision_row, &allowed)
+      != WYRELOG_E_OK)
+    return 181;
+  if (allowed)
+    return 182;
+  return 0;
+}
+
+static gint
 check_decision_query_rejects_missing_pair (void)
 {
   g_autoptr (WylHandle) handle = NULL;
@@ -716,6 +746,8 @@ main (void)
   if ((rc = check_decision_query_denies_sod_violation ()) != 0)
     return rc;
   if ((rc = check_decision_query_denies_unarmed_catalogue_permission ()) != 0)
+    return rc;
+  if ((rc = check_decision_query_denies_armed_catalogue_permission ()) != 0)
     return rc;
   if ((rc = check_decision_query_rejects_missing_pair ()) != 0)
     return rc;

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -5,6 +5,7 @@
 #include "wyl-handle-private.h"
 #include "wyl-id-private.h"
 #include "wyl-log-private.h"
+#include "wyl-permission-scope-private.h"
 
 #ifdef WYL_HAS_AUDIT
 #include "audit/conn-private.h"
@@ -61,6 +62,25 @@ wyl_handle_init (WylHandle *self)
   if (wyl_id_new (&self->id) != WYRELOG_E_OK)
     g_error ("wyl_handle_init: failed to mint identifier");
   self->created_at_us = g_get_real_time ();
+}
+
+static wyrelog_error_t
+wyl_handle_seed_perm_arm_rules (WylHandle *self)
+{
+  for (gsize i = 0; i < wyl_perm_arm_rule_count (); i++) {
+    gint64 row[2];
+    wyrelog_error_t rc = wyl_handle_intern_engine_symbol (self,
+        wyl_perm_arm_rule_perm_id (i), &row[0]);
+    if (rc != WYRELOG_E_OK)
+      return rc;
+    rc = wyl_handle_intern_engine_symbol (self, "_v0_deferred", &row[1]);
+    if (rc != WYRELOG_E_OK)
+      return rc;
+    rc = wyl_handle_engine_insert (self, "perm_arm_rule", row, 2);
+    if (rc != WYRELOG_E_OK)
+      return rc;
+  }
+  return WYRELOG_E_OK;
 }
 
 wyrelog_error_t
@@ -171,6 +191,12 @@ wyl_handle_open_engine_pair (WylHandle *self, const gchar *template_dir)
 
   self->read_engine = read_engine;
   self->delta_engine = delta_engine;
+  rc = wyl_handle_seed_perm_arm_rules (self);
+  if (rc != WYRELOG_E_OK) {
+    g_clear_object (&self->read_engine);
+    g_clear_object (&self->delta_engine);
+    return rc;
+  }
   return WYRELOG_E_OK;
 }
 


### PR DESCRIPTION
## Summary
- seed the guarded permission catalogue into policy engine pairs
- project guarded permissions into `guarded_perm` for Datalog checks
- keep guarded permissions out of the state-driven `allow_bool` path
- add engine-backed coverage for armed catalogue permission denial

## Tests
- meson test -C builddir --print-errorlogs