### PR TITLE
policy: feed guard facts into wirelog

### DIFF
--- a/templates/access/decision.dl
+++ b/templates/access/decision.dl
@@ -59,8 +59,7 @@ guarded_perm(P) :- perm_arm_rule(P, G).
 
 allow(U, P, S) :-
     allow_guard_base(U, P, S),
-    armed(U, P, S),
-    !guarded_perm(P).
+    armed(U, P, S).
 
 allow_bool(U, P, S) :- allow(U, P, S).
 

--- a/templates/access/fsm/permission_scope.dl
+++ b/templates/access/fsm/permission_scope.dl
@@ -6,23 +6,20 @@
 //
 // Stateless armed/3 derivation. The version-0 perm-scope is a pure
 // IDB rule set with no transition lifecycle: the host must inject
-// perm_state(user, perm, scope, "armed") for permissions that are
-// ready to participate in allow/3. Guard-derived arming lands in a
-// future commit when compound guard payloads are bridged into the
-// engine.
+// perm_state(user, perm, scope, "armed") for unguarded permissions
+// that are ready to participate in allow/3. Guarded permissions are
+// armed only when the host injects the request-local context_now/2
+// and eval_guard/3 bridge facts for a satisfied guard expression.
 //
 // EDB schemas (host-populated, no clauses below):
 //   perm_state(user, perm, scope, state)        -- v0 row count = 0
 //   has_permission(user, perm, scope)            -- declared in
 //                                                   bootstrap.dl
 //   perm_arm_rule(perm, guard_handle)            -- compound guard
-//                                                   payload deferred
-//                                                   to a follow-up
-//                                                   commit; for v0
-//                                                   this relation is
-//                                                   declared but the
-//                                                   gated armed/3
-//                                                   rule is omitted.
+//                                                   payload key
+//   context_now(user, scope)                     -- request context
+//                                                   activation
+//   eval_guard(user, perm, scope)                -- host guard result
 //
 // Row order in any future perm_arm_rule block will be load-bearing:
 // the test harness compares the perm-id list line by line against
@@ -31,6 +28,8 @@
 
 .decl perm_state(user: symbol, perm: symbol, scope: symbol, state: symbol)
 .decl perm_arm_rule(perm: symbol, guard_handle: symbol)
+.decl context_now(user: symbol, scope: symbol)
+.decl eval_guard(user: symbol, perm: symbol, scope: symbol)
 .decl armed(user: symbol, perm: symbol, scope: symbol)
 
 // --- perm_arm_rule catalogue mirror ----------------------------------
@@ -41,7 +40,8 @@
 // other will fail the build. The second argument is a guard handle —
 // the compound-term guard payload itself lives in the C catalogue,
 // keyed by perm-id; the `_v0_deferred` placeholder pins the row count
-// without committing to a wirelog encoding for compound guards.
+// while the host bridge exposes satisfied guard decisions as
+// eval_guard/3 facts.
 
 perm_arm_rule("wr.sys.admin",        "_v0_deferred").
 perm_arm_rule("wr.sys.key_rotate",   "_v0_deferred").
@@ -57,13 +57,18 @@ perm_arm_rule("wr.audit.explain",    "_v0_deferred").
 // --- armed/3 derivation ----------------------------------------------
 
 // rule-1: state-driven path. perm_state is host-populated; an
-// "armed" entry directly arms the (user, perm, scope) tuple.
-armed(U, P, S) :- perm_state(U, P, S, "armed").
+// "armed" entry directly arms the (user, perm, scope) tuple only
+// when the permission is not guarded by the catalogue.
+armed(U, P, S) :-
+    perm_state(U, P, S, "armed"),
+    !perm_arm_rule(P, _).
 
-// rule-3: gated permission with compound-term guard payload.
-// Deferred: the embedded Datalog engine supports compound terms
-// (`functor/arity`), but the host-bridged `eval_guard/2` predicate
-// and the wirelog encoding of guard expressions need their own
-// atomic commit. Until that lands, the gated armed/3 path is served
-// by the C-side wyl_eval_guard against the catalogue keyed by
-// perm-id.
+// rule-3: gated permission with compound-term guard payload. The
+// payload tree remains in the C catalogue for now, keyed by P; the
+// host evaluates it against request context and injects eval_guard/3
+// only when the guard is satisfied.
+armed(U, P, S) :-
+    has_permission(U, P, S),
+    context_now(U, S),
+    perm_arm_rule(P, _),
+    eval_guard(U, P, S).

--- a/tests/test-access-decision.c
+++ b/tests/test-access-decision.c
@@ -36,7 +36,6 @@ check_stratification (void)
   static const wyl_dl_body_atom_t allow_body[] = {
     {.predicate = "allow_guard_base",.negated = FALSE},
     {.predicate = "armed",.negated = FALSE},
-    {.predicate = "guarded_perm",.negated = TRUE},
   };
   static const wyl_dl_body_atom_t guarded_perm_body[] = {
     {.predicate = "perm_arm_rule",.negated = FALSE},

--- a/tests/test-fsm-permission-scope.c
+++ b/tests/test-fsm-permission-scope.c
@@ -14,22 +14,20 @@
 /* --- Stratification self-check ---------------------------------- */
 
 /*
- * Lifts the three armed/3 rules + the eval_guard host bridge fact
+ * Lifts the two armed/3 rules + the eval_guard host bridge fact
  * into wyl_dl_rule_t form and asserts the program is stratified.
- * The two negation edges (rule-2 references \+ perm_arm_rule, and
- * the rule-3 path goes through eval_guard / context_now) cannot
- * close a cycle because perm_arm_rule, perm_state, has_permission,
- * context_now, eval_guard and in_window are EDB-only — none of
- * them appears as a head predicate in the lifted rule set.
+ * The negation edge in the state-driven rule references
+ * \+ perm_arm_rule, and the guarded rule goes through eval_guard /
+ * context_now. No edge can close a cycle because perm_arm_rule,
+ * perm_state, has_permission, context_now and eval_guard are
+ * EDB-only — none of them appears as a head predicate in the
+ * lifted rule set.
  */
 static gint
 check_stratification (void)
 {
   static const wyl_dl_body_atom_t rule1_body[] = {
     {.predicate = "perm_state",.negated = FALSE},
-  };
-  static const wyl_dl_body_atom_t rule2_body[] = {
-    {.predicate = "has_permission",.negated = FALSE},
     {.predicate = "perm_arm_rule",.negated = TRUE},
   };
   static const wyl_dl_body_atom_t rule3_body[] = {
@@ -40,7 +38,6 @@ check_stratification (void)
   };
   wyl_dl_rule_t rules[] = {
     {.head = "armed",.body = rule1_body,.body_len = G_N_ELEMENTS (rule1_body)},
-    {.head = "armed",.body = rule2_body,.body_len = G_N_ELEMENTS (rule2_body)},
     {.head = "armed",.body = rule3_body,.body_len = G_N_ELEMENTS (rule3_body)},
   };
 

--- a/wyrelog/wyl-decide.c
+++ b/wyrelog/wyl-decide.c
@@ -162,15 +162,11 @@ wyl_decide_resp_get_decision (const wyl_decide_resp_t *resp)
   return resp->decision;
 }
 
-static wyrelog_error_t
-guard_base_decide_if_satisfied (WylHandle *handle,
-    const wyl_guard_expr_t *guard, const wyl_decide_req_t *req,
-    const gint64 row[3], gboolean *out_allowed)
+static gboolean
+guard_is_satisfied (const wyl_guard_expr_t *guard, const wyl_decide_req_t *req)
 {
-  *out_allowed = FALSE;
-
   if (guard == NULL || !req->has_guard_context)
-    return WYRELOG_E_OK;
+    return FALSE;
 
   wyl_scope_t scope = {
     .user = wyl_decide_req_get_subject_id (req),
@@ -178,11 +174,19 @@ guard_base_decide_if_satisfied (WylHandle *handle,
     .loc_class = req->guard_loc_class,
     .risk = req->guard_risk,
   };
-  if (!wyl_eval_guard (guard, &scope))
-    return WYRELOG_E_OK;
+  return wyl_eval_guard (guard, &scope);
+}
 
-  return wyl_handle_engine_contains (handle, "allow_guard_base", row, 3,
-      out_allowed);
+static wyrelog_error_t
+insert_guard_eval_facts (WylHandle *handle, const gint64 row[3])
+{
+  gint64 context_row[2] = { row[0], row[2] };
+  wyrelog_error_t rc =
+      wyl_handle_engine_insert (handle, "context_now", context_row, 2);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  return wyl_handle_engine_insert (handle, "eval_guard", row, 3);
 }
 
 wyrelog_error_t
@@ -217,17 +221,21 @@ wyl_decide (WylHandle *handle, const wyl_decide_req_t *req,
     const wyl_guard_expr_t *guard =
         wyl_perm_arm_rule_lookup (wyl_decide_req_get_action (req));
     if (guard != NULL) {
-      rc = guard_base_decide_if_satisfied (handle, guard, req, row, &allowed);
-      if (rc != WYRELOG_E_OK)
-        return rc;
-    } else {
-      rc = wyl_handle_engine_decide (handle, row, &allowed);
+      if (!guard_is_satisfied (guard, req))
+        goto emit_audit;
+      rc = insert_guard_eval_facts (handle, row);
       if (rc != WYRELOG_E_OK)
         return rc;
     }
+
+    rc = wyl_handle_engine_decide (handle, row, &allowed);
+    if (rc != WYRELOG_E_OK)
+      return rc;
     if (allowed)
       wyl_decide_resp_set_decision (resp, WYL_DECISION_ALLOW);
   }
+emit_audit:
+  ;
 #ifdef WYL_HAS_AUDIT
   /* Mirror the decision into the audit log so every decide call
    * leaves a row regardless of whether downstream callers also


### PR DESCRIPTION
## Summary
- derive guarded armed tuples from context_now and eval_guard facts
- route satisfied guard decisions through allow_bool in the Datalog path
- update static rule oracles for the revised guarded permission shape

## Validation
- meson test -C builddir --print-errorlogs
- meson test -C builddir-audit --print-errorlogs