### PR TITLE
daemon: query audit event store

### DIFF
--- a/tests/test-audit-emit.c
+++ b/tests/test-audit-emit.c
@@ -239,6 +239,88 @@ check_emit_persists_event_fields (void)
 }
 
 static gint
+check_query_events_json_filters_rows (void)
+{
+  WylHandle *handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 140;
+
+  g_autoptr (WylAuditEvent) denied = wyl_audit_event_new ();
+  wyl_audit_event_set_subject_id (denied, "json-bob");
+  wyl_audit_event_set_action (denied, "write");
+  wyl_audit_event_set_resource_id (denied, "doc/99");
+  wyl_audit_event_set_deny_reason (denied, "not_armed");
+  wyl_audit_event_set_deny_origin (denied, "perm_state");
+  wyl_audit_event_set_decision (denied, WYL_DECISION_DENY);
+
+  g_autoptr (WylAuditEvent) allowed = wyl_audit_event_new ();
+  wyl_audit_event_set_subject_id (allowed, "json-alice");
+  wyl_audit_event_set_action (allowed, "read");
+  wyl_audit_event_set_resource_id (allowed, "doc/42");
+  wyl_audit_event_set_decision (allowed, WYL_DECISION_ALLOW);
+
+  if (wyl_audit_emit (handle, denied) != WYRELOG_E_OK
+      || wyl_audit_emit (handle, allowed) != WYRELOG_E_OK) {
+    g_object_unref (handle);
+    return 141;
+  }
+
+  wyl_audit_conn_t *conn = wyl_handle_get_audit_conn (handle);
+  g_autofree gchar *deny_json = NULL;
+  if (wyl_audit_conn_query_events_json (conn, "decision=deny", &deny_json)
+      != WYRELOG_E_OK) {
+    g_object_unref (handle);
+    return 142;
+  }
+  if (g_strstr_len (deny_json, -1, "\"subject_id\":\"json-bob\"") == NULL
+      || g_strstr_len (deny_json, -1, "\"subject_id\":\"json-alice\"")
+      != NULL || g_strstr_len (deny_json, -1, "\"decision\":0") == NULL) {
+    g_object_unref (handle);
+    return 143;
+  }
+
+  g_autofree gchar *action_json = NULL;
+  if (wyl_audit_conn_query_events_json (conn, "action=read", &action_json)
+      != WYRELOG_E_OK) {
+    g_object_unref (handle);
+    return 144;
+  }
+  if (g_strstr_len (action_json, -1, "\"subject_id\":\"json-alice\"") == NULL
+      || g_strstr_len (action_json, -1, "\"subject_id\":\"json-bob\"")
+      != NULL) {
+    g_object_unref (handle);
+    return 145;
+  }
+
+  g_autofree gchar *all_json = NULL;
+  if (wyl_audit_conn_query_events_json (conn, NULL, &all_json)
+      != WYRELOG_E_OK) {
+    g_object_unref (handle);
+    return 146;
+  }
+  if (g_strstr_len (all_json, -1, "\"subject_id\":\"json-alice\"") == NULL
+      || g_strstr_len (all_json, -1, "\"subject_id\":\"json-bob\"")
+      == NULL) {
+    g_object_unref (handle);
+    return 147;
+  }
+
+  g_autofree gchar *bad_json = NULL;
+  if (wyl_audit_conn_query_events_json (conn, "decision=maybe", &bad_json)
+      != WYRELOG_E_INVALID) {
+    g_object_unref (handle);
+    return 148;
+  }
+  if (bad_json != NULL) {
+    g_object_unref (handle);
+    return 149;
+  }
+
+  g_object_unref (handle);
+  return 0;
+}
+
+static gint
 check_decide_persists_representative_deny_reason (void)
 {
   WylHandle *handle = NULL;
@@ -807,6 +889,8 @@ main (void)
   if ((rc = check_emit_inserts_a_row ()) != 0)
     return rc;
   if ((rc = check_emit_persists_event_fields ()) != 0)
+    return rc;
+  if ((rc = check_query_events_json_filters_rows ()) != 0)
     return rc;
   if ((rc = check_decide_persists_representative_deny_reason ()) != 0)
     return rc;

--- a/wyrelog/audit/conn-private.h
+++ b/wyrelog/audit/conn-private.h
@@ -93,4 +93,20 @@ wyrelog_error_t wyl_audit_conn_create_schema (wyl_audit_conn_t * conn);
 wyrelog_error_t wyl_audit_conn_table_exists (wyl_audit_conn_t * conn,
     const gchar * table_name, gboolean * out_exists);
 
+/*
+ * Serialises audit_events rows to a compact JSON array ordered by newest
+ * first. @filter may be NULL/empty or one exact-match term:
+ *
+ *   decision=deny|allow
+ *   subject_id=<value>
+ *   action=<value>
+ *   resource_id=<value>
+ *   deny_reason=<value>
+ *   deny_origin=<value>
+ *
+ * On success @out_json owns a newly allocated string.
+ */
+wyrelog_error_t wyl_audit_conn_query_events_json (wyl_audit_conn_t * conn,
+    const gchar * filter, gchar ** out_json);
+
 G_END_DECLS;

--- a/wyrelog/audit/conn.c
+++ b/wyrelog/audit/conn.c
@@ -3,6 +3,8 @@
 
 #include <string.h>
 
+#include "wyrelog/decide.h"
+
 struct wyl_audit_conn_t
 {
   duckdb_database db;
@@ -131,5 +133,200 @@ wyl_audit_conn_table_exists (wyl_audit_conn_t *conn, const gchar *table_name,
 
   *out_exists = duckdb_value_int64 (&result, 0, 0) > 0;
   duckdb_destroy_result (&result);
+  return WYRELOG_E_OK;
+}
+
+static void
+append_json_string (GString *json, const gchar *value)
+{
+  g_string_append_c (json, '"');
+
+  for (const guchar * p = (const guchar *)value; *p != '\0'; p++) {
+    switch (*p) {
+      case '"':
+        g_string_append (json, "\\\"");
+        break;
+      case '\\':
+        g_string_append (json, "\\\\");
+        break;
+      case '\b':
+        g_string_append (json, "\\b");
+        break;
+      case '\f':
+        g_string_append (json, "\\f");
+        break;
+      case '\n':
+        g_string_append (json, "\\n");
+        break;
+      case '\r':
+        g_string_append (json, "\\r");
+        break;
+      case '\t':
+        g_string_append (json, "\\t");
+        break;
+      default:
+        if (*p < 0x20)
+          g_string_append_printf (json, "\\u%04x", *p);
+        else
+          g_string_append_c (json, (gchar) * p);
+        break;
+    }
+  }
+
+  g_string_append_c (json, '"');
+}
+
+static void
+append_json_member_string (GString *json, const gchar *name,
+    duckdb_result *result, idx_t col, idx_t row)
+{
+  g_string_append_c (json, '"');
+  g_string_append (json, name);
+  g_string_append (json, "\":");
+
+  if (duckdb_value_is_null (result, col, row)) {
+    g_string_append (json, "null");
+    return;
+  }
+
+  gchar *value = duckdb_value_varchar (result, col, row);
+  append_json_string (json, value);
+  duckdb_free (value);
+}
+
+static gboolean
+parse_audit_filter (const gchar *filter, const gchar **out_column,
+    gint16 *out_decision, const gchar **out_string)
+{
+  *out_column = NULL;
+  *out_string = NULL;
+  *out_decision = WYL_DECISION_DENY;
+
+  if (filter == NULL || filter[0] == '\0')
+    return TRUE;
+
+  const gchar *eq = strchr (filter, '=');
+  if (eq == NULL || eq == filter || eq[1] == '\0')
+    return FALSE;
+
+  g_autofree gchar *key = g_strndup (filter, (gsize) (eq - filter));
+  const gchar *value = eq + 1;
+
+  if (g_strcmp0 (key, "decision") == 0) {
+    *out_column = "decision";
+    if (g_strcmp0 (value, "deny") == 0) {
+      *out_decision = WYL_DECISION_DENY;
+      return TRUE;
+    }
+    if (g_strcmp0 (value, "allow") == 0) {
+      *out_decision = WYL_DECISION_ALLOW;
+      return TRUE;
+    }
+    return FALSE;
+  }
+
+  if (g_strcmp0 (key, "subject_id") == 0)
+    *out_column = "subject_id";
+  else if (g_strcmp0 (key, "action") == 0)
+    *out_column = "action";
+  else if (g_strcmp0 (key, "resource_id") == 0)
+    *out_column = "resource_id";
+  else if (g_strcmp0 (key, "deny_reason") == 0)
+    *out_column = "deny_reason";
+  else if (g_strcmp0 (key, "deny_origin") == 0)
+    *out_column = "deny_origin";
+
+  if (*out_column != NULL) {
+    *out_string = value;
+    return TRUE;
+  }
+
+  return FALSE;
+}
+
+wyrelog_error_t
+wyl_audit_conn_query_events_json (wyl_audit_conn_t *conn,
+    const gchar *filter, gchar **out_json)
+{
+  const gchar *column;
+  const gchar *string_value;
+  gint16 decision_value;
+  duckdb_prepared_statement stmt;
+  duckdb_result result;
+  duckdb_state rc;
+
+  if (conn == NULL || out_json == NULL)
+    return WYRELOG_E_INVALID;
+  *out_json = NULL;
+
+  if (!parse_audit_filter (filter, &column, &decision_value, &string_value))
+    return WYRELOG_E_INVALID;
+
+  g_autofree gchar *sql = NULL;
+  if (column == NULL) {
+    sql =
+        g_strdup ("SELECT id, created_at_us, subject_id, action, resource_id, "
+        "deny_reason, deny_origin, decision " "FROM audit_events "
+        "ORDER BY created_at_us DESC, id DESC " "LIMIT 100;");
+  } else {
+    sql =
+        g_strdup_printf
+        ("SELECT id, created_at_us, subject_id, action, resource_id, "
+        "deny_reason, deny_origin, decision " "FROM audit_events "
+        "WHERE %s = ? " "ORDER BY created_at_us DESC, id DESC " "LIMIT 100;",
+        column);
+  }
+
+  if (duckdb_prepare (conn->conn, sql, &stmt) != DuckDBSuccess) {
+    duckdb_destroy_prepare (&stmt);
+    return WYRELOG_E_IO;
+  }
+
+  if (column != NULL) {
+    duckdb_state bind_rc;
+    if (g_strcmp0 (column, "decision") == 0)
+      bind_rc = duckdb_bind_int16 (stmt, 1, decision_value);
+    else
+      bind_rc = duckdb_bind_varchar (stmt, 1, string_value);
+    if (bind_rc != DuckDBSuccess) {
+      duckdb_destroy_prepare (&stmt);
+      return WYRELOG_E_IO;
+    }
+  }
+
+  rc = duckdb_execute_prepared (stmt, &result);
+  duckdb_destroy_prepare (&stmt);
+  if (rc != DuckDBSuccess) {
+    duckdb_destroy_result (&result);
+    return WYRELOG_E_IO;
+  }
+
+  g_autoptr (GString) json = g_string_new ("[");
+  idx_t rows = duckdb_row_count (&result);
+  for (idx_t row = 0; row < rows; row++) {
+    if (row > 0)
+      g_string_append_c (json, ',');
+
+    g_string_append_c (json, '{');
+    append_json_member_string (json, "id", &result, 0, row);
+    g_string_append_printf (json, ",\"created_at_us\":%" G_GINT64_FORMAT,
+        duckdb_value_int64 (&result, 1, row));
+    g_string_append_c (json, ',');
+    append_json_member_string (json, "subject_id", &result, 2, row);
+    g_string_append_c (json, ',');
+    append_json_member_string (json, "action", &result, 3, row);
+    g_string_append_c (json, ',');
+    append_json_member_string (json, "resource_id", &result, 4, row);
+    g_string_append_c (json, ',');
+    append_json_member_string (json, "deny_reason", &result, 5, row);
+    g_string_append_c (json, ',');
+    append_json_member_string (json, "deny_origin", &result, 6, row);
+    g_string_append_printf (json, ",\"decision\":%" G_GINT16_FORMAT "}",
+        (gint16) duckdb_value_int64 (&result, 7, row));
+  }
+  g_string_append_c (json, ']');
+
+  duckdb_destroy_result (&result);
+  *out_json = g_string_free (g_steal_pointer (&json), FALSE);
   return WYRELOG_E_OK;
 }

--- a/wyrelog/daemon/wyrelogd.c
+++ b/wyrelog/daemon/wyrelogd.c
@@ -101,19 +101,48 @@ audit_events_handler (SoupServer *server, SoupServerMessage *msg,
 {
   (void) server;
   (void) path;
+
+#ifdef WYL_HAS_AUDIT
+  const gchar *filter = NULL;
+  if (query != NULL)
+    filter = g_hash_table_lookup (query, "filter");
+
+  WylHandle *handle = user_data;
+  g_autofree gchar *body = NULL;
+  wyrelog_error_t rc =
+      wyl_audit_conn_query_events_json (wyl_handle_get_audit_conn (handle),
+      filter, &body);
+  if (rc == WYRELOG_E_INVALID) {
+    const gchar *error_body = "{\"error\":\"invalid_filter\"}";
+    soup_server_message_set_status (msg, 400, NULL);
+    soup_server_message_set_response (msg, "application/json",
+        SOUP_MEMORY_COPY, error_body, strlen (error_body));
+    return;
+  }
+  if (rc != WYRELOG_E_OK) {
+    const gchar *error_body = "{\"error\":\"audit_query_failed\"}";
+    soup_server_message_set_status (msg, 500, NULL);
+    soup_server_message_set_response (msg, "application/json",
+        SOUP_MEMORY_COPY, error_body, strlen (error_body));
+    return;
+  }
+#else
   (void) query;
   (void) user_data;
-
   const gchar *body = "[]";
+#endif
+
   soup_server_message_set_status (msg, 200, NULL);
   soup_server_message_set_response (msg, "application/json",
       SOUP_MEMORY_COPY, body, strlen (body));
 }
 
 static SoupServer *
-start_http_server (const WylDaemonOptions *opts, GError **error)
+start_http_server (const WylDaemonOptions *opts, WylHandle *handle,
+    GError **error)
 {
   g_return_val_if_fail (opts != NULL, NULL);
+  g_return_val_if_fail (WYL_IS_HANDLE (handle), NULL);
 
   if (opts->listen_port < 0 || opts->listen_port > 65535) {
     g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_BAD_VALUE,
@@ -123,8 +152,8 @@ start_http_server (const WylDaemonOptions *opts, GError **error)
 
   SoupServer *server = soup_server_new (NULL, NULL);
   soup_server_add_handler (server, "/healthz", healthz_handler, NULL, NULL);
-  soup_server_add_handler (server, "/audit/events", audit_events_handler, NULL,
-      NULL);
+  soup_server_add_handler (server, "/audit/events", audit_events_handler,
+      handle, NULL);
   if (!soup_server_listen_local (server, (guint) opts->listen_port, 0, error)) {
     g_object_unref (server);
     return NULL;
@@ -366,7 +395,7 @@ main (int argc, char **argv)
 
   g_autoptr (GMainLoop) loop = g_main_loop_new (NULL, FALSE);
 #ifdef WYL_HAS_DAEMON_HTTP
-  g_autoptr (SoupServer) server = start_http_server (&opts, &error);
+  g_autoptr (SoupServer) server = start_http_server (&opts, handle, &error);
   if (server == NULL) {
     g_printerr ("wyrelogd: listen failed: %s\n", error->message);
     return 1;

--- a/wyrelog/meson.build
+++ b/wyrelog/meson.build
@@ -114,6 +114,10 @@ if libsoup_dep.found()
   wyrelogd_deps += libsoup_dep
   wyrelogd_c_args += '-DWYL_HAS_DAEMON_HTTP'
 endif
+if get_option('enable_audit').allowed()
+  wyrelogd_deps += duckdb_dep
+  wyrelogd_c_args += '-DWYL_HAS_AUDIT'
+endif
 
 wyrelogd_exe = executable('wyrelogd',
   files('daemon/wyrelogd.c'),


### PR DESCRIPTION
## Summary
- add a private audit query helper that emits recent events as JSON
- route daemon audit event requests through the handle-owned audit store
- keep audit-disabled daemon builds on the existing empty response path

## Tests
- git diff --check
- meson test -C builddir --print-errorlogs wyrelogd-healthz client-audit-daemon
- meson test -C builddir-audit --print-errorlogs audit-emit wyrelogd-healthz client-audit-daemon
- meson test -C builddir-noclient --print-errorlogs wyrelogd-check
- meson test -C builddir-audit --print-errorlogs