### PR TITLE
session: close durable session state

### DIFF
--- a/tests/test-session-username.c
+++ b/tests/test-session-username.c
@@ -506,6 +506,96 @@ check_login_skip_mfa_authenticates_principal (void)
   return 0;
 }
 
+static gint
+check_session_close_persists_closed_state (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 160;
+
+  g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
+  wyl_login_req_set_username (login, "close-state-user");
+  g_autoptr (WylSession) session = NULL;
+  if (wyl_session_login (handle, login, &session) != WYRELOG_E_OK)
+    return 161;
+  if (wyl_session_close (handle, session) != WYRELOG_E_OK)
+    return 162;
+
+  g_autofree gchar *session_id = wyl_session_dup_id_string (session);
+  if (session_id == NULL)
+    return 163;
+  SessionStateExpect expect = {
+    .session_id = session_id,
+    .state = "closed",
+  };
+  if (wyl_policy_store_foreach_session_state (wyl_handle_get_policy_store
+          (handle), session_state_expect_cb, &expect) != WYRELOG_E_OK)
+    return 164;
+  if (expect.matches != 1)
+    return 165;
+  return 0;
+}
+
+static gint
+check_session_close_deactivates_decision_scope (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 170;
+
+  if (insert_symbol_row2 (handle, "role_permission", "wr.close-role",
+          "wr.close-permission") != WYRELOG_E_OK)
+    return 171;
+
+  g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
+  wyl_login_req_set_username (login, "close-user");
+  wyl_login_req_set_skip_mfa (login, TRUE);
+  g_autoptr (WylSession) session = NULL;
+  if (wyl_session_login (handle, login, &session) != WYRELOG_E_OK)
+    return 172;
+
+  g_autofree gchar *session_id = wyl_session_dup_id_string (session);
+  if (session_id == NULL)
+    return 173;
+  if (insert_symbol_row3 (handle, "member_of", "close-user", "wr.close-role",
+          session_id) != WYRELOG_E_OK)
+    return 174;
+  if (insert_symbol_row4 (handle, "perm_state", "close-user",
+          "wr.close-permission", session_id, "armed") != WYRELOG_E_OK)
+    return 175;
+
+  if (wyl_session_close (handle, session) != WYRELOG_E_OK)
+    return 176;
+
+  g_autoptr (wyl_decide_req_t) after = wyl_decide_req_new ();
+  wyl_decide_req_set_subject_id (after, "close-user");
+  wyl_decide_req_set_action (after, "wr.close-permission");
+  wyl_decide_req_set_resource_id (after, session_id);
+  g_autoptr (wyl_decide_resp_t) after_resp = wyl_decide_resp_new ();
+  if (wyl_decide (handle, after, after_resp) != WYRELOG_E_OK)
+    return 177;
+  if (wyl_decide_resp_get_decision (after_resp) != WYL_DECISION_DENY)
+    return 178;
+  if (g_strcmp0 (wyl_decide_resp_get_deny_reason (after_resp),
+          "session_inactive") != 0)
+    return 179;
+  return 0;
+}
+
+static gint
+check_session_close_rejects_invalid_args (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 190;
+
+  if (wyl_session_close (NULL, NULL) != WYRELOG_E_INVALID)
+    return 191;
+  if (wyl_session_close (handle, NULL) != WYRELOG_E_INVALID)
+    return 192;
+  return 0;
+}
+
 int
 main (void)
 {
@@ -538,6 +628,12 @@ main (void)
   if ((rc = check_login_session_id_is_active_decision_scope ()) != 0)
     return rc;
   if ((rc = check_login_skip_mfa_authenticates_principal ()) != 0)
+    return rc;
+  if ((rc = check_session_close_persists_closed_state ()) != 0)
+    return rc;
+  if ((rc = check_session_close_deactivates_decision_scope ()) != 0)
+    return rc;
+  if ((rc = check_session_close_rejects_invalid_args ()) != 0)
     return rc;
 
   return 0;

--- a/wyrelog/session.h
+++ b/wyrelog/session.h
@@ -64,6 +64,7 @@ wyrelog_error_t wyl_session_login (WylHandle * handle,
     const wyl_login_req_t * req, WylSession ** out_session);
 wyrelog_error_t wyl_session_mfa_verify (WylHandle * handle,
     WylSession * session);
+wyrelog_error_t wyl_session_close (WylHandle * handle, WylSession * session);
 wyrelog_error_t wyl_session_logout (WylHandle * handle, wyl_session_id_t sid);
 
 /*

--- a/wyrelog/wyl-fsm-session-private.h
+++ b/wyrelog/wyl-fsm-session-private.h
@@ -36,6 +36,8 @@ typedef enum wyl_session_state_t
   WYL_SESSION_STATE_LAST_,
 } wyl_session_state_t;
 
+#ifndef WYL_SESSION_EVENT_T_DEFINED
+#define WYL_SESSION_EVENT_T_DEFINED
 typedef enum wyl_session_event_t
 {
   WYL_SESSION_EVENT_REQUEST = 0,
@@ -46,6 +48,7 @@ typedef enum wyl_session_event_t
   WYL_SESSION_EVENT_LOGOUT,
   WYL_SESSION_EVENT_LAST_,
 } wyl_session_event_t;
+#endif /* WYL_SESSION_EVENT_T_DEFINED */
 
 typedef struct wyl_session_transition_t
 {

--- a/wyrelog/wyl-session.c
+++ b/wyrelog/wyl-session.c
@@ -2,6 +2,7 @@
 #include "wyrelog/wyrelog.h"
 
 #include "wyl-fsm-principal-private.h"
+#include "wyl-fsm-session-private.h"
 #include "wyl-handle-private.h"
 #include "wyl-id-private.h"
 #include "policy/store-private.h"
@@ -153,6 +154,26 @@ insert_session_state (WylHandle *handle, const gchar *session_id,
 }
 
 static wyrelog_error_t
+remove_session_state (WylHandle *handle, const gchar *session_id,
+    const gchar *state)
+{
+  if (session_id == NULL || wyl_handle_get_read_engine (handle) == NULL)
+    return WYRELOG_E_OK;
+  if (state == NULL)
+    return WYRELOG_E_INVALID;
+
+  gint64 row[2];
+  wyrelog_error_t rc =
+      wyl_handle_intern_engine_symbol (handle, session_id, &row[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, state, &row[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_engine_remove (handle, "session_state", row, 2);
+}
+
+static wyrelog_error_t
 store_session_state (WylHandle *handle, const gchar *session_id,
     const gchar *state)
 {
@@ -176,6 +197,26 @@ set_session_state (WylHandle *handle, WylSession *session, const gchar *state)
   if (rc != WYRELOG_E_OK)
     return rc;
   return store_session_state (handle, session_id, state);
+}
+
+static wyrelog_error_t
+transition_session_state (WylHandle *handle, WylSession *session,
+    wyl_session_state_t old_state, wyl_session_state_t new_state)
+{
+  g_autofree gchar *session_id = wyl_session_dup_id_string (session);
+  const gchar *old_state_name = wyl_session_state_name (old_state);
+  const gchar *new_state_name = wyl_session_state_name (new_state);
+  if (old_state_name == NULL || new_state_name == NULL)
+    return WYRELOG_E_INTERNAL;
+
+  wyrelog_error_t rc =
+      remove_session_state (handle, session_id, old_state_name);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = insert_session_state (handle, session_id, new_state_name);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return store_session_state (handle, session_id, new_state_name);
 }
 
 wyrelog_error_t
@@ -242,6 +283,22 @@ wyl_session_mfa_verify (WylHandle *handle, WylSession *session)
 
   return transition_principal_state (handle, session->username,
       WYL_PRINCIPAL_STATE_MFA_REQUIRED, state);
+}
+
+wyrelog_error_t
+wyl_session_close (WylHandle *handle, WylSession *session)
+{
+  if (handle == NULL || session == NULL || !WYL_IS_SESSION (session))
+    return WYRELOG_E_INVALID;
+
+  wyl_session_state_t state = WYL_SESSION_STATE_LAST_;
+  wyrelog_error_t rc = wyl_fsm_session_step (WYL_SESSION_STATE_ACTIVE,
+      WYL_SESSION_EVENT_LOGOUT, &state);
+  if (rc != WYRELOG_E_OK || state != WYL_SESSION_STATE_CLOSED)
+    return (rc == WYRELOG_E_OK) ? WYRELOG_E_INTERNAL : rc;
+
+  return transition_session_state (handle, session, WYL_SESSION_STATE_ACTIVE,
+      state);
 }
 
 wyrelog_error_t


### PR DESCRIPTION
## Summary
- add a session close API backed by the session FSM logout transition
- replace active session_state facts with closed state on close
- cover persisted closed state and denied decisions for closed sessions

## Validation
- git diff --check
- meson test -C builddir --print-errorlogs session-username fsm-session
- meson test -C builddir-audit --print-errorlogs session-username fsm-session
- meson test -C builddir --print-errorlogs
- meson test -C builddir-audit --print-errorlogs