### PR TITLE
audit: accept compound filters

### DIFF
--- a/tests/test-audit-emit.c
+++ b/tests/test-audit-emit.c
@@ -280,8 +280,8 @@ check_query_events_json_filters_rows (void)
   }
 
   g_autofree gchar *action_json = NULL;
-  if (wyl_audit_conn_query_events_json (conn, "action=read", &action_json)
-      != WYRELOG_E_OK) {
+  if (wyl_audit_conn_query_events_json (conn, "action(\"read\")",
+          &action_json) != WYRELOG_E_OK) {
     g_object_unref (handle);
     return 144;
   }
@@ -314,6 +314,33 @@ check_query_events_json_filters_rows (void)
   if (bad_json != NULL) {
     g_object_unref (handle);
     return 149;
+  }
+
+  g_autofree gchar *bad_compound_json = NULL;
+  if (wyl_audit_conn_query_events_json (conn, "action()", &bad_compound_json)
+      != WYRELOG_E_INVALID) {
+    g_object_unref (handle);
+    return 152;
+  }
+  if (bad_compound_json != NULL) {
+    g_object_unref (handle);
+    return 153;
+  }
+
+  g_autofree gchar *compound_decision_json = NULL;
+  if (wyl_audit_conn_query_events_json (conn, "decision(\"allow\")",
+          &compound_decision_json) != WYRELOG_E_OK) {
+    g_object_unref (handle);
+    return 150;
+  }
+  if (g_strstr_len (compound_decision_json, -1,
+          "\"subject_id\":\"json-alice\"") == NULL
+      || g_strstr_len (compound_decision_json, -1,
+          "\"subject_id\":\"json-bob\"") != NULL
+      || g_strstr_len (compound_decision_json, -1, "\"decision\":1")
+      == NULL) {
+    g_object_unref (handle);
+    return 151;
   }
 
   g_object_unref (handle);

--- a/tests/test-client-audit-daemon.c
+++ b/tests/test-client-audit-daemon.c
@@ -31,7 +31,7 @@ main (int argc, char **argv)
 
 #ifdef WYL_TEST_HAS_AUDIT
   g_autoptr (WylAuditIter) start_iter = NULL;
-  if (wyl_client_audit_query (client, "action=daemon_start", &start_iter)
+  if (wyl_client_audit_query (client, "action(\"daemon_start\")", &start_iter)
       != WYRELOG_E_OK)
     return 8;
 

--- a/wyrelog/audit/conn-private.h
+++ b/wyrelog/audit/conn-private.h
@@ -95,14 +95,21 @@ wyrelog_error_t wyl_audit_conn_table_exists (wyl_audit_conn_t * conn,
 
 /*
  * Serialises audit_events rows to a compact JSON array ordered by newest
- * first. @filter may be NULL/empty or one exact-match term:
+ * first. @filter may be NULL/empty or one exact-match term. Both
+ * key=value and compound predicate forms are accepted:
  *
  *   decision=deny|allow
+ *   decision("deny"|"allow")
  *   subject_id=<value>
+ *   subject_id("<value>")
  *   action=<value>
+ *   action("<value>")
  *   resource_id=<value>
+ *   resource_id("<value>")
  *   deny_reason=<value>
+ *   deny_reason("<value>")
  *   deny_origin=<value>
+ *   deny_origin("<value>")
  *
  * On success @out_json owns a newly allocated string.
  */

--- a/wyrelog/audit/conn.c
+++ b/wyrelog/audit/conn.c
@@ -195,8 +195,63 @@ append_json_member_string (GString *json, const gchar *name,
 }
 
 static gboolean
+parse_filter_key_value (const gchar *filter, gchar **out_key, gchar **out_value)
+{
+  const gchar *eq = strchr (filter, '=');
+  if (eq == NULL)
+    return FALSE;
+  if (eq == filter || eq[1] == '\0')
+    return FALSE;
+
+  *out_key = g_strndup (filter, (gsize) (eq - filter));
+  *out_value = g_strdup (eq + 1);
+  return TRUE;
+}
+
+static gboolean
+parse_filter_compound_term (const gchar *filter, gchar **out_key,
+    gchar **out_value)
+{
+  const gchar *open = strchr (filter, '(');
+  if (open == NULL)
+    return FALSE;
+  if (open == filter)
+    return FALSE;
+
+  const gchar *close = filter + strlen (filter);
+  while (close > open && g_ascii_isspace (close[-1]))
+    close--;
+  if (close <= open + 1 || close[-1] != ')')
+    return FALSE;
+  close--;
+
+  const gchar *value_start = open + 1;
+  const gchar *value_end = close;
+  while (value_start < value_end && g_ascii_isspace (*value_start))
+    value_start++;
+  while (value_end > value_start && g_ascii_isspace (value_end[-1]))
+    value_end--;
+  if (value_start >= value_end)
+    return FALSE;
+
+  if (*value_start == '"') {
+    value_start++;
+    if (value_end <= value_start || value_end[-1] != '"')
+      return FALSE;
+    value_end--;
+  }
+  if (value_start >= value_end)
+    return FALSE;
+
+  *out_key = g_strndup (filter, (gsize) (open - filter));
+  g_strstrip (*out_key);
+  *out_value = g_strndup (value_start, (gsize) (value_end - value_start));
+  return (*out_key)[0] != '\0';
+}
+
+static gboolean
 parse_audit_filter (const gchar *filter, const gchar **out_column,
-    gint16 *out_decision, const gchar **out_string)
+    gint16 *out_decision, gchar **out_string)
 {
   *out_column = NULL;
   *out_string = NULL;
@@ -205,12 +260,11 @@ parse_audit_filter (const gchar *filter, const gchar **out_column,
   if (filter == NULL || filter[0] == '\0')
     return TRUE;
 
-  const gchar *eq = strchr (filter, '=');
-  if (eq == NULL || eq == filter || eq[1] == '\0')
+  g_autofree gchar *key = NULL;
+  g_autofree gchar *value = NULL;
+  if (!parse_filter_key_value (filter, &key, &value)
+      && !parse_filter_compound_term (filter, &key, &value))
     return FALSE;
-
-  g_autofree gchar *key = g_strndup (filter, (gsize) (eq - filter));
-  const gchar *value = eq + 1;
 
   if (g_strcmp0 (key, "decision") == 0) {
     *out_column = "decision";
@@ -237,7 +291,7 @@ parse_audit_filter (const gchar *filter, const gchar **out_column,
     *out_column = "deny_origin";
 
   if (*out_column != NULL) {
-    *out_string = value;
+    *out_string = g_steal_pointer (&value);
     return TRUE;
   }
 
@@ -249,7 +303,7 @@ wyl_audit_conn_query_events_json (wyl_audit_conn_t *conn,
     const gchar *filter, gchar **out_json)
 {
   const gchar *column;
-  const gchar *string_value;
+  g_autofree gchar *string_value = NULL;
   gint16 decision_value;
   duckdb_prepared_statement stmt;
   duckdb_result result;


### PR DESCRIPTION
## Summary
- accept predicate-style compound audit filters alongside key=value filters
- normalize both forms through the same whitelisted exact-match query path
- cover compound action, decision, and invalid filter cases

## Tests
- git diff --check
- meson test -C builddir-audit --print-errorlogs audit-emit client-audit-daemon
- meson test -C builddir --print-errorlogs client-audit-daemon