### PR TITLE
session: wire login skip mfa

### DIFF
--- a/tests/test-login-req.c
+++ b/tests/test-login-req.c
@@ -12,6 +12,8 @@ check_default_username_is_null (void)
     return 10;
   if (wyl_login_req_get_username (req) != NULL)
     return 11;
+  if (wyl_login_req_get_skip_mfa (req))
+    return 12;
   return 0;
 }
 
@@ -84,6 +86,27 @@ check_free_null_is_safe (void)
   return 0;
 }
 
+static gint
+check_skip_mfa_set_then_get (void)
+{
+  g_autoptr (wyl_login_req_t) req = wyl_login_req_new ();
+  wyl_login_req_set_skip_mfa (req, TRUE);
+  if (!wyl_login_req_get_skip_mfa (req))
+    return 80;
+  wyl_login_req_set_skip_mfa (req, FALSE);
+  if (wyl_login_req_get_skip_mfa (req))
+    return 81;
+  return 0;
+}
+
+static gint
+check_skip_mfa_null_request (void)
+{
+  if (wyl_login_req_get_skip_mfa (NULL))
+    return 90;
+  return 0;
+}
+
 int
 main (void)
 {
@@ -102,6 +125,10 @@ main (void)
   if ((rc = check_get_null_request ()) != 0)
     return rc;
   if ((rc = check_free_null_is_safe ()) != 0)
+    return rc;
+  if ((rc = check_skip_mfa_set_then_get ()) != 0)
+    return rc;
+  if ((rc = check_skip_mfa_null_request ()) != 0)
     return rc;
 
   return 0;

--- a/tests/test-session-username.c
+++ b/tests/test-session-username.c
@@ -456,6 +456,56 @@ check_login_session_id_is_active_decision_scope (void)
   return 0;
 }
 
+static gint
+check_login_skip_mfa_authenticates_principal (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 150;
+
+  if (insert_symbol_row2 (handle, "role_permission", "wr.skip-mfa-role",
+          "wr.skip-mfa-permission") != WYRELOG_E_OK)
+    return 151;
+  if (insert_symbol_row3 (handle, "member_of", "skip-mfa-user",
+          "wr.skip-mfa-role", "skip-mfa-scope") != WYRELOG_E_OK)
+    return 152;
+  if (insert_symbol_row2 (handle, "session_state", "skip-mfa-scope", "active")
+      != WYRELOG_E_OK)
+    return 153;
+  if (insert_symbol_row4 (handle, "perm_state", "skip-mfa-user",
+          "wr.skip-mfa-permission", "skip-mfa-scope", "armed") != WYRELOG_E_OK)
+    return 154;
+
+  g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
+  wyl_login_req_set_username (login, "skip-mfa-user");
+  wyl_login_req_set_skip_mfa (login, TRUE);
+  g_autoptr (WylSession) session = NULL;
+  if (wyl_session_login (handle, login, &session) != WYRELOG_E_OK)
+    return 155;
+
+  PrincipalStateExpect expect = {
+    .subject_id = "skip-mfa-user",
+    .state = "authenticated",
+  };
+  if (wyl_policy_store_foreach_principal_state (wyl_handle_get_policy_store
+          (handle), principal_state_expect_cb, &expect) != WYRELOG_E_OK)
+    return 156;
+  if (expect.matches != 1)
+    return 157;
+
+  g_autoptr (wyl_decide_req_t) decide = wyl_decide_req_new ();
+  wyl_decide_req_set_subject_id (decide, "skip-mfa-user");
+  wyl_decide_req_set_action (decide, "wr.skip-mfa-permission");
+  wyl_decide_req_set_resource_id (decide, "skip-mfa-scope");
+
+  g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
+  if (wyl_decide (handle, decide, resp) != WYRELOG_E_OK)
+    return 158;
+  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_ALLOW)
+    return 159;
+  return 0;
+}
+
 int
 main (void)
 {
@@ -486,6 +536,8 @@ main (void)
   if ((rc = check_login_persists_active_session_state ()) != 0)
     return rc;
   if ((rc = check_login_session_id_is_active_decision_scope ()) != 0)
+    return rc;
+  if ((rc = check_login_skip_mfa_authenticates_principal ()) != 0)
     return rc;
 
   return 0;

--- a/wyrelog/session.h
+++ b/wyrelog/session.h
@@ -51,6 +51,15 @@ void wyl_login_req_set_username (wyl_login_req_t * req, const gchar * username);
  */
 const gchar *wyl_login_req_get_username (const wyl_login_req_t * req);
 
+/*
+ * Marks the request as already satisfying the MFA requirement. When
+ * TRUE, wyl_session_login drives the principal FSM through the
+ * login_skip_mfa event and records the principal as authenticated.
+ * The default for a fresh request is FALSE.
+ */
+void wyl_login_req_set_skip_mfa (wyl_login_req_t * req, gboolean skip_mfa);
+gboolean wyl_login_req_get_skip_mfa (const wyl_login_req_t * req);
+
 wyrelog_error_t wyl_session_login (WylHandle * handle,
     const wyl_login_req_t * req, WylSession ** out_session);
 wyrelog_error_t wyl_session_mfa_verify (WylHandle * handle,

--- a/wyrelog/wyl-perm.c
+++ b/wyrelog/wyl-perm.c
@@ -7,6 +7,7 @@
 struct _wyl_login_req
 {
   gchar *username;
+  gboolean skip_mfa;
 };
 
 struct _wyl_grant_req
@@ -51,6 +52,20 @@ wyl_login_req_get_username (const wyl_login_req_t *req)
 {
   g_return_val_if_fail (req != NULL, NULL);
   return req->username;
+}
+
+void
+wyl_login_req_set_skip_mfa (wyl_login_req_t *req, gboolean skip_mfa)
+{
+  g_return_if_fail (req != NULL);
+  req->skip_mfa = skip_mfa;
+}
+
+gboolean
+wyl_login_req_get_skip_mfa (const wyl_login_req_t *req)
+{
+  g_return_val_if_fail (req != NULL, FALSE);
+  return req->skip_mfa;
 }
 
 wyl_grant_req_t *

--- a/wyrelog/wyl-session.c
+++ b/wyrelog/wyl-session.c
@@ -197,9 +197,15 @@ wyl_session_login (WylHandle *handle, const wyl_login_req_t *req,
 
   if (username != NULL) {
     wyl_principal_state_t state = WYL_PRINCIPAL_STATE_LAST_;
+    wyl_principal_event_t event = WYL_PRINCIPAL_EVENT_LOGIN_OK;
+    wyl_principal_state_t expected = WYL_PRINCIPAL_STATE_MFA_REQUIRED;
+    if (req != NULL && wyl_login_req_get_skip_mfa (req)) {
+      event = WYL_PRINCIPAL_EVENT_LOGIN_SKIP_MFA;
+      expected = WYL_PRINCIPAL_STATE_AUTHENTICATED;
+    }
     wyrelog_error_t rc = wyl_fsm_principal_step (WYL_PRINCIPAL_STATE_UNVERIFIED,
-        WYL_PRINCIPAL_EVENT_LOGIN_OK, &state);
-    if (rc != WYRELOG_E_OK || state != WYL_PRINCIPAL_STATE_MFA_REQUIRED) {
+        event, &state);
+    if (rc != WYRELOG_E_OK || state != expected) {
       g_object_unref (session);
       return (rc == WYRELOG_E_OK) ? WYRELOG_E_INTERNAL : rc;
     }


### PR DESCRIPTION
## Summary
- add a skip-mfa flag to login requests
- route skip-mfa logins through the principal FSM event
- persist authenticated state and cover immediate decisions

## Validation
- git diff --check
- meson test -C builddir --print-errorlogs login-req session-username
- meson test -C builddir --print-errorlogs
- meson test -C builddir-audit --print-errorlogs