### PR TITLE
client: retain audit iterator state

### DIFF
--- a/tests/test-client-smoke.c
+++ b/tests/test-client-smoke.c
@@ -35,10 +35,17 @@ main (void)
   /* Audit iterator returns a non-NULL WylAuditIter on success and
    * yields no rows in the stub state. */
   g_autoptr (WylAuditIter) iter = NULL;
-  if (wyl_client_audit_query (client, NULL, &iter) != WYRELOG_E_OK)
+  if (wyl_client_audit_query (NULL, NULL, &iter) != WYRELOG_E_INVALID)
+    return 13;
+  if (wyl_client_audit_query (client, NULL, NULL) != WYRELOG_E_INVALID)
+    return 14;
+  if (wyl_client_audit_query (client, "decision=deny", &iter) != WYRELOG_E_OK)
     return 5;
   if (iter == NULL)
     return 6;
+  g_autofree gchar *query_filter = wyl_audit_iter_dup_query_filter (iter);
+  if (g_strcmp0 (query_filter, "decision=deny") != 0)
+    return 15;
 
   gboolean has_next = TRUE;
   if (wyl_audit_iter_next (iter, &has_next) != WYRELOG_E_OK)

--- a/wyrelog/audit/iter.c
+++ b/wyrelog/audit/iter.c
@@ -4,14 +4,29 @@
 struct _WylAuditIter
 {
   GObject parent_instance;
+  WylClient *client;
+  gchar *query_filter;
 };
 
 G_DEFINE_FINAL_TYPE (WylAuditIter, wyl_audit_iter, G_TYPE_OBJECT);
 
 static void
+wyl_audit_iter_finalize (GObject *object)
+{
+  WylAuditIter *self = WYL_AUDIT_ITER (object);
+
+  g_clear_object (&self->client);
+  g_free (self->query_filter);
+
+  G_OBJECT_CLASS (wyl_audit_iter_parent_class)->finalize (object);
+}
+
+static void
 wyl_audit_iter_class_init (WylAuditIterClass *klass)
 {
-  (void) klass;
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->finalize = wyl_audit_iter_finalize;
 }
 
 static void
@@ -24,22 +39,30 @@ wyrelog_error_t
 wyl_client_audit_query (WylClient *client, const gchar *query_filter,
     WylAuditIter **out_iter)
 {
-  (void) client;
-  (void) query_filter;
-
   if (out_iter == NULL)
     return WYRELOG_E_INVALID;
+  *out_iter = NULL;
+  if (client == NULL || !WYL_IS_CLIENT (client))
+    return WYRELOG_E_INVALID;
 
-  *out_iter = g_object_new (WYL_TYPE_AUDIT_ITER, NULL);
+  WylAuditIter *iter = g_object_new (WYL_TYPE_AUDIT_ITER, NULL);
+  iter->client = g_object_ref (client);
+  iter->query_filter = g_strdup (query_filter);
+  *out_iter = iter;
   return WYRELOG_E_OK;
+}
+
+gchar *
+wyl_audit_iter_dup_query_filter (const WylAuditIter *iter)
+{
+  g_return_val_if_fail (WYL_IS_AUDIT_ITER ((WylAuditIter *) iter), NULL);
+  return g_strdup (iter->query_filter);
 }
 
 wyrelog_error_t
 wyl_audit_iter_next (WylAuditIter *iter, gboolean *out_has_next)
 {
-  (void) iter;
-
-  if (out_has_next == NULL)
+  if (iter == NULL || !WYL_IS_AUDIT_ITER (iter) || out_has_next == NULL)
     return WYRELOG_E_INVALID;
 
   *out_has_next = FALSE;

--- a/wyrelog/client.h
+++ b/wyrelog/client.h
@@ -47,6 +47,7 @@ wyrelog_error_t wyl_client_decide (WylClient * client,
 /* Audit query (iterator) */
 wyrelog_error_t wyl_client_audit_query (WylClient * client,
     const gchar * query_filter, WylAuditIter ** out_iter);
+gchar *wyl_audit_iter_dup_query_filter (const WylAuditIter * iter);
 wyrelog_error_t wyl_audit_iter_next (WylAuditIter * iter,
     gboolean * out_has_next);
 


### PR DESCRIPTION
## Summary
- store client references on audit iterators
- retain audit query filters for future page requests
- validate audit query client and output arguments

## Tests
- git diff --check
- meson test -C builddir --print-errorlogs client-smoke
- meson test -C builddir-audit --print-errorlogs client-smoke
- meson test -C builddir --print-errorlogs
- meson test -C builddir-audit --print-errorlogs