### PR TITLE
client: own soup session

### DIFF
--- a/wyrelog/wyl-client.c
+++ b/wyrelog/wyl-client.c
@@ -1,10 +1,13 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <libsoup/soup.h>
+
 #include "wyrelog/client.h"
 
 struct _WylClient
 {
   GObject parent_instance;
   gchar *base_url;
+  SoupSession *session;
 };
 
 G_DEFINE_FINAL_TYPE (WylClient, wyl_client, G_TYPE_OBJECT);
@@ -15,6 +18,7 @@ wyl_client_finalize (GObject *object)
   WylClient *self = WYL_CLIENT (object);
 
   g_free (self->base_url);
+  g_clear_object (&self->session);
 
   G_OBJECT_CLASS (wyl_client_parent_class)->finalize (object);
 }
@@ -53,6 +57,7 @@ wyl_client_new (const gchar *base_url, WylClient **out_client)
 
   WylClient *client = g_object_new (WYL_TYPE_CLIENT, NULL);
   client->base_url = g_strdup (base_url);
+  client->session = soup_session_new ();
   *out_client = client;
   return WYRELOG_E_OK;
 }


### PR DESCRIPTION
## Summary
- keep a SoupSession on each client instance
- tie the HTTP session to client construction and finalization
- prepare the client transport layer to share one session per base URL

## Tests
- git diff --check
- meson test -C builddir --print-errorlogs client-smoke
- meson test -C builddir-audit --print-errorlogs client-smoke
- meson test -C builddir --print-errorlogs
- meson test -C builddir-audit --print-errorlogs