### PR TITLE
Replicate policy grants into wirelog

### DIFF
--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -738,6 +738,57 @@ check_decision_query_rejects_missing_pair (void)
   return 0;
 }
 
+static gint
+check_policy_store_role_permissions_load_into_engine (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 320;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (wyl_policy_store_upsert_role (store, "wr.store-role", "store role")
+      != WYRELOG_E_OK)
+    return 321;
+  if (wyl_policy_store_upsert_permission (store, "wr.store.read",
+          "store read", "basic") != WYRELOG_E_OK)
+    return 322;
+  if (wyl_policy_store_grant_role_permission (store, "wr.store-role",
+          "wr.store.read") != WYRELOG_E_OK)
+    return 323;
+  if (wyl_handle_load_policy_store_role_permissions (handle) != WYRELOG_E_OK)
+    return 324;
+
+  gint64 decision_row[3];
+  if (insert_decision_fixture (handle, "store-user", "wr.store-role",
+          "wr.store.read", "store-scope", "authenticated", "active",
+          decision_row) != WYRELOG_E_OK)
+    return 325;
+  gboolean allowed = FALSE;
+  if (wyl_handle_engine_decide (handle, decision_row, &allowed)
+      != WYRELOG_E_OK)
+    return 326;
+  if (!allowed)
+    return 328;
+  return 0;
+}
+
+static gint
+check_policy_store_role_permissions_require_engine_pair (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 330;
+  if (wyl_handle_load_policy_store_role_permissions (NULL)
+      != WYRELOG_E_INVALID)
+    return 331;
+  if (wyl_handle_load_policy_store_role_permissions (handle)
+      != WYRELOG_E_INVALID)
+    return 332;
+  return 0;
+}
+
 int
 main (void)
 {
@@ -788,6 +839,10 @@ main (void)
   if ((rc = check_decision_query_denies_armed_catalogue_permission ()) != 0)
     return rc;
   if ((rc = check_decision_query_rejects_missing_pair ()) != 0)
+    return rc;
+  if ((rc = check_policy_store_role_permissions_load_into_engine ()) != 0)
+    return rc;
+  if ((rc = check_policy_store_role_permissions_require_engine_pair ()) != 0)
     return rc;
 
   return 0;

--- a/tests/test-policy-store.c
+++ b/tests/test-policy-store.c
@@ -77,6 +77,82 @@ check_handle_owns_policy_store (void)
   return 0;
 }
 
+typedef struct
+{
+  const gchar *role_id;
+  const gchar *perm_id;
+  guint matches;
+} RolePermissionExpect;
+
+static wyrelog_error_t
+role_permission_expect_cb (const gchar *role_id, const gchar *perm_id,
+    gpointer user_data)
+{
+  RolePermissionExpect *expect = user_data;
+
+  if (g_strcmp0 (role_id, expect->role_id) == 0
+      && g_strcmp0 (perm_id, expect->perm_id) == 0)
+    expect->matches++;
+  return WYRELOG_E_OK;
+}
+
+static gint
+check_store_grants_role_permission (void)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 40;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 41;
+  if (wyl_policy_store_upsert_role (store, "wr.test-role", "test role")
+      != WYRELOG_E_OK)
+    return 42;
+  if (wyl_policy_store_upsert_permission (store, "wr.test.read", "test read",
+          "basic") != WYRELOG_E_OK)
+    return 43;
+  if (wyl_policy_store_grant_role_permission (store, "wr.test-role",
+          "wr.test.read") != WYRELOG_E_OK)
+    return 44;
+  if (wyl_policy_store_grant_role_permission (store, "wr.test-role",
+          "wr.test.read") != WYRELOG_E_OK)
+    return 45;
+
+  RolePermissionExpect expect = {
+    .role_id = "wr.test-role",
+    .perm_id = "wr.test.read",
+  };
+  if (wyl_policy_store_foreach_role_permission (store,
+          role_permission_expect_cb, &expect) != WYRELOG_E_OK)
+    return 46;
+  if (expect.matches != 1)
+    return 47;
+  return 0;
+}
+
+static gint
+check_store_rejects_bad_role_permission (void)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 50;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 51;
+  if (wyl_policy_store_grant_role_permission (store, "missing-role",
+          "missing-perm") != WYRELOG_E_IO)
+    return 52;
+  if (wyl_policy_store_upsert_role (NULL, "role", "role") != WYRELOG_E_INVALID)
+    return 53;
+  if (wyl_policy_store_upsert_permission (store, "perm", "perm", "unknown")
+      != WYRELOG_E_IO)
+    return 54;
+  if (wyl_policy_store_foreach_role_permission (store, NULL, NULL)
+      != WYRELOG_E_INVALID)
+    return 55;
+  return 0;
+}
+
 int
 main (void)
 {
@@ -87,6 +163,10 @@ main (void)
   if ((rc = check_store_rejects_invalid_args ()) != 0)
     return rc;
   if ((rc = check_handle_owns_policy_store ()) != 0)
+    return rc;
+  if ((rc = check_store_grants_role_permission ()) != 0)
+    return rc;
+  if ((rc = check_store_rejects_bad_role_permission ()) != 0)
     return rc;
   return 0;
 }

--- a/wyrelog/policy/store-private.h
+++ b/wyrelog/policy/store-private.h
@@ -10,6 +10,9 @@ G_BEGIN_DECLS;
 
 typedef struct wyl_policy_store_t wyl_policy_store_t;
 
+typedef wyrelog_error_t (*wyl_policy_role_permission_cb) (const gchar * role_id,
+    const gchar * perm_id, gpointer user_data);
+
 /*
  * Policy authority store lifecycle wrapper.
  *
@@ -28,5 +31,13 @@ sqlite3 *wyl_policy_store_get_db (wyl_policy_store_t * store);
 wyrelog_error_t wyl_policy_store_create_schema (wyl_policy_store_t * store);
 wyrelog_error_t wyl_policy_store_table_exists (wyl_policy_store_t * store,
     const gchar * table_name, gboolean * out_exists);
+wyrelog_error_t wyl_policy_store_upsert_role (wyl_policy_store_t * store,
+    const gchar * role_id, const gchar * role_name);
+wyrelog_error_t wyl_policy_store_upsert_permission (wyl_policy_store_t * store,
+    const gchar * perm_id, const gchar * perm_name, const gchar * klass);
+wyrelog_error_t wyl_policy_store_grant_role_permission (wyl_policy_store_t *
+    store, const gchar * role_id, const gchar * perm_id);
+wyrelog_error_t wyl_policy_store_foreach_role_permission (wyl_policy_store_t *
+    store, wyl_policy_role_permission_cb cb, gpointer user_data);
 
 G_END_DECLS;

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -18,6 +18,23 @@ exec_sql (sqlite3 *db, const gchar *sql)
   return WYRELOG_E_OK;
 }
 
+static wyrelog_error_t
+prepare_stmt (sqlite3 *db, const gchar *sql, sqlite3_stmt **out_stmt)
+{
+  if (sqlite3_prepare_v2 (db, sql, -1, out_stmt, NULL) != SQLITE_OK)
+    return WYRELOG_E_IO;
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+bind_text (sqlite3_stmt *stmt, int index, const gchar *value)
+{
+  if (sqlite3_bind_text (stmt, index, value, -1, SQLITE_TRANSIENT)
+      != SQLITE_OK)
+    return WYRELOG_E_IO;
+  return WYRELOG_E_OK;
+}
+
 wyrelog_error_t
 wyl_policy_store_open (const gchar *path, wyl_policy_store_t **out_store)
 {
@@ -140,4 +157,123 @@ wyl_policy_store_table_exists (wyl_policy_store_t *store,
 
   sqlite3_finalize (stmt);
   return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
+wyl_policy_store_upsert_role (wyl_policy_store_t *store, const gchar *role_id,
+    const gchar *role_name)
+{
+  sqlite3_stmt *stmt = NULL;
+
+  if (store == NULL || store->db == NULL || role_id == NULL
+      || role_name == NULL)
+    return WYRELOG_E_INVALID;
+
+  static const gchar *sql =
+      "INSERT INTO roles (role_id, role_name, created_at, modified_at) "
+      "VALUES (?, ?, unixepoch(), unixepoch()) "
+      "ON CONFLICT(role_id) DO UPDATE SET "
+      "  role_name = excluded.role_name,"
+      "  modified_at = excluded.modified_at;";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if ((rc = bind_text (stmt, 1, role_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 2, role_name)) != WYRELOG_E_OK) {
+    sqlite3_finalize (stmt);
+    return rc;
+  }
+
+  int step_rc = sqlite3_step (stmt);
+  sqlite3_finalize (stmt);
+  return (step_rc == SQLITE_DONE) ? WYRELOG_E_OK : WYRELOG_E_IO;
+}
+
+wyrelog_error_t
+wyl_policy_store_upsert_permission (wyl_policy_store_t *store,
+    const gchar *perm_id, const gchar *perm_name, const gchar *klass)
+{
+  sqlite3_stmt *stmt = NULL;
+
+  if (store == NULL || store->db == NULL || perm_id == NULL
+      || perm_name == NULL || klass == NULL)
+    return WYRELOG_E_INVALID;
+
+  static const gchar *sql =
+      "INSERT INTO permissions (perm_id, perm_name, class, created_at) "
+      "VALUES (?, ?, ?, unixepoch()) "
+      "ON CONFLICT(perm_id) DO UPDATE SET "
+      "  perm_name = excluded.perm_name," "  class = excluded.class;";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if ((rc = bind_text (stmt, 1, perm_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 2, perm_name)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 3, klass)) != WYRELOG_E_OK) {
+    sqlite3_finalize (stmt);
+    return rc;
+  }
+
+  int step_rc = sqlite3_step (stmt);
+  sqlite3_finalize (stmt);
+  return (step_rc == SQLITE_DONE) ? WYRELOG_E_OK : WYRELOG_E_IO;
+}
+
+wyrelog_error_t
+wyl_policy_store_grant_role_permission (wyl_policy_store_t *store,
+    const gchar *role_id, const gchar *perm_id)
+{
+  sqlite3_stmt *stmt = NULL;
+
+  if (store == NULL || store->db == NULL || role_id == NULL || perm_id == NULL)
+    return WYRELOG_E_INVALID;
+
+  static const gchar *sql =
+      "INSERT INTO role_permissions (role_id, perm_id, granted_at) "
+      "VALUES (?, ?, unixepoch()) "
+      "ON CONFLICT(role_id, perm_id) DO UPDATE SET "
+      "  granted_at = excluded.granted_at;";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if ((rc = bind_text (stmt, 1, role_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 2, perm_id)) != WYRELOG_E_OK) {
+    sqlite3_finalize (stmt);
+    return rc;
+  }
+
+  int step_rc = sqlite3_step (stmt);
+  sqlite3_finalize (stmt);
+  return (step_rc == SQLITE_DONE) ? WYRELOG_E_OK : WYRELOG_E_IO;
+}
+
+wyrelog_error_t
+wyl_policy_store_foreach_role_permission (wyl_policy_store_t *store,
+    wyl_policy_role_permission_cb cb, gpointer user_data)
+{
+  sqlite3_stmt *stmt = NULL;
+
+  if (store == NULL || store->db == NULL || cb == NULL)
+    return WYRELOG_E_INVALID;
+
+  static const gchar *sql =
+      "SELECT role_id, perm_id FROM role_permissions "
+      "ORDER BY role_id, perm_id;";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  int step_rc;
+  while ((step_rc = sqlite3_step (stmt)) == SQLITE_ROW) {
+    const gchar *role_id = (const gchar *) sqlite3_column_text (stmt, 0);
+    const gchar *perm_id = (const gchar *) sqlite3_column_text (stmt, 1);
+    rc = cb (role_id, perm_id, user_data);
+    if (rc != WYRELOG_E_OK) {
+      sqlite3_finalize (stmt);
+      return rc;
+    }
+  }
+
+  sqlite3_finalize (stmt);
+  return (step_rc == SQLITE_DONE) ? WYRELOG_E_OK : WYRELOG_E_IO;
 }

--- a/wyrelog/wyl-handle-private.h
+++ b/wyrelog/wyl-handle-private.h
@@ -71,6 +71,14 @@ wyrelog_error_t wyl_handle_engine_set_delta_callback (WylHandle * self,
     WylDeltaCallback cb, gpointer user_data);
 
 /*
+ * Loads role_permission rows from the handle-owned policy authority store into
+ * the attached read/delta engine pair. Rejected unless both the store and
+ * engine pair are available.
+ */
+wyrelog_error_t wyl_handle_load_policy_store_role_permissions (WylHandle *
+    self);
+
+/*
  * Probes the read engine for an exact EDB/IDB row match. Rejected unless the
  * engine pair is already open.
  */

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -324,6 +324,35 @@ wyl_handle_engine_set_delta_callback (WylHandle *self, WylDeltaCallback cb,
   return wyl_engine_set_delta_callback (self->delta_engine, cb, user_data);
 }
 
+static wyrelog_error_t
+insert_policy_store_role_permission (const gchar *role_id,
+    const gchar *perm_id, gpointer user_data)
+{
+  WylHandle *self = user_data;
+  gint64 row[2];
+
+  wyrelog_error_t rc = wyl_handle_intern_engine_symbol (self, role_id, &row[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (self, perm_id, &row[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_engine_insert (self, "role_permission", row, 2);
+}
+
+wyrelog_error_t
+wyl_handle_load_policy_store_role_permissions (WylHandle *self)
+{
+  if (self == NULL || !WYL_IS_HANDLE (self))
+    return WYRELOG_E_INVALID;
+  if (self->policy_store == NULL || self->read_engine == NULL
+      || self->delta_engine == NULL)
+    return WYRELOG_E_INVALID;
+
+  return wyl_policy_store_foreach_role_permission (self->policy_store,
+      insert_policy_store_role_permission, self);
+}
+
 typedef struct
 {
   const gchar *relation;


### PR DESCRIPTION
## Summary
- add private SQLite helpers for role, permission, and role-permission authority rows
- stream role-permission grants from the policy store in deterministic order
- load stored role-permission grants into the handle-owned wirelog engine pair

## Tests
- meson test -C builddir --print-errorlogs
- meson test -C builddir-audit --print-errorlogs