### PR TITLE
daemon: audit startup event

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -49,8 +49,14 @@ test_client_smoke = executable('test-client-smoke',
 
 test('client-smoke', test_client_smoke)
 
+test_client_audit_daemon_c_args = []
+if get_option('enable_audit').allowed()
+  test_client_audit_daemon_c_args += '-DWYL_TEST_HAS_AUDIT'
+endif
+
 test_client_audit_daemon = executable('test-client-audit-daemon',
   'test-client-audit-daemon.c',
+  c_args : test_client_audit_daemon_c_args,
   dependencies : [wyrelog_client_dep],
 )
 

--- a/tests/test-client-audit-daemon.c
+++ b/tests/test-client-audit-daemon.c
@@ -29,5 +29,24 @@ main (int argc, char **argv)
   if (has_next)
     return 7;
 
+#ifdef WYL_TEST_HAS_AUDIT
+  g_autoptr (WylAuditIter) start_iter = NULL;
+  if (wyl_client_audit_query (client, "action=daemon_start", &start_iter)
+      != WYRELOG_E_OK)
+    return 8;
+
+  has_next = FALSE;
+  if (wyl_audit_iter_next (start_iter, &has_next) != WYRELOG_E_OK)
+    return 9;
+  if (!has_next)
+    return 10;
+
+  has_next = TRUE;
+  if (wyl_audit_iter_next (start_iter, &has_next) != WYRELOG_E_OK)
+    return 11;
+  if (has_next)
+    return 12;
+#endif
+
   return 0;
 }

--- a/wyrelog/daemon/wyrelogd.c
+++ b/wyrelog/daemon/wyrelogd.c
@@ -216,6 +216,22 @@ check_audit_sink_ready (WylHandle *handle)
   return WYRELOG_E_OK;
 }
 
+static wyrelog_error_t
+emit_daemon_start_event (WylHandle *handle)
+{
+#ifdef WYL_HAS_AUDIT
+  g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
+  wyl_audit_event_set_subject_id (ev, "wyrelogd");
+  wyl_audit_event_set_action (ev, "daemon_start");
+  wyl_audit_event_set_resource_id (ev, "audit_events");
+  wyl_audit_event_set_decision (ev, WYL_DECISION_ALLOW);
+  return wyl_audit_emit (handle, ev);
+#else
+  (void) handle;
+  return WYRELOG_E_OK;
+#endif
+}
+
 static void
 daemon_delta_cb (const gchar *relation, const gint64 *row, guint ncols,
     WylDeltaKind kind, gpointer user_data)
@@ -389,6 +405,12 @@ main (int argc, char **argv)
   rc = start_wirelog_delta_callbacks (handle, &runtime);
   if (rc != WYRELOG_E_OK) {
     g_printerr ("wyrelogd: delta callback setup failed: %s\n",
+        wyrelog_error_string (rc));
+    return 1;
+  }
+  rc = emit_daemon_start_event (handle);
+  if (rc != WYRELOG_E_OK) {
+    g_printerr ("wyrelogd: audit start event failed: %s\n",
         wyrelog_error_string (rc));
     return 1;
   }


### PR DESCRIPTION
## Summary
- emit a daemon_start audit event during normal daemon startup when audit is enabled
- keep audit-disabled startup on a no-op path
- extend the client-daemon smoke to cover a non-empty audit route response

## Tests
- git diff --check
- meson test -C builddir --print-errorlogs client-audit-daemon
- meson test -C builddir-audit --print-errorlogs client-audit-daemon wyrelogd-healthz audit-emit
- meson test -C builddir-noclient --print-errorlogs wyrelogd-check