### PR TITLE
handle: step membership delta updates

### DIFF
--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -446,10 +446,8 @@ check_insert_fanout_reaches_delta_engine (void)
   if (wyl_handle_engine_insert (handle, "member_of", member_row, 3)
       != WYRELOG_E_OK)
     return 104;
-  if (wyl_handle_engine_step_delta (handle) != WYRELOG_E_OK)
-    return 105;
   if (expect.matching == 0)
-    return 106;
+    return 105;
   return 0;
 }
 

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -251,7 +251,10 @@ wyl_handle_engine_insert (WylHandle *self, const gchar *relation,
 
   if (!relation_fans_out_to_delta (relation))
     return WYRELOG_E_OK;
-  return wyl_engine_insert (self->delta_engine, relation, row, ncols);
+  rc = wyl_engine_insert (self->delta_engine, relation, row, ncols);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_engine_step (self->delta_engine);
 }
 
 wyrelog_error_t
@@ -270,7 +273,10 @@ wyl_handle_engine_remove (WylHandle *self, const gchar *relation,
 
   if (!relation_fans_out_to_delta (relation))
     return WYRELOG_E_OK;
-  return wyl_engine_remove (self->delta_engine, relation, row, ncols);
+  rc = wyl_engine_remove (self->delta_engine, relation, row, ncols);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_engine_step (self->delta_engine);
 }
 
 wyrelog_error_t


### PR DESCRIPTION
## Summary
- advance the delta engine after member_of inserts and removes
- let registered delta callbacks observe membership changes during mutation
- update handle-pair coverage so insert itself reaches the callback

## Tests
- meson test -C builddir --print-errorlogs