### PR TITLE
audit: persist deny reason tags

### DIFF
--- a/tests/test-audit-emit.c
+++ b/tests/test-audit-emit.c
@@ -62,6 +62,8 @@ check_emit_persists_event_fields (void)
   wyl_audit_event_set_subject_id (ev, "bob");
   wyl_audit_event_set_action (ev, "write");
   wyl_audit_event_set_resource_id (ev, "doc/99");
+  wyl_audit_event_set_deny_reason (ev, "not_armed");
+  wyl_audit_event_set_deny_origin (ev, "perm_state");
   wyl_audit_event_set_decision (ev, WYL_DECISION_DENY);
 
   g_autofree gchar *expected_id = wyl_audit_event_dup_id_string (ev);
@@ -75,7 +77,8 @@ check_emit_persists_event_fields (void)
       wyl_audit_conn_get_connection (wyl_handle_get_audit_conn (handle));
   duckdb_result result;
   if (duckdb_query (conn,
-          "SELECT id, subject_id, action, resource_id, decision "
+          "SELECT id, subject_id, action, resource_id, deny_reason, "
+          "deny_origin, decision "
           "FROM audit_events;", &result) != DuckDBSuccess) {
     duckdb_destroy_result (&result);
     g_object_unref (handle);
@@ -86,7 +89,9 @@ check_emit_persists_event_fields (void)
   const gchar *subject = duckdb_value_varchar (&result, 1, 0);
   const gchar *action = duckdb_value_varchar (&result, 2, 0);
   const gchar *resource = duckdb_value_varchar (&result, 3, 0);
-  gint16 decision = (gint16) duckdb_value_int64 (&result, 4, 0);
+  const gchar *deny_reason = duckdb_value_varchar (&result, 4, 0);
+  const gchar *deny_origin = duckdb_value_varchar (&result, 5, 0);
+  gint16 decision = (gint16) duckdb_value_int64 (&result, 6, 0);
 
   if (g_strcmp0 (id, expected_id) != 0)
     rc = 23;
@@ -96,13 +101,19 @@ check_emit_persists_event_fields (void)
     rc = 25;
   else if (g_strcmp0 (resource, "doc/99") != 0)
     rc = 26;
-  else if (decision != WYL_DECISION_DENY)
+  else if (g_strcmp0 (deny_reason, "not_armed") != 0)
     rc = 27;
+  else if (g_strcmp0 (deny_origin, "perm_state") != 0)
+    rc = 28;
+  else if (decision != WYL_DECISION_DENY)
+    rc = 29;
 
   duckdb_free ((void *) id);
   duckdb_free ((void *) subject);
   duckdb_free ((void *) action);
   duckdb_free ((void *) resource);
+  duckdb_free ((void *) deny_reason);
+  duckdb_free ((void *) deny_origin);
   duckdb_destroy_result (&result);
   g_object_unref (handle);
   return rc;

--- a/tests/test-audit-event.c
+++ b/tests/test-audit-event.c
@@ -132,6 +132,10 @@ check_string_field_defaults_are_null (void)
     return 141;
   if (wyl_audit_event_get_resource_id (ev) != NULL)
     return 142;
+  if (wyl_audit_event_get_deny_reason (ev) != NULL)
+    return 143;
+  if (wyl_audit_event_get_deny_origin (ev) != NULL)
+    return 144;
   return 0;
 }
 
@@ -142,12 +146,20 @@ check_string_field_round_trips (void)
   wyl_audit_event_set_subject_id (ev, "alice");
   wyl_audit_event_set_action (ev, "read");
   wyl_audit_event_set_resource_id (ev, "doc/42");
+  wyl_audit_event_set_deny_reason (ev, "not_authenticated");
+  wyl_audit_event_set_deny_origin (ev, "principal_state");
   if (g_strcmp0 (wyl_audit_event_get_subject_id (ev), "alice") != 0)
     return 150;
   if (g_strcmp0 (wyl_audit_event_get_action (ev), "read") != 0)
     return 151;
   if (g_strcmp0 (wyl_audit_event_get_resource_id (ev), "doc/42") != 0)
     return 152;
+  if (g_strcmp0 (wyl_audit_event_get_deny_reason (ev), "not_authenticated")
+      != 0)
+    return 153;
+  if (g_strcmp0 (wyl_audit_event_get_deny_origin (ev), "principal_state")
+      != 0)
+    return 154;
   return 0;
 }
 
@@ -156,9 +168,17 @@ check_string_set_null_clears (void)
 {
   g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
   wyl_audit_event_set_subject_id (ev, "alice");
+  wyl_audit_event_set_deny_reason (ev, "not_armed");
+  wyl_audit_event_set_deny_origin (ev, "perm_state");
   wyl_audit_event_set_subject_id (ev, NULL);
+  wyl_audit_event_set_deny_reason (ev, NULL);
+  wyl_audit_event_set_deny_origin (ev, NULL);
   if (wyl_audit_event_get_subject_id (ev) != NULL)
     return 160;
+  if (wyl_audit_event_get_deny_reason (ev) != NULL)
+    return 161;
+  if (wyl_audit_event_get_deny_origin (ev) != NULL)
+    return 162;
   return 0;
 }
 
@@ -183,6 +203,10 @@ check_string_get_null_event (void)
     return 181;
   if (wyl_audit_event_get_resource_id (NULL) != NULL)
     return 182;
+  if (wyl_audit_event_get_deny_reason (NULL) != NULL)
+    return 183;
+  if (wyl_audit_event_get_deny_origin (NULL) != NULL)
+    return 184;
   return 0;
 }
 

--- a/wyrelog/audit.h
+++ b/wyrelog/audit.h
@@ -57,6 +57,14 @@ void wyl_audit_event_set_resource_id (WylAuditEvent * self,
     const gchar * resource_id);
 const gchar *wyl_audit_event_get_resource_id (const WylAuditEvent * self);
 
+void wyl_audit_event_set_deny_reason (WylAuditEvent * self,
+    const gchar * deny_reason);
+const gchar *wyl_audit_event_get_deny_reason (const WylAuditEvent * self);
+
+void wyl_audit_event_set_deny_origin (WylAuditEvent * self,
+    const gchar * deny_origin);
+const gchar *wyl_audit_event_get_deny_origin (const WylAuditEvent * self);
+
 /*
  * Records the verdict produced for the request the event describes.
  * Default for a freshly constructed event is WYL_DECISION_DENY so

--- a/wyrelog/audit/conn-private.h
+++ b/wyrelog/audit/conn-private.h
@@ -76,6 +76,8 @@ duckdb_connection wyl_audit_conn_get_connection (wyl_audit_conn_t * conn);
  *   subject_id    VARCHAR
  *   action        VARCHAR
  *   resource_id   VARCHAR
+ *   deny_reason   VARCHAR              -- representative deny code
+ *   deny_origin   VARCHAR              -- source relation tag
  *   decision      SMALLINT             -- 0 = DENY, 1 = ALLOW
  *
  * Returns WYRELOG_E_OK on success, WYRELOG_E_INVALID for a NULL

--- a/wyrelog/audit/conn.c
+++ b/wyrelog/audit/conn.c
@@ -71,7 +71,9 @@ wyl_audit_conn_create_schema (wyl_audit_conn_t *conn)
       "  created_at_us BIGINT  NOT NULL,"
       "  subject_id    VARCHAR,"
       "  action        VARCHAR,"
-      "  resource_id   VARCHAR," "  decision      SMALLINT NOT NULL" ");";
+      "  resource_id   VARCHAR,"
+      "  deny_reason   VARCHAR,"
+      "  deny_origin   VARCHAR," "  decision      SMALLINT NOT NULL" ");";
 
   if (conn == NULL)
     return WYRELOG_E_INVALID;

--- a/wyrelog/audit/event.c
+++ b/wyrelog/audit/event.c
@@ -18,6 +18,8 @@ struct _WylAuditEvent
   gchar *subject_id;
   gchar *action;
   gchar *resource_id;
+  gchar *deny_reason;
+  gchar *deny_origin;
   wyl_decision_t decision;
 };
 
@@ -31,6 +33,8 @@ wyl_audit_event_finalize (GObject *object)
   g_free (self->subject_id);
   g_free (self->action);
   g_free (self->resource_id);
+  g_free (self->deny_reason);
+  g_free (self->deny_origin);
 
   G_OBJECT_CLASS (wyl_audit_event_parent_class)->finalize (object);
 }
@@ -132,6 +136,36 @@ wyl_audit_event_get_resource_id (const WylAuditEvent *self)
 }
 
 void
+wyl_audit_event_set_deny_reason (WylAuditEvent *self, const gchar *deny_reason)
+{
+  g_return_if_fail (WYL_IS_AUDIT_EVENT (self));
+  g_free (self->deny_reason);
+  self->deny_reason = g_strdup (deny_reason);
+}
+
+const gchar *
+wyl_audit_event_get_deny_reason (const WylAuditEvent *self)
+{
+  g_return_val_if_fail (WYL_IS_AUDIT_EVENT (self), NULL);
+  return self->deny_reason;
+}
+
+void
+wyl_audit_event_set_deny_origin (WylAuditEvent *self, const gchar *deny_origin)
+{
+  g_return_if_fail (WYL_IS_AUDIT_EVENT (self));
+  g_free (self->deny_origin);
+  self->deny_origin = g_strdup (deny_origin);
+}
+
+const gchar *
+wyl_audit_event_get_deny_origin (const WylAuditEvent *self)
+{
+  g_return_val_if_fail (WYL_IS_AUDIT_EVENT (self), NULL);
+  return self->deny_origin;
+}
+
+void
 wyl_audit_event_set_decision (WylAuditEvent *self, wyl_decision_t decision)
 {
   g_return_if_fail (WYL_IS_AUDIT_EVENT (self));
@@ -170,8 +204,8 @@ wyl_audit_emit (WylHandle *handle, const WylAuditEvent *event)
 
   static const gchar *sql =
       "INSERT INTO audit_events "
-      "(id, created_at_us, subject_id, action, resource_id, decision) "
-      "VALUES (?, ?, ?, ?, ?, ?);";
+      "(id, created_at_us, subject_id, action, resource_id, "
+      "deny_reason, deny_origin, decision) " "VALUES (?, ?, ?, ?, ?, ?, ?, ?);";
 
   if (duckdb_prepare (conn, sql, &stmt) != DuckDBSuccess) {
     duckdb_destroy_prepare (&stmt);
@@ -203,7 +237,19 @@ wyl_audit_emit (WylHandle *handle, const WylAuditEvent *event)
   else
     duckdb_bind_null (stmt, 5);
 
-  duckdb_bind_int16 (stmt, 6, (int16_t) event->decision);
+  value = event->deny_reason;
+  if (value != NULL)
+    duckdb_bind_varchar (stmt, 6, value);
+  else
+    duckdb_bind_null (stmt, 6);
+
+  value = event->deny_origin;
+  if (value != NULL)
+    duckdb_bind_varchar (stmt, 7, value);
+  else
+    duckdb_bind_null (stmt, 7);
+
+  duckdb_bind_int16 (stmt, 8, (int16_t) event->decision);
 
   rc = duckdb_execute_prepared (stmt, &result);
   duckdb_destroy_result (&result);

--- a/wyrelog/wyl-decide.c
+++ b/wyrelog/wyl-decide.c
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #include "wyrelog/wyrelog.h"
 
+#include "access/decision-private.h"
 #include "wyl-handle-private.h"
 #include "wyl-permission-scope-private.h"
 
@@ -189,6 +190,53 @@ insert_guard_eval_facts (WylHandle *handle, const gint64 row[3])
   return wyl_handle_engine_insert (handle, "eval_guard", row, 3);
 }
 
+static wyrelog_error_t
+intern_deny_reason_catalog (WylHandle *handle,
+    gint64 names[WYL_DENY_REASON_LAST_], gint64 origins[WYL_DENY_REASON_LAST_])
+{
+  for (guint i = 0; i < wyl_deny_reason_count (); i++) {
+    const gchar *name = wyl_deny_reason_name ((wyl_deny_reason_code_t) i);
+    const gchar *origin = wyl_deny_reason_origin ((wyl_deny_reason_code_t) i);
+    if (name == NULL || origin == NULL)
+      return WYRELOG_E_INTERNAL;
+
+    wyrelog_error_t rc =
+        wyl_handle_intern_engine_symbol (handle, name, &names[i]);
+    if (rc != WYRELOG_E_OK)
+      return rc;
+    rc = wyl_handle_intern_engine_symbol (handle, origin, &origins[i]);
+    if (rc != WYRELOG_E_OK)
+      return rc;
+  }
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+find_deny_reason (WylHandle *handle, const gint64 row[3],
+    const gint64 names[WYL_DENY_REASON_LAST_],
+    const gint64 origins[WYL_DENY_REASON_LAST_],
+    wyl_deny_reason_code_t *out_code)
+{
+  if (out_code == NULL)
+    return WYRELOG_E_INVALID;
+  *out_code = WYL_DENY_REASON_LAST_;
+
+  for (guint i = 0; i < wyl_deny_reason_count (); i++) {
+    gint64 reason_row[5] = { row[0], row[1], row[2], names[i], origins[i] };
+
+    gboolean found = FALSE;
+    wyrelog_error_t rc = wyl_handle_engine_contains (handle, "deny_reason",
+        reason_row, 5, &found);
+    if (rc != WYRELOG_E_OK)
+      return rc;
+    if (found) {
+      *out_code = (wyl_deny_reason_code_t) i;
+      return WYRELOG_E_OK;
+    }
+  }
+  return WYRELOG_E_OK;
+}
+
 wyrelog_error_t
 wyl_decide (WylHandle *handle, const wyl_decide_req_t *req,
     wyl_decide_resp_t *resp)
@@ -202,6 +250,8 @@ wyl_decide (WylHandle *handle, const wyl_decide_req_t *req,
       || wyl_decide_req_get_resource_id (req) == NULL)
     return WYRELOG_E_INVALID;
 
+  const gchar *deny_reason = NULL;
+  const gchar *deny_origin = NULL;
   if (wyl_handle_get_read_engine (handle) != NULL) {
     gint64 row[3];
     wyrelog_error_t rc = wyl_handle_intern_engine_symbol (handle,
@@ -216,13 +266,26 @@ wyl_decide (WylHandle *handle, const wyl_decide_req_t *req,
         wyl_decide_req_get_resource_id (req), &row[2]);
     if (rc != WYRELOG_E_OK)
       return rc;
+    gint64 reason_names[WYL_DENY_REASON_LAST_] = { 0 };
+    gint64 reason_origins[WYL_DENY_REASON_LAST_] = { 0 };
+    rc = intern_deny_reason_catalog (handle, reason_names, reason_origins);
+    if (rc != WYRELOG_E_OK)
+      return rc;
 
     gboolean allowed = FALSE;
     const wyl_guard_expr_t *guard =
         wyl_perm_arm_rule_lookup (wyl_decide_req_get_action (req));
     if (guard != NULL) {
-      if (!guard_is_satisfied (guard, req))
+      if (!guard_is_satisfied (guard, req)) {
+        wyl_deny_reason_code_t code = WYL_DENY_REASON_LAST_;
+        rc = find_deny_reason (handle, row, reason_names, reason_origins,
+            &code);
+        if (rc != WYRELOG_E_OK)
+          return rc;
+        deny_reason = wyl_deny_reason_name (code);
+        deny_origin = wyl_deny_reason_origin (code);
         goto emit_audit;
+      }
       rc = insert_guard_eval_facts (handle, row);
       if (rc != WYRELOG_E_OK)
         return rc;
@@ -231,11 +294,23 @@ wyl_decide (WylHandle *handle, const wyl_decide_req_t *req,
     rc = wyl_handle_engine_decide (handle, row, &allowed);
     if (rc != WYRELOG_E_OK)
       return rc;
-    if (allowed)
+    if (allowed) {
       wyl_decide_resp_set_decision (resp, WYL_DECISION_ALLOW);
+    } else {
+      wyl_deny_reason_code_t code = WYL_DENY_REASON_LAST_;
+      rc = find_deny_reason (handle, row, reason_names, reason_origins, &code);
+      if (rc != WYRELOG_E_OK)
+        return rc;
+      deny_reason = wyl_deny_reason_name (code);
+      deny_origin = wyl_deny_reason_origin (code);
+    }
   }
 emit_audit:
   ;
+#ifndef WYL_HAS_AUDIT
+  (void) deny_reason;
+  (void) deny_origin;
+#endif
 #ifdef WYL_HAS_AUDIT
   /* Mirror the decision into the audit log so every decide call
    * leaves a row regardless of whether downstream callers also
@@ -246,6 +321,8 @@ emit_audit:
   wyl_audit_event_set_subject_id (ev, wyl_decide_req_get_subject_id (req));
   wyl_audit_event_set_action (ev, wyl_decide_req_get_action (req));
   wyl_audit_event_set_resource_id (ev, wyl_decide_req_get_resource_id (req));
+  wyl_audit_event_set_deny_reason (ev, deny_reason);
+  wyl_audit_event_set_deny_origin (ev, deny_origin);
   wyl_audit_event_set_decision (ev, wyl_decide_resp_get_decision (resp));
   (void) wyl_audit_emit (handle, ev);
 #endif


### PR DESCRIPTION
## Summary
- capture representative wirelog deny_reason rows during decide
- add deny reason and origin fields to audit events and append schema
- cover the new audit event accessors and persisted DuckDB fields

## Validation
- meson test -C builddir --print-errorlogs
- meson test -C builddir-audit --print-errorlogs