### PR TITLE
audit: align template event schema

### DIFF
--- a/templates/access/duckdb-schema.sql
+++ b/templates/access/duckdb-schema.sql
@@ -48,33 +48,35 @@ CREATE INDEX IF NOT EXISTS idx_context_facts_timestamp
     ON context_facts (timestamp);
 
 -- ---------------------------------------------------------------------------
--- Table: audit_log
--- Append-only WORM ledger. Written by FSM S6 COMMIT.
--- Merkle chain: each row seals the hash of the previous event.
--- TSA response attached asynchronously after insertion.
+-- Table: audit_events
+-- Runtime audit sink used by libwyrelog. The id is minted by the host and
+-- created_at_us carries a microsecond wall-clock timestamp.
 -- ---------------------------------------------------------------------------
-CREATE SEQUENCE IF NOT EXISTS audit_log_seq START 1;
-
-CREATE TABLE IF NOT EXISTS audit_log (
-    event_id     INTEGER     PRIMARY KEY DEFAULT nextval('audit_log_seq'),
-    timestamp    INTEGER     NOT NULL,   -- Unix epoch (seconds)
-    user_id      TEXT        NOT NULL,
-    operation    TEXT        NOT NULL,   -- e.g. 'authorize', 'deny', 'stepup'
-    resource     TEXT,                   -- target resource identifier
-    decision     TEXT,                   -- 'grant', 'deny', 'stepup', 'approval'
-    seal_merkle  BLOB,                   -- Merkle hash chain (previous || current)
-    tsa_response BLOB,                   -- TSA timestamp authority response (async)
-    created_at   INTEGER     NOT NULL    -- wall-clock insertion time
+CREATE TABLE IF NOT EXISTS audit_events (
+    id            VARCHAR PRIMARY KEY,
+    created_at_us BIGINT  NOT NULL,
+    subject_id    VARCHAR,
+    action        VARCHAR,
+    resource_id   VARCHAR,
+    deny_reason   VARCHAR,
+    deny_origin   VARCHAR,
+    decision      SMALLINT NOT NULL
 );
 
-CREATE INDEX IF NOT EXISTS idx_audit_log_timestamp
-    ON audit_log (timestamp);
+CREATE INDEX IF NOT EXISTS idx_audit_events_created_at_us
+    ON audit_events (created_at_us);
 
-CREATE INDEX IF NOT EXISTS idx_audit_log_user_id
-    ON audit_log (user_id);
+CREATE INDEX IF NOT EXISTS idx_audit_events_subject_id
+    ON audit_events (subject_id);
 
-CREATE INDEX IF NOT EXISTS idx_audit_log_decision
-    ON audit_log (decision);
+CREATE INDEX IF NOT EXISTS idx_audit_events_action
+    ON audit_events (action);
+
+CREATE INDEX IF NOT EXISTS idx_audit_events_decision
+    ON audit_events (decision);
+
+CREATE INDEX IF NOT EXISTS idx_audit_events_deny_reason
+    ON audit_events (deny_reason);
 
 -- ---------------------------------------------------------------------------
 -- Table: cache

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -345,6 +345,9 @@ if get_option('enable_audit').allowed()
 
   test_audit_conn = executable('test-audit-conn',
     'test-audit-conn.c',
+    c_args : [
+      '-DWYL_TEST_DUCKDB_SCHEMA_PATH="' + meson.project_source_root() / 'templates' / 'access' / 'duckdb-schema.sql' + '"',
+    ],
     dependencies : [wyrelog_dep, duckdb_dep],
   )
 

--- a/tests/test-audit-conn.c
+++ b/tests/test-audit-conn.c
@@ -5,6 +5,10 @@
 
 #include "wyrelog/audit/conn-private.h"
 
+#ifndef WYL_TEST_DUCKDB_SCHEMA_PATH
+#error "WYL_TEST_DUCKDB_SCHEMA_PATH must be defined by the build."
+#endif
+
 /* --- in-memory open/close lifecycle ---------------------------- */
 
 static gint
@@ -170,6 +174,37 @@ check_create_schema_null_arg (void)
 }
 
 static gint
+check_template_schema_creates_audit_events (void)
+{
+  g_autoptr (wyl_audit_conn_t) conn = NULL;
+  g_autofree gchar *schema = NULL;
+  gsize schema_len = 0;
+  g_autoptr (GError) error = NULL;
+  duckdb_result result;
+
+  if (wyl_audit_conn_open (NULL, &conn) != WYRELOG_E_OK)
+    return 85;
+  if (!g_file_get_contents (WYL_TEST_DUCKDB_SCHEMA_PATH, &schema,
+          &schema_len, &error))
+    return 86;
+
+  duckdb_connection h = wyl_audit_conn_get_connection (conn);
+  if (duckdb_query (h, schema, &result) != DuckDBSuccess) {
+    duckdb_destroy_result (&result);
+    return 87;
+  }
+  duckdb_destroy_result (&result);
+
+  gboolean exists = FALSE;
+  if (wyl_audit_conn_table_exists (conn, "audit_events", &exists)
+      != WYRELOG_E_OK)
+    return 88;
+  if (!exists)
+    return 89;
+  return 0;
+}
+
+static gint
 check_table_probe_reports_schema (void)
 {
   g_autoptr (wyl_audit_conn_t) conn = NULL;
@@ -235,6 +270,8 @@ main (void)
   if ((rc = check_create_schema ()) != 0)
     return rc;
   if ((rc = check_create_schema_null_arg ()) != 0)
+    return rc;
+  if ((rc = check_template_schema_creates_audit_events ()) != 0)
     return rc;
   if ((rc = check_table_probe_reports_schema ()) != 0)
     return rc;


### PR DESCRIPTION
## Summary
- replace the stale DuckDB audit_log template block with audit_events
- add indexes for runtime audit query fields
- execute the DuckDB template in the audit connection test

## Tests
- git diff --check
- meson test -C builddir-audit --print-errorlogs audit-conn
- meson test -C builddir --print-errorlogs
- meson test -C builddir-audit --print-errorlogs