### PR TITLE
daemon: test audit filter errors

### DIFF
--- a/tests/check-wyrelogd-healthz.sh
+++ b/tests/check-wyrelogd-healthz.sh
@@ -6,6 +6,7 @@ set -eu
 WYRELOGD=$1
 TEMPLATE_DIR=$2
 PYTHON=$3
+EXPECT_AUDIT=${4:-0}
 PORT=$((39000 + $$ % 20000))
 
 "$WYRELOGD" --template-dir "$TEMPLATE_DIR" --listen-port "$PORT" &
@@ -16,14 +17,26 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 
-"$PYTHON" - "$PORT" <<'PY'
+"$PYTHON" - "$PORT" "$EXPECT_AUDIT" <<'PY'
 import sys
 import time
 import urllib.request
+import urllib.error
 
 port = sys.argv[1]
+expect_audit = sys.argv[2] == "1"
 base = f"http://127.0.0.1:{port}"
 last_error = None
+
+def invalid_filter_is_rejected():
+    try:
+        urllib.request.urlopen(
+            f"{base}/audit/events?filter=action%28%29",
+            timeout=1,
+        ).read()
+        return False
+    except urllib.error.HTTPError as exc:
+        return exc.code == 400
 
 for _ in range(50):
     try:
@@ -32,7 +45,11 @@ for _ in range(50):
             f"{base}/audit/events?filter=decision%3Ddeny",
             timeout=1,
         ).read()
-        sys.exit(0 if health == b"ok\n" and events == b"[]" else 1)
+        if health != b"ok\n" or events != b"[]":
+            sys.exit(1)
+        if expect_audit and not invalid_filter_is_rejected():
+            sys.exit(1)
+        sys.exit(0)
     except Exception as exc:
         last_error = exc
         time.sleep(0.1)

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -31,12 +31,17 @@ if host_machine.system() != 'windows'
   )
 
   python3 = find_program('python3')
+  wyrelogd_healthz_expect_audit = '0'
+  if get_option('enable_audit').allowed()
+    wyrelogd_healthz_expect_audit = '1'
+  endif
   test('wyrelogd-healthz', sh,
     args : [
       meson.current_source_dir() / 'check-wyrelogd-healthz.sh',
       wyrelogd_exe.full_path(),
       meson.project_source_root() / 'templates' / 'access',
       python3.full_path(),
+      wyrelogd_healthz_expect_audit,
     ],
     depends : wyrelogd_exe,
   )


### PR DESCRIPTION
## Summary
- pass an audit-enabled expectation into the daemon health smoke
- check malformed audit filters return HTTP 400 when audit routing is active
- keep audit-disabled builds on the existing empty-response path

## Tests
- git diff --check
- meson test -C builddir --print-errorlogs wyrelogd-healthz
- meson test -C builddir-audit --print-errorlogs wyrelogd-healthz