### PR TITLE
client: build audit query uri

### DIFF
--- a/tests/test-client-smoke.c
+++ b/tests/test-client-smoke.c
@@ -46,6 +46,10 @@ main (void)
   g_autofree gchar *query_filter = wyl_audit_iter_dup_query_filter (iter);
   if (g_strcmp0 (query_filter, "decision=deny") != 0)
     return 15;
+  g_autofree gchar *request_uri = wyl_audit_iter_dup_request_uri (iter);
+  if (g_strcmp0 (request_uri,
+          "http://example.invalid/audit/events?filter=decision%3Ddeny") != 0)
+    return 16;
 
   gboolean has_next = TRUE;
   if (wyl_audit_iter_next (iter, &has_next) != WYRELOG_E_OK)

--- a/wyrelog/audit/iter.c
+++ b/wyrelog/audit/iter.c
@@ -59,6 +59,23 @@ wyl_audit_iter_dup_query_filter (const WylAuditIter *iter)
   return g_strdup (iter->query_filter);
 }
 
+gchar *
+wyl_audit_iter_dup_request_uri (const WylAuditIter *iter)
+{
+  g_return_val_if_fail (WYL_IS_AUDIT_ITER ((WylAuditIter *) iter), NULL);
+
+  g_autofree gchar *base_url = wyl_client_dup_base_url (iter->client);
+  const gchar *separator = g_str_has_suffix (base_url, "/") ? "" : "/";
+  g_autofree gchar *path =
+      g_strdup_printf ("%s%saudit/events", base_url, separator);
+  if (iter->query_filter == NULL || iter->query_filter[0] == '\0')
+    return g_steal_pointer (&path);
+
+  g_autofree gchar *escaped =
+      g_uri_escape_string (iter->query_filter, NULL, TRUE);
+  return g_strdup_printf ("%s?filter=%s", path, escaped);
+}
+
 wyrelog_error_t
 wyl_audit_iter_next (WylAuditIter *iter, gboolean *out_has_next)
 {

--- a/wyrelog/client.h
+++ b/wyrelog/client.h
@@ -48,6 +48,7 @@ wyrelog_error_t wyl_client_decide (WylClient * client,
 wyrelog_error_t wyl_client_audit_query (WylClient * client,
     const gchar * query_filter, WylAuditIter ** out_iter);
 gchar *wyl_audit_iter_dup_query_filter (const WylAuditIter * iter);
+gchar *wyl_audit_iter_dup_request_uri (const WylAuditIter * iter);
 wyrelog_error_t wyl_audit_iter_next (WylAuditIter * iter,
     gboolean * out_has_next);
 


### PR DESCRIPTION
## Summary
- build audit event request URIs from iterator-owned client state
- append the audit event path to the configured base URL
- escape query filters into the request URI

## Tests
- git diff --check
- meson test -C builddir --print-errorlogs client-smoke
- meson test -C builddir-audit --print-errorlogs client-smoke
- meson test -C builddir --print-errorlogs
- meson test -C builddir-audit --print-errorlogs