### PR TITLE
session: require MFA before authentication

### DIFF
--- a/tests/test-perm.c
+++ b/tests/test-perm.c
@@ -135,6 +135,8 @@ check_grant_allows_engine_decide (void)
   g_autoptr (WylSession) session = NULL;
   if (wyl_session_login (handle, login, &session) != WYRELOG_E_OK)
     return 52;
+  if (wyl_session_mfa_verify (handle, session) != WYRELOG_E_OK)
+    return 59;
 
   gint64 active_row[1];
   if (wyl_handle_intern_engine_symbol (handle, "active", &active_row[0])

--- a/tests/test-session-username.c
+++ b/tests/test-session-username.c
@@ -189,7 +189,7 @@ check_dup_null_session (void)
 }
 
 static gint
-check_login_authenticates_engine_principal (void)
+check_login_requires_mfa_before_allow (void)
 {
   g_autoptr (WylHandle) handle = NULL;
   if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
@@ -226,8 +226,73 @@ check_login_authenticates_engine_principal (void)
   g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
   if (wyl_decide (handle, decide, resp) != WYRELOG_E_OK)
     return 78;
-  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_ALLOW)
+  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_DENY)
     return 79;
+  return 0;
+}
+
+static gint
+check_mfa_verify_authenticates_engine_principal (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 80;
+
+  if (insert_symbol_row2 (handle, "role_permission", "wr.login-role",
+          "wr.login-permission") != WYRELOG_E_OK)
+    return 81;
+  if (insert_symbol_row3 (handle, "member_of", "login-user",
+          "wr.login-role", "login-scope") != WYRELOG_E_OK)
+    return 82;
+  if (insert_symbol_row2 (handle, "session_state", "login-scope", "active")
+      != WYRELOG_E_OK)
+    return 83;
+  if (insert_symbol_row1 (handle, "session_active", "active") != WYRELOG_E_OK)
+    return 84;
+  if (insert_symbol_row4 (handle, "perm_state", "login-user",
+          "wr.login-permission", "login-scope", "armed") != WYRELOG_E_OK)
+    return 85;
+
+  g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
+  wyl_login_req_set_username (login, "login-user");
+  g_autoptr (WylSession) session = NULL;
+  if (wyl_session_login (handle, login, &session) != WYRELOG_E_OK)
+    return 86;
+  if (session == NULL)
+    return 87;
+  if (wyl_session_mfa_verify (handle, session) != WYRELOG_E_OK)
+    return 88;
+
+  g_autoptr (wyl_decide_req_t) decide = wyl_decide_req_new ();
+  wyl_decide_req_set_subject_id (decide, "login-user");
+  wyl_decide_req_set_action (decide, "wr.login-permission");
+  wyl_decide_req_set_resource_id (decide, "login-scope");
+
+  g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
+  if (wyl_decide (handle, decide, resp) != WYRELOG_E_OK)
+    return 89;
+  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_ALLOW)
+    return 90;
+  return 0;
+}
+
+static gint
+check_mfa_verify_rejects_invalid_args (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 100;
+
+  if (wyl_session_mfa_verify (NULL, NULL) != WYRELOG_E_INVALID)
+    return 101;
+  if (wyl_session_mfa_verify (handle, NULL) != WYRELOG_E_INVALID)
+    return 102;
+
+  g_autoptr (WylSession) session = NULL;
+  if (wyl_session_login (handle, NULL, &session) != WYRELOG_E_OK)
+    return 103;
+  if (wyl_session_mfa_verify (handle, session) != WYRELOG_E_INVALID)
+    return 104;
   return 0;
 }
 
@@ -248,7 +313,11 @@ main (void)
     return rc;
   if ((rc = check_dup_null_session ()) != 0)
     return rc;
-  if ((rc = check_login_authenticates_engine_principal ()) != 0)
+  if ((rc = check_login_requires_mfa_before_allow ()) != 0)
+    return rc;
+  if ((rc = check_mfa_verify_authenticates_engine_principal ()) != 0)
+    return rc;
+  if ((rc = check_mfa_verify_rejects_invalid_args ()) != 0)
     return rc;
 
   return 0;

--- a/wyrelog/session.h
+++ b/wyrelog/session.h
@@ -10,7 +10,7 @@
 G_BEGIN_DECLS;
 
 /*
- * WylSession - active authenticated session.
+ * WylSession - active login session.
  *
  * Carries the principal identity, MFA state, and tenant binding for a
  * sequence of decide calls. Acquired through wyl_session_login,
@@ -53,6 +53,8 @@ const gchar *wyl_login_req_get_username (const wyl_login_req_t * req);
 
 wyrelog_error_t wyl_session_login (WylHandle * handle,
     const wyl_login_req_t * req, WylSession ** out_session);
+wyrelog_error_t wyl_session_mfa_verify (WylHandle * handle,
+    WylSession * session);
 wyrelog_error_t wyl_session_logout (WylHandle * handle, wyl_session_id_t sid);
 
 /*

--- a/wyrelog/wyl-fsm-principal-private.h
+++ b/wyrelog/wyl-fsm-principal-private.h
@@ -32,6 +32,8 @@ typedef enum wyl_principal_state_t
   WYL_PRINCIPAL_STATE_LAST_,
 } wyl_principal_state_t;
 
+#ifndef WYL_PRINCIPAL_EVENT_T_DEFINED
+#define WYL_PRINCIPAL_EVENT_T_DEFINED
 typedef enum wyl_principal_event_t
 {
   WYL_PRINCIPAL_EVENT_LOGIN_OK = 0,
@@ -43,6 +45,7 @@ typedef enum wyl_principal_event_t
   WYL_PRINCIPAL_EVENT_REVOKE,
   WYL_PRINCIPAL_EVENT_LAST_,
 } wyl_principal_event_t;
+#endif /* WYL_PRINCIPAL_EVENT_T_DEFINED */
 
 typedef struct wyl_principal_transition_t
 {

--- a/wyrelog/wyl-session.c
+++ b/wyrelog/wyl-session.c
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #include "wyrelog/wyrelog.h"
 
+#include "wyl-fsm-principal-private.h"
 #include "wyl-handle-private.h"
 #include "wyl-id-private.h"
 
@@ -48,6 +49,50 @@ wyl_session_init (WylSession *self)
   self->created_at_us = g_get_real_time ();
 }
 
+static wyrelog_error_t
+insert_principal_state (WylHandle *handle, const gchar *username,
+    wyl_principal_state_t state)
+{
+  if (username == NULL || wyl_handle_get_read_engine (handle) == NULL)
+    return WYRELOG_E_OK;
+
+  const gchar *state_name = wyl_principal_state_name (state);
+  if (state_name == NULL)
+    return WYRELOG_E_INTERNAL;
+
+  gint64 row[2];
+  wyrelog_error_t rc =
+      wyl_handle_intern_engine_symbol (handle, username, &row[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, state_name, &row[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_engine_insert (handle, "principal_state", row, 2);
+}
+
+static wyrelog_error_t
+remove_principal_state (WylHandle *handle, const gchar *username,
+    wyl_principal_state_t state)
+{
+  if (username == NULL || wyl_handle_get_read_engine (handle) == NULL)
+    return WYRELOG_E_OK;
+
+  const gchar *state_name = wyl_principal_state_name (state);
+  if (state_name == NULL)
+    return WYRELOG_E_INTERNAL;
+
+  gint64 row[2];
+  wyrelog_error_t rc =
+      wyl_handle_intern_engine_symbol (handle, username, &row[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, state_name, &row[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_engine_remove (handle, "principal_state", row, 2);
+}
+
 wyrelog_error_t
 wyl_session_login (WylHandle *handle, const wyl_login_req_t *req,
     WylSession **out_session)
@@ -65,20 +110,15 @@ wyl_session_login (WylHandle *handle, const wyl_login_req_t *req,
     session->username = g_strdup (username);
   }
 
-  if (username != NULL && wyl_handle_get_read_engine (handle) != NULL) {
-    gint64 row[2];
-    wyrelog_error_t rc =
-        wyl_handle_intern_engine_symbol (handle, username, &row[0]);
-    if (rc != WYRELOG_E_OK) {
+  if (username != NULL) {
+    wyl_principal_state_t state = WYL_PRINCIPAL_STATE_LAST_;
+    wyrelog_error_t rc = wyl_fsm_principal_step (WYL_PRINCIPAL_STATE_UNVERIFIED,
+        WYL_PRINCIPAL_EVENT_LOGIN_OK, &state);
+    if (rc != WYRELOG_E_OK || state != WYL_PRINCIPAL_STATE_MFA_REQUIRED) {
       g_object_unref (session);
-      return rc;
+      return (rc == WYRELOG_E_OK) ? WYRELOG_E_INTERNAL : rc;
     }
-    rc = wyl_handle_intern_engine_symbol (handle, "authenticated", &row[1]);
-    if (rc != WYRELOG_E_OK) {
-      g_object_unref (session);
-      return rc;
-    }
-    rc = wyl_handle_engine_insert (handle, "principal_state", row, 2);
+    rc = insert_principal_state (handle, username, state);
     if (rc != WYRELOG_E_OK) {
       g_object_unref (session);
       return rc;
@@ -87,6 +127,27 @@ wyl_session_login (WylHandle *handle, const wyl_login_req_t *req,
 
   *out_session = session;
   return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
+wyl_session_mfa_verify (WylHandle *handle, WylSession *session)
+{
+  if (handle == NULL || session == NULL || !WYL_IS_SESSION (session))
+    return WYRELOG_E_INVALID;
+  if (session->username == NULL)
+    return WYRELOG_E_INVALID;
+
+  wyl_principal_state_t state = WYL_PRINCIPAL_STATE_LAST_;
+  wyrelog_error_t rc = wyl_fsm_principal_step (WYL_PRINCIPAL_STATE_MFA_REQUIRED,
+      WYL_PRINCIPAL_EVENT_MFA_OK, &state);
+  if (rc != WYRELOG_E_OK || state != WYL_PRINCIPAL_STATE_AUTHENTICATED)
+    return (rc == WYRELOG_E_OK) ? WYRELOG_E_INTERNAL : rc;
+
+  rc = remove_principal_state (handle, session->username,
+      WYL_PRINCIPAL_STATE_MFA_REQUIRED);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return insert_principal_state (handle, session->username, state);
 }
 
 wyrelog_error_t


### PR DESCRIPTION
## Summary
- route session login through the principal FSM and seed mfa_required
- add explicit MFA verification to advance sessions to authenticated
- update permission and session coverage for the two-step login flow

## Validation
- meson test -C builddir --print-errorlogs
- meson test -C builddir-audit --print-errorlogs