### PR TITLE
daemon: add wyrelogd smoke entrypoint

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -12,6 +12,14 @@ test_boot_smoke = executable('test-boot-smoke',
 
 test('boot-smoke', test_boot_smoke)
 
+test('wyrelogd-check', wyrelogd_exe,
+  args : [
+    '--template-dir',
+    meson.project_source_root() / 'templates' / 'access',
+    '--check',
+  ],
+)
+
 test_client_smoke = executable('test-client-smoke',
   'test-client-smoke.c',
   dependencies : [wyrelog_client_dep],

--- a/tests/test-decide-req.c
+++ b/tests/test-decide-req.c
@@ -16,6 +16,8 @@ check_defaults_are_null (void)
     return 12;
   if (wyl_decide_req_get_resource_id (req) != NULL)
     return 13;
+  if (wyl_decide_req_has_guard_context (req))
+    return 14;
   return 0;
 }
 
@@ -121,6 +123,68 @@ check_free_null_is_safe (void)
   return 0;
 }
 
+static gint
+check_guard_context_round_trip (void)
+{
+  g_autoptr (wyl_decide_req_t) req = wyl_decide_req_new ();
+  wyl_decide_req_set_guard_context (req, 1234, "trusted", 42);
+
+  if (!wyl_decide_req_has_guard_context (req))
+    return 110;
+  if (wyl_decide_req_get_guard_timestamp (req) != 1234)
+    return 111;
+  if (g_strcmp0 (wyl_decide_req_get_guard_loc_class (req), "trusted") != 0)
+    return 112;
+  if (wyl_decide_req_get_guard_risk (req) != 42)
+    return 113;
+  return 0;
+}
+
+static gint
+check_guard_context_copies_loc_class (void)
+{
+  g_autoptr (wyl_decide_req_t) req = wyl_decide_req_new ();
+  gchar loc_class[16] = "public";
+  wyl_decide_req_set_guard_context (req, 99, loc_class, 7);
+  loc_class[0] = 'X';
+
+  if (g_strcmp0 (wyl_decide_req_get_guard_loc_class (req), "public") != 0)
+    return 120;
+  return 0;
+}
+
+static gint
+check_guard_context_clear_resets_fields (void)
+{
+  g_autoptr (wyl_decide_req_t) req = wyl_decide_req_new ();
+  wyl_decide_req_set_guard_context (req, 1234, "trusted", 42);
+  wyl_decide_req_clear_guard_context (req);
+
+  if (wyl_decide_req_has_guard_context (req))
+    return 130;
+  if (wyl_decide_req_get_guard_timestamp (req) != 0)
+    return 131;
+  if (wyl_decide_req_get_guard_loc_class (req) != NULL)
+    return 132;
+  if (wyl_decide_req_get_guard_risk (req) != 0)
+    return 133;
+  return 0;
+}
+
+static gint
+check_guard_context_get_null_request (void)
+{
+  if (wyl_decide_req_has_guard_context (NULL))
+    return 140;
+  if (wyl_decide_req_get_guard_timestamp (NULL) != 0)
+    return 141;
+  if (wyl_decide_req_get_guard_loc_class (NULL) != NULL)
+    return 142;
+  if (wyl_decide_req_get_guard_risk (NULL) != 0)
+    return 143;
+  return 0;
+}
+
 int
 main (void)
 {
@@ -145,6 +209,14 @@ main (void)
   if ((rc = check_get_null_request ()) != 0)
     return rc;
   if ((rc = check_free_null_is_safe ()) != 0)
+    return rc;
+  if ((rc = check_guard_context_round_trip ()) != 0)
+    return rc;
+  if ((rc = check_guard_context_copies_loc_class ()) != 0)
+    return rc;
+  if ((rc = check_guard_context_clear_resets_fields ()) != 0)
+    return rc;
+  if ((rc = check_guard_context_get_null_request ()) != 0)
     return rc;
 
   return 0;

--- a/wyrelog/daemon/wyrelogd.c
+++ b/wyrelog/daemon/wyrelogd.c
@@ -1,0 +1,69 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <glib.h>
+
+#include "wyrelog/wyrelog.h"
+
+#ifndef WYL_DEFAULT_TEMPLATE_DIR
+#error "WYL_DEFAULT_TEMPLATE_DIR must be defined by the build."
+#endif
+
+typedef struct
+{
+  const gchar *template_dir;
+  gboolean check_only;
+  gboolean show_version;
+} WylDaemonOptions;
+
+static gboolean
+parse_options (gint *argc, gchar ***argv, WylDaemonOptions *opts,
+    GError **error)
+{
+  GOptionEntry entries[] = {
+    {"template-dir", 0, 0, G_OPTION_ARG_STRING, &opts->template_dir,
+        "Access policy template directory", "DIR"},
+    {"check", 0, 0, G_OPTION_ARG_NONE, &opts->check_only,
+        "Load policy templates and exit", NULL},
+    {"version", 0, 0, G_OPTION_ARG_NONE, &opts->show_version,
+        "Print version and exit", NULL},
+    {NULL}
+  };
+
+  g_autoptr (GOptionContext) context =
+      g_option_context_new ("- wyrelog daemon");
+  g_option_context_add_main_entries (context, entries, NULL);
+
+  return g_option_context_parse (context, argc, argv, error);
+}
+
+int
+main (int argc, char **argv)
+{
+  WylDaemonOptions opts = {
+    .template_dir = WYL_DEFAULT_TEMPLATE_DIR,
+  };
+  g_autoptr (GError) error = NULL;
+
+  if (!parse_options (&argc, &argv, &opts, &error)) {
+    g_printerr ("wyrelogd: %s\n", error->message);
+    return 2;
+  }
+
+  if (opts.show_version) {
+    g_print ("%s\n", wyrelog_version_string ());
+    return 0;
+  }
+
+  g_autoptr (WylHandle) handle = NULL;
+  wyrelog_error_t rc = wyl_init (opts.template_dir, &handle);
+  if (rc != WYRELOG_E_OK) {
+    g_printerr ("wyrelogd: init failed: %s\n", wyrelog_error_string (rc));
+    return 1;
+  }
+
+  if (opts.check_only)
+    return 0;
+
+  g_autoptr (GMainLoop) loop = g_main_loop_new (NULL, FALSE);
+  g_main_loop_run (loop);
+  return 0;
+}

--- a/wyrelog/decide.h
+++ b/wyrelog/decide.h
@@ -60,6 +60,10 @@ const gchar *wyl_decide_req_get_resource_id (const wyl_decide_req_t * req);
 void wyl_decide_req_set_guard_context (wyl_decide_req_t * req,
     gint64 timestamp, const gchar * loc_class, gint64 risk);
 void wyl_decide_req_clear_guard_context (wyl_decide_req_t * req);
+gboolean wyl_decide_req_has_guard_context (const wyl_decide_req_t * req);
+gint64 wyl_decide_req_get_guard_timestamp (const wyl_decide_req_t * req);
+const gchar *wyl_decide_req_get_guard_loc_class (const wyl_decide_req_t * req);
+gint64 wyl_decide_req_get_guard_risk (const wyl_decide_req_t * req);
 
 wyl_decide_resp_t *wyl_decide_resp_new (void);
 void wyl_decide_resp_free (wyl_decide_resp_t * resp);

--- a/wyrelog/meson.build
+++ b/wyrelog/meson.build
@@ -104,3 +104,13 @@ if build_client
 else
   wyrelog_client_dep = disabler()
 endif
+
+wyrelogd_exe = executable('wyrelogd',
+  files('daemon/wyrelogd.c'),
+  include_directories : wyrelog_inc,
+  dependencies : [wyrelog_dep, glib_dep, gio_dep],
+  c_args : [
+    '-DWYL_DEFAULT_TEMPLATE_DIR="' + get_option('datadir') / 'wyrelog' / 'access' + '"',
+  ],
+  install : true,
+)

--- a/wyrelog/wyl-decide.c
+++ b/wyrelog/wyl-decide.c
@@ -105,6 +105,34 @@ wyl_decide_req_clear_guard_context (wyl_decide_req_t *req)
   req->guard_risk = 0;
 }
 
+gboolean
+wyl_decide_req_has_guard_context (const wyl_decide_req_t *req)
+{
+  g_return_val_if_fail (req != NULL, FALSE);
+  return req->has_guard_context;
+}
+
+gint64
+wyl_decide_req_get_guard_timestamp (const wyl_decide_req_t *req)
+{
+  g_return_val_if_fail (req != NULL, 0);
+  return req->guard_timestamp;
+}
+
+const gchar *
+wyl_decide_req_get_guard_loc_class (const wyl_decide_req_t *req)
+{
+  g_return_val_if_fail (req != NULL, NULL);
+  return req->guard_loc_class;
+}
+
+gint64
+wyl_decide_req_get_guard_risk (const wyl_decide_req_t *req)
+{
+  g_return_val_if_fail (req != NULL, 0);
+  return req->guard_risk;
+}
+
 wyl_decide_resp_t *
 wyl_decide_resp_new (void)
 {


### PR DESCRIPTION
## Summary
- expose guard context accessors on decide requests
- add an installable `wyrelogd` executable
- support `--check`, `--version`, and foreground main-loop execution
- add a `wyrelogd --check` smoke test against in-tree access templates

## Tests
- meson test -C builddir --print-errorlogs
- builddir/daemon/wyrelogd --template-dir templates/access --check
- timeout 1s builddir/daemon/wyrelogd --template-dir templates/access