### PR TITLE
handle: seed active session states

### DIFF
--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -904,8 +904,6 @@ check_policy_store_principal_states_autoload_on_open (void)
   if (insert2_symbol (handle, "session_state", "state-scope", "active")
       != WYRELOG_E_OK)
     return 374;
-  if (insert1_symbol (handle, "session_active", "active") != WYRELOG_E_OK)
-    return 375;
   gint64 member_row[3];
   if (intern3 (handle, "state-load-user", "wr.state-role", "state-scope",
           member_row) != WYRELOG_E_OK)
@@ -968,8 +966,6 @@ check_policy_store_session_states_autoload_on_open (void)
   if (insert2_symbol (handle, "principal_state", "session-load-user",
           "authenticated") != WYRELOG_E_OK)
     return 394;
-  if (insert1_symbol (handle, "session_active", "active") != WYRELOG_E_OK)
-    return 395;
   gint64 member_row[3];
   if (intern3 (handle, "session-load-user", "wr.session-role",
           "session-load-scope", member_row) != WYRELOG_E_OK)

--- a/tests/test-session-username.c
+++ b/tests/test-session-username.c
@@ -414,6 +414,48 @@ check_login_persists_active_session_state (void)
   return 0;
 }
 
+static gint
+check_login_session_id_is_active_decision_scope (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 140;
+
+  if (insert_symbol_row2 (handle, "role_permission", "wr.session-id-role",
+          "wr.session-id-permission") != WYRELOG_E_OK)
+    return 141;
+
+  g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
+  wyl_login_req_set_username (login, "session-id-user");
+  g_autoptr (WylSession) session = NULL;
+  if (wyl_session_login (handle, login, &session) != WYRELOG_E_OK)
+    return 142;
+  if (wyl_session_mfa_verify (handle, session) != WYRELOG_E_OK)
+    return 143;
+
+  g_autofree gchar *session_id = wyl_session_dup_id_string (session);
+  if (session_id == NULL)
+    return 144;
+  if (insert_symbol_row3 (handle, "member_of", "session-id-user",
+          "wr.session-id-role", session_id) != WYRELOG_E_OK)
+    return 145;
+  if (insert_symbol_row4 (handle, "perm_state", "session-id-user",
+          "wr.session-id-permission", session_id, "armed") != WYRELOG_E_OK)
+    return 146;
+
+  g_autoptr (wyl_decide_req_t) decide = wyl_decide_req_new ();
+  wyl_decide_req_set_subject_id (decide, "session-id-user");
+  wyl_decide_req_set_action (decide, "wr.session-id-permission");
+  wyl_decide_req_set_resource_id (decide, session_id);
+
+  g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
+  if (wyl_decide (handle, decide, resp) != WYRELOG_E_OK)
+    return 147;
+  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_ALLOW)
+    return 148;
+  return 0;
+}
+
 int
 main (void)
 {
@@ -442,6 +484,8 @@ main (void)
   if ((rc = check_mfa_verify_persists_authenticated_state ()) != 0)
     return rc;
   if ((rc = check_login_persists_active_session_state ()) != 0)
+    return rc;
+  if ((rc = check_login_session_id_is_active_decision_scope ()) != 0)
     return rc;
 
   return 0;

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -86,6 +86,27 @@ wyl_handle_seed_perm_arm_rules (WylHandle *self)
   return WYRELOG_E_OK;
 }
 
+static wyrelog_error_t
+wyl_handle_seed_session_active_states (WylHandle *self)
+{
+  static const gchar *states[] = {
+    "active",
+    "elevated",
+  };
+
+  for (gsize i = 0; i < G_N_ELEMENTS (states); i++) {
+    gint64 row[1];
+    wyrelog_error_t rc =
+        wyl_handle_intern_engine_symbol (self, states[i], &row[0]);
+    if (rc != WYRELOG_E_OK)
+      return rc;
+    rc = wyl_handle_engine_insert (self, "session_active", row, 1);
+    if (rc != WYRELOG_E_OK)
+      return rc;
+  }
+  return WYRELOG_E_OK;
+}
+
 wyrelog_error_t
 wyl_init (const gchar *config_path, WylHandle **out_handle)
 {
@@ -214,6 +235,12 @@ wyl_handle_open_engine_pair (WylHandle *self, const gchar *template_dir)
   self->read_engine = read_engine;
   self->delta_engine = delta_engine;
   rc = wyl_handle_seed_perm_arm_rules (self);
+  if (rc != WYRELOG_E_OK) {
+    g_clear_object (&self->read_engine);
+    g_clear_object (&self->delta_engine);
+    return rc;
+  }
+  rc = wyl_handle_seed_session_active_states (self);
   if (rc != WYRELOG_E_OK) {
     g_clear_object (&self->read_engine);
     g_clear_object (&self->delta_engine);


### PR DESCRIPTION
## Summary
- seed active and elevated session_active facts when opening engine pairs
- rely on seeded session_active rows in policy-store autoload tests
- cover login-created session ids as active decision scopes

## Validation
- git diff --check
- meson test -C builddir --print-errorlogs handle-engine-pair session-username