### PR TITLE
daemon: serve empty audit events

### DIFF
--- a/tests/check-wyrelogd-healthz.sh
+++ b/tests/check-wyrelogd-healthz.sh
@@ -22,13 +22,17 @@ import time
 import urllib.request
 
 port = sys.argv[1]
-url = f"http://127.0.0.1:{port}/healthz"
+base = f"http://127.0.0.1:{port}"
 last_error = None
 
 for _ in range(50):
     try:
-        body = urllib.request.urlopen(url, timeout=1).read()
-        sys.exit(0 if body == b"ok\n" else 1)
+        health = urllib.request.urlopen(f"{base}/healthz", timeout=1).read()
+        events = urllib.request.urlopen(
+            f"{base}/audit/events?filter=decision%3Ddeny",
+            timeout=1,
+        ).read()
+        sys.exit(0 if health == b"ok\n" and events == b"[]" else 1)
     except Exception as exc:
         last_error = exc
         time.sleep(0.1)

--- a/wyrelog/daemon/wyrelogd.c
+++ b/wyrelog/daemon/wyrelogd.c
@@ -95,6 +95,21 @@ healthz_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
       strlen (body));
 }
 
+static void
+audit_events_handler (SoupServer *server, SoupServerMessage *msg,
+    const char *path, GHashTable *query, gpointer user_data)
+{
+  (void) server;
+  (void) path;
+  (void) query;
+  (void) user_data;
+
+  const gchar *body = "[]";
+  soup_server_message_set_status (msg, 200, NULL);
+  soup_server_message_set_response (msg, "application/json",
+      SOUP_MEMORY_COPY, body, strlen (body));
+}
+
 static SoupServer *
 start_http_server (const WylDaemonOptions *opts, GError **error)
 {
@@ -108,6 +123,8 @@ start_http_server (const WylDaemonOptions *opts, GError **error)
 
   SoupServer *server = soup_server_new (NULL, NULL);
   soup_server_add_handler (server, "/healthz", healthz_handler, NULL, NULL);
+  soup_server_add_handler (server, "/audit/events", audit_events_handler, NULL,
+      NULL);
   if (!soup_server_listen_local (server, (guint) opts->listen_port, 0, error)) {
     g_object_unref (server);
     return NULL;


### PR DESCRIPTION
## Summary
- add a daemon /audit/events HTTP route
- return an empty JSON page from the audit events endpoint
- extend the daemon smoke test to cover the audit events route

## Tests
- git diff --check
- meson test -C builddir --print-errorlogs wyrelogd-healthz client-smoke
- meson test -C builddir-audit --print-errorlogs wyrelogd-healthz client-smoke
- meson test -C builddir-noclient --print-errorlogs wyrelogd-check
- meson test -C builddir --print-errorlogs
- meson test -C builddir-audit --print-errorlogs