### PR TITLE
policy: persist session states

### DIFF
--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -946,6 +946,69 @@ check_policy_store_principal_states_require_engine_pair (void)
   return 0;
 }
 
+static gint
+check_policy_store_session_states_autoload_on_open (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 390;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (wyl_policy_store_set_session_state (store, "session-load-scope",
+          "active") != WYRELOG_E_OK)
+    return 391;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 392;
+
+  if (insert2_symbol (handle, "role_permission", "wr.session-role",
+          "wr.session.read") != WYRELOG_E_OK)
+    return 393;
+  if (insert2_symbol (handle, "principal_state", "session-load-user",
+          "authenticated") != WYRELOG_E_OK)
+    return 394;
+  if (insert1_symbol (handle, "session_active", "active") != WYRELOG_E_OK)
+    return 395;
+  gint64 member_row[3];
+  if (intern3 (handle, "session-load-user", "wr.session-role",
+          "session-load-scope", member_row) != WYRELOG_E_OK)
+    return 396;
+  if (wyl_handle_engine_insert (handle, "member_of", member_row, 3)
+      != WYRELOG_E_OK)
+    return 397;
+  if (insert4_symbol (handle, "perm_state", "session-load-user",
+          "wr.session.read", "session-load-scope", "armed") != WYRELOG_E_OK)
+    return 398;
+
+  gint64 row[3];
+  if (intern3 (handle, "session-load-user", "wr.session.read",
+          "session-load-scope", row) != WYRELOG_E_OK)
+    return 399;
+  gboolean allowed = FALSE;
+  if (wyl_handle_engine_decide (handle, row, &allowed)
+      != WYRELOG_E_OK)
+    return 400;
+  if (!allowed)
+    return 401;
+  return 0;
+}
+
+static gint
+check_policy_store_session_states_require_engine_pair (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 410;
+  if (wyl_handle_load_policy_store_session_states (NULL) != WYRELOG_E_INVALID)
+    return 411;
+  if (wyl_handle_load_policy_store_session_states (handle)
+      != WYRELOG_E_INVALID)
+    return 412;
+  return 0;
+}
+
 int
 main (void)
 {
@@ -1010,6 +1073,10 @@ main (void)
   if ((rc = check_policy_store_principal_states_autoload_on_open ()) != 0)
     return rc;
   if ((rc = check_policy_store_principal_states_require_engine_pair ()) != 0)
+    return rc;
+  if ((rc = check_policy_store_session_states_autoload_on_open ()) != 0)
+    return rc;
+  if ((rc = check_policy_store_session_states_require_engine_pair ()) != 0)
     return rc;
 
   return 0;

--- a/tests/test-policy-store.c
+++ b/tests/test-policy-store.c
@@ -21,6 +21,7 @@ check_store_creates_authority_schema (void)
     "role_permissions",
     "direct_permissions",
     "principal_states",
+    "session_states",
     "policy_signatures",
   };
   for (gsize i = 0; i < G_N_ELEMENTS (tables); i++) {
@@ -114,6 +115,25 @@ principal_state_expect_cb (const gchar *subject_id, const gchar *state,
   PrincipalStateExpect *expect = user_data;
 
   if (g_strcmp0 (subject_id, expect->subject_id) == 0
+      && g_strcmp0 (state, expect->state) == 0)
+    expect->matches++;
+  return WYRELOG_E_OK;
+}
+
+typedef struct
+{
+  const gchar *session_id;
+  const gchar *state;
+  guint matches;
+} SessionStateExpect;
+
+static wyrelog_error_t
+session_state_expect_cb (const gchar *session_id, const gchar *state,
+    gpointer user_data)
+{
+  SessionStateExpect *expect = user_data;
+
+  if (g_strcmp0 (session_id, expect->session_id) == 0
       && g_strcmp0 (state, expect->state) == 0)
     expect->matches++;
   return WYRELOG_E_OK;
@@ -247,6 +267,34 @@ check_store_sets_principal_state (void)
 }
 
 static gint
+check_store_sets_session_state (void)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 86;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 87;
+  if (wyl_policy_store_set_session_state (store, "session/1", "active")
+      != WYRELOG_E_OK)
+    return 88;
+  if (wyl_policy_store_set_session_state (store, "session/1", "closed")
+      != WYRELOG_E_OK)
+    return 89;
+
+  SessionStateExpect expect = {
+    .session_id = "session/1",
+    .state = "closed",
+  };
+  if (wyl_policy_store_foreach_session_state (store,
+          session_state_expect_cb, &expect) != WYRELOG_E_OK)
+    return 90;
+  if (expect.matches != 1)
+    return 91;
+  return 0;
+}
+
+static gint
 check_store_rejects_bad_direct_permission (void)
 {
   g_autoptr (wyl_policy_store_t) store = NULL;
@@ -305,6 +353,12 @@ check_store_rejects_bad_role_permission (void)
   if (wyl_policy_store_foreach_principal_state (store, NULL, NULL)
       != WYRELOG_E_INVALID)
     return 57;
+  if (wyl_policy_store_set_session_state (store, NULL, "active")
+      != WYRELOG_E_INVALID)
+    return 58;
+  if (wyl_policy_store_foreach_session_state (store, NULL, NULL)
+      != WYRELOG_E_INVALID)
+    return 59;
   return 0;
 }
 
@@ -324,6 +378,8 @@ main (void)
   if ((rc = check_store_grants_direct_permission ()) != 0)
     return rc;
   if ((rc = check_store_sets_principal_state ()) != 0)
+    return rc;
+  if ((rc = check_store_sets_session_state ()) != 0)
     return rc;
   if ((rc = check_store_rejects_bad_direct_permission ()) != 0)
     return rc;

--- a/tests/test-session-username.c
+++ b/tests/test-session-username.c
@@ -79,6 +79,25 @@ insert_symbol_row4 (WylHandle *handle, const gchar *relation,
 
 typedef struct
 {
+  const gchar *session_id;
+  const gchar *state;
+  guint matches;
+} SessionStateExpect;
+
+static wyrelog_error_t
+session_state_expect_cb (const gchar *session_id, const gchar *state,
+    gpointer user_data)
+{
+  SessionStateExpect *expect = user_data;
+
+  if (g_strcmp0 (session_id, expect->session_id) == 0
+      && g_strcmp0 (state, expect->state) == 0)
+    expect->matches++;
+  return WYRELOG_E_OK;
+}
+
+typedef struct
+{
   const gchar *subject_id;
   const gchar *state;
   guint matches;
@@ -367,6 +386,34 @@ check_mfa_verify_persists_authenticated_state (void)
   return 0;
 }
 
+static gint
+check_login_persists_active_session_state (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 130;
+
+  g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
+  wyl_login_req_set_username (login, "session-state-user");
+  g_autoptr (WylSession) session = NULL;
+  if (wyl_session_login (handle, login, &session) != WYRELOG_E_OK)
+    return 131;
+
+  g_autofree gchar *session_id = wyl_session_dup_id_string (session);
+  if (session_id == NULL)
+    return 132;
+  SessionStateExpect expect = {
+    .session_id = session_id,
+    .state = "active",
+  };
+  if (wyl_policy_store_foreach_session_state (wyl_handle_get_policy_store
+          (handle), session_state_expect_cb, &expect) != WYRELOG_E_OK)
+    return 133;
+  if (expect.matches != 1)
+    return 134;
+  return 0;
+}
+
 int
 main (void)
 {
@@ -393,6 +440,8 @@ main (void)
   if ((rc = check_login_persists_mfa_required_state ()) != 0)
     return rc;
   if ((rc = check_mfa_verify_persists_authenticated_state ()) != 0)
+    return rc;
+  if ((rc = check_login_persists_active_session_state ()) != 0)
     return rc;
 
   return 0;

--- a/wyrelog/policy/store-private.h
+++ b/wyrelog/policy/store-private.h
@@ -16,6 +16,8 @@ typedef wyrelog_error_t (*wyl_policy_direct_permission_cb) (const gchar *
     subject_id, const gchar * perm_id, const gchar * scope, gpointer user_data);
 typedef wyrelog_error_t (*wyl_policy_principal_state_cb) (const gchar *
     subject_id, const gchar * state, gpointer user_data);
+typedef wyrelog_error_t (*wyl_policy_session_state_cb) (const gchar *
+    session_id, const gchar * state, gpointer user_data);
 
 /*
  * Policy authority store lifecycle wrapper.
@@ -58,5 +60,9 @@ wyrelog_error_t wyl_policy_store_set_principal_state (wyl_policy_store_t *
     store, const gchar * subject_id, const gchar * state);
 wyrelog_error_t wyl_policy_store_foreach_principal_state (wyl_policy_store_t *
     store, wyl_policy_principal_state_cb cb, gpointer user_data);
+wyrelog_error_t wyl_policy_store_set_session_state (wyl_policy_store_t * store,
+    const gchar * session_id, const gchar * state);
+wyrelog_error_t wyl_policy_store_foreach_session_state (wyl_policy_store_t *
+    store, wyl_policy_session_state_cb cb, gpointer user_data);
 
 G_END_DECLS;

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -134,6 +134,13 @@ wyl_policy_store_create_schema (wyl_policy_store_t *store)
       ");"
       "CREATE INDEX IF NOT EXISTS idx_principal_states_state "
       "  ON principal_states (state);"
+      "CREATE TABLE IF NOT EXISTS session_states ("
+      "  session_id TEXT PRIMARY KEY,"
+      "  state TEXT NOT NULL,"
+      "  updated_at INTEGER"
+      ");"
+      "CREATE INDEX IF NOT EXISTS idx_session_states_state "
+      "  ON session_states (state);"
       "CREATE TABLE IF NOT EXISTS policy_signatures ("
       "  policy_version INTEGER PRIMARY KEY,"
       "  policy_hash BLOB NOT NULL,"
@@ -384,6 +391,64 @@ wyl_policy_store_foreach_principal_state (wyl_policy_store_t *store,
     const gchar *subject_id = (const gchar *) sqlite3_column_text (stmt, 0);
     const gchar *state = (const gchar *) sqlite3_column_text (stmt, 1);
     rc = cb (subject_id, state, user_data);
+    if (rc != WYRELOG_E_OK) {
+      sqlite3_finalize (stmt);
+      return rc;
+    }
+  }
+
+  sqlite3_finalize (stmt);
+  return (step_rc == SQLITE_DONE) ? WYRELOG_E_OK : WYRELOG_E_IO;
+}
+
+wyrelog_error_t
+wyl_policy_store_set_session_state (wyl_policy_store_t *store,
+    const gchar *session_id, const gchar *state)
+{
+  sqlite3_stmt *stmt = NULL;
+
+  if (store == NULL || store->db == NULL || session_id == NULL || state == NULL)
+    return WYRELOG_E_INVALID;
+
+  static const gchar *sql =
+      "INSERT INTO session_states (session_id, state, updated_at) "
+      "VALUES (?, ?, unixepoch()) "
+      "ON CONFLICT(session_id) DO UPDATE SET "
+      "  state = excluded.state," "  updated_at = excluded.updated_at;";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if ((rc = bind_text (stmt, 1, session_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 2, state)) != WYRELOG_E_OK) {
+    sqlite3_finalize (stmt);
+    return rc;
+  }
+
+  int step_rc = sqlite3_step (stmt);
+  sqlite3_finalize (stmt);
+  return (step_rc == SQLITE_DONE) ? WYRELOG_E_OK : WYRELOG_E_IO;
+}
+
+wyrelog_error_t
+wyl_policy_store_foreach_session_state (wyl_policy_store_t *store,
+    wyl_policy_session_state_cb cb, gpointer user_data)
+{
+  sqlite3_stmt *stmt = NULL;
+
+  if (store == NULL || store->db == NULL || cb == NULL)
+    return WYRELOG_E_INVALID;
+
+  static const gchar *sql =
+      "SELECT session_id, state FROM session_states " "ORDER BY session_id;";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  int step_rc;
+  while ((step_rc = sqlite3_step (stmt)) == SQLITE_ROW) {
+    const gchar *session_id = (const gchar *) sqlite3_column_text (stmt, 0);
+    const gchar *state = (const gchar *) sqlite3_column_text (stmt, 1);
+    rc = cb (session_id, state, user_data);
     if (rc != WYRELOG_E_OK) {
       sqlite3_finalize (stmt);
       return rc;

--- a/wyrelog/wyl-handle-private.h
+++ b/wyrelog/wyl-handle-private.h
@@ -96,6 +96,13 @@ wyrelog_error_t wyl_handle_load_policy_store_principal_states (WylHandle *
     self);
 
 /*
+ * Loads session_state rows from the handle-owned policy authority store into
+ * the attached read/delta engine pair. Rejected unless both the store and
+ * engine pair are available.
+ */
+wyrelog_error_t wyl_handle_load_policy_store_session_states (WylHandle * self);
+
+/*
  * Probes the read engine for an exact EDB/IDB row match. Rejected unless the
  * engine pair is already open.
  */

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -237,6 +237,12 @@ wyl_handle_open_engine_pair (WylHandle *self, const gchar *template_dir)
     g_clear_object (&self->delta_engine);
     return rc;
   }
+  rc = wyl_handle_load_policy_store_session_states (self);
+  if (rc != WYRELOG_E_OK) {
+    g_clear_object (&self->read_engine);
+    g_clear_object (&self->delta_engine);
+    return rc;
+  }
   return WYRELOG_E_OK;
 }
 
@@ -444,6 +450,36 @@ wyl_handle_load_policy_store_principal_states (WylHandle *self)
 
   return wyl_policy_store_foreach_principal_state (self->policy_store,
       insert_policy_store_principal_state, self);
+}
+
+static wyrelog_error_t
+insert_policy_store_session_state (const gchar *session_id,
+    const gchar *state, gpointer user_data)
+{
+  WylHandle *self = user_data;
+  gint64 row[2];
+
+  wyrelog_error_t rc =
+      wyl_handle_intern_engine_symbol (self, session_id, &row[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (self, state, &row[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_engine_insert (self, "session_state", row, 2);
+}
+
+wyrelog_error_t
+wyl_handle_load_policy_store_session_states (WylHandle *self)
+{
+  if (self == NULL || !WYL_IS_HANDLE (self))
+    return WYRELOG_E_INVALID;
+  if (self->policy_store == NULL || self->read_engine == NULL
+      || self->delta_engine == NULL)
+    return WYRELOG_E_INVALID;
+
+  return wyl_policy_store_foreach_session_state (self->policy_store,
+      insert_policy_store_session_state, self);
 }
 
 typedef struct

--- a/wyrelog/wyl-session.c
+++ b/wyrelog/wyl-session.c
@@ -132,6 +132,52 @@ transition_principal_state (WylHandle *handle, const gchar *username,
   return set_principal_state (handle, username, new_state);
 }
 
+static wyrelog_error_t
+insert_session_state (WylHandle *handle, const gchar *session_id,
+    const gchar *state)
+{
+  if (session_id == NULL || wyl_handle_get_read_engine (handle) == NULL)
+    return WYRELOG_E_OK;
+  if (state == NULL)
+    return WYRELOG_E_INVALID;
+
+  gint64 row[2];
+  wyrelog_error_t rc =
+      wyl_handle_intern_engine_symbol (handle, session_id, &row[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, state, &row[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_engine_insert (handle, "session_state", row, 2);
+}
+
+static wyrelog_error_t
+store_session_state (WylHandle *handle, const gchar *session_id,
+    const gchar *state)
+{
+  if (session_id == NULL)
+    return WYRELOG_E_OK;
+  if (state == NULL)
+    return WYRELOG_E_INVALID;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (store == NULL)
+    return WYRELOG_E_OK;
+
+  return wyl_policy_store_set_session_state (store, session_id, state);
+}
+
+static wyrelog_error_t
+set_session_state (WylHandle *handle, WylSession *session, const gchar *state)
+{
+  g_autofree gchar *session_id = wyl_session_dup_id_string (session);
+  wyrelog_error_t rc = insert_session_state (handle, session_id, state);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return store_session_state (handle, session_id, state);
+}
+
 wyrelog_error_t
 wyl_session_login (WylHandle *handle, const wyl_login_req_t *req,
     WylSession **out_session)
@@ -162,6 +208,12 @@ wyl_session_login (WylHandle *handle, const wyl_login_req_t *req,
       g_object_unref (session);
       return rc;
     }
+  }
+
+  wyrelog_error_t rc = set_session_state (handle, session, "active");
+  if (rc != WYRELOG_E_OK) {
+    g_object_unref (session);
+    return rc;
   }
 
   *out_session = session;


### PR DESCRIPTION
## Summary
- add session state rows to the SQLite policy authority store
- load stored session states into wirelog when opening engine pairs
- record newly created login sessions as active under their session id

## Validation
- git diff --check
- meson test -C builddir --print-errorlogs
- meson test -C builddir-audit --print-errorlogs