### PR TITLE
client: smoke audit daemon route

### DIFF
--- a/tests/check-client-audit-daemon.sh
+++ b/tests/check-client-audit-daemon.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+set -eu
+
+WYRELOGD=$1
+CLIENT_TEST=$2
+TEMPLATE_DIR=$3
+PYTHON=$4
+PORT=$((39000 + $$ % 20000))
+
+"$WYRELOGD" --template-dir "$TEMPLATE_DIR" --listen-port "$PORT" &
+PID=$!
+
+cleanup() {
+  kill "$PID" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+"$PYTHON" - "$PORT" <<'PY'
+import sys
+import time
+import urllib.request
+
+port = sys.argv[1]
+url = f"http://127.0.0.1:{port}/healthz"
+last_error = None
+
+for _ in range(50):
+    try:
+        urllib.request.urlopen(url, timeout=1).read()
+        sys.exit(0)
+    except Exception as exc:
+        last_error = exc
+        time.sleep(0.1)
+
+print(last_error, file=sys.stderr)
+sys.exit(1)
+PY
+
+"$CLIENT_TEST" "http://127.0.0.1:$PORT"
+
+kill -TERM "$PID"
+wait "$PID"
+trap - EXIT INT TERM

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -49,6 +49,24 @@ test_client_smoke = executable('test-client-smoke',
 
 test('client-smoke', test_client_smoke)
 
+test_client_audit_daemon = executable('test-client-audit-daemon',
+  'test-client-audit-daemon.c',
+  dependencies : [wyrelog_client_dep],
+)
+
+if host_machine.system() != 'windows' and build_client
+  test('client-audit-daemon', sh,
+    args : [
+      meson.current_source_dir() / 'check-client-audit-daemon.sh',
+      wyrelogd_exe.full_path(),
+      test_client_audit_daemon.full_path(),
+      meson.project_source_root() / 'templates' / 'access',
+      python3.full_path(),
+    ],
+    depends : [wyrelogd_exe, test_client_audit_daemon],
+  )
+endif
+
 test_traits_compile = executable('test-traits-compile',
   'test-traits-compile.c',
   dependencies : [wyrelog_dep],

--- a/tests/test-client-audit-daemon.c
+++ b/tests/test-client-audit-daemon.c
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <glib.h>
+
+#include "wyrelog/client.h"
+
+int
+main (int argc, char **argv)
+{
+  if (argc != 2)
+    return 1;
+
+  g_autoptr (WylClient) client = NULL;
+  if (wyl_client_new (argv[1], &client) != WYRELOG_E_OK)
+    return 2;
+
+  g_autoptr (WylAuditIter) iter = NULL;
+  if (wyl_client_audit_query (client, "decision=deny", &iter) != WYRELOG_E_OK)
+    return 3;
+
+  gboolean has_next = TRUE;
+  if (wyl_audit_iter_next (iter, &has_next) != WYRELOG_E_OK)
+    return 4;
+  if (has_next)
+    return 5;
+
+  has_next = TRUE;
+  if (wyl_audit_iter_next (iter, &has_next) != WYRELOG_E_OK)
+    return 6;
+  if (has_next)
+    return 7;
+
+  return 0;
+}


### PR DESCRIPTION
## Summary
- add an end-to-end smoke for client audit queries against wyrelogd
- start the daemon on an ephemeral port for the test
- cover first and repeated iterator next calls through the daemon route

## Tests
- git diff --check
- meson test -C builddir --print-errorlogs client-audit-daemon
- meson test -C builddir-audit --print-errorlogs client-audit-daemon
- meson setup builddir-noclient -Denable_client=disabled -Denable_audit=disabled -Denable_tpm=disabled --wipe && meson test -C builddir-noclient --print-errorlogs wyrelogd-check
- meson test -C builddir --print-errorlogs
- meson test -C builddir-audit --print-errorlogs