### PR TITLE
session: persist elevation state

### DIFF
--- a/tests/test-session-username.c
+++ b/tests/test-session-username.c
@@ -596,6 +596,128 @@ check_session_close_rejects_invalid_args (void)
   return 0;
 }
 
+static gint
+check_session_elevate_persists_elevated_state (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 200;
+
+  g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
+  wyl_login_req_set_username (login, "elevate-state-user");
+  g_autoptr (WylSession) session = NULL;
+  if (wyl_session_login (handle, login, &session) != WYRELOG_E_OK)
+    return 201;
+  if (wyl_session_elevate (handle, session) != WYRELOG_E_OK)
+    return 202;
+
+  g_autofree gchar *session_id = wyl_session_dup_id_string (session);
+  if (session_id == NULL)
+    return 203;
+  SessionStateExpect expect = {
+    .session_id = session_id,
+    .state = "elevated",
+  };
+  if (wyl_policy_store_foreach_session_state (wyl_handle_get_policy_store
+          (handle), session_state_expect_cb, &expect) != WYRELOG_E_OK)
+    return 204;
+  if (expect.matches != 1)
+    return 205;
+  return 0;
+}
+
+static gint
+check_session_drop_elevation_persists_active_state (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 210;
+
+  g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
+  wyl_login_req_set_username (login, "drop-state-user");
+  g_autoptr (WylSession) session = NULL;
+  if (wyl_session_login (handle, login, &session) != WYRELOG_E_OK)
+    return 211;
+  if (wyl_session_elevate (handle, session) != WYRELOG_E_OK)
+    return 212;
+  if (wyl_session_drop_elevation (handle, session) != WYRELOG_E_OK)
+    return 213;
+
+  g_autofree gchar *session_id = wyl_session_dup_id_string (session);
+  if (session_id == NULL)
+    return 214;
+  SessionStateExpect expect = {
+    .session_id = session_id,
+    .state = "active",
+  };
+  if (wyl_policy_store_foreach_session_state (wyl_handle_get_policy_store
+          (handle), session_state_expect_cb, &expect) != WYRELOG_E_OK)
+    return 215;
+  if (expect.matches != 1)
+    return 216;
+  return 0;
+}
+
+static gint
+check_elevated_session_remains_active_decision_scope (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 220;
+
+  if (insert_symbol_row2 (handle, "role_permission", "wr.elevate-role",
+          "wr.elevate-permission") != WYRELOG_E_OK)
+    return 221;
+
+  g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
+  wyl_login_req_set_username (login, "elevate-user");
+  wyl_login_req_set_skip_mfa (login, TRUE);
+  g_autoptr (WylSession) session = NULL;
+  if (wyl_session_login (handle, login, &session) != WYRELOG_E_OK)
+    return 222;
+  if (wyl_session_elevate (handle, session) != WYRELOG_E_OK)
+    return 223;
+
+  g_autofree gchar *session_id = wyl_session_dup_id_string (session);
+  if (session_id == NULL)
+    return 224;
+  if (insert_symbol_row3 (handle, "member_of", "elevate-user",
+          "wr.elevate-role", session_id) != WYRELOG_E_OK)
+    return 225;
+  if (insert_symbol_row4 (handle, "perm_state", "elevate-user",
+          "wr.elevate-permission", session_id, "armed") != WYRELOG_E_OK)
+    return 226;
+
+  g_autoptr (wyl_decide_req_t) decide = wyl_decide_req_new ();
+  wyl_decide_req_set_subject_id (decide, "elevate-user");
+  wyl_decide_req_set_action (decide, "wr.elevate-permission");
+  wyl_decide_req_set_resource_id (decide, session_id);
+  g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
+  if (wyl_decide (handle, decide, resp) != WYRELOG_E_OK)
+    return 227;
+  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_ALLOW)
+    return 228;
+  return 0;
+}
+
+static gint
+check_session_elevation_rejects_invalid_args (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 230;
+
+  if (wyl_session_elevate (NULL, NULL) != WYRELOG_E_INVALID)
+    return 231;
+  if (wyl_session_elevate (handle, NULL) != WYRELOG_E_INVALID)
+    return 232;
+  if (wyl_session_drop_elevation (NULL, NULL) != WYRELOG_E_INVALID)
+    return 233;
+  if (wyl_session_drop_elevation (handle, NULL) != WYRELOG_E_INVALID)
+    return 234;
+  return 0;
+}
+
 int
 main (void)
 {
@@ -634,6 +756,14 @@ main (void)
   if ((rc = check_session_close_deactivates_decision_scope ()) != 0)
     return rc;
   if ((rc = check_session_close_rejects_invalid_args ()) != 0)
+    return rc;
+  if ((rc = check_session_elevate_persists_elevated_state ()) != 0)
+    return rc;
+  if ((rc = check_session_drop_elevation_persists_active_state ()) != 0)
+    return rc;
+  if ((rc = check_elevated_session_remains_active_decision_scope ()) != 0)
+    return rc;
+  if ((rc = check_session_elevation_rejects_invalid_args ()) != 0)
     return rc;
 
   return 0;

--- a/wyrelog/session.h
+++ b/wyrelog/session.h
@@ -64,6 +64,9 @@ wyrelog_error_t wyl_session_login (WylHandle * handle,
     const wyl_login_req_t * req, WylSession ** out_session);
 wyrelog_error_t wyl_session_mfa_verify (WylHandle * handle,
     WylSession * session);
+wyrelog_error_t wyl_session_elevate (WylHandle * handle, WylSession * session);
+wyrelog_error_t wyl_session_drop_elevation (WylHandle * handle,
+    WylSession * session);
 wyrelog_error_t wyl_session_close (WylHandle * handle, WylSession * session);
 wyrelog_error_t wyl_session_logout (WylHandle * handle, wyl_session_id_t sid);
 

--- a/wyrelog/wyl-session.c
+++ b/wyrelog/wyl-session.c
@@ -302,6 +302,38 @@ wyl_session_close (WylHandle *handle, WylSession *session)
 }
 
 wyrelog_error_t
+wyl_session_elevate (WylHandle *handle, WylSession *session)
+{
+  if (handle == NULL || session == NULL || !WYL_IS_SESSION (session))
+    return WYRELOG_E_INVALID;
+
+  wyl_session_state_t state = WYL_SESSION_STATE_LAST_;
+  wyrelog_error_t rc = wyl_fsm_session_step (WYL_SESSION_STATE_ACTIVE,
+      WYL_SESSION_EVENT_ELEVATE_GRANT, &state);
+  if (rc != WYRELOG_E_OK || state != WYL_SESSION_STATE_ELEVATED)
+    return (rc == WYRELOG_E_OK) ? WYRELOG_E_INTERNAL : rc;
+
+  return transition_session_state (handle, session, WYL_SESSION_STATE_ACTIVE,
+      state);
+}
+
+wyrelog_error_t
+wyl_session_drop_elevation (WylHandle *handle, WylSession *session)
+{
+  if (handle == NULL || session == NULL || !WYL_IS_SESSION (session))
+    return WYRELOG_E_INVALID;
+
+  wyl_session_state_t state = WYL_SESSION_STATE_LAST_;
+  wyrelog_error_t rc = wyl_fsm_session_step (WYL_SESSION_STATE_ELEVATED,
+      WYL_SESSION_EVENT_ELEVATE_DROP, &state);
+  if (rc != WYRELOG_E_OK || state != WYL_SESSION_STATE_ACTIVE)
+    return (rc == WYRELOG_E_OK) ? WYRELOG_E_INTERNAL : rc;
+
+  return transition_session_state (handle, session, WYL_SESSION_STATE_ELEVATED,
+      state);
+}
+
+wyrelog_error_t
 wyl_session_logout (WylHandle *handle, wyl_session_id_t sid)
 {
   if (handle == NULL)


### PR DESCRIPTION
## Summary
- add session elevation and drop-elevation APIs
- persist elevated and active session state transitions
- cover elevated sessions as valid decision scopes

## Validation
- git diff --check
- meson test -C builddir --print-errorlogs session-username fsm-session
- meson test -C builddir-audit --print-errorlogs session-username fsm-session
- meson test -C builddir --print-errorlogs
- meson test -C builddir-audit --print-errorlogs