### PR TITLE
client: expose private soup session

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -33,7 +33,7 @@ endif
 
 test_client_smoke = executable('test-client-smoke',
   'test-client-smoke.c',
-  dependencies : [wyrelog_client_dep],
+  dependencies : [wyrelog_client_dep, libsoup_dep],
 )
 
 test('client-smoke', test_client_smoke)

--- a/tests/test-client-smoke.c
+++ b/tests/test-client-smoke.c
@@ -2,6 +2,7 @@
 #include <glib.h>
 
 #include "wyrelog/client.h"
+#include "wyrelog/wyl-client-private.h"
 
 int
 main (void)
@@ -31,6 +32,8 @@ main (void)
   g_autofree gchar *base_url = wyl_client_dup_base_url (client);
   if (g_strcmp0 (base_url, "http://example.invalid") != 0)
     return 12;
+  if (wyl_client_get_soup_session (client) == NULL)
+    return 17;
 
   /* Audit iterator returns a non-NULL WylAuditIter on success and
    * yields no rows in the stub state. */

--- a/wyrelog/wyl-client-private.h
+++ b/wyrelog/wyl-client-private.h
@@ -1,0 +1,11 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#ifndef WYL_CLIENT_PRIVATE_H
+#define WYL_CLIENT_PRIVATE_H
+
+#include <libsoup/soup.h>
+
+#include "wyrelog/client.h"
+
+SoupSession *wyl_client_get_soup_session (WylClient * client);
+
+#endif /* WYL_CLIENT_PRIVATE_H */

--- a/wyrelog/wyl-client.c
+++ b/wyrelog/wyl-client.c
@@ -1,7 +1,5 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
-#include <libsoup/soup.h>
-
-#include "wyrelog/client.h"
+#include "wyrelog/wyl-client-private.h"
 
 struct _WylClient
 {
@@ -67,6 +65,13 @@ wyl_client_dup_base_url (const WylClient *client)
 {
   g_return_val_if_fail (WYL_IS_CLIENT ((WylClient *) client), NULL);
   return g_strdup (client->base_url);
+}
+
+SoupSession *
+wyl_client_get_soup_session (WylClient *client)
+{
+  g_return_val_if_fail (WYL_IS_CLIENT (client), NULL);
+  return client->session;
 }
 
 wyrelog_error_t


### PR DESCRIPTION
## Summary
- add a private helper for accessing the client SoupSession
- keep HTTP transport state outside the public client API
- cover the helper in the client smoke test

## Tests
- git diff --check
- meson test -C builddir --print-errorlogs client-smoke check-private-headers-not-installed
- meson test -C builddir-audit --print-errorlogs client-smoke check-private-headers-not-installed
- meson test -C builddir --print-errorlogs
- meson test -C builddir-audit --print-errorlogs