### PR TITLE
client: send soup messages

### DIFF
--- a/tests/test-client-smoke.c
+++ b/tests/test-client-smoke.c
@@ -1,9 +1,41 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <string.h>
+
 #include <glib.h>
 
 #include "wyrelog/audit/iter-private.h"
 #include "wyrelog/client.h"
 #include "wyrelog/wyl-client-private.h"
+
+typedef struct
+{
+  SoupServer *server;
+  GMainLoop *loop;
+} TestHttpServer;
+
+static gpointer
+test_http_server_thread (gpointer data)
+{
+  TestHttpServer *http = data;
+
+  g_main_loop_run (http->loop);
+  return NULL;
+}
+
+static void
+test_http_server_handler (SoupServer *server, SoupServerMessage *msg,
+    const char *path, GHashTable *query, gpointer user_data)
+{
+  (void) server;
+  (void) path;
+  (void) query;
+  (void) user_data;
+
+  const gchar *body = "[]";
+  soup_server_message_set_status (msg, 200, NULL);
+  soup_server_message_set_response (msg, "application/json", SOUP_MEMORY_COPY,
+      body, strlen (body));
+}
 
 int
 main (void)
@@ -63,6 +95,46 @@ main (void)
       g_uri_to_string (soup_message_get_uri (message));
   if (g_strcmp0 (message_uri, request_uri) != 0)
     return 20;
+
+  TestHttpServer http = { 0 };
+  http.server = soup_server_new (NULL, NULL);
+  http.loop = g_main_loop_new (NULL, FALSE);
+  soup_server_add_handler (http.server, NULL, test_http_server_handler, NULL,
+      NULL);
+  g_autoptr (GError) listen_error = NULL;
+  if (!soup_server_listen_local (http.server, 0, 0, &listen_error))
+    return 21;
+  GThread *thread = g_thread_new ("client-smoke-http",
+      test_http_server_thread, &http);
+
+  GSList *uris = soup_server_get_uris (http.server);
+  if (uris == NULL)
+    return 22;
+  g_autofree gchar *local_base_url = g_uri_to_string (uris->data);
+  g_slist_free_full (uris, (GDestroyNotify) g_uri_unref);
+
+  g_autoptr (WylClient) local_client = NULL;
+  if (wyl_client_new (local_base_url, &local_client) != WYRELOG_E_OK)
+    return 23;
+  g_autoptr (WylAuditIter) local_iter = NULL;
+  if (wyl_client_audit_query (local_client, NULL, &local_iter) != WYRELOG_E_OK)
+    return 24;
+  g_autoptr (SoupMessage) local_message =
+      wyl_audit_iter_new_request_message (local_iter);
+  g_autoptr (GBytes) body = NULL;
+  if (wyl_client_send_message (local_client, local_message, &body) !=
+      WYRELOG_E_OK)
+    return 25;
+  gsize body_size = 0;
+  const gchar *body_data = g_bytes_get_data (body, &body_size);
+  if (body_size != 2 || memcmp (body_data, "[]", 2) != 0)
+    return 26;
+
+  g_main_loop_quit (http.loop);
+  g_thread_join (thread);
+  soup_server_disconnect (http.server);
+  g_clear_object (&http.server);
+  g_clear_pointer (&http.loop, g_main_loop_unref);
 
   gboolean has_next = TRUE;
   if (wyl_audit_iter_next (iter, &has_next) != WYRELOG_E_OK)

--- a/wyrelog/wyl-client-private.h
+++ b/wyrelog/wyl-client-private.h
@@ -7,5 +7,7 @@
 #include "wyrelog/client.h"
 
 SoupSession *wyl_client_get_soup_session (WylClient * client);
+wyrelog_error_t wyl_client_send_message (WylClient * client,
+    SoupMessage * message, GBytes ** out_body);
 
 #endif /* WYL_CLIENT_PRIVATE_H */

--- a/wyrelog/wyl-client.c
+++ b/wyrelog/wyl-client.c
@@ -75,6 +75,31 @@ wyl_client_get_soup_session (WylClient *client)
 }
 
 wyrelog_error_t
+wyl_client_send_message (WylClient *client, SoupMessage *message,
+    GBytes **out_body)
+{
+  if (client == NULL || !WYL_IS_CLIENT (client) || message == NULL ||
+      out_body == NULL)
+    return WYRELOG_E_INVALID;
+  *out_body = NULL;
+
+  g_autoptr (GError) error = NULL;
+  GBytes *body = soup_session_send_and_read (client->session, message, NULL,
+      &error);
+  if (body == NULL)
+    return WYRELOG_E_IO;
+
+  guint status = soup_message_get_status (message);
+  if (status < 200 || status >= 300) {
+    g_bytes_unref (body);
+    return WYRELOG_E_IO;
+  }
+
+  *out_body = body;
+  return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
 wyl_client_login (WylClient *client, const gchar *username,
     const gchar *password)
 {


### PR DESCRIPTION
## Summary
- add a private helper for dispatching SoupMessage objects
- return response bytes for successful HTTP statuses
- cover the send path with an in-process HTTP server smoke test

## Tests
- git diff --check
- meson test -C builddir --print-errorlogs client-smoke
- meson test -C builddir-audit --print-errorlogs client-smoke
- meson test -C builddir --print-errorlogs
- meson test -C builddir-audit --print-errorlogs