### PR TITLE
Autoload direct grants into wirelog

### DIFF
--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -825,6 +825,63 @@ check_policy_store_role_permissions_require_engine_pair (void)
   return 0;
 }
 
+static gint
+check_policy_store_direct_permissions_autoload_on_open (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 350;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (wyl_policy_store_upsert_permission (store, "wr.direct.autoload",
+          "direct autoload", "basic") != WYRELOG_E_OK)
+    return 351;
+  if (wyl_policy_store_grant_direct_permission (store, "direct-load-user",
+          "wr.direct.autoload", "direct-load-scope") != WYRELOG_E_OK)
+    return 352;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 353;
+
+  if (insert2_symbol (handle, "principal_state", "direct-load-user",
+          "authenticated") != WYRELOG_E_OK)
+    return 354;
+  if (insert2_symbol (handle, "session_state", "direct-load-scope",
+          "active") != WYRELOG_E_OK)
+    return 355;
+  if (insert1_symbol (handle, "session_active", "active") != WYRELOG_E_OK)
+    return 356;
+
+  gint64 decision_row[3];
+  if (intern3 (handle, "direct-load-user", "wr.direct.autoload",
+          "direct-load-scope", decision_row) != WYRELOG_E_OK)
+    return 357;
+  gboolean allowed = FALSE;
+  if (wyl_handle_engine_decide (handle, decision_row, &allowed)
+      != WYRELOG_E_OK)
+    return 358;
+  if (!allowed)
+    return 359;
+  return 0;
+}
+
+static gint
+check_policy_store_direct_permissions_require_engine_pair (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 360;
+  if (wyl_handle_load_policy_store_direct_permissions (NULL)
+      != WYRELOG_E_INVALID)
+    return 361;
+  if (wyl_handle_load_policy_store_direct_permissions (handle)
+      != WYRELOG_E_INVALID)
+    return 362;
+  return 0;
+}
+
 int
 main (void)
 {
@@ -881,6 +938,10 @@ main (void)
   if ((rc = check_policy_store_role_permissions_autoload_on_open ()) != 0)
     return rc;
   if ((rc = check_policy_store_role_permissions_require_engine_pair ()) != 0)
+    return rc;
+  if ((rc = check_policy_store_direct_permissions_autoload_on_open ()) != 0)
+    return rc;
+  if ((rc = check_policy_store_direct_permissions_require_engine_pair ()) != 0)
     return rc;
 
   return 0;

--- a/tests/test-policy-store.c
+++ b/tests/test-policy-store.c
@@ -80,6 +80,27 @@ check_handle_owns_policy_store (void)
 
 typedef struct
 {
+  const gchar *subject_id;
+  const gchar *perm_id;
+  const gchar *scope;
+  guint matches;
+} DirectPermissionExpect;
+
+static wyrelog_error_t
+direct_permission_expect_cb (const gchar *subject_id, const gchar *perm_id,
+    const gchar *scope, gpointer user_data)
+{
+  DirectPermissionExpect *expect = user_data;
+
+  if (g_strcmp0 (subject_id, expect->subject_id) == 0
+      && g_strcmp0 (perm_id, expect->perm_id) == 0
+      && g_strcmp0 (scope, expect->scope) == 0)
+    expect->matches++;
+  return WYRELOG_E_OK;
+}
+
+typedef struct
+{
   const gchar *role_id;
   const gchar *perm_id;
   guint matches;
@@ -156,6 +177,16 @@ check_store_grants_direct_permission (void)
     return 65;
   if (!exists)
     return 66;
+  DirectPermissionExpect expect = {
+    .subject_id = "direct-user",
+    .perm_id = "wr.direct.read",
+    .scope = "direct-scope",
+  };
+  if (wyl_policy_store_foreach_direct_permission (store,
+          direct_permission_expect_cb, &expect) != WYRELOG_E_OK)
+    return 78;
+  if (expect.matches != 1)
+    return 79;
   if (wyl_policy_store_revoke_direct_permission (store, "direct-user",
           "wr.direct.read", "direct-scope") != WYRELOG_E_OK)
     return 67;
@@ -189,6 +220,9 @@ check_store_rejects_bad_direct_permission (void)
   if (wyl_policy_store_direct_permission_exists (store, "direct-user",
           "missing-perm", "direct-scope", NULL) != WYRELOG_E_INVALID)
     return 75;
+  if (wyl_policy_store_foreach_direct_permission (store, NULL, NULL)
+      != WYRELOG_E_INVALID)
+    return 78;
   if (wyl_policy_store_direct_permission_exists (store, "direct-user",
           "missing-perm", "direct-scope", &exists) != WYRELOG_E_OK)
     return 76;

--- a/wyrelog/policy/store-private.h
+++ b/wyrelog/policy/store-private.h
@@ -12,6 +12,8 @@ typedef struct wyl_policy_store_t wyl_policy_store_t;
 
 typedef wyrelog_error_t (*wyl_policy_role_permission_cb) (const gchar * role_id,
     const gchar * perm_id, gpointer user_data);
+typedef wyrelog_error_t (*wyl_policy_direct_permission_cb) (const gchar *
+    subject_id, const gchar * perm_id, const gchar * scope, gpointer user_data);
 
 /*
  * Policy authority store lifecycle wrapper.
@@ -48,5 +50,7 @@ wyrelog_error_t wyl_policy_store_revoke_direct_permission (wyl_policy_store_t *
 wyrelog_error_t wyl_policy_store_direct_permission_exists (wyl_policy_store_t *
     store, const gchar * subject_id, const gchar * perm_id, const gchar * scope,
     gboolean * out_exists);
+wyrelog_error_t wyl_policy_store_foreach_direct_permission (wyl_policy_store_t *
+    store, wyl_policy_direct_permission_cb cb, gpointer user_data);
 
 G_END_DECLS;

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -298,6 +298,38 @@ wyl_policy_store_direct_permission_exists (wyl_policy_store_t *store,
 }
 
 wyrelog_error_t
+wyl_policy_store_foreach_direct_permission (wyl_policy_store_t *store,
+    wyl_policy_direct_permission_cb cb, gpointer user_data)
+{
+  sqlite3_stmt *stmt = NULL;
+
+  if (store == NULL || store->db == NULL || cb == NULL)
+    return WYRELOG_E_INVALID;
+
+  static const gchar *sql =
+      "SELECT subject_id, perm_id, scope FROM direct_permissions "
+      "ORDER BY subject_id, perm_id, scope;";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  int step_rc;
+  while ((step_rc = sqlite3_step (stmt)) == SQLITE_ROW) {
+    const gchar *subject_id = (const gchar *) sqlite3_column_text (stmt, 0);
+    const gchar *perm_id = (const gchar *) sqlite3_column_text (stmt, 1);
+    const gchar *scope = (const gchar *) sqlite3_column_text (stmt, 2);
+    rc = cb (subject_id, perm_id, scope, user_data);
+    if (rc != WYRELOG_E_OK) {
+      sqlite3_finalize (stmt);
+      return rc;
+    }
+  }
+
+  sqlite3_finalize (stmt);
+  return (step_rc == SQLITE_DONE) ? WYRELOG_E_OK : WYRELOG_E_IO;
+}
+
+wyrelog_error_t
 wyl_policy_store_upsert_permission (wyl_policy_store_t *store,
     const gchar *perm_id, const gchar *perm_name, const gchar *klass)
 {

--- a/wyrelog/wyl-handle-private.h
+++ b/wyrelog/wyl-handle-private.h
@@ -79,6 +79,15 @@ wyrelog_error_t wyl_handle_load_policy_store_role_permissions (WylHandle *
     self);
 
 /*
+ * Loads direct_permission rows from the handle-owned policy authority store
+ * into the attached read/delta engine pair, together with their "armed"
+ * perm_state rows. Rejected unless both the store and engine pair are
+ * available.
+ */
+wyrelog_error_t wyl_handle_load_policy_store_direct_permissions (WylHandle *
+    self);
+
+/*
  * Probes the read engine for an exact EDB/IDB row match. Rejected unless the
  * engine pair is already open.
  */

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -225,6 +225,12 @@ wyl_handle_open_engine_pair (WylHandle *self, const gchar *template_dir)
     g_clear_object (&self->delta_engine);
     return rc;
   }
+  rc = wyl_handle_load_policy_store_direct_permissions (self);
+  if (rc != WYRELOG_E_OK) {
+    g_clear_object (&self->read_engine);
+    g_clear_object (&self->delta_engine);
+    return rc;
+  }
   return WYRELOG_E_OK;
 }
 
@@ -357,6 +363,51 @@ wyl_handle_load_policy_store_role_permissions (WylHandle *self)
 
   return wyl_policy_store_foreach_role_permission (self->policy_store,
       insert_policy_store_role_permission, self);
+}
+
+static wyrelog_error_t
+insert_policy_store_direct_permission (const gchar *subject_id,
+    const gchar *perm_id, const gchar *scope, gpointer user_data)
+{
+  WylHandle *self = user_data;
+  gint64 row[3];
+  gint64 state_row[4];
+
+  wyrelog_error_t rc =
+      wyl_handle_intern_engine_symbol (self, subject_id, &row[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (self, perm_id, &row[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (self, scope, &row[2]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  state_row[0] = row[0];
+  state_row[1] = row[1];
+  state_row[2] = row[2];
+  rc = wyl_handle_intern_engine_symbol (self, "armed", &state_row[3]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  rc = wyl_handle_engine_insert (self, "direct_permission", row, 3);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_engine_insert (self, "perm_state", state_row, 4);
+}
+
+wyrelog_error_t
+wyl_handle_load_policy_store_direct_permissions (WylHandle *self)
+{
+  if (self == NULL || !WYL_IS_HANDLE (self))
+    return WYRELOG_E_INVALID;
+  if (self->policy_store == NULL || self->read_engine == NULL
+      || self->delta_engine == NULL)
+    return WYRELOG_E_INVALID;
+
+  return wyl_policy_store_foreach_direct_permission (self->policy_store,
+      insert_policy_store_direct_permission, self);
 }
 
 typedef struct


### PR DESCRIPTION
## Summary
- stream policy-store direct grants into the handle engine pair
- mirror direct_permission and armed perm_state facts on engine open
- cover the pre-open store path through a normal decision query

## Tests
- meson test -C builddir --print-errorlogs
- meson test -C builddir-audit --print-errorlogs