### PR TITLE
session: audit login session state

### DIFF
--- a/tests/test-audit-emit.c
+++ b/tests/test-audit-emit.c
@@ -370,7 +370,8 @@ check_session_transition_emits_audit_row (void)
   duckdb_result result;
   if (duckdb_query (conn,
           "SELECT subject_id, action, resource_id, deny_origin, decision "
-          "FROM audit_events WHERE action = 'session_state';", &result)
+          "FROM audit_events WHERE action = 'session_state' "
+          "AND deny_origin = 'active';", &result)
       != DuckDBSuccess) {
     duckdb_destroy_result (&result);
     g_object_unref (handle);
@@ -398,6 +399,69 @@ check_session_transition_emits_audit_row (void)
     rc = 69;
   else if (decision != WYL_DECISION_ALLOW)
     rc = 70;
+
+  duckdb_free ((void *) subject);
+  duckdb_free ((void *) action);
+  duckdb_free ((void *) resource);
+  duckdb_free ((void *) old_state);
+  duckdb_destroy_result (&result);
+  g_object_unref (handle);
+  return rc;
+}
+
+static gint
+check_login_session_state_emits_audit_row (void)
+{
+  WylHandle *handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 110;
+
+  g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
+  wyl_login_req_set_username (login, "audit-login-session-user");
+  g_autoptr (WylSession) session = NULL;
+  if (wyl_session_login (handle, login, &session) != WYRELOG_E_OK) {
+    g_object_unref (handle);
+    return 111;
+  }
+  g_autofree gchar *session_id = wyl_session_dup_id_string (session);
+  if (session_id == NULL) {
+    g_object_unref (handle);
+    return 112;
+  }
+
+  duckdb_connection conn =
+      wyl_audit_conn_get_connection (wyl_handle_get_audit_conn (handle));
+  duckdb_result result;
+  if (duckdb_query (conn,
+          "SELECT subject_id, action, resource_id, deny_origin, decision "
+          "FROM audit_events WHERE action = 'session_state';", &result)
+      != DuckDBSuccess) {
+    duckdb_destroy_result (&result);
+    g_object_unref (handle);
+    return 113;
+  }
+  if (duckdb_row_count (&result) != 1) {
+    duckdb_destroy_result (&result);
+    g_object_unref (handle);
+    return 114;
+  }
+
+  gint rc = 0;
+  const gchar *subject = duckdb_value_varchar (&result, 0, 0);
+  const gchar *action = duckdb_value_varchar (&result, 1, 0);
+  const gchar *resource = duckdb_value_varchar (&result, 2, 0);
+  const gchar *old_state = duckdb_value_varchar (&result, 3, 0);
+  gint16 decision = (gint16) duckdb_value_int64 (&result, 4, 0);
+  if (g_strcmp0 (subject, session_id) != 0)
+    rc = 115;
+  else if (g_strcmp0 (action, "session_state") != 0)
+    rc = 116;
+  else if (g_strcmp0 (resource, "active") != 0)
+    rc = 117;
+  else if (g_strcmp0 (old_state, "idle") != 0)
+    rc = 118;
+  else if (decision != WYL_DECISION_ALLOW)
+    rc = 119;
 
   duckdb_free ((void *) subject);
   duckdb_free ((void *) action);
@@ -622,6 +686,8 @@ main (void)
   if ((rc = check_decide_fail_closes_on_audit_append_failure ()) != 0)
     return rc;
   if ((rc = check_session_transition_emits_audit_row ()) != 0)
+    return rc;
+  if ((rc = check_login_session_state_emits_audit_row ()) != 0)
     return rc;
   if ((rc = check_principal_transition_emits_audit_row ()) != 0)
     return rc;

--- a/wyrelog/wyl-session.c
+++ b/wyrelog/wyl-session.c
@@ -320,6 +320,11 @@ wyl_session_login (WylHandle *handle, const wyl_login_req_t *req,
     g_object_unref (session);
     return rc;
   }
+#ifdef WYL_HAS_AUDIT
+  g_autofree gchar *session_id = wyl_session_dup_id_string (session);
+  emit_session_state_audit (handle, session_id,
+      wyl_session_state_name (session->state), "active");
+#endif
   session->state = WYL_SESSION_STATE_ACTIVE;
 
   *out_session = session;


### PR DESCRIPTION
## Summary
- emit audit rows after login stores active session state
- record session id, previous state, new state, and allow decision
- keep session transition audit checks scoped to transition rows

## Tests
- git diff --check
- meson test -C builddir-audit --print-errorlogs audit-emit session-username
- meson test -C builddir --print-errorlogs
- meson test -C builddir-audit --print-errorlogs