### PR TITLE
daemon: check audit append readiness

### DIFF
--- a/wyrelog/daemon/wyrelogd.c
+++ b/wyrelog/daemon/wyrelogd.c
@@ -106,6 +106,15 @@ check_audit_sink_ready (WylHandle *handle)
     return rc;
   if (!found)
     return WYRELOG_E_IO;
+
+  g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
+  wyl_audit_event_set_subject_id (ev, "wyrelogd");
+  wyl_audit_event_set_action (ev, "daemon_check");
+  wyl_audit_event_set_resource_id (ev, "audit_events");
+  wyl_audit_event_set_decision (ev, WYL_DECISION_ALLOW);
+  rc = wyl_audit_emit (handle, ev);
+  if (rc != WYRELOG_E_OK)
+    return rc;
 #else
   (void) handle;
 #endif


### PR DESCRIPTION
## Summary
- append an audit row during audit-enabled daemon readiness checks
- keep audit_events table validation before the append check
- fail startup checks when the audit sink cannot accept an event

## Tests
- git diff --check
- meson test -C builddir --print-errorlogs wyrelogd-check wyrelogd-sigterm
- meson test -C builddir-audit --print-errorlogs wyrelogd-check wyrelogd-sigterm audit-emit
- meson test -C builddir --print-errorlogs
- meson test -C builddir-audit --print-errorlogs