### PR TITLE
session: track current session state

### DIFF
--- a/tests/test-session-username.c
+++ b/tests/test-session-username.c
@@ -701,20 +701,68 @@ check_elevated_session_remains_active_decision_scope (void)
 }
 
 static gint
+check_elevated_session_close_deactivates_decision_scope (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 230;
+
+  if (insert_symbol_row2 (handle, "role_permission", "wr.elevated-close-role",
+          "wr.elevated-close-permission") != WYRELOG_E_OK)
+    return 231;
+
+  g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
+  wyl_login_req_set_username (login, "elevated-close-user");
+  wyl_login_req_set_skip_mfa (login, TRUE);
+  g_autoptr (WylSession) session = NULL;
+  if (wyl_session_login (handle, login, &session) != WYRELOG_E_OK)
+    return 232;
+  if (wyl_session_elevate (handle, session) != WYRELOG_E_OK)
+    return 233;
+
+  g_autofree gchar *session_id = wyl_session_dup_id_string (session);
+  if (session_id == NULL)
+    return 234;
+  if (insert_symbol_row3 (handle, "member_of", "elevated-close-user",
+          "wr.elevated-close-role", session_id) != WYRELOG_E_OK)
+    return 235;
+  if (insert_symbol_row4 (handle, "perm_state", "elevated-close-user",
+          "wr.elevated-close-permission", session_id, "armed") != WYRELOG_E_OK)
+    return 236;
+
+  if (wyl_session_close (handle, session) != WYRELOG_E_OK)
+    return 237;
+
+  g_autoptr (wyl_decide_req_t) decide = wyl_decide_req_new ();
+  wyl_decide_req_set_subject_id (decide, "elevated-close-user");
+  wyl_decide_req_set_action (decide, "wr.elevated-close-permission");
+  wyl_decide_req_set_resource_id (decide, session_id);
+  g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
+  if (wyl_decide (handle, decide, resp) != WYRELOG_E_OK)
+    return 238;
+  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_DENY)
+    return 239;
+  if (g_strcmp0 (wyl_decide_resp_get_deny_reason (resp),
+          "session_inactive") != 0)
+    return 240;
+  return 0;
+}
+
+static gint
 check_session_elevation_rejects_invalid_args (void)
 {
   g_autoptr (WylHandle) handle = NULL;
   if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
-    return 230;
+    return 250;
 
   if (wyl_session_elevate (NULL, NULL) != WYRELOG_E_INVALID)
-    return 231;
+    return 251;
   if (wyl_session_elevate (handle, NULL) != WYRELOG_E_INVALID)
-    return 232;
+    return 252;
   if (wyl_session_drop_elevation (NULL, NULL) != WYRELOG_E_INVALID)
-    return 233;
+    return 253;
   if (wyl_session_drop_elevation (handle, NULL) != WYRELOG_E_INVALID)
-    return 234;
+    return 254;
   return 0;
 }
 
@@ -762,6 +810,8 @@ main (void)
   if ((rc = check_session_drop_elevation_persists_active_state ()) != 0)
     return rc;
   if ((rc = check_elevated_session_remains_active_decision_scope ()) != 0)
+    return rc;
+  if ((rc = check_elevated_session_close_deactivates_decision_scope ()) != 0)
     return rc;
   if ((rc = check_session_elevation_rejects_invalid_args ()) != 0)
     return rc;

--- a/wyrelog/wyl-session.c
+++ b/wyrelog/wyl-session.c
@@ -13,6 +13,7 @@ struct _WylSession
   wyl_id_t id;
   gint64 created_at_us;
   gchar *username;
+  wyl_session_state_t state;
 };
 
 G_DEFINE_FINAL_TYPE (WylSession, wyl_session, G_TYPE_OBJECT);
@@ -49,6 +50,7 @@ wyl_session_init (WylSession *self)
   if (wyl_id_new (&self->id) != WYRELOG_E_OK)
     g_error ("wyl_session_init: failed to mint identifier");
   self->created_at_us = g_get_real_time ();
+  self->state = WYL_SESSION_STATE_IDLE;
 }
 
 static wyrelog_error_t
@@ -216,7 +218,11 @@ transition_session_state (WylHandle *handle, WylSession *session,
   rc = insert_session_state (handle, session_id, new_state_name);
   if (rc != WYRELOG_E_OK)
     return rc;
-  return store_session_state (handle, session_id, new_state_name);
+  rc = store_session_state (handle, session_id, new_state_name);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  session->state = new_state;
+  return WYRELOG_E_OK;
 }
 
 wyrelog_error_t
@@ -262,6 +268,7 @@ wyl_session_login (WylHandle *handle, const wyl_login_req_t *req,
     g_object_unref (session);
     return rc;
   }
+  session->state = WYL_SESSION_STATE_ACTIVE;
 
   *out_session = session;
   return WYRELOG_E_OK;
@@ -292,13 +299,12 @@ wyl_session_close (WylHandle *handle, WylSession *session)
     return WYRELOG_E_INVALID;
 
   wyl_session_state_t state = WYL_SESSION_STATE_LAST_;
-  wyrelog_error_t rc = wyl_fsm_session_step (WYL_SESSION_STATE_ACTIVE,
-      WYL_SESSION_EVENT_LOGOUT, &state);
+  wyrelog_error_t rc =
+      wyl_fsm_session_step (session->state, WYL_SESSION_EVENT_LOGOUT, &state);
   if (rc != WYRELOG_E_OK || state != WYL_SESSION_STATE_CLOSED)
     return (rc == WYRELOG_E_OK) ? WYRELOG_E_INTERNAL : rc;
 
-  return transition_session_state (handle, session, WYL_SESSION_STATE_ACTIVE,
-      state);
+  return transition_session_state (handle, session, session->state, state);
 }
 
 wyrelog_error_t
@@ -308,13 +314,12 @@ wyl_session_elevate (WylHandle *handle, WylSession *session)
     return WYRELOG_E_INVALID;
 
   wyl_session_state_t state = WYL_SESSION_STATE_LAST_;
-  wyrelog_error_t rc = wyl_fsm_session_step (WYL_SESSION_STATE_ACTIVE,
+  wyrelog_error_t rc = wyl_fsm_session_step (session->state,
       WYL_SESSION_EVENT_ELEVATE_GRANT, &state);
   if (rc != WYRELOG_E_OK || state != WYL_SESSION_STATE_ELEVATED)
     return (rc == WYRELOG_E_OK) ? WYRELOG_E_INTERNAL : rc;
 
-  return transition_session_state (handle, session, WYL_SESSION_STATE_ACTIVE,
-      state);
+  return transition_session_state (handle, session, session->state, state);
 }
 
 wyrelog_error_t
@@ -324,13 +329,12 @@ wyl_session_drop_elevation (WylHandle *handle, WylSession *session)
     return WYRELOG_E_INVALID;
 
   wyl_session_state_t state = WYL_SESSION_STATE_LAST_;
-  wyrelog_error_t rc = wyl_fsm_session_step (WYL_SESSION_STATE_ELEVATED,
+  wyrelog_error_t rc = wyl_fsm_session_step (session->state,
       WYL_SESSION_EVENT_ELEVATE_DROP, &state);
   if (rc != WYRELOG_E_OK || state != WYL_SESSION_STATE_ACTIVE)
     return (rc == WYRELOG_E_OK) ? WYRELOG_E_INTERNAL : rc;
 
-  return transition_session_state (handle, session, WYL_SESSION_STATE_ELEVATED,
-      state);
+  return transition_session_state (handle, session, session->state, state);
 }
 
 wyrelog_error_t


### PR DESCRIPTION
## Summary
- track the current FSM state on each session object
- drive close and elevation transitions from the stored state
- cover elevated session close so stale elevated facts are removed

## Validation
- git diff --check
- meson test -C builddir --print-errorlogs session-username
- meson test -C builddir-audit --print-errorlogs session-username
- meson test -C builddir --print-errorlogs
- meson test -C builddir-audit --print-errorlogs