### PR TITLE
Persist direct permission grants in policy store

### DIFF
--- a/templates/access/sqlite-schema.sql
+++ b/templates/access/sqlite-schema.sql
@@ -52,6 +52,25 @@ CREATE INDEX IF NOT EXISTS idx_role_permissions_perm_id
     ON role_permissions (perm_id);
 
 -- ---------------------------------------------------------------------------
+-- Table: direct_permissions
+-- Per-principal direct grants mirrored into direct_permission/3.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS direct_permissions (
+    subject_id TEXT NOT NULL,
+    perm_id    TEXT NOT NULL,
+    scope      TEXT NOT NULL,
+    granted_at INTEGER,               -- Unix epoch (seconds)
+    PRIMARY KEY (subject_id, perm_id, scope),
+    FOREIGN KEY (perm_id) REFERENCES permissions (perm_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_direct_permissions_perm_id
+    ON direct_permissions (perm_id);
+
+CREATE INDEX IF NOT EXISTS idx_direct_permissions_subject_scope
+    ON direct_permissions (subject_id, scope);
+
+-- ---------------------------------------------------------------------------
 -- Table: policy_signatures
 -- Ed25519 signatures over policy snapshots, authored by security_officer.
 -- Each policy version is immutably signed; versions are monotonically

--- a/tests/test-perm.c
+++ b/tests/test-perm.c
@@ -10,11 +10,10 @@
 
 /*
  * v0 contract for wyl_perm_grant / wyl_perm_revoke: validate
- * arguments, mirror direct permission plus armed-state facts into
- * any attached policy engine pair, record the admin operation in
- * the audit log when audit is enabled, and return WYRELOG_E_OK
- * without touching a durable permission store. The store wiring is
- * a follow-up.
+ * arguments, persist direct permission authority rows, mirror direct
+ * permission plus armed-state facts into any attached policy engine
+ * pair, record the admin operation in the audit log when audit is
+ * enabled, and return WYRELOG_E_OK.
  */
 
 static gint
@@ -182,6 +181,62 @@ check_gated_grant_is_rejected_by_engine_path (void)
 }
 
 static gint
+check_grant_persists_direct_permission (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 70;
+
+  g_autoptr (wyl_grant_req_t) req = wyl_grant_req_new ();
+  wyl_grant_req_set_subject_id (req, "store-user");
+  wyl_grant_req_set_action (req, "wr.store-direct");
+  wyl_grant_req_set_resource_id (req, "store-scope");
+  if (wyl_perm_grant (handle, req) != WYRELOG_E_OK)
+    return 71;
+
+  gboolean exists = FALSE;
+  if (wyl_policy_store_direct_permission_exists (wyl_handle_get_policy_store
+          (handle), "store-user", "wr.store-direct", "store-scope",
+          &exists) != WYRELOG_E_OK)
+    return 72;
+  if (!exists)
+    return 73;
+  return 0;
+}
+
+static gint
+check_revoke_removes_store_grant (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 80;
+
+  g_autoptr (wyl_grant_req_t) grant = wyl_grant_req_new ();
+  wyl_grant_req_set_subject_id (grant, "store-revoke-user");
+  wyl_grant_req_set_action (grant, "wr.store-revoke");
+  wyl_grant_req_set_resource_id (grant, "store-revoke-scope");
+  if (wyl_perm_grant (handle, grant) != WYRELOG_E_OK)
+    return 81;
+
+  g_autoptr (wyl_revoke_req_t) revoke = wyl_revoke_req_new ();
+  wyl_revoke_req_set_subject_id (revoke, "store-revoke-user");
+  wyl_revoke_req_set_action (revoke, "wr.store-revoke");
+  wyl_revoke_req_set_resource_id (revoke, "store-revoke-scope");
+  if (wyl_perm_revoke (handle, revoke) != WYRELOG_E_OK)
+    return 82;
+
+  gboolean exists = TRUE;
+  if (wyl_policy_store_direct_permission_exists (wyl_handle_get_policy_store
+          (handle), "store-revoke-user", "wr.store-revoke",
+          "store-revoke-scope", &exists)
+      != WYRELOG_E_OK)
+    return 83;
+  if (exists)
+    return 84;
+  return 0;
+}
+
+static gint
 check_revoke_removes_engine_grant (void)
 {
   g_autoptr (WylHandle) handle = NULL;
@@ -239,6 +294,10 @@ main (void)
   if ((rc = check_grant_allows_engine_decide ()) != 0)
     return rc;
   if ((rc = check_gated_grant_is_rejected_by_engine_path ()) != 0)
+    return rc;
+  if ((rc = check_grant_persists_direct_permission ()) != 0)
+    return rc;
+  if ((rc = check_revoke_removes_store_grant ()) != 0)
     return rc;
   if ((rc = check_revoke_removes_engine_grant ()) != 0)
     return rc;

--- a/tests/test-policy-store.c
+++ b/tests/test-policy-store.c
@@ -19,6 +19,7 @@ check_store_creates_authority_schema (void)
     "roles",
     "permissions",
     "role_permissions",
+    "direct_permissions",
     "policy_signatures",
   };
   for (gsize i = 0; i < G_N_ELEMENTS (tables); i++) {
@@ -131,6 +132,72 @@ check_store_grants_role_permission (void)
 }
 
 static gint
+check_store_grants_direct_permission (void)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 60;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 61;
+  if (wyl_policy_store_upsert_permission (store, "wr.direct.read",
+          "direct read", "basic") != WYRELOG_E_OK)
+    return 62;
+  if (wyl_policy_store_grant_direct_permission (store, "direct-user",
+          "wr.direct.read", "direct-scope") != WYRELOG_E_OK)
+    return 63;
+  if (wyl_policy_store_grant_direct_permission (store, "direct-user",
+          "wr.direct.read", "direct-scope") != WYRELOG_E_OK)
+    return 64;
+
+  gboolean exists = FALSE;
+  if (wyl_policy_store_direct_permission_exists (store, "direct-user",
+          "wr.direct.read", "direct-scope", &exists) != WYRELOG_E_OK)
+    return 65;
+  if (!exists)
+    return 66;
+  if (wyl_policy_store_revoke_direct_permission (store, "direct-user",
+          "wr.direct.read", "direct-scope") != WYRELOG_E_OK)
+    return 67;
+  if (wyl_policy_store_direct_permission_exists (store, "direct-user",
+          "wr.direct.read", "direct-scope", &exists) != WYRELOG_E_OK)
+    return 68;
+  if (exists)
+    return 69;
+  return 0;
+}
+
+static gint
+check_store_rejects_bad_direct_permission (void)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+  gboolean exists = FALSE;
+
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 70;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 71;
+  if (wyl_policy_store_grant_direct_permission (store, "direct-user",
+          "missing-perm", "direct-scope") != WYRELOG_E_IO)
+    return 72;
+  if (wyl_policy_store_grant_direct_permission (NULL, "direct-user",
+          "missing-perm", "direct-scope") != WYRELOG_E_INVALID)
+    return 73;
+  if (wyl_policy_store_revoke_direct_permission (store, NULL,
+          "missing-perm", "direct-scope") != WYRELOG_E_INVALID)
+    return 74;
+  if (wyl_policy_store_direct_permission_exists (store, "direct-user",
+          "missing-perm", "direct-scope", NULL) != WYRELOG_E_INVALID)
+    return 75;
+  if (wyl_policy_store_direct_permission_exists (store, "direct-user",
+          "missing-perm", "direct-scope", &exists) != WYRELOG_E_OK)
+    return 76;
+  if (exists)
+    return 77;
+  return 0;
+}
+
+static gint
 check_store_rejects_bad_role_permission (void)
 {
   g_autoptr (wyl_policy_store_t) store = NULL;
@@ -165,6 +232,10 @@ main (void)
   if ((rc = check_handle_owns_policy_store ()) != 0)
     return rc;
   if ((rc = check_store_grants_role_permission ()) != 0)
+    return rc;
+  if ((rc = check_store_grants_direct_permission ()) != 0)
+    return rc;
+  if ((rc = check_store_rejects_bad_direct_permission ()) != 0)
     return rc;
   if ((rc = check_store_rejects_bad_role_permission ()) != 0)
     return rc;

--- a/wyrelog/daemon/wyrelogd.c
+++ b/wyrelog/daemon/wyrelogd.c
@@ -76,6 +76,7 @@ check_policy_store_ready (WylHandle *handle)
     "roles",
     "permissions",
     "role_permissions",
+    "direct_permissions",
     "policy_signatures",
   };
 

--- a/wyrelog/policy/store-private.h
+++ b/wyrelog/policy/store-private.h
@@ -39,5 +39,14 @@ wyrelog_error_t wyl_policy_store_grant_role_permission (wyl_policy_store_t *
     store, const gchar * role_id, const gchar * perm_id);
 wyrelog_error_t wyl_policy_store_foreach_role_permission (wyl_policy_store_t *
     store, wyl_policy_role_permission_cb cb, gpointer user_data);
+wyrelog_error_t wyl_policy_store_grant_direct_permission (wyl_policy_store_t *
+    store, const gchar * subject_id, const gchar * perm_id,
+    const gchar * scope);
+wyrelog_error_t wyl_policy_store_revoke_direct_permission (wyl_policy_store_t *
+    store, const gchar * subject_id, const gchar * perm_id,
+    const gchar * scope);
+wyrelog_error_t wyl_policy_store_direct_permission_exists (wyl_policy_store_t *
+    store, const gchar * subject_id, const gchar * perm_id, const gchar * scope,
+    gboolean * out_exists);
 
 G_END_DECLS;

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -115,6 +115,18 @@ wyl_policy_store_create_schema (wyl_policy_store_t *store)
       "  ON role_permissions (role_id);"
       "CREATE INDEX IF NOT EXISTS idx_role_permissions_perm_id "
       "  ON role_permissions (perm_id);"
+      "CREATE TABLE IF NOT EXISTS direct_permissions ("
+      "  subject_id TEXT NOT NULL,"
+      "  perm_id TEXT NOT NULL,"
+      "  scope TEXT NOT NULL,"
+      "  granted_at INTEGER,"
+      "  PRIMARY KEY (subject_id, perm_id, scope),"
+      "  FOREIGN KEY (perm_id) REFERENCES permissions (perm_id)"
+      ");"
+      "CREATE INDEX IF NOT EXISTS idx_direct_permissions_perm_id "
+      "  ON direct_permissions (perm_id);"
+      "CREATE INDEX IF NOT EXISTS idx_direct_permissions_subject_scope "
+      "  ON direct_permissions (subject_id, scope);"
       "CREATE TABLE IF NOT EXISTS policy_signatures ("
       "  policy_version INTEGER PRIMARY KEY,"
       "  policy_hash BLOB NOT NULL,"
@@ -187,6 +199,102 @@ wyl_policy_store_upsert_role (wyl_policy_store_t *store, const gchar *role_id,
   int step_rc = sqlite3_step (stmt);
   sqlite3_finalize (stmt);
   return (step_rc == SQLITE_DONE) ? WYRELOG_E_OK : WYRELOG_E_IO;
+}
+
+wyrelog_error_t
+wyl_policy_store_grant_direct_permission (wyl_policy_store_t *store,
+    const gchar *subject_id, const gchar *perm_id, const gchar *scope)
+{
+  sqlite3_stmt *stmt = NULL;
+
+  if (store == NULL || store->db == NULL || subject_id == NULL
+      || perm_id == NULL || scope == NULL)
+    return WYRELOG_E_INVALID;
+
+  static const gchar *sql =
+      "INSERT INTO direct_permissions "
+      "  (subject_id, perm_id, scope, granted_at) "
+      "VALUES (?, ?, ?, unixepoch()) "
+      "ON CONFLICT(subject_id, perm_id, scope) DO UPDATE SET "
+      "  granted_at = excluded.granted_at;";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if ((rc = bind_text (stmt, 1, subject_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 2, perm_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 3, scope)) != WYRELOG_E_OK) {
+    sqlite3_finalize (stmt);
+    return rc;
+  }
+
+  int step_rc = sqlite3_step (stmt);
+  sqlite3_finalize (stmt);
+  return (step_rc == SQLITE_DONE) ? WYRELOG_E_OK : WYRELOG_E_IO;
+}
+
+wyrelog_error_t
+wyl_policy_store_revoke_direct_permission (wyl_policy_store_t *store,
+    const gchar *subject_id, const gchar *perm_id, const gchar *scope)
+{
+  sqlite3_stmt *stmt = NULL;
+
+  if (store == NULL || store->db == NULL || subject_id == NULL
+      || perm_id == NULL || scope == NULL)
+    return WYRELOG_E_INVALID;
+
+  static const gchar *sql =
+      "DELETE FROM direct_permissions "
+      "WHERE subject_id = ? AND perm_id = ? AND scope = ?;";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if ((rc = bind_text (stmt, 1, subject_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 2, perm_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 3, scope)) != WYRELOG_E_OK) {
+    sqlite3_finalize (stmt);
+    return rc;
+  }
+
+  int step_rc = sqlite3_step (stmt);
+  sqlite3_finalize (stmt);
+  return (step_rc == SQLITE_DONE) ? WYRELOG_E_OK : WYRELOG_E_IO;
+}
+
+wyrelog_error_t
+wyl_policy_store_direct_permission_exists (wyl_policy_store_t *store,
+    const gchar *subject_id, const gchar *perm_id, const gchar *scope,
+    gboolean *out_exists)
+{
+  sqlite3_stmt *stmt = NULL;
+
+  if (store == NULL || store->db == NULL || subject_id == NULL
+      || perm_id == NULL || scope == NULL || out_exists == NULL)
+    return WYRELOG_E_INVALID;
+
+  *out_exists = FALSE;
+  static const gchar *sql =
+      "SELECT 1 FROM direct_permissions "
+      "WHERE subject_id = ? AND perm_id = ? AND scope = ?;";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if ((rc = bind_text (stmt, 1, subject_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 2, perm_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 3, scope)) != WYRELOG_E_OK) {
+    sqlite3_finalize (stmt);
+    return rc;
+  }
+
+  int step_rc = sqlite3_step (stmt);
+  if (step_rc == SQLITE_ROW)
+    *out_exists = TRUE;
+  else if (step_rc != SQLITE_DONE) {
+    sqlite3_finalize (stmt);
+    return WYRELOG_E_IO;
+  }
+
+  sqlite3_finalize (stmt);
+  return WYRELOG_E_OK;
 }
 
 wyrelog_error_t

--- a/wyrelog/wyl-perm.c
+++ b/wyrelog/wyl-perm.c
@@ -178,6 +178,27 @@ wyl_revoke_req_get_resource_id (const wyl_revoke_req_t *req)
 }
 
 static wyrelog_error_t
+update_direct_permission_store (WylHandle *handle, const gchar *subject_id,
+    const gchar *action, const gchar *resource_id, gboolean insert)
+{
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (store == NULL)
+    return WYRELOG_E_INVALID;
+
+  if (insert) {
+    wyrelog_error_t rc =
+        wyl_policy_store_upsert_permission (store, action, action, "basic");
+    if (rc != WYRELOG_E_OK)
+      return rc;
+    return wyl_policy_store_grant_direct_permission (store, subject_id,
+        action, resource_id);
+  }
+
+  return wyl_policy_store_revoke_direct_permission (store, subject_id,
+      action, resource_id);
+}
+
+static wyrelog_error_t
 update_direct_permission (WylHandle *handle, const gchar *subject_id,
     const gchar *action, const gchar *resource_id, gboolean insert)
 {
@@ -225,10 +246,18 @@ wyl_perm_grant (WylHandle *handle, const wyl_grant_req_t *req)
       || wyl_grant_req_get_action (req) == NULL
       || wyl_grant_req_get_resource_id (req) == NULL)
     return WYRELOG_E_INVALID;
+  if (wyl_handle_get_read_engine (handle) != NULL
+      && wyl_perm_arm_rule_lookup (wyl_grant_req_get_action (req)) != NULL)
+    return WYRELOG_E_POLICY;
 
-  wyrelog_error_t rc = update_direct_permission (handle,
+  wyrelog_error_t rc = update_direct_permission_store (handle,
       wyl_grant_req_get_subject_id (req), wyl_grant_req_get_action (req),
       wyl_grant_req_get_resource_id (req), TRUE);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = update_direct_permission (handle, wyl_grant_req_get_subject_id (req),
+      wyl_grant_req_get_action (req), wyl_grant_req_get_resource_id (req),
+      TRUE);
   if (rc != WYRELOG_E_OK)
     return rc;
 
@@ -248,9 +277,6 @@ wyl_perm_grant (WylHandle *handle, const wyl_grant_req_t *req)
   (void) wyl_audit_emit (handle, ev);
 #endif
 
-  /* Durable permission-store persistence lands in a follow-up; v0
-   * mirrors the direct fact into the attached engine pair and records
-   * the accepted operation in the audit log. */
   return WYRELOG_E_OK;
 }
 
@@ -264,9 +290,14 @@ wyl_perm_revoke (WylHandle *handle, const wyl_revoke_req_t *req)
       || wyl_revoke_req_get_resource_id (req) == NULL)
     return WYRELOG_E_INVALID;
 
-  wyrelog_error_t rc = update_direct_permission (handle,
+  wyrelog_error_t rc = update_direct_permission_store (handle,
       wyl_revoke_req_get_subject_id (req), wyl_revoke_req_get_action (req),
       wyl_revoke_req_get_resource_id (req), FALSE);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = update_direct_permission (handle, wyl_revoke_req_get_subject_id (req),
+      wyl_revoke_req_get_action (req), wyl_revoke_req_get_resource_id (req),
+      FALSE);
   if (rc != WYRELOG_E_OK)
     return rc;
 


### PR DESCRIPTION
## Summary
- add direct permission authority rows to the policy store schema
- persist grant and revoke API updates before engine mirroring
- extend daemon readiness and policy-store tests for the new table

## Tests
- meson test -C builddir --print-errorlogs
- meson test -C builddir-audit --print-errorlogs