### PR TITLE
client: store base url

### DIFF
--- a/tests/test-client-smoke.c
+++ b/tests/test-client-smoke.c
@@ -10,16 +10,27 @@ main (void)
   if (version == NULL || version[0] == '\0')
     return 1;
 
+  g_autoptr (WylClient) client = NULL;
+
   /* Input validation: NULL out_client must be rejected. */
   if (wyl_client_new ("http://example.invalid", NULL) != WYRELOG_E_INVALID)
     return 2;
+  if (wyl_client_new (NULL, &client) != WYRELOG_E_INVALID)
+    return 9;
+  if (wyl_client_new ("", &client) != WYRELOG_E_INVALID)
+    return 10;
+  if (wyl_client_new ("file:///tmp/wyrelog.sock", &client) != WYRELOG_E_INVALID)
+    return 11;
 
   /* Successful path returns a non-NULL WylClient. */
-  g_autoptr (WylClient) client = NULL;
+  client = NULL;
   if (wyl_client_new ("http://example.invalid", &client) != WYRELOG_E_OK)
     return 3;
   if (client == NULL)
     return 4;
+  g_autofree gchar *base_url = wyl_client_dup_base_url (client);
+  if (g_strcmp0 (base_url, "http://example.invalid") != 0)
+    return 12;
 
   /* Audit iterator returns a non-NULL WylAuditIter on success and
    * yields no rows in the stub state. */

--- a/wyrelog/client.h
+++ b/wyrelog/client.h
@@ -31,6 +31,7 @@ G_DECLARE_FINAL_TYPE (WylAuditIter, wyl_audit_iter, WYL, AUDIT_ITER, GObject);
 /* Lifecycle */
 wyrelog_error_t wyl_client_new (const gchar * base_url,
     WylClient ** out_client);
+gchar *wyl_client_dup_base_url (const WylClient * client);
 
 /* Authentication */
 wyrelog_error_t wyl_client_login (WylClient * client,

--- a/wyrelog/wyl-client.c
+++ b/wyrelog/wyl-client.c
@@ -4,14 +4,27 @@
 struct _WylClient
 {
   GObject parent_instance;
+  gchar *base_url;
 };
 
 G_DEFINE_FINAL_TYPE (WylClient, wyl_client, G_TYPE_OBJECT);
 
 static void
+wyl_client_finalize (GObject *object)
+{
+  WylClient *self = WYL_CLIENT (object);
+
+  g_free (self->base_url);
+
+  G_OBJECT_CLASS (wyl_client_parent_class)->finalize (object);
+}
+
+static void
 wyl_client_class_init (WylClientClass *klass)
 {
-  (void) klass;
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->finalize = wyl_client_finalize;
 }
 
 static void
@@ -23,13 +36,32 @@ wyl_client_init (WylClient *self)
 wyrelog_error_t
 wyl_client_new (const gchar *base_url, WylClient **out_client)
 {
-  (void) base_url;
-
   if (out_client == NULL)
     return WYRELOG_E_INVALID;
+  *out_client = NULL;
+  if (base_url == NULL || base_url[0] == '\0')
+    return WYRELOG_E_INVALID;
 
-  *out_client = g_object_new (WYL_TYPE_CLIENT, NULL);
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GUri) uri = g_uri_parse (base_url, G_URI_FLAGS_NONE, &error);
+  if (uri == NULL)
+    return WYRELOG_E_INVALID;
+
+  const gchar *scheme = g_uri_get_scheme (uri);
+  if (g_strcmp0 (scheme, "http") != 0 && g_strcmp0 (scheme, "https") != 0)
+    return WYRELOG_E_INVALID;
+
+  WylClient *client = g_object_new (WYL_TYPE_CLIENT, NULL);
+  client->base_url = g_strdup (base_url);
+  *out_client = client;
   return WYRELOG_E_OK;
+}
+
+gchar *
+wyl_client_dup_base_url (const WylClient *client)
+{
+  g_return_val_if_fail (WYL_IS_CLIENT ((WylClient *) client), NULL);
+  return g_strdup (client->base_url);
 }
 
 wyrelog_error_t


### PR DESCRIPTION
## Summary
- validate client base URLs during construction
- retain the accepted base URL on WylClient
- expose a duplicate getter for future transport requests

## Tests
- git diff --check
- meson test -C builddir --print-errorlogs client-smoke
- meson test -C builddir-audit --print-errorlogs client-smoke
- meson test -C builddir --print-errorlogs
- meson test -C builddir-audit --print-errorlogs