### PR TITLE
client: build audit request message

### DIFF
--- a/tests/test-client-smoke.c
+++ b/tests/test-client-smoke.c
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #include <glib.h>
 
+#include "wyrelog/audit/iter-private.h"
 #include "wyrelog/client.h"
 #include "wyrelog/wyl-client-private.h"
 
@@ -53,6 +54,15 @@ main (void)
   if (g_strcmp0 (request_uri,
           "http://example.invalid/audit/events?filter=decision%3Ddeny") != 0)
     return 16;
+  g_autoptr (SoupMessage) message = wyl_audit_iter_new_request_message (iter);
+  if (message == NULL)
+    return 18;
+  if (g_strcmp0 (soup_message_get_method (message), "GET") != 0)
+    return 19;
+  g_autofree gchar *message_uri =
+      g_uri_to_string (soup_message_get_uri (message));
+  if (g_strcmp0 (message_uri, request_uri) != 0)
+    return 20;
 
   gboolean has_next = TRUE;
   if (wyl_audit_iter_next (iter, &has_next) != WYRELOG_E_OK)

--- a/wyrelog/audit/iter-private.h
+++ b/wyrelog/audit/iter-private.h
@@ -1,0 +1,11 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#ifndef WYL_AUDIT_ITER_PRIVATE_H
+#define WYL_AUDIT_ITER_PRIVATE_H
+
+#include <libsoup/soup.h>
+
+#include "wyrelog/client.h"
+
+SoupMessage *wyl_audit_iter_new_request_message (WylAuditIter * iter);
+
+#endif /* WYL_AUDIT_ITER_PRIVATE_H */

--- a/wyrelog/audit/iter.c
+++ b/wyrelog/audit/iter.c
@@ -1,4 +1,5 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "wyrelog/audit/iter-private.h"
 #include "wyrelog/client.h"
 
 struct _WylAuditIter
@@ -74,6 +75,15 @@ wyl_audit_iter_dup_request_uri (const WylAuditIter *iter)
   g_autofree gchar *escaped =
       g_uri_escape_string (iter->query_filter, NULL, TRUE);
   return g_strdup_printf ("%s?filter=%s", path, escaped);
+}
+
+SoupMessage *
+wyl_audit_iter_new_request_message (WylAuditIter *iter)
+{
+  g_return_val_if_fail (WYL_IS_AUDIT_ITER (iter), NULL);
+
+  g_autofree gchar *request_uri = wyl_audit_iter_dup_request_uri (iter);
+  return soup_message_new ("GET", request_uri);
 }
 
 wyrelog_error_t


### PR DESCRIPTION
## Summary
- add a private audit iterator helper for building GET requests
- derive the request message from the iterator request URI
- cover the method and URI in the client smoke test

## Tests
- git diff --check
- meson test -C builddir --print-errorlogs client-smoke check-private-headers-not-installed
- meson test -C builddir-audit --print-errorlogs client-smoke check-private-headers-not-installed
- meson test -C builddir --print-errorlogs
- meson test -C builddir-audit --print-errorlogs