### PR TITLE
daemon: serve health check

### DIFF
--- a/tests/check-wyrelogd-healthz.sh
+++ b/tests/check-wyrelogd-healthz.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+set -eu
+
+WYRELOGD=$1
+TEMPLATE_DIR=$2
+PYTHON=$3
+PORT=$((39000 + $$ % 20000))
+
+"$WYRELOGD" --template-dir "$TEMPLATE_DIR" --listen-port "$PORT" &
+PID=$!
+
+cleanup() {
+  kill "$PID" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+"$PYTHON" - "$PORT" <<'PY'
+import sys
+import time
+import urllib.request
+
+port = sys.argv[1]
+url = f"http://127.0.0.1:{port}/healthz"
+last_error = None
+
+for _ in range(50):
+    try:
+        body = urllib.request.urlopen(url, timeout=1).read()
+        sys.exit(0 if body == b"ok\n" else 1)
+    except Exception as exc:
+        last_error = exc
+        time.sleep(0.1)
+
+print(last_error, file=sys.stderr)
+sys.exit(1)
+PY
+
+kill -TERM "$PID"
+wait "$PID"
+trap - EXIT INT TERM

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -25,7 +25,18 @@ if host_machine.system() != 'windows'
   test('wyrelogd-sigterm', sh,
     args : [
       '-c',
-      '"' + wyrelogd_exe.full_path() + '" --template-dir "' + meson.project_source_root() / 'templates' / 'access' + '" & pid=$!; sleep 1; kill -TERM "$pid"; wait "$pid"',
+      '"' + wyrelogd_exe.full_path() + '" --template-dir "' + meson.project_source_root() / 'templates' / 'access' + '" --listen-port 0 & pid=$!; sleep 1; kill -TERM "$pid"; wait "$pid"',
+    ],
+    depends : wyrelogd_exe,
+  )
+
+  python3 = find_program('python3')
+  test('wyrelogd-healthz', sh,
+    args : [
+      meson.current_source_dir() / 'check-wyrelogd-healthz.sh',
+      wyrelogd_exe.full_path(),
+      meson.project_source_root() / 'templates' / 'access',
+      python3.full_path(),
     ],
     depends : wyrelogd_exe,
   )

--- a/wyrelog/daemon/wyrelogd.c
+++ b/wyrelog/daemon/wyrelogd.c
@@ -2,6 +2,11 @@
 #include <glib.h>
 #include <signal.h>
 
+#ifdef WYL_HAS_DAEMON_HTTP
+#include <libsoup/soup.h>
+#include <string.h>
+#endif
+
 #ifdef G_OS_UNIX
 #include <glib-unix.h>
 #endif
@@ -16,6 +21,7 @@
 typedef struct
 {
   const gchar *template_dir;
+  gint listen_port;
   gboolean check_only;
   gboolean show_version;
 } WylDaemonOptions;
@@ -37,6 +43,10 @@ parse_options (gint *argc, gchar ***argv, WylDaemonOptions *opts,
   GOptionEntry entries[] = {
     {"template-dir", 0, 0, G_OPTION_ARG_STRING, &opts->template_dir,
         "Access policy template directory", "DIR"},
+#ifdef WYL_HAS_DAEMON_HTTP
+    {"listen-port", 0, 0, G_OPTION_ARG_INT, &opts->listen_port,
+        "HTTP listen port", "PORT"},
+#endif
     {"check", 0, 0, G_OPTION_ARG_NONE, &opts->check_only,
         "Load policy templates and exit", NULL},
     {"version", 0, 0, G_OPTION_ARG_NONE, &opts->show_version,
@@ -68,6 +78,44 @@ check_wirelog_policy_ready (WylHandle *handle)
     return WYRELOG_E_POLICY;
   return WYRELOG_E_OK;
 }
+
+#ifdef WYL_HAS_DAEMON_HTTP
+static void
+healthz_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
+    GHashTable *query, gpointer user_data)
+{
+  (void) server;
+  (void) path;
+  (void) query;
+  (void) user_data;
+
+  const gchar *body = "ok\n";
+  soup_server_message_set_status (msg, 200, NULL);
+  soup_server_message_set_response (msg, "text/plain", SOUP_MEMORY_COPY, body,
+      strlen (body));
+}
+
+static SoupServer *
+start_http_server (const WylDaemonOptions *opts, GError **error)
+{
+  g_return_val_if_fail (opts != NULL, NULL);
+
+  if (opts->listen_port < 0 || opts->listen_port > 65535) {
+    g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_BAD_VALUE,
+        "listen port must be between 0 and 65535");
+    return NULL;
+  }
+
+  SoupServer *server = soup_server_new (NULL, NULL);
+  soup_server_add_handler (server, "/healthz", healthz_handler, NULL, NULL);
+  if (!soup_server_listen_local (server, (guint) opts->listen_port, 0, error)) {
+    g_object_unref (server);
+    return NULL;
+  }
+
+  return server;
+}
+#endif
 
 static wyrelog_error_t
 check_policy_store_ready (WylHandle *handle)
@@ -242,6 +290,7 @@ main (int argc, char **argv)
 {
   WylDaemonOptions opts = {
     .template_dir = WYL_DEFAULT_TEMPLATE_DIR,
+    .listen_port = 8765,
   };
   g_autoptr (GError) error = NULL;
 
@@ -299,10 +348,21 @@ main (int argc, char **argv)
   }
 
   g_autoptr (GMainLoop) loop = g_main_loop_new (NULL, FALSE);
+#ifdef WYL_HAS_DAEMON_HTTP
+  g_autoptr (SoupServer) server = start_http_server (&opts, &error);
+  if (server == NULL) {
+    g_printerr ("wyrelogd: listen failed: %s\n", error->message);
+    return 1;
+  }
+#endif
+
   guint sigint_id = 0;
   guint sigterm_id = 0;
   install_signal_handlers (loop, &sigint_id, &sigterm_id);
   g_main_loop_run (loop);
+#ifdef WYL_HAS_DAEMON_HTTP
+  soup_server_disconnect (server);
+#endif
   remove_signal_handler (&sigterm_id);
   remove_signal_handler (&sigint_id);
   return 0;

--- a/wyrelog/meson.build
+++ b/wyrelog/meson.build
@@ -106,12 +106,19 @@ else
   wyrelog_client_dep = disabler()
 endif
 
+wyrelogd_deps = [wyrelog_dep, glib_dep, gio_dep]
+wyrelogd_c_args = [
+  '-DWYL_DEFAULT_TEMPLATE_DIR="' + get_option('datadir') / 'wyrelog' / 'access' + '"',
+]
+if libsoup_dep.found()
+  wyrelogd_deps += libsoup_dep
+  wyrelogd_c_args += '-DWYL_HAS_DAEMON_HTTP'
+endif
+
 wyrelogd_exe = executable('wyrelogd',
   files('daemon/wyrelogd.c'),
   include_directories : wyrelog_inc,
-  dependencies : [wyrelog_dep, glib_dep, gio_dep],
-  c_args : [
-    '-DWYL_DEFAULT_TEMPLATE_DIR="' + get_option('datadir') / 'wyrelog' / 'access' + '"',
-  ],
+  dependencies : wyrelogd_deps,
+  c_args : wyrelogd_c_args,
   install : true,
 )


### PR DESCRIPTION
## Summary
- start a libsoup HTTP server when daemon HTTP support is available
- add a /healthz endpoint for basic daemon readiness checks
- cover the endpoint with an ephemeral-port smoke test
- keep no-client builds working when libsoup is disabled

## Tests
- git diff --check
- meson test -C builddir --print-errorlogs wyrelogd-check wyrelogd-sigterm wyrelogd-healthz
- meson setup builddir-noclient -Denable_client=disabled -Denable_audit=disabled -Denable_tpm=disabled --wipe && meson test -C builddir-noclient --print-errorlogs wyrelogd-check
- meson test -C builddir --print-errorlogs
- meson test -C builddir-audit --print-errorlogs