### PR TITLE
handle: wrap delta engine stepping

### DIFF
--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -446,7 +446,7 @@ check_insert_fanout_reaches_delta_engine (void)
   if (wyl_handle_engine_insert (handle, "member_of", member_row, 3)
       != WYRELOG_E_OK)
     return 104;
-  if (wyl_engine_step (wyl_handle_get_delta_engine (handle)) != WYRELOG_E_OK)
+  if (wyl_handle_engine_step_delta (handle) != WYRELOG_E_OK)
     return 105;
   if (expect.matching == 0)
     return 106;
@@ -496,6 +496,8 @@ check_insert_fanout_rejects_missing_pair (void)
   if (wyl_handle_engine_remove (handle, "member_of", row, 3)
       != WYRELOG_E_INVALID)
     return 122;
+  if (wyl_handle_engine_step_delta (handle) != WYRELOG_E_INVALID)
+    return 123;
   return 0;
 }
 

--- a/wyrelog/wyl-handle-private.h
+++ b/wyrelog/wyl-handle-private.h
@@ -50,6 +50,13 @@ wyrelog_error_t wyl_handle_engine_remove (WylHandle * self,
     const gchar * relation, const gint64 * row, gsize ncols);
 
 /*
+ * Advances the handle-owned delta engine by one logical step. Rejected unless
+ * the engine pair is already open. The read engine is untouched so snapshot
+ * decision probes remain available.
+ */
+wyrelog_error_t wyl_handle_engine_step_delta (WylHandle * self);
+
+/*
  * Probes the read engine for an exact EDB/IDB row match. Rejected unless the
  * engine pair is already open.
  */

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -263,6 +263,17 @@ wyl_handle_engine_remove (WylHandle *self, const gchar *relation,
   return wyl_engine_remove (self->delta_engine, relation, row, ncols);
 }
 
+wyrelog_error_t
+wyl_handle_engine_step_delta (WylHandle *self)
+{
+  if (self == NULL || !WYL_IS_HANDLE (self))
+    return WYRELOG_E_INVALID;
+  if (self->delta_engine == NULL)
+    return WYRELOG_E_INVALID;
+
+  return wyl_engine_step (self->delta_engine);
+}
+
 typedef struct
 {
   const gchar *relation;


### PR DESCRIPTION
## Summary
- add a handle-owned helper for advancing the delta engine only
- keep read-engine snapshot probes separate from incremental stepping
- route the handle-pair delta fanout test through the helper

## Tests
- meson test -C builddir --print-errorlogs