### PR TITLE
client: dispatch audit iterator requests

### DIFF
--- a/tests/test-client-smoke.c
+++ b/tests/test-client-smoke.c
@@ -130,17 +130,22 @@ main (void)
   if (body_size != 2 || memcmp (body_data, "[]", 2) != 0)
     return 26;
 
+  gboolean has_next = TRUE;
+  if (wyl_audit_iter_next (local_iter, &has_next) != WYRELOG_E_OK)
+    return 7;
+  if (has_next)
+    return 8;
+  has_next = TRUE;
+  if (wyl_audit_iter_next (local_iter, &has_next) != WYRELOG_E_OK)
+    return 27;
+  if (has_next)
+    return 28;
+
   g_main_loop_quit (http.loop);
   g_thread_join (thread);
   soup_server_disconnect (http.server);
   g_clear_object (&http.server);
   g_clear_pointer (&http.loop, g_main_loop_unref);
-
-  gboolean has_next = TRUE;
-  if (wyl_audit_iter_next (iter, &has_next) != WYRELOG_E_OK)
-    return 7;
-  if (has_next)
-    return 8;
 
   return 0;
 }

--- a/wyrelog/audit/iter.c
+++ b/wyrelog/audit/iter.c
@@ -1,12 +1,14 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #include "wyrelog/audit/iter-private.h"
 #include "wyrelog/client.h"
+#include "wyrelog/wyl-client-private.h"
 
 struct _WylAuditIter
 {
   GObject parent_instance;
   WylClient *client;
   gchar *query_filter;
+  gboolean exhausted;
 };
 
 G_DEFINE_FINAL_TYPE (WylAuditIter, wyl_audit_iter, G_TYPE_OBJECT);
@@ -92,6 +94,18 @@ wyl_audit_iter_next (WylAuditIter *iter, gboolean *out_has_next)
   if (iter == NULL || !WYL_IS_AUDIT_ITER (iter) || out_has_next == NULL)
     return WYRELOG_E_INVALID;
 
+  if (iter->exhausted) {
+    *out_has_next = FALSE;
+    return WYRELOG_E_OK;
+  }
+
+  g_autoptr (SoupMessage) message = wyl_audit_iter_new_request_message (iter);
+  g_autoptr (GBytes) body = NULL;
+  wyrelog_error_t rc = wyl_client_send_message (iter->client, message, &body);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  iter->exhausted = TRUE;
   *out_has_next = FALSE;
   return WYRELOG_E_OK;
 }


### PR DESCRIPTION
## Summary
- dispatch audit iterator requests through the client session
- mark iterators exhausted after a successful empty response
- cover first and repeated next calls against the local HTTP smoke server

## Tests
- git diff --check
- meson test -C builddir --print-errorlogs client-smoke
- meson test -C builddir-audit --print-errorlogs client-smoke
- meson test -C builddir --print-errorlogs
- meson test -C builddir-audit --print-errorlogs