### PR TITLE
daemon: install wirelog delta callback

### DIFF
--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -440,8 +440,8 @@ check_insert_fanout_reaches_delta_engine (void)
   if (intern3 (handle, "fanout-user-b", "wr.viewer", "fanout-scope-b",
           member_row) != WYRELOG_E_OK)
     return 102;
-  if (wyl_engine_set_delta_callback (wyl_handle_get_delta_engine (handle),
-          delta_expect_cb, &expect) != WYRELOG_E_OK)
+  if (wyl_handle_engine_set_delta_callback (handle, delta_expect_cb, &expect)
+      != WYRELOG_E_OK)
     return 103;
   if (wyl_handle_engine_insert (handle, "member_of", member_row, 3)
       != WYRELOG_E_OK)
@@ -498,6 +498,9 @@ check_insert_fanout_rejects_missing_pair (void)
     return 122;
   if (wyl_handle_engine_step_delta (handle) != WYRELOG_E_INVALID)
     return 123;
+  if (wyl_handle_engine_set_delta_callback (handle, delta_expect_cb, NULL)
+      != WYRELOG_E_INVALID)
+    return 124;
   return 0;
 }
 

--- a/wyrelog/daemon/wyrelogd.c
+++ b/wyrelog/daemon/wyrelogd.c
@@ -59,6 +59,23 @@ check_wirelog_policy_ready (WylHandle *handle)
   return WYRELOG_E_OK;
 }
 
+static void
+daemon_delta_cb (const gchar *relation, const gint64 *row, guint ncols,
+    WylDeltaKind kind, gpointer user_data)
+{
+  (void) relation;
+  (void) row;
+  (void) ncols;
+  (void) kind;
+  (void) user_data;
+}
+
+static wyrelog_error_t
+start_wirelog_delta_callbacks (WylHandle *handle)
+{
+  return wyl_handle_engine_set_delta_callback (handle, daemon_delta_cb, NULL);
+}
+
 #ifdef G_OS_UNIX
 static gboolean
 quit_loop_from_signal (gpointer user_data)
@@ -133,6 +150,13 @@ main (int argc, char **argv)
       return 1;
     }
     return 0;
+  }
+
+  rc = start_wirelog_delta_callbacks (handle);
+  if (rc != WYRELOG_E_OK) {
+    g_printerr ("wyrelogd: delta callback setup failed: %s\n",
+        wyrelog_error_string (rc));
+    return 1;
   }
 
   g_autoptr (GMainLoop) loop = g_main_loop_new (NULL, FALSE);

--- a/wyrelog/wyl-handle-private.h
+++ b/wyrelog/wyl-handle-private.h
@@ -57,6 +57,13 @@ wyrelog_error_t wyl_handle_engine_remove (WylHandle * self,
 wyrelog_error_t wyl_handle_engine_step_delta (WylHandle * self);
 
 /*
+ * Installs or clears the handle-owned delta engine callback. Rejected unless
+ * the engine pair is already open. Passing NULL for @cb clears the callback.
+ */
+wyrelog_error_t wyl_handle_engine_set_delta_callback (WylHandle * self,
+    WylDeltaCallback cb, gpointer user_data);
+
+/*
  * Probes the read engine for an exact EDB/IDB row match. Rejected unless the
  * engine pair is already open.
  */

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -274,6 +274,18 @@ wyl_handle_engine_step_delta (WylHandle *self)
   return wyl_engine_step (self->delta_engine);
 }
 
+wyrelog_error_t
+wyl_handle_engine_set_delta_callback (WylHandle *self, WylDeltaCallback cb,
+    gpointer user_data)
+{
+  if (self == NULL || !WYL_IS_HANDLE (self))
+    return WYRELOG_E_INVALID;
+  if (self->delta_engine == NULL)
+    return WYRELOG_E_INVALID;
+
+  return wyl_engine_set_delta_callback (self->delta_engine, cb, user_data);
+}
+
 typedef struct
 {
   const gchar *relation;


### PR DESCRIPTION
## Summary
- add a handle-owned wrapper for delta callback setup
- install a no-op wirelog delta callback during foreground daemon startup
- keep startup from advancing an empty incremental epoch

## Tests
- meson test -C builddir --print-errorlogs