### PR TITLE
decide: fail closed on audit failure

### DIFF
--- a/tests/test-audit-emit.c
+++ b/tests/test-audit-emit.c
@@ -67,6 +67,26 @@ insert_symbol_row3 (WylHandle *handle, const gchar *relation, const gchar *a,
 }
 
 static wyrelog_error_t
+insert_symbol_row4 (WylHandle *handle, const gchar *relation, const gchar *a,
+    const gchar *b, const gchar *c, const gchar *d)
+{
+  gint64 row[4];
+  wyrelog_error_t rc = intern_symbol (handle, a, &row[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = intern_symbol (handle, b, &row[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = intern_symbol (handle, c, &row[2]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = intern_symbol (handle, d, &row[3]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_engine_insert (handle, relation, row, 4);
+}
+
+static wyrelog_error_t
 insert_not_armed_decide_fixture (WylHandle *handle)
 {
   wyrelog_error_t rc = insert_symbol_row2 (handle, "role_permission",
@@ -85,6 +105,32 @@ insert_not_armed_decide_fixture (WylHandle *handle)
   if (rc != WYRELOG_E_OK)
     return rc;
   return insert_symbol_row1 (handle, "session_active", "active");
+}
+
+static wyrelog_error_t
+insert_allow_decide_fixture (WylHandle *handle)
+{
+  wyrelog_error_t rc = insert_symbol_row2 (handle, "role_permission",
+      "wr.audit-allow-role", "wr.audit-allow");
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = insert_symbol_row3 (handle, "member_of", "audit-allow-user",
+      "wr.audit-allow-role", "audit-allow-scope");
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = insert_symbol_row2 (handle, "principal_state", "audit-allow-user",
+      "authenticated");
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = insert_symbol_row2 (handle, "session_state", "audit-allow-scope",
+      "active");
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = insert_symbol_row1 (handle, "session_active", "active");
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return insert_symbol_row4 (handle, "perm_state", "audit-allow-user",
+      "wr.audit-allow", "audit-allow-scope", "armed");
 }
 
 static gint
@@ -247,6 +293,55 @@ check_decide_persists_representative_deny_reason (void)
 }
 
 static gint
+check_decide_fail_closes_on_audit_append_failure (void)
+{
+  WylHandle *handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 50;
+  if (insert_allow_decide_fixture (handle) != WYRELOG_E_OK) {
+    g_object_unref (handle);
+    return 51;
+  }
+
+  duckdb_connection conn =
+      wyl_audit_conn_get_connection (wyl_handle_get_audit_conn (handle));
+  duckdb_result result;
+  if (duckdb_query (conn, "DROP TABLE audit_events;", &result)
+      != DuckDBSuccess) {
+    duckdb_destroy_result (&result);
+    g_object_unref (handle);
+    return 52;
+  }
+  duckdb_destroy_result (&result);
+
+  g_autoptr (wyl_decide_req_t) req = wyl_decide_req_new ();
+  wyl_decide_req_set_subject_id (req, "audit-allow-user");
+  wyl_decide_req_set_action (req, "wr.audit-allow");
+  wyl_decide_req_set_resource_id (req, "audit-allow-scope");
+  g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
+  if (wyl_decide (handle, req, resp) != WYRELOG_E_OK) {
+    g_object_unref (handle);
+    return 53;
+  }
+  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_DENY) {
+    g_object_unref (handle);
+    return 54;
+  }
+  if (g_strcmp0 (wyl_decide_resp_get_deny_reason (resp),
+          "audit_unavailable") != 0) {
+    g_object_unref (handle);
+    return 55;
+  }
+  if (g_strcmp0 (wyl_decide_resp_get_deny_origin (resp), "audit_events") != 0) {
+    g_object_unref (handle);
+    return 56;
+  }
+
+  g_object_unref (handle);
+  return 0;
+}
+
+static gint
 check_emit_rejects_null_args (void)
 {
   WylHandle *handle = NULL;
@@ -276,6 +371,8 @@ main (void)
   if ((rc = check_emit_persists_event_fields ()) != 0)
     return rc;
   if ((rc = check_decide_persists_representative_deny_reason ()) != 0)
+    return rc;
+  if ((rc = check_decide_fail_closes_on_audit_append_failure ()) != 0)
     return rc;
   if ((rc = check_emit_rejects_null_args ()) != 0)
     return rc;

--- a/wyrelog/wyl-decide.c
+++ b/wyrelog/wyl-decide.c
@@ -268,6 +268,15 @@ find_deny_reason (WylHandle *handle, const gint64 row[3],
   return WYRELOG_E_OK;
 }
 
+#ifdef WYL_HAS_AUDIT
+static void
+fail_closed_for_audit (wyl_decide_resp_t *resp)
+{
+  wyl_decide_resp_set_decision (resp, WYL_DECISION_DENY);
+  wyl_decide_resp_set_deny_tags (resp, "audit_unavailable", "audit_events");
+}
+#endif
+
 wyrelog_error_t
 wyl_decide (WylHandle *handle, const wyl_decide_req_t *req,
     wyl_decide_resp_t *resp)
@@ -348,9 +357,8 @@ emit_audit:
 #ifdef WYL_HAS_AUDIT
   /* Mirror the decision into the audit log so every decide call
    * leaves a row regardless of whether downstream callers also
-   * emit explicitly. Failures from emit are intentionally not
-   * propagated: a decision was made and reported; the audit-side
-   * write is best-effort relative to the caller's contract. */
+   * emit explicitly. If the append fails, close the response back
+   * to DENY so the caller never observes an unaudited ALLOW. */
   g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
   wyl_audit_event_set_subject_id (ev, wyl_decide_req_get_subject_id (req));
   wyl_audit_event_set_action (ev, wyl_decide_req_get_action (req));
@@ -358,7 +366,8 @@ emit_audit:
   wyl_audit_event_set_deny_reason (ev, deny_reason);
   wyl_audit_event_set_deny_origin (ev, deny_origin);
   wyl_audit_event_set_decision (ev, wyl_decide_resp_get_decision (resp));
-  (void) wyl_audit_emit (handle, ev);
+  if (wyl_audit_emit (handle, ev) != WYRELOG_E_OK)
+    fail_closed_for_audit (resp);
 #endif
 
   return WYRELOG_E_OK;


### PR DESCRIPTION
## Summary
- close audited decisions back to deny when audit append fails
- tag the response with audit_unavailable / audit_events
- add an audit build test that removes the audit table before decide

## Tests
- git diff --check
- meson test -C builddir-audit --print-errorlogs audit-emit decide
- meson test -C builddir --print-errorlogs decide
- meson test -C builddir --print-errorlogs
- meson test -C builddir-audit --print-errorlogs