### PR TITLE
decide: expose deny reason tags

### DIFF
--- a/tests/test-decide-resp.c
+++ b/tests/test-decide-resp.c
@@ -11,6 +11,10 @@ check_default_is_deny (void)
     return 10;
   if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_DENY)
     return 11;
+  if (wyl_decide_resp_get_deny_reason (resp) != NULL)
+    return 12;
+  if (wyl_decide_resp_get_deny_origin (resp) != NULL)
+    return 13;
   return 0;
 }
 
@@ -42,6 +46,10 @@ check_get_null_is_deny (void)
    * produced", which downstream consumers must treat as a denial. */
   if (wyl_decide_resp_get_decision (NULL) != WYL_DECISION_DENY)
     return 40;
+  if (wyl_decide_resp_get_deny_reason (NULL) != NULL)
+    return 41;
+  if (wyl_decide_resp_get_deny_origin (NULL) != NULL)
+    return 42;
   return 0;
 }
 

--- a/tests/test-decide.c
+++ b/tests/test-decide.c
@@ -200,6 +200,10 @@ check_decide_allows_engine_tuple (void)
     return 43;
   if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_ALLOW)
     return 44;
+  if (wyl_decide_resp_get_deny_reason (resp) != NULL)
+    return 45;
+  if (wyl_decide_resp_get_deny_origin (resp) != NULL)
+    return 46;
   return 0;
 }
 
@@ -289,6 +293,10 @@ check_decide_denies_guarded_permission_on_context_miss (void)
     return 73;
   if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_DENY)
     return 74;
+  if (g_strcmp0 (wyl_decide_resp_get_deny_reason (resp), "not_armed") != 0)
+    return 75;
+  if (g_strcmp0 (wyl_decide_resp_get_deny_origin (resp), "perm_state") != 0)
+    return 76;
 
   return 0;
 }

--- a/wyrelog/decide.h
+++ b/wyrelog/decide.h
@@ -83,6 +83,14 @@ void wyl_decide_resp_set_decision (wyl_decide_resp_t * resp,
  */
 wyl_decision_t wyl_decide_resp_get_decision (const wyl_decide_resp_t * resp);
 
+/*
+ * Returns the representative deny reason and source relation tag carried by
+ * |resp|. Both return NULL when the decision is ALLOW, when no policy engine
+ * was available to produce deny_reason/5 rows, or when |resp| is NULL.
+ */
+const gchar *wyl_decide_resp_get_deny_reason (const wyl_decide_resp_t * resp);
+const gchar *wyl_decide_resp_get_deny_origin (const wyl_decide_resp_t * resp);
+
 wyrelog_error_t wyl_decide (WylHandle * handle,
     const wyl_decide_req_t * req, wyl_decide_resp_t * resp);
 

--- a/wyrelog/wyl-decide.c
+++ b/wyrelog/wyl-decide.c
@@ -19,6 +19,8 @@ struct _wyl_decide_req
 struct _wyl_decide_resp
 {
   wyl_decision_t decision;
+  gchar *deny_reason;
+  gchar *deny_origin;
 };
 
 wyl_decide_req_t *
@@ -143,6 +145,10 @@ wyl_decide_resp_new (void)
 void
 wyl_decide_resp_free (wyl_decide_resp_t *resp)
 {
+  if (resp == NULL)
+    return;
+  g_free (resp->deny_reason);
+  g_free (resp->deny_origin);
   g_free (resp);
 }
 
@@ -153,6 +159,17 @@ wyl_decide_resp_set_decision (wyl_decide_resp_t *resp, wyl_decision_t decision)
   resp->decision = decision;
 }
 
+static void
+wyl_decide_resp_set_deny_tags (wyl_decide_resp_t *resp,
+    const gchar *deny_reason, const gchar *deny_origin)
+{
+  g_return_if_fail (resp != NULL);
+  g_free (resp->deny_reason);
+  g_free (resp->deny_origin);
+  resp->deny_reason = g_strdup (deny_reason);
+  resp->deny_origin = g_strdup (deny_origin);
+}
+
 wyl_decision_t
 wyl_decide_resp_get_decision (const wyl_decide_resp_t *resp)
 {
@@ -161,6 +178,20 @@ wyl_decide_resp_get_decision (const wyl_decide_resp_t *resp)
    * response must not silently observe an ALLOW. */
   g_return_val_if_fail (resp != NULL, WYL_DECISION_DENY);
   return resp->decision;
+}
+
+const gchar *
+wyl_decide_resp_get_deny_reason (const wyl_decide_resp_t *resp)
+{
+  g_return_val_if_fail (resp != NULL, NULL);
+  return resp->deny_reason;
+}
+
+const gchar *
+wyl_decide_resp_get_deny_origin (const wyl_decide_resp_t *resp)
+{
+  g_return_val_if_fail (resp != NULL, NULL);
+  return resp->deny_origin;
 }
 
 static gboolean
@@ -245,6 +276,7 @@ wyl_decide (WylHandle *handle, const wyl_decide_req_t *req,
     return WYRELOG_E_INVALID;
 
   wyl_decide_resp_set_decision (resp, WYL_DECISION_DENY);
+  wyl_decide_resp_set_deny_tags (resp, NULL, NULL);
   if (wyl_decide_req_get_subject_id (req) == NULL
       || wyl_decide_req_get_action (req) == NULL
       || wyl_decide_req_get_resource_id (req) == NULL)
@@ -284,6 +316,7 @@ wyl_decide (WylHandle *handle, const wyl_decide_req_t *req,
           return rc;
         deny_reason = wyl_deny_reason_name (code);
         deny_origin = wyl_deny_reason_origin (code);
+        wyl_decide_resp_set_deny_tags (resp, deny_reason, deny_origin);
         goto emit_audit;
       }
       rc = insert_guard_eval_facts (handle, row);
@@ -305,6 +338,7 @@ wyl_decide (WylHandle *handle, const wyl_decide_req_t *req,
       deny_origin = wyl_deny_reason_origin (code);
     }
   }
+  wyl_decide_resp_set_deny_tags (resp, deny_reason, deny_origin);
 emit_audit:
   ;
 #ifndef WYL_HAS_AUDIT


### PR DESCRIPTION
## Summary
- expose representative deny reason and origin getters on decide responses
- populate those fields from wirelog deny_reason rows during decide
- cover default, allow, and guarded deny response behavior

## Validation
- git diff --check
- meson test -C builddir --print-errorlogs
- meson test -C builddir-audit --print-errorlogs