### PR TITLE
session: audit principal transitions

### DIFF
--- a/tests/test-audit-emit.c
+++ b/tests/test-audit-emit.c
@@ -409,6 +409,68 @@ check_session_transition_emits_audit_row (void)
 }
 
 static gint
+check_principal_transition_emits_audit_row (void)
+{
+  WylHandle *handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 80;
+
+  g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
+  wyl_login_req_set_username (login, "audit-principal-user");
+  g_autoptr (WylSession) session = NULL;
+  if (wyl_session_login (handle, login, &session) != WYRELOG_E_OK) {
+    g_object_unref (handle);
+    return 81;
+  }
+  if (wyl_session_mfa_verify (handle, session) != WYRELOG_E_OK) {
+    g_object_unref (handle);
+    return 82;
+  }
+
+  duckdb_connection conn =
+      wyl_audit_conn_get_connection (wyl_handle_get_audit_conn (handle));
+  duckdb_result result;
+  if (duckdb_query (conn,
+          "SELECT subject_id, action, resource_id, deny_origin, decision "
+          "FROM audit_events WHERE action = 'principal_state';", &result)
+      != DuckDBSuccess) {
+    duckdb_destroy_result (&result);
+    g_object_unref (handle);
+    return 83;
+  }
+  if (duckdb_row_count (&result) != 1) {
+    duckdb_destroy_result (&result);
+    g_object_unref (handle);
+    return 84;
+  }
+
+  gint rc = 0;
+  const gchar *subject = duckdb_value_varchar (&result, 0, 0);
+  const gchar *action = duckdb_value_varchar (&result, 1, 0);
+  const gchar *resource = duckdb_value_varchar (&result, 2, 0);
+  const gchar *old_state = duckdb_value_varchar (&result, 3, 0);
+  gint16 decision = (gint16) duckdb_value_int64 (&result, 4, 0);
+  if (g_strcmp0 (subject, "audit-principal-user") != 0)
+    rc = 85;
+  else if (g_strcmp0 (action, "principal_state") != 0)
+    rc = 86;
+  else if (g_strcmp0 (resource, "authenticated") != 0)
+    rc = 87;
+  else if (g_strcmp0 (old_state, "mfa_required") != 0)
+    rc = 88;
+  else if (decision != WYL_DECISION_ALLOW)
+    rc = 89;
+
+  duckdb_free ((void *) subject);
+  duckdb_free ((void *) action);
+  duckdb_free ((void *) resource);
+  duckdb_free ((void *) old_state);
+  duckdb_destroy_result (&result);
+  g_object_unref (handle);
+  return rc;
+}
+
+static gint
 check_emit_rejects_null_args (void)
 {
   WylHandle *handle = NULL;
@@ -442,6 +504,8 @@ main (void)
   if ((rc = check_decide_fail_closes_on_audit_append_failure ()) != 0)
     return rc;
   if ((rc = check_session_transition_emits_audit_row ()) != 0)
+    return rc;
+  if ((rc = check_principal_transition_emits_audit_row ()) != 0)
     return rc;
   if ((rc = check_emit_rejects_null_args ()) != 0)
     return rc;

--- a/wyrelog/wyl-session.c
+++ b/wyrelog/wyl-session.c
@@ -125,14 +125,43 @@ set_principal_state (WylHandle *handle, const gchar *username,
   return store_principal_state (handle, username, state);
 }
 
+#ifdef WYL_HAS_AUDIT
+static void
+emit_principal_state_audit (WylHandle *handle, const gchar *username,
+    const gchar *old_state, const gchar *new_state)
+{
+  g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
+  wyl_audit_event_set_subject_id (ev, username);
+  wyl_audit_event_set_action (ev, "principal_state");
+  wyl_audit_event_set_resource_id (ev, new_state);
+  wyl_audit_event_set_deny_origin (ev, old_state);
+  wyl_audit_event_set_decision (ev, WYL_DECISION_ALLOW);
+  (void) wyl_audit_emit (handle, ev);
+}
+#endif
+
 static wyrelog_error_t
 transition_principal_state (WylHandle *handle, const gchar *username,
     wyl_principal_state_t old_state, wyl_principal_state_t new_state)
 {
+  const gchar *old_state_name = wyl_principal_state_name (old_state);
+  const gchar *new_state_name = wyl_principal_state_name (new_state);
+  if (old_state_name == NULL || new_state_name == NULL)
+    return WYRELOG_E_INTERNAL;
+
   wyrelog_error_t rc = remove_principal_state (handle, username, old_state);
   if (rc != WYRELOG_E_OK)
     return rc;
-  return set_principal_state (handle, username, new_state);
+  rc = insert_principal_state (handle, username, new_state);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = store_principal_state (handle, username, new_state);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+#ifdef WYL_HAS_AUDIT
+  emit_principal_state_audit (handle, username, old_state_name, new_state_name);
+#endif
+  return WYRELOG_E_OK;
 }
 
 static wyrelog_error_t


### PR DESCRIPTION
## Summary
- emit audit rows for durable principal state transitions
- record subject, previous state, new state, and allow decision
- cover MFA verification transition audit output

## Tests
- git diff --check
- meson test -C builddir-audit --print-errorlogs audit-emit session-username
- meson test -C builddir --print-errorlogs
- meson test -C builddir-audit --print-errorlogs