### PR TITLE
policy: persist principal states

### DIFF
--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -882,6 +882,70 @@ check_policy_store_direct_permissions_require_engine_pair (void)
   return 0;
 }
 
+static gint
+check_policy_store_principal_states_autoload_on_open (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 370;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (wyl_policy_store_set_principal_state (store, "state-load-user",
+          "authenticated") != WYRELOG_E_OK)
+    return 371;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 372;
+
+  if (insert2_symbol (handle, "role_permission", "wr.state-role",
+          "wr.state.read") != WYRELOG_E_OK)
+    return 373;
+  if (insert2_symbol (handle, "session_state", "state-scope", "active")
+      != WYRELOG_E_OK)
+    return 374;
+  if (insert1_symbol (handle, "session_active", "active") != WYRELOG_E_OK)
+    return 375;
+  gint64 member_row[3];
+  if (intern3 (handle, "state-load-user", "wr.state-role", "state-scope",
+          member_row) != WYRELOG_E_OK)
+    return 376;
+  if (wyl_handle_engine_insert (handle, "member_of", member_row, 3)
+      != WYRELOG_E_OK)
+    return 384;
+  if (insert4_symbol (handle, "perm_state", "state-load-user",
+          "wr.state.read", "state-scope", "armed") != WYRELOG_E_OK)
+    return 377;
+
+  gint64 row[3];
+  if (intern3 (handle, "state-load-user", "wr.state.read", "state-scope",
+          row) != WYRELOG_E_OK)
+    return 378;
+  gboolean allowed = FALSE;
+  if (wyl_handle_engine_decide (handle, row, &allowed)
+      != WYRELOG_E_OK)
+    return 379;
+  if (!allowed)
+    return 383;
+  return 0;
+}
+
+static gint
+check_policy_store_principal_states_require_engine_pair (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 380;
+  if (wyl_handle_load_policy_store_principal_states (NULL)
+      != WYRELOG_E_INVALID)
+    return 381;
+  if (wyl_handle_load_policy_store_principal_states (handle)
+      != WYRELOG_E_INVALID)
+    return 382;
+  return 0;
+}
+
 int
 main (void)
 {
@@ -942,6 +1006,10 @@ main (void)
   if ((rc = check_policy_store_direct_permissions_autoload_on_open ()) != 0)
     return rc;
   if ((rc = check_policy_store_direct_permissions_require_engine_pair ()) != 0)
+    return rc;
+  if ((rc = check_policy_store_principal_states_autoload_on_open ()) != 0)
+    return rc;
+  if ((rc = check_policy_store_principal_states_require_engine_pair ()) != 0)
     return rc;
 
   return 0;

--- a/tests/test-policy-store.c
+++ b/tests/test-policy-store.c
@@ -20,6 +20,7 @@ check_store_creates_authority_schema (void)
     "permissions",
     "role_permissions",
     "direct_permissions",
+    "principal_states",
     "policy_signatures",
   };
   for (gsize i = 0; i < G_N_ELEMENTS (tables); i++) {
@@ -95,6 +96,25 @@ direct_permission_expect_cb (const gchar *subject_id, const gchar *perm_id,
   if (g_strcmp0 (subject_id, expect->subject_id) == 0
       && g_strcmp0 (perm_id, expect->perm_id) == 0
       && g_strcmp0 (scope, expect->scope) == 0)
+    expect->matches++;
+  return WYRELOG_E_OK;
+}
+
+typedef struct
+{
+  const gchar *subject_id;
+  const gchar *state;
+  guint matches;
+} PrincipalStateExpect;
+
+static wyrelog_error_t
+principal_state_expect_cb (const gchar *subject_id, const gchar *state,
+    gpointer user_data)
+{
+  PrincipalStateExpect *expect = user_data;
+
+  if (g_strcmp0 (subject_id, expect->subject_id) == 0
+      && g_strcmp0 (state, expect->state) == 0)
     expect->matches++;
   return WYRELOG_E_OK;
 }
@@ -199,6 +219,34 @@ check_store_grants_direct_permission (void)
 }
 
 static gint
+check_store_sets_principal_state (void)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 80;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 81;
+  if (wyl_policy_store_set_principal_state (store, "principal-user",
+          "mfa_required") != WYRELOG_E_OK)
+    return 82;
+  if (wyl_policy_store_set_principal_state (store, "principal-user",
+          "authenticated") != WYRELOG_E_OK)
+    return 83;
+
+  PrincipalStateExpect expect = {
+    .subject_id = "principal-user",
+    .state = "authenticated",
+  };
+  if (wyl_policy_store_foreach_principal_state (store,
+          principal_state_expect_cb, &expect) != WYRELOG_E_OK)
+    return 84;
+  if (expect.matches != 1)
+    return 85;
+  return 0;
+}
+
+static gint
 check_store_rejects_bad_direct_permission (void)
 {
   g_autoptr (wyl_policy_store_t) store = NULL;
@@ -251,6 +299,12 @@ check_store_rejects_bad_role_permission (void)
   if (wyl_policy_store_foreach_role_permission (store, NULL, NULL)
       != WYRELOG_E_INVALID)
     return 55;
+  if (wyl_policy_store_set_principal_state (store, NULL, "authenticated")
+      != WYRELOG_E_INVALID)
+    return 56;
+  if (wyl_policy_store_foreach_principal_state (store, NULL, NULL)
+      != WYRELOG_E_INVALID)
+    return 57;
   return 0;
 }
 
@@ -268,6 +322,8 @@ main (void)
   if ((rc = check_store_grants_role_permission ()) != 0)
     return rc;
   if ((rc = check_store_grants_direct_permission ()) != 0)
+    return rc;
+  if ((rc = check_store_sets_principal_state ()) != 0)
     return rc;
   if ((rc = check_store_rejects_bad_direct_permission ()) != 0)
     return rc;

--- a/tests/test-session-username.c
+++ b/tests/test-session-username.c
@@ -77,6 +77,25 @@ insert_symbol_row4 (WylHandle *handle, const gchar *relation,
   return wyl_handle_engine_insert (handle, relation, row, 4);
 }
 
+typedef struct
+{
+  const gchar *subject_id;
+  const gchar *state;
+  guint matches;
+} PrincipalStateExpect;
+
+static wyrelog_error_t
+principal_state_expect_cb (const gchar *subject_id, const gchar *state,
+    gpointer user_data)
+{
+  PrincipalStateExpect *expect = user_data;
+
+  if (g_strcmp0 (subject_id, expect->subject_id) == 0
+      && g_strcmp0 (state, expect->state) == 0)
+    expect->matches++;
+  return WYRELOG_E_OK;
+}
+
 static WylSession *
 login_with_username (const gchar *username)
 {
@@ -296,6 +315,58 @@ check_mfa_verify_rejects_invalid_args (void)
   return 0;
 }
 
+static gint
+check_login_persists_mfa_required_state (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 110;
+
+  g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
+  wyl_login_req_set_username (login, "persist-user");
+  g_autoptr (WylSession) session = NULL;
+  if (wyl_session_login (handle, login, &session) != WYRELOG_E_OK)
+    return 111;
+
+  PrincipalStateExpect expect = {
+    .subject_id = "persist-user",
+    .state = "mfa_required",
+  };
+  if (wyl_policy_store_foreach_principal_state (wyl_handle_get_policy_store
+          (handle), principal_state_expect_cb, &expect) != WYRELOG_E_OK)
+    return 112;
+  if (expect.matches != 1)
+    return 113;
+  return 0;
+}
+
+static gint
+check_mfa_verify_persists_authenticated_state (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 120;
+
+  g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
+  wyl_login_req_set_username (login, "persist-user");
+  g_autoptr (WylSession) session = NULL;
+  if (wyl_session_login (handle, login, &session) != WYRELOG_E_OK)
+    return 121;
+  if (wyl_session_mfa_verify (handle, session) != WYRELOG_E_OK)
+    return 122;
+
+  PrincipalStateExpect expect = {
+    .subject_id = "persist-user",
+    .state = "authenticated",
+  };
+  if (wyl_policy_store_foreach_principal_state (wyl_handle_get_policy_store
+          (handle), principal_state_expect_cb, &expect) != WYRELOG_E_OK)
+    return 123;
+  if (expect.matches != 1)
+    return 124;
+  return 0;
+}
+
 int
 main (void)
 {
@@ -318,6 +389,10 @@ main (void)
   if ((rc = check_mfa_verify_authenticates_engine_principal ()) != 0)
     return rc;
   if ((rc = check_mfa_verify_rejects_invalid_args ()) != 0)
+    return rc;
+  if ((rc = check_login_persists_mfa_required_state ()) != 0)
+    return rc;
+  if ((rc = check_mfa_verify_persists_authenticated_state ()) != 0)
     return rc;
 
   return 0;

--- a/wyrelog/policy/store-private.h
+++ b/wyrelog/policy/store-private.h
@@ -14,6 +14,8 @@ typedef wyrelog_error_t (*wyl_policy_role_permission_cb) (const gchar * role_id,
     const gchar * perm_id, gpointer user_data);
 typedef wyrelog_error_t (*wyl_policy_direct_permission_cb) (const gchar *
     subject_id, const gchar * perm_id, const gchar * scope, gpointer user_data);
+typedef wyrelog_error_t (*wyl_policy_principal_state_cb) (const gchar *
+    subject_id, const gchar * state, gpointer user_data);
 
 /*
  * Policy authority store lifecycle wrapper.
@@ -52,5 +54,9 @@ wyrelog_error_t wyl_policy_store_direct_permission_exists (wyl_policy_store_t *
     gboolean * out_exists);
 wyrelog_error_t wyl_policy_store_foreach_direct_permission (wyl_policy_store_t *
     store, wyl_policy_direct_permission_cb cb, gpointer user_data);
+wyrelog_error_t wyl_policy_store_set_principal_state (wyl_policy_store_t *
+    store, const gchar * subject_id, const gchar * state);
+wyrelog_error_t wyl_policy_store_foreach_principal_state (wyl_policy_store_t *
+    store, wyl_policy_principal_state_cb cb, gpointer user_data);
 
 G_END_DECLS;

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -127,6 +127,13 @@ wyl_policy_store_create_schema (wyl_policy_store_t *store)
       "  ON direct_permissions (perm_id);"
       "CREATE INDEX IF NOT EXISTS idx_direct_permissions_subject_scope "
       "  ON direct_permissions (subject_id, scope);"
+      "CREATE TABLE IF NOT EXISTS principal_states ("
+      "  subject_id TEXT PRIMARY KEY,"
+      "  state TEXT NOT NULL,"
+      "  updated_at INTEGER"
+      ");"
+      "CREATE INDEX IF NOT EXISTS idx_principal_states_state "
+      "  ON principal_states (state);"
       "CREATE TABLE IF NOT EXISTS policy_signatures ("
       "  policy_version INTEGER PRIMARY KEY,"
       "  policy_hash BLOB NOT NULL,"
@@ -319,6 +326,64 @@ wyl_policy_store_foreach_direct_permission (wyl_policy_store_t *store,
     const gchar *perm_id = (const gchar *) sqlite3_column_text (stmt, 1);
     const gchar *scope = (const gchar *) sqlite3_column_text (stmt, 2);
     rc = cb (subject_id, perm_id, scope, user_data);
+    if (rc != WYRELOG_E_OK) {
+      sqlite3_finalize (stmt);
+      return rc;
+    }
+  }
+
+  sqlite3_finalize (stmt);
+  return (step_rc == SQLITE_DONE) ? WYRELOG_E_OK : WYRELOG_E_IO;
+}
+
+wyrelog_error_t
+wyl_policy_store_set_principal_state (wyl_policy_store_t *store,
+    const gchar *subject_id, const gchar *state)
+{
+  sqlite3_stmt *stmt = NULL;
+
+  if (store == NULL || store->db == NULL || subject_id == NULL || state == NULL)
+    return WYRELOG_E_INVALID;
+
+  static const gchar *sql =
+      "INSERT INTO principal_states (subject_id, state, updated_at) "
+      "VALUES (?, ?, unixepoch()) "
+      "ON CONFLICT(subject_id) DO UPDATE SET "
+      "  state = excluded.state," "  updated_at = excluded.updated_at;";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if ((rc = bind_text (stmt, 1, subject_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 2, state)) != WYRELOG_E_OK) {
+    sqlite3_finalize (stmt);
+    return rc;
+  }
+
+  int step_rc = sqlite3_step (stmt);
+  sqlite3_finalize (stmt);
+  return (step_rc == SQLITE_DONE) ? WYRELOG_E_OK : WYRELOG_E_IO;
+}
+
+wyrelog_error_t
+wyl_policy_store_foreach_principal_state (wyl_policy_store_t *store,
+    wyl_policy_principal_state_cb cb, gpointer user_data)
+{
+  sqlite3_stmt *stmt = NULL;
+
+  if (store == NULL || store->db == NULL || cb == NULL)
+    return WYRELOG_E_INVALID;
+
+  static const gchar *sql =
+      "SELECT subject_id, state FROM principal_states " "ORDER BY subject_id;";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  int step_rc;
+  while ((step_rc = sqlite3_step (stmt)) == SQLITE_ROW) {
+    const gchar *subject_id = (const gchar *) sqlite3_column_text (stmt, 0);
+    const gchar *state = (const gchar *) sqlite3_column_text (stmt, 1);
+    rc = cb (subject_id, state, user_data);
     if (rc != WYRELOG_E_OK) {
       sqlite3_finalize (stmt);
       return rc;

--- a/wyrelog/wyl-handle-private.h
+++ b/wyrelog/wyl-handle-private.h
@@ -88,6 +88,14 @@ wyrelog_error_t wyl_handle_load_policy_store_direct_permissions (WylHandle *
     self);
 
 /*
+ * Loads principal_state rows from the handle-owned policy authority store into
+ * the attached read/delta engine pair. Rejected unless both the store and
+ * engine pair are available.
+ */
+wyrelog_error_t wyl_handle_load_policy_store_principal_states (WylHandle *
+    self);
+
+/*
  * Probes the read engine for an exact EDB/IDB row match. Rejected unless the
  * engine pair is already open.
  */

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -231,6 +231,12 @@ wyl_handle_open_engine_pair (WylHandle *self, const gchar *template_dir)
     g_clear_object (&self->delta_engine);
     return rc;
   }
+  rc = wyl_handle_load_policy_store_principal_states (self);
+  if (rc != WYRELOG_E_OK) {
+    g_clear_object (&self->read_engine);
+    g_clear_object (&self->delta_engine);
+    return rc;
+  }
   return WYRELOG_E_OK;
 }
 
@@ -408,6 +414,36 @@ wyl_handle_load_policy_store_direct_permissions (WylHandle *self)
 
   return wyl_policy_store_foreach_direct_permission (self->policy_store,
       insert_policy_store_direct_permission, self);
+}
+
+static wyrelog_error_t
+insert_policy_store_principal_state (const gchar *subject_id,
+    const gchar *state, gpointer user_data)
+{
+  WylHandle *self = user_data;
+  gint64 row[2];
+
+  wyrelog_error_t rc =
+      wyl_handle_intern_engine_symbol (self, subject_id, &row[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (self, state, &row[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_engine_insert (self, "principal_state", row, 2);
+}
+
+wyrelog_error_t
+wyl_handle_load_policy_store_principal_states (WylHandle *self)
+{
+  if (self == NULL || !WYL_IS_HANDLE (self))
+    return WYRELOG_E_INVALID;
+  if (self->policy_store == NULL || self->read_engine == NULL
+      || self->delta_engine == NULL)
+    return WYRELOG_E_INVALID;
+
+  return wyl_policy_store_foreach_principal_state (self->policy_store,
+      insert_policy_store_principal_state, self);
 }
 
 typedef struct

--- a/wyrelog/wyl-session.c
+++ b/wyrelog/wyl-session.c
@@ -4,6 +4,7 @@
 #include "wyl-fsm-principal-private.h"
 #include "wyl-handle-private.h"
 #include "wyl-id-private.h"
+#include "policy/store-private.h"
 
 struct _WylSession
 {
@@ -93,6 +94,44 @@ remove_principal_state (WylHandle *handle, const gchar *username,
   return wyl_handle_engine_remove (handle, "principal_state", row, 2);
 }
 
+static wyrelog_error_t
+store_principal_state (WylHandle *handle, const gchar *username,
+    wyl_principal_state_t state)
+{
+  if (username == NULL)
+    return WYRELOG_E_OK;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (store == NULL)
+    return WYRELOG_E_OK;
+
+  const gchar *state_name = wyl_principal_state_name (state);
+  if (state_name == NULL)
+    return WYRELOG_E_INTERNAL;
+
+  return wyl_policy_store_set_principal_state (store, username, state_name);
+}
+
+static wyrelog_error_t
+set_principal_state (WylHandle *handle, const gchar *username,
+    wyl_principal_state_t state)
+{
+  wyrelog_error_t rc = insert_principal_state (handle, username, state);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return store_principal_state (handle, username, state);
+}
+
+static wyrelog_error_t
+transition_principal_state (WylHandle *handle, const gchar *username,
+    wyl_principal_state_t old_state, wyl_principal_state_t new_state)
+{
+  wyrelog_error_t rc = remove_principal_state (handle, username, old_state);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return set_principal_state (handle, username, new_state);
+}
+
 wyrelog_error_t
 wyl_session_login (WylHandle *handle, const wyl_login_req_t *req,
     WylSession **out_session)
@@ -118,7 +157,7 @@ wyl_session_login (WylHandle *handle, const wyl_login_req_t *req,
       g_object_unref (session);
       return (rc == WYRELOG_E_OK) ? WYRELOG_E_INTERNAL : rc;
     }
-    rc = insert_principal_state (handle, username, state);
+    rc = set_principal_state (handle, username, state);
     if (rc != WYRELOG_E_OK) {
       g_object_unref (session);
       return rc;
@@ -143,11 +182,8 @@ wyl_session_mfa_verify (WylHandle *handle, WylSession *session)
   if (rc != WYRELOG_E_OK || state != WYL_PRINCIPAL_STATE_AUTHENTICATED)
     return (rc == WYRELOG_E_OK) ? WYRELOG_E_INTERNAL : rc;
 
-  rc = remove_principal_state (handle, session->username,
-      WYL_PRINCIPAL_STATE_MFA_REQUIRED);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  return insert_principal_state (handle, session->username, state);
+  return transition_principal_state (handle, session->username,
+      WYL_PRINCIPAL_STATE_MFA_REQUIRED, state);
 }
 
 wyrelog_error_t


### PR DESCRIPTION
## Summary
- add principal state rows to the SQLite policy authority store
- load stored principal states into wirelog when opening engine pairs
- persist login and MFA state transitions through the policy store

## Validation
- git diff --check
- meson test -C builddir --print-errorlogs
- meson test -C builddir-audit --print-errorlogs