### PR TITLE
LoBAC policy and audit readiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,14 +36,14 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             meson ninja-build pkg-config \
-            libglib2.0-dev libsoup-3.0-dev libsodium-dev \
+            libglib2.0-dev libsqlite3-dev libsoup-3.0-dev libsodium-dev \
             libtss2-dev
 
       - name: Install build dependencies (macOS)
         if: runner.os == 'macOS'
         run: |
           brew update
-          brew install meson ninja pkg-config glib libsoup libsodium
+          brew install meson ninja pkg-config glib sqlite libsoup libsodium
 
       - name: Cache meson packagecache
         uses: actions/cache@v4
@@ -121,7 +121,7 @@ jobs:
         shell: cmd
         run: |
           @echo off
-          "%VCPKG_ROOT%\vcpkg.exe" install glib:x64-windows libsodium:x64-windows --x-abi-tools-use-exact-versions
+          "%VCPKG_ROOT%\vcpkg.exe" install glib:x64-windows sqlite3:x64-windows libsodium:x64-windows --x-abi-tools-use-exact-versions
 
       - name: Cache meson packagecache
         uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           brew install meson ninja pkg-config glib sqlite libsoup libsodium
 
       - name: Cache meson packagecache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: subprojects/packagecache
           key: ${{ runner.os }}-packagecache-${{ hashFiles('subprojects/*.wrap') }}
@@ -65,7 +65,7 @@ jobs:
 
       - name: Upload meson logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: meson-logs-${{ matrix.os }}
           path: builddir/meson-logs/
@@ -124,7 +124,7 @@ jobs:
           "%VCPKG_ROOT%\vcpkg.exe" install glib:x64-windows sqlite3:x64-windows libsodium:x64-windows --x-abi-tools-use-exact-versions
 
       - name: Cache meson packagecache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: subprojects/packagecache
           key: windows-packagecache-${{ hashFiles('subprojects/*.wrap') }}
@@ -149,7 +149,7 @@ jobs:
 
       - name: Upload meson logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: meson-logs-windows
           path: builddir/meson-logs/

--- a/meson.build
+++ b/meson.build
@@ -15,6 +15,7 @@ libsoup_dep = dependency('libsoup-3.0',
   required : get_option('enable_client'),
 )
 sodium_dep = dependency('libsodium', required : true)
+sqlite_dep = dependency('sqlite3', required : true)
 tss2_esys_dep = dependency('tss2-esys', required : get_option('enable_tpm'))
 enable_audit_opt = get_option('enable_audit')
 if enable_audit_opt.allowed()

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -25,7 +25,7 @@ if host_machine.system() != 'windows'
   test('wyrelogd-sigterm', sh,
     args : [
       '-c',
-      '"' + wyrelogd_exe.full_path() + '" --template-dir "' + meson.project_source_root() / 'templates' / 'access' + '" & pid=$!; sleep 0.2; kill -TERM "$pid"; wait "$pid"',
+      '"' + wyrelogd_exe.full_path() + '" --template-dir "' + meson.project_source_root() / 'templates' / 'access' + '" & pid=$!; sleep 1; kill -TERM "$pid"; wait "$pid"',
     ],
     depends : wyrelogd_exe,
   )
@@ -44,6 +44,13 @@ test_traits_compile = executable('test-traits-compile',
 )
 
 test('traits-compile', test_traits_compile)
+
+test_policy_store = executable('test-policy-store',
+  'test-policy-store.c',
+  dependencies : [wyrelog_dep, sqlite_dep],
+)
+
+test('policy-store', test_policy_store)
 
 test_dl_static = executable('test-dl-static',
   'test-dl-static.c',

--- a/tests/test-audit-conn.c
+++ b/tests/test-audit-conn.c
@@ -169,6 +169,51 @@ check_create_schema_null_arg (void)
   return 0;
 }
 
+static gint
+check_table_probe_reports_schema (void)
+{
+  g_autoptr (wyl_audit_conn_t) conn = NULL;
+
+  if (wyl_audit_conn_open (NULL, &conn) != WYRELOG_E_OK)
+    return 90;
+  if (wyl_audit_conn_create_schema (conn) != WYRELOG_E_OK)
+    return 91;
+
+  gboolean exists = FALSE;
+  if (wyl_audit_conn_table_exists (conn, "audit_events", &exists)
+      != WYRELOG_E_OK)
+    return 92;
+  if (!exists)
+    return 93;
+
+  if (wyl_audit_conn_table_exists (conn, "missing_table", &exists)
+      != WYRELOG_E_OK)
+    return 94;
+  if (exists)
+    return 95;
+  return 0;
+}
+
+static gint
+check_table_probe_rejects_invalid_args (void)
+{
+  g_autoptr (wyl_audit_conn_t) conn = NULL;
+  gboolean exists = FALSE;
+
+  if (wyl_audit_conn_open (NULL, &conn) != WYRELOG_E_OK)
+    return 100;
+  if (wyl_audit_conn_table_exists (NULL, "audit_events", &exists)
+      != WYRELOG_E_INVALID)
+    return 101;
+  if (wyl_audit_conn_table_exists (conn, NULL, &exists)
+      != WYRELOG_E_INVALID)
+    return 102;
+  if (wyl_audit_conn_table_exists (conn, "audit_events", NULL)
+      != WYRELOG_E_INVALID)
+    return 103;
+  return 0;
+}
+
 int
 main (void)
 {
@@ -190,6 +235,10 @@ main (void)
   if ((rc = check_create_schema ()) != 0)
     return rc;
   if ((rc = check_create_schema_null_arg ()) != 0)
+    return rc;
+  if ((rc = check_table_probe_reports_schema ()) != 0)
+    return rc;
+  if ((rc = check_table_probe_rejects_invalid_args ()) != 0)
     return rc;
   return 0;
 }

--- a/tests/test-policy-store.c
+++ b/tests/test-policy-store.c
@@ -1,0 +1,92 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <glib.h>
+
+#include "wyrelog/wyrelog.h"
+#include "wyrelog/policy/store-private.h"
+#include "wyrelog/wyl-handle-private.h"
+
+static gint
+check_store_creates_authority_schema (void)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 10;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 11;
+
+  const gchar *tables[] = {
+    "roles",
+    "permissions",
+    "role_permissions",
+    "policy_signatures",
+  };
+  for (gsize i = 0; i < G_N_ELEMENTS (tables); i++) {
+    gboolean exists = FALSE;
+    if (wyl_policy_store_table_exists (store, tables[i], &exists)
+        != WYRELOG_E_OK)
+      return 12;
+    if (!exists)
+      return 13;
+  }
+
+  return 0;
+}
+
+static gint
+check_store_rejects_invalid_args (void)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 20;
+  gboolean exists = FALSE;
+  if (wyl_policy_store_create_schema (NULL) != WYRELOG_E_INVALID)
+    return 21;
+  if (wyl_policy_store_table_exists (NULL, "roles", &exists)
+      != WYRELOG_E_INVALID)
+    return 22;
+  if (wyl_policy_store_table_exists (store, NULL, &exists)
+      != WYRELOG_E_INVALID)
+    return 23;
+  if (wyl_policy_store_table_exists (store, "roles", NULL)
+      != WYRELOG_E_INVALID)
+    return 24;
+  return 0;
+}
+
+static gint
+check_handle_owns_policy_store (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 30;
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (store == NULL)
+    return 31;
+  if (wyl_policy_store_get_db (store) == NULL)
+    return 32;
+
+  gboolean exists = FALSE;
+  if (wyl_policy_store_table_exists (store, "role_permissions", &exists)
+      != WYRELOG_E_OK)
+    return 33;
+  if (!exists)
+    return 34;
+  return 0;
+}
+
+int
+main (void)
+{
+  gint rc;
+
+  if ((rc = check_store_creates_authority_schema ()) != 0)
+    return rc;
+  if ((rc = check_store_rejects_invalid_args ()) != 0)
+    return rc;
+  if ((rc = check_handle_owns_policy_store ()) != 0)
+    return rc;
+  return 0;
+}

--- a/wyrelog/audit/conn-private.h
+++ b/wyrelog/audit/conn-private.h
@@ -83,4 +83,12 @@ duckdb_connection wyl_audit_conn_get_connection (wyl_audit_conn_t * conn);
  */
 wyrelog_error_t wyl_audit_conn_create_schema (wyl_audit_conn_t * conn);
 
+/*
+ * Probes whether @table_name exists in the audit DuckDB catalog. Intended for
+ * daemon readiness checks and private tests; append/query paths should use
+ * their typed APIs rather than catalog inspection.
+ */
+wyrelog_error_t wyl_audit_conn_table_exists (wyl_audit_conn_t * conn,
+    const gchar * table_name, gboolean * out_exists);
+
 G_END_DECLS;

--- a/wyrelog/audit/conn.c
+++ b/wyrelog/audit/conn.c
@@ -84,3 +84,38 @@ wyl_audit_conn_create_schema (wyl_audit_conn_t *conn)
   duckdb_destroy_result (&result);
   return WYRELOG_E_OK;
 }
+
+wyrelog_error_t
+wyl_audit_conn_table_exists (wyl_audit_conn_t *conn, const gchar *table_name,
+    gboolean *out_exists)
+{
+  duckdb_prepared_statement stmt;
+  duckdb_result result;
+  duckdb_state rc;
+
+  if (conn == NULL || table_name == NULL || out_exists == NULL)
+    return WYRELOG_E_INVALID;
+
+  *out_exists = FALSE;
+  static const gchar *sql =
+      "SELECT COUNT(*) FROM information_schema.tables " "WHERE table_name = ?;";
+  if (duckdb_prepare (conn->conn, sql, &stmt) != DuckDBSuccess) {
+    duckdb_destroy_prepare (&stmt);
+    return WYRELOG_E_IO;
+  }
+  if (duckdb_bind_varchar (stmt, 1, table_name) != DuckDBSuccess) {
+    duckdb_destroy_prepare (&stmt);
+    return WYRELOG_E_IO;
+  }
+
+  rc = duckdb_execute_prepared (stmt, &result);
+  duckdb_destroy_prepare (&stmt);
+  if (rc != DuckDBSuccess) {
+    duckdb_destroy_result (&result);
+    return WYRELOG_E_IO;
+  }
+
+  *out_exists = duckdb_value_int64 (&result, 0, 0) > 0;
+  duckdb_destroy_result (&result);
+  return WYRELOG_E_OK;
+}

--- a/wyrelog/daemon/wyrelogd.c
+++ b/wyrelog/daemon/wyrelogd.c
@@ -68,6 +68,25 @@ check_wirelog_policy_ready (WylHandle *handle)
   return WYRELOG_E_OK;
 }
 
+static wyrelog_error_t
+check_audit_sink_ready (WylHandle *handle)
+{
+#ifdef WYL_HAS_AUDIT
+  wyl_audit_conn_t *conn = wyl_handle_get_audit_conn (handle);
+  gboolean found = FALSE;
+
+  wyrelog_error_t rc =
+      wyl_audit_conn_table_exists (conn, "audit_events", &found);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if (!found)
+    return WYRELOG_E_IO;
+#else
+  (void) handle;
+#endif
+  return WYRELOG_E_OK;
+}
+
 static void
 daemon_delta_cb (const gchar *relation, const gint64 *row, guint ncols,
     WylDeltaKind kind, gpointer user_data)
@@ -209,6 +228,12 @@ main (int argc, char **argv)
     rc = check_wirelog_policy_ready (handle);
     if (rc != WYRELOG_E_OK) {
       g_printerr ("wyrelogd: policy readiness check failed: %s\n",
+          wyrelog_error_string (rc));
+      return 1;
+    }
+    rc = check_audit_sink_ready (handle);
+    if (rc != WYRELOG_E_OK) {
+      g_printerr ("wyrelogd: audit readiness check failed: %s\n",
           wyrelog_error_string (rc));
       return 1;
     }

--- a/wyrelog/daemon/wyrelogd.c
+++ b/wyrelog/daemon/wyrelogd.c
@@ -69,6 +69,30 @@ check_wirelog_policy_ready (WylHandle *handle)
 }
 
 static wyrelog_error_t
+check_policy_store_ready (WylHandle *handle)
+{
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  const gchar *tables[] = {
+    "roles",
+    "permissions",
+    "role_permissions",
+    "policy_signatures",
+  };
+
+  for (gsize i = 0; i < G_N_ELEMENTS (tables); i++) {
+    gboolean found = FALSE;
+    wyrelog_error_t rc =
+        wyl_policy_store_table_exists (store, tables[i], &found);
+    if (rc != WYRELOG_E_OK)
+      return rc;
+    if (!found)
+      return WYRELOG_E_POLICY;
+  }
+
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
 check_audit_sink_ready (WylHandle *handle)
 {
 #ifdef WYL_HAS_AUDIT
@@ -228,6 +252,12 @@ main (int argc, char **argv)
     rc = check_wirelog_policy_ready (handle);
     if (rc != WYRELOG_E_OK) {
       g_printerr ("wyrelogd: policy readiness check failed: %s\n",
+          wyrelog_error_string (rc));
+      return 1;
+    }
+    rc = check_policy_store_ready (handle);
+    if (rc != WYRELOG_E_OK) {
+      g_printerr ("wyrelogd: policy store readiness check failed: %s\n",
           wyrelog_error_string (rc));
       return 1;
     }

--- a/wyrelog/meson.build
+++ b/wyrelog/meson.build
@@ -16,6 +16,7 @@ wyrelog_public_headers = files(
 wyrelog_sources = files(
   'access/decision.c',
   'audit/event.c',
+  'policy/store.c',
   'wyl-boot.c',
   'wyl-decide.c',
   'wyl-dl-static.c',
@@ -35,7 +36,7 @@ wyrelog_sources = files(
   'wyl-version.c',
 )
 
-wyrelog_deps = [glib_dep, gio_dep, libchronoid_dep, wirelog_dep]
+wyrelog_deps = [glib_dep, gio_dep, libchronoid_dep, sqlite_dep, wirelog_dep]
 
 wyrelog_log_levels = {
   'none' : 0,

--- a/wyrelog/policy/store-private.h
+++ b/wyrelog/policy/store-private.h
@@ -1,0 +1,32 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+
+#include <glib.h>
+#include <sqlite3.h>
+
+#include "wyrelog/error.h"
+
+G_BEGIN_DECLS;
+
+typedef struct wyl_policy_store_t wyl_policy_store_t;
+
+/*
+ * Policy authority store lifecycle wrapper.
+ *
+ * v0 uses SQLite directly so the handle owns a real ACID policy DB before
+ * SQLCipher key negotiation is wired in. The private boundary keeps callers
+ * out of the raw sqlite3 handle except for tests and future migrator code.
+ */
+wyrelog_error_t wyl_policy_store_open (const gchar * path,
+    wyl_policy_store_t ** out_store);
+void wyl_policy_store_close (wyl_policy_store_t * store);
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (wyl_policy_store_t, wyl_policy_store_close);
+
+sqlite3 *wyl_policy_store_get_db (wyl_policy_store_t * store);
+
+wyrelog_error_t wyl_policy_store_create_schema (wyl_policy_store_t * store);
+wyrelog_error_t wyl_policy_store_table_exists (wyl_policy_store_t * store,
+    const gchar * table_name, gboolean * out_exists);
+
+G_END_DECLS;

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -1,0 +1,143 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "store-private.h"
+
+struct wyl_policy_store_t
+{
+  sqlite3 *db;
+};
+
+static wyrelog_error_t
+exec_sql (sqlite3 *db, const gchar *sql)
+{
+  char *errmsg = NULL;
+
+  if (sqlite3_exec (db, sql, NULL, NULL, &errmsg) != SQLITE_OK) {
+    sqlite3_free (errmsg);
+    return WYRELOG_E_IO;
+  }
+  return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
+wyl_policy_store_open (const gchar *path, wyl_policy_store_t **out_store)
+{
+  if (out_store == NULL)
+    return WYRELOG_E_INVALID;
+
+  const gchar *effective_path = path;
+  if (effective_path == NULL || g_strcmp0 (effective_path, ":memory:") == 0)
+    effective_path = ":memory:";
+
+  wyl_policy_store_t *self = g_new0 (wyl_policy_store_t, 1);
+  if (sqlite3_open_v2 (effective_path, &self->db,
+          SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX,
+          NULL) != SQLITE_OK) {
+    if (self->db != NULL)
+      sqlite3_close (self->db);
+    g_free (self);
+    return WYRELOG_E_IO;
+  }
+
+  wyrelog_error_t rc = exec_sql (self->db,
+      "PRAGMA foreign_keys = ON;" "PRAGMA journal_mode = WAL;");
+  if (rc != WYRELOG_E_OK) {
+    wyl_policy_store_close (self);
+    return rc;
+  }
+
+  *out_store = self;
+  return WYRELOG_E_OK;
+}
+
+void
+wyl_policy_store_close (wyl_policy_store_t *store)
+{
+  if (store == NULL)
+    return;
+  if (store->db != NULL)
+    sqlite3_close (store->db);
+  g_free (store);
+}
+
+sqlite3 *
+wyl_policy_store_get_db (wyl_policy_store_t *store)
+{
+  if (store == NULL)
+    return NULL;
+  return store->db;
+}
+
+wyrelog_error_t
+wyl_policy_store_create_schema (wyl_policy_store_t *store)
+{
+  static const gchar *ddl =
+      "CREATE TABLE IF NOT EXISTS roles ("
+      "  role_id TEXT PRIMARY KEY,"
+      "  role_name TEXT UNIQUE NOT NULL,"
+      "  description TEXT,"
+      "  created_at INTEGER,"
+      "  modified_at INTEGER"
+      ");"
+      "CREATE TABLE IF NOT EXISTS permissions ("
+      "  perm_id TEXT PRIMARY KEY,"
+      "  perm_name TEXT UNIQUE NOT NULL,"
+      "  class TEXT NOT NULL CHECK "
+      "    (class IN ('basic', 'sensitive', 'critical')),"
+      "  created_at INTEGER"
+      ");"
+      "CREATE TABLE IF NOT EXISTS role_permissions ("
+      "  role_id TEXT NOT NULL,"
+      "  perm_id TEXT NOT NULL,"
+      "  granted_at INTEGER,"
+      "  granted_by TEXT,"
+      "  PRIMARY KEY (role_id, perm_id),"
+      "  FOREIGN KEY (role_id) REFERENCES roles (role_id),"
+      "  FOREIGN KEY (perm_id) REFERENCES permissions (perm_id)"
+      ");"
+      "CREATE INDEX IF NOT EXISTS idx_role_permissions_role_id "
+      "  ON role_permissions (role_id);"
+      "CREATE INDEX IF NOT EXISTS idx_role_permissions_perm_id "
+      "  ON role_permissions (perm_id);"
+      "CREATE TABLE IF NOT EXISTS policy_signatures ("
+      "  policy_version INTEGER PRIMARY KEY,"
+      "  policy_hash BLOB NOT NULL,"
+      "  signature BLOB NOT NULL,"
+      "  signed_by TEXT NOT NULL," "  signed_at INTEGER NOT NULL" ");";
+
+  if (store == NULL || store->db == NULL)
+    return WYRELOG_E_INVALID;
+  return exec_sql (store->db, ddl);
+}
+
+wyrelog_error_t
+wyl_policy_store_table_exists (wyl_policy_store_t *store,
+    const gchar *table_name, gboolean *out_exists)
+{
+  sqlite3_stmt *stmt = NULL;
+
+  if (store == NULL || store->db == NULL || table_name == NULL
+      || out_exists == NULL)
+    return WYRELOG_E_INVALID;
+
+  *out_exists = FALSE;
+  static const gchar *sql =
+      "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?;";
+  if (sqlite3_prepare_v2 (store->db, sql, -1, &stmt, NULL) != SQLITE_OK)
+    return WYRELOG_E_IO;
+  if (sqlite3_bind_text (stmt, 1, table_name, -1, SQLITE_TRANSIENT)
+      != SQLITE_OK) {
+    sqlite3_finalize (stmt);
+    return WYRELOG_E_IO;
+  }
+
+  int rc = sqlite3_step (stmt);
+  if (rc == SQLITE_ROW)
+    *out_exists = TRUE;
+  else if (rc != SQLITE_DONE) {
+    sqlite3_finalize (stmt);
+    return WYRELOG_E_IO;
+  }
+
+  sqlite3_finalize (stmt);
+  return WYRELOG_E_OK;
+}

--- a/wyrelog/wyl-handle-private.h
+++ b/wyrelog/wyl-handle-private.h
@@ -5,6 +5,7 @@
 
 #include "wyrelog/handle.h"
 #include "wyrelog/engine.h"
+#include "policy/store-private.h"
 
 #ifdef WYL_HAS_AUDIT
 #include "audit/conn-private.h"
@@ -22,6 +23,12 @@ G_BEGIN_DECLS;
  */
 wyl_audit_conn_t *wyl_handle_get_audit_conn (WylHandle * self);
 #endif
+
+/*
+ * Returns the borrowed policy authority store owned by |self|. The pointer is
+ * valid until wyl_shutdown or g_object_unref.
+ */
+wyl_policy_store_t *wyl_handle_get_policy_store (WylHandle * self);
 
 /*
  * Opens the handle-owned policy engine pair from @template_dir.

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -6,6 +6,7 @@
 #include "wyl-id-private.h"
 #include "wyl-log-private.h"
 #include "wyl-permission-scope-private.h"
+#include "policy/store-private.h"
 
 #ifdef WYL_HAS_AUDIT
 #include "audit/conn-private.h"
@@ -18,6 +19,7 @@ struct _WylHandle
   gint64 created_at_us;
   WylEngine *read_engine;
   WylEngine *delta_engine;
+  wyl_policy_store_t *policy_store;
 #ifdef WYL_HAS_AUDIT
   wyl_audit_conn_t *audit_conn;
 #endif
@@ -32,6 +34,7 @@ wyl_handle_finalize (GObject *object)
 
   g_clear_object (&self->read_engine);
   g_clear_object (&self->delta_engine);
+  g_clear_pointer (&self->policy_store, wyl_policy_store_close);
 #ifdef WYL_HAS_AUDIT
   /* NULL-safe: if wyl_shutdown already closed the conn the pointer
    * was reset to NULL there; otherwise this is the only close site
@@ -97,8 +100,19 @@ wyl_init (const gchar *config_path, WylHandle **out_handle)
 
   WylHandle *self = g_object_new (WYL_TYPE_HANDLE, NULL);
 
+  wyrelog_error_t rc = wyl_policy_store_open (NULL, &self->policy_store);
+  if (rc != WYRELOG_E_OK) {
+    g_object_unref (self);
+    return rc;
+  }
+  rc = wyl_policy_store_create_schema (self->policy_store);
+  if (rc != WYRELOG_E_OK) {
+    g_object_unref (self);
+    return rc;
+  }
+
   if (config_path != NULL) {
-    wyrelog_error_t rc = wyl_handle_open_engine_pair (self, config_path);
+    rc = wyl_handle_open_engine_pair (self, config_path);
     if (rc != WYRELOG_E_OK) {
       g_object_unref (self);
       return rc;
@@ -107,7 +121,7 @@ wyl_init (const gchar *config_path, WylHandle **out_handle)
 #ifdef WYL_HAS_AUDIT
   /* Open an in-memory audit database and create the audit_events
    * schema. Audit persistence is not wired to config_path yet. */
-  wyrelog_error_t rc = wyl_audit_conn_open (NULL, &self->audit_conn);
+  rc = wyl_audit_conn_open (NULL, &self->audit_conn);
   if (rc != WYRELOG_E_OK) {
     g_object_unref (self);
     return rc;
@@ -135,6 +149,7 @@ wyl_shutdown (WylHandle *handle)
    * will not double-close. */
   g_clear_pointer (&handle->audit_conn, wyl_audit_conn_close);
 #endif
+  g_clear_pointer (&handle->policy_store, wyl_policy_store_close);
   g_clear_object (&handle->read_engine);
   g_clear_object (&handle->delta_engine);
 }
@@ -166,6 +181,13 @@ wyl_handle_get_audit_conn (WylHandle *self)
   return self->audit_conn;
 }
 #endif
+
+wyl_policy_store_t *
+wyl_handle_get_policy_store (WylHandle *self)
+{
+  g_return_val_if_fail (WYL_IS_HANDLE (self), NULL);
+  return self->policy_store;
+}
 
 wyrelog_error_t
 wyl_handle_open_engine_pair (WylHandle *self, const gchar *template_dir)


### PR DESCRIPTION
## Summary
- add a private SQLite policy authority store owned by WylHandle
- add policy-store and audit-sink readiness checks to wyrelogd --check
- add SQLite CI dependencies and focused coverage for the new private store/probes

## Tests
- meson test -C builddir --print-errorlogs
- meson test -C builddir-audit --print-errorlogs