### PR TITLE
client: count audit response events

### DIFF
--- a/tests/test-client-smoke.c
+++ b/tests/test-client-smoke.c
@@ -11,6 +11,7 @@ typedef struct
 {
   SoupServer *server;
   GMainLoop *loop;
+  const gchar *body;
 } TestHttpServer;
 
 static gpointer
@@ -29,9 +30,9 @@ test_http_server_handler (SoupServer *server, SoupServerMessage *msg,
   (void) server;
   (void) path;
   (void) query;
-  (void) user_data;
+  TestHttpServer *http = user_data;
 
-  const gchar *body = "[]";
+  const gchar *body = http->body != NULL ? http->body : "[]";
   soup_server_message_set_status (msg, 200, NULL);
   soup_server_message_set_response (msg, "application/json", SOUP_MEMORY_COPY,
       body, strlen (body));
@@ -99,7 +100,8 @@ main (void)
   TestHttpServer http = { 0 };
   http.server = soup_server_new (NULL, NULL);
   http.loop = g_main_loop_new (NULL, FALSE);
-  soup_server_add_handler (http.server, NULL, test_http_server_handler, NULL,
+  http.body = "[]";
+  soup_server_add_handler (http.server, NULL, test_http_server_handler, &http,
       NULL);
   g_autoptr (GError) listen_error = NULL;
   if (!soup_server_listen_local (http.server, 0, 0, &listen_error))
@@ -140,6 +142,35 @@ main (void)
     return 27;
   if (has_next)
     return 28;
+
+  http.body = "[{\"id\":\"a\"},{\"id\":\"b\"}]";
+  g_autoptr (WylAuditIter) rows_iter = NULL;
+  if (wyl_client_audit_query (local_client, NULL, &rows_iter) != WYRELOG_E_OK)
+    return 29;
+  has_next = FALSE;
+  if (wyl_audit_iter_next (rows_iter, &has_next) != WYRELOG_E_OK)
+    return 30;
+  if (!has_next)
+    return 31;
+  has_next = FALSE;
+  if (wyl_audit_iter_next (rows_iter, &has_next) != WYRELOG_E_OK)
+    return 32;
+  if (!has_next)
+    return 33;
+  has_next = TRUE;
+  if (wyl_audit_iter_next (rows_iter, &has_next) != WYRELOG_E_OK)
+    return 34;
+  if (has_next)
+    return 35;
+
+  http.body = "not-json";
+  g_autoptr (WylAuditIter) invalid_iter = NULL;
+  if (wyl_client_audit_query (local_client, NULL, &invalid_iter)
+      != WYRELOG_E_OK)
+    return 36;
+  has_next = FALSE;
+  if (wyl_audit_iter_next (invalid_iter, &has_next) == WYRELOG_E_OK)
+    return 37;
 
   g_main_loop_quit (http.loop);
   g_thread_join (thread);

--- a/wyrelog/audit/iter.c
+++ b/wyrelog/audit/iter.c
@@ -8,6 +8,7 @@ struct _WylAuditIter
   GObject parent_instance;
   WylClient *client;
   gchar *query_filter;
+  guint pending_events;
   gboolean exhausted;
 };
 
@@ -88,11 +89,92 @@ wyl_audit_iter_new_request_message (WylAuditIter *iter)
   return soup_message_new ("GET", request_uri);
 }
 
+static wyrelog_error_t
+count_top_level_json_objects (const gchar *data, gsize size, guint *out_count)
+{
+  if (data == NULL || out_count == NULL)
+    return WYRELOG_E_INVALID;
+
+  gsize i = 0;
+  while (i < size && g_ascii_isspace (data[i]))
+    i++;
+  if (i >= size || data[i] != '[')
+    return WYRELOG_E_IO;
+  i++;
+
+  guint count = 0;
+  gint depth = 1;
+  gboolean in_string = FALSE;
+  gboolean escaped = FALSE;
+
+  for (; i < size; i++) {
+    gchar ch = data[i];
+
+    if (in_string) {
+      if (escaped) {
+        escaped = FALSE;
+      } else if (ch == '\\') {
+        escaped = TRUE;
+      } else if (ch == '"') {
+        in_string = FALSE;
+      }
+      continue;
+    }
+
+    if (ch == '"') {
+      in_string = TRUE;
+      continue;
+    }
+    if (g_ascii_isspace (ch) || ch == ',')
+      continue;
+    if (ch == '{') {
+      if (depth == 1)
+        count++;
+      depth++;
+      continue;
+    }
+    if (ch == '}') {
+      depth--;
+      if (depth < 1)
+        return WYRELOG_E_IO;
+      continue;
+    }
+    if (ch == '[') {
+      depth++;
+      continue;
+    }
+    if (ch == ']') {
+      depth--;
+      if (depth != 0)
+        return WYRELOG_E_IO;
+      i++;
+      break;
+    }
+
+    if (depth == 1)
+      return WYRELOG_E_IO;
+  }
+
+  while (i < size && g_ascii_isspace (data[i]))
+    i++;
+  if (depth != 0 || i != size || in_string || escaped)
+    return WYRELOG_E_IO;
+
+  *out_count = count;
+  return WYRELOG_E_OK;
+}
+
 wyrelog_error_t
 wyl_audit_iter_next (WylAuditIter *iter, gboolean *out_has_next)
 {
   if (iter == NULL || !WYL_IS_AUDIT_ITER (iter) || out_has_next == NULL)
     return WYRELOG_E_INVALID;
+
+  if (iter->pending_events > 0) {
+    iter->pending_events--;
+    *out_has_next = TRUE;
+    return WYRELOG_E_OK;
+  }
 
   if (iter->exhausted) {
     *out_has_next = FALSE;
@@ -105,7 +187,20 @@ wyl_audit_iter_next (WylAuditIter *iter, gboolean *out_has_next)
   if (rc != WYRELOG_E_OK)
     return rc;
 
+  gsize body_size = 0;
+  const gchar *body_data = g_bytes_get_data (body, &body_size);
+  guint event_count = 0;
+  rc = count_top_level_json_objects (body_data, body_size, &event_count);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
   iter->exhausted = TRUE;
-  *out_has_next = FALSE;
+  if (event_count == 0) {
+    *out_has_next = FALSE;
+    return WYRELOG_E_OK;
+  }
+
+  iter->pending_events = event_count - 1;
+  *out_has_next = TRUE;
   return WYRELOG_E_OK;
 }


### PR DESCRIPTION
## Summary
- parse audit response arrays enough to count returned events
- report buffered events through repeated iterator next calls
- cover empty, non-empty, and malformed response bodies in client smoke

## Tests
- git diff --check
- meson test -C builddir --print-errorlogs client-smoke client-audit-daemon
- meson test -C builddir --print-errorlogs client-smoke
- meson test -C builddir-audit --print-errorlogs client-smoke client-audit-daemon
- meson test -C builddir-audit --print-errorlogs client-smoke