### PR TITLE
client: materialize audit events

### DIFF
--- a/tests/test-audit-event.c
+++ b/tests/test-audit-event.c
@@ -3,6 +3,7 @@
 #include <string.h>
 
 #include "wyrelog/wyrelog.h"
+#include "wyrelog/audit/event-private.h"
 
 static gint
 check_construction (void)
@@ -79,6 +80,56 @@ check_created_at_monotonic_with_minting_order (void)
   if (wyl_audit_event_get_created_at_us (a)
       >= wyl_audit_event_get_created_at_us (b))
     return 60;
+  return 0;
+}
+
+static gint
+check_private_rehydrate_preserves_fields (void)
+{
+  const gchar *id = "018f3f9b-7f4d-7a2e-8a51-467a0bc7d001";
+  g_autoptr (WylAuditEvent) ev = NULL;
+  if (wyl_audit_event_new_from_fields (id, 1234567, "alice", "read",
+          "doc/42", "not_armed", "perm_state", WYL_DECISION_ALLOW, &ev)
+      != WYRELOG_E_OK)
+    return 65;
+
+  g_autofree gchar *actual_id = wyl_audit_event_dup_id_string (ev);
+  if (g_strcmp0 (actual_id, id) != 0)
+    return 66;
+  if (wyl_audit_event_get_created_at_us (ev) != 1234567)
+    return 67;
+  if (g_strcmp0 (wyl_audit_event_get_subject_id (ev), "alice") != 0)
+    return 68;
+  if (g_strcmp0 (wyl_audit_event_get_action (ev), "read") != 0)
+    return 69;
+  if (g_strcmp0 (wyl_audit_event_get_resource_id (ev), "doc/42") != 0)
+    return 72;
+  if (g_strcmp0 (wyl_audit_event_get_deny_reason (ev), "not_armed") != 0)
+    return 73;
+  if (g_strcmp0 (wyl_audit_event_get_deny_origin (ev), "perm_state") != 0)
+    return 74;
+  if (wyl_audit_event_get_decision (ev) != WYL_DECISION_ALLOW)
+    return 75;
+  return 0;
+}
+
+static gint
+check_private_rehydrate_rejects_invalid_fields (void)
+{
+  WylAuditEvent *ev = (WylAuditEvent *) (gpointer) 0x1;
+  if (wyl_audit_event_new_from_fields (NULL, 1, NULL, NULL, NULL, NULL, NULL,
+          WYL_DECISION_DENY, &ev) != WYRELOG_E_INVALID)
+    return 76;
+  if (ev != NULL)
+    return 77;
+  if (wyl_audit_event_new_from_fields ("018f3f9b-7f4d-7a2e-8a51-467a0bc7d001",
+          -1, NULL, NULL, NULL, NULL, NULL, WYL_DECISION_DENY,
+          &ev) != WYRELOG_E_INVALID)
+    return 78;
+  if (wyl_audit_event_new_from_fields ("018f3f9b-7f4d-7a2e-8a51-467a0bc7d001",
+          1, NULL, NULL, NULL, NULL, NULL, (wyl_decision_t) 99,
+          &ev) != WYRELOG_E_INVALID)
+    return 79;
   return 0;
 }
 
@@ -226,6 +277,10 @@ main (void)
   if ((rc = check_created_at_is_recent ()) != 0)
     return rc;
   if ((rc = check_created_at_monotonic_with_minting_order ()) != 0)
+    return rc;
+  if ((rc = check_private_rehydrate_preserves_fields ()) != 0)
+    return rc;
+  if ((rc = check_private_rehydrate_rejects_invalid_fields ()) != 0)
     return rc;
   if ((rc = check_accessor_null_safety ()) != 0)
     return rc;

--- a/tests/test-client-audit-daemon.c
+++ b/tests/test-client-audit-daemon.c
@@ -40,6 +40,12 @@ main (int argc, char **argv)
     return 9;
   if (!has_next)
     return 10;
+  g_autoptr (WylAuditEvent) start_event = wyl_audit_iter_ref_event (start_iter);
+  if (start_event == NULL)
+    return 13;
+  if (g_strcmp0 (wyl_audit_event_get_action (start_event), "daemon_start")
+      != 0)
+    return 14;
 
   has_next = TRUE;
   if (wyl_audit_iter_next (start_iter, &has_next) != WYRELOG_E_OK)

--- a/tests/test-client-smoke.c
+++ b/tests/test-client-smoke.c
@@ -14,6 +14,23 @@ typedef struct
   const gchar *body;
 } TestHttpServer;
 
+static const gchar *two_event_body =
+    "[{\"id\":\"018f3f9b-7f4d-7a2e-8a51-467a0bc7d001\","
+    "\"created_at_us\":1234567,"
+    "\"subject_id\":\"alice\","
+    "\"action\":\"read\","
+    "\"resource_id\":\"doc/42\","
+    "\"deny_reason\":null,"
+    "\"deny_origin\":null,"
+    "\"decision\":1},"
+    "{\"id\":\"018f3f9b-7f4d-7a2e-8a51-467a0bc7d002\","
+    "\"created_at_us\":1234568,"
+    "\"subject_id\":\"bob\","
+    "\"action\":\"write\","
+    "\"resource_id\":\"doc/43\","
+    "\"deny_reason\":\"missing_grant\","
+    "\"deny_origin\":\"policy\"," "\"decision\":0}]";
+
 static gpointer
 test_http_server_thread (gpointer data)
 {
@@ -142,8 +159,10 @@ main (void)
     return 27;
   if (has_next)
     return 28;
+  if (wyl_audit_iter_ref_event (local_iter) != NULL)
+    return 38;
 
-  http.body = "[{\"id\":\"a\"},{\"id\":\"b\"}]";
+  http.body = two_event_body;
   g_autoptr (WylAuditIter) rows_iter = NULL;
   if (wyl_client_audit_query (local_client, NULL, &rows_iter) != WYRELOG_E_OK)
     return 29;
@@ -152,16 +171,43 @@ main (void)
     return 30;
   if (!has_next)
     return 31;
+  g_autoptr (WylAuditEvent) first_event = wyl_audit_iter_ref_event (rows_iter);
+  if (first_event == NULL)
+    return 39;
+  if (wyl_audit_event_get_created_at_us (first_event) != 1234567)
+    return 40;
+  if (g_strcmp0 (wyl_audit_event_get_subject_id (first_event), "alice") != 0)
+    return 41;
+  if (g_strcmp0 (wyl_audit_event_get_action (first_event), "read") != 0)
+    return 42;
+  if (g_strcmp0 (wyl_audit_event_get_resource_id (first_event), "doc/42") != 0)
+    return 43;
+  if (wyl_audit_event_get_decision (first_event) != WYL_DECISION_ALLOW)
+    return 44;
   has_next = FALSE;
   if (wyl_audit_iter_next (rows_iter, &has_next) != WYRELOG_E_OK)
     return 32;
   if (!has_next)
     return 33;
+  g_autoptr (WylAuditEvent) second_event = wyl_audit_iter_ref_event (rows_iter);
+  if (second_event == NULL)
+    return 45;
+  if (g_strcmp0 (wyl_audit_event_get_subject_id (second_event), "bob") != 0)
+    return 46;
+  if (g_strcmp0 (wyl_audit_event_get_deny_reason (second_event),
+          "missing_grant") != 0)
+    return 47;
+  if (g_strcmp0 (wyl_audit_event_get_deny_origin (second_event), "policy") != 0)
+    return 48;
+  if (wyl_audit_event_get_decision (second_event) != WYL_DECISION_DENY)
+    return 49;
   has_next = TRUE;
   if (wyl_audit_iter_next (rows_iter, &has_next) != WYRELOG_E_OK)
     return 34;
   if (has_next)
     return 35;
+  if (wyl_audit_iter_ref_event (rows_iter) != NULL)
+    return 50;
 
   http.body = "not-json";
   g_autoptr (WylAuditIter) invalid_iter = NULL;

--- a/wyrelog/audit/event-private.h
+++ b/wyrelog/audit/event-private.h
@@ -1,0 +1,22 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+
+#include "wyrelog/audit.h"
+
+G_BEGIN_DECLS;
+
+/*
+ * Rehydrates an audit event from persisted wire/store fields. This is private
+ * because callers should not mint arbitrary ids or timestamps for newly
+ * produced audit events.
+ */
+wyrelog_error_t wyl_audit_event_new_from_fields (const gchar * id,
+    gint64 created_at_us,
+    const gchar * subject_id,
+    const gchar * action,
+    const gchar * resource_id,
+    const gchar * deny_reason,
+    const gchar * deny_origin,
+    wyl_decision_t decision, WylAuditEvent ** out_event);
+
+G_END_DECLS;

--- a/wyrelog/audit/event.c
+++ b/wyrelog/audit/event.c
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #include "wyrelog/wyrelog.h"
 
+#include "audit/event-private.h"
 #include "wyl-id-private.h"
 
 #ifdef WYL_HAS_AUDIT
@@ -69,6 +70,39 @@ WylAuditEvent *
 wyl_audit_event_new (void)
 {
   return g_object_new (WYL_TYPE_AUDIT_EVENT, NULL);
+}
+
+wyrelog_error_t
+wyl_audit_event_new_from_fields (const gchar *id, gint64 created_at_us,
+    const gchar *subject_id, const gchar *action, const gchar *resource_id,
+    const gchar *deny_reason, const gchar *deny_origin,
+    wyl_decision_t decision, WylAuditEvent **out_event)
+{
+  wyl_id_t parsed_id;
+
+  if (out_event == NULL)
+    return WYRELOG_E_INVALID;
+  *out_event = NULL;
+  if (id == NULL || created_at_us < 0)
+    return WYRELOG_E_INVALID;
+  if (decision != WYL_DECISION_DENY && decision != WYL_DECISION_ALLOW)
+    return WYRELOG_E_INVALID;
+  wyrelog_error_t rc = wyl_id_parse (id, &parsed_id);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  WylAuditEvent *self = wyl_audit_event_new ();
+  self->id = parsed_id;
+  self->created_at_us = created_at_us;
+  wyl_audit_event_set_subject_id (self, subject_id);
+  wyl_audit_event_set_action (self, action);
+  wyl_audit_event_set_resource_id (self, resource_id);
+  wyl_audit_event_set_deny_reason (self, deny_reason);
+  wyl_audit_event_set_deny_origin (self, deny_origin);
+  wyl_audit_event_set_decision (self, decision);
+
+  *out_event = self;
+  return WYRELOG_E_OK;
 }
 
 gchar *

--- a/wyrelog/audit/iter.c
+++ b/wyrelog/audit/iter.c
@@ -3,12 +3,18 @@
 #include "wyrelog/client.h"
 #include "wyrelog/wyl-client-private.h"
 
+#include <string.h>
+
+#include "audit/event-private.h"
+
 struct _WylAuditIter
 {
   GObject parent_instance;
   WylClient *client;
   gchar *query_filter;
-  guint pending_events;
+  GPtrArray *events;
+  guint event_index;
+  WylAuditEvent *current_event;
   gboolean exhausted;
 };
 
@@ -20,6 +26,8 @@ wyl_audit_iter_finalize (GObject *object)
   WylAuditIter *self = WYL_AUDIT_ITER (object);
 
   g_clear_object (&self->client);
+  g_clear_pointer (&self->events, g_ptr_array_unref);
+  g_clear_object (&self->current_event);
   g_free (self->query_filter);
 
   G_OBJECT_CLASS (wyl_audit_iter_parent_class)->finalize (object);
@@ -89,78 +97,296 @@ wyl_audit_iter_new_request_message (WylAuditIter *iter)
   return soup_message_new ("GET", request_uri);
 }
 
-static wyrelog_error_t
-count_top_level_json_objects (const gchar *data, gsize size, guint *out_count)
+WylAuditEvent *
+wyl_audit_iter_ref_event (const WylAuditIter *iter)
 {
-  if (data == NULL || out_count == NULL)
-    return WYRELOG_E_INVALID;
+  g_return_val_if_fail (WYL_IS_AUDIT_ITER ((WylAuditIter *) iter), NULL);
+  if (iter->current_event == NULL)
+    return NULL;
+  return g_object_ref (iter->current_event);
+}
 
-  gsize i = 0;
-  while (i < size && g_ascii_isspace (data[i]))
-    i++;
-  if (i >= size || data[i] != '[')
-    return WYRELOG_E_IO;
-  i++;
+typedef struct
+{
+  const gchar *data;
+  gsize size;
+  gsize pos;
+} JsonCursor;
 
-  guint count = 0;
-  gint depth = 1;
-  gboolean in_string = FALSE;
-  gboolean escaped = FALSE;
+static void
+json_skip_ws (JsonCursor *cursor)
+{
+  while (cursor->pos < cursor->size
+      && g_ascii_isspace (cursor->data[cursor->pos]))
+    cursor->pos++;
+}
 
-  for (; i < size; i++) {
-    gchar ch = data[i];
+static gboolean
+json_consume (JsonCursor *cursor, gchar ch)
+{
+  json_skip_ws (cursor);
+  if (cursor->pos >= cursor->size || cursor->data[cursor->pos] != ch)
+    return FALSE;
+  cursor->pos++;
+  return TRUE;
+}
 
-    if (in_string) {
-      if (escaped) {
-        escaped = FALSE;
-      } else if (ch == '\\') {
-        escaped = TRUE;
-      } else if (ch == '"') {
-        in_string = FALSE;
-      }
-      continue;
-    }
+static gint
+json_hex_value (gchar ch)
+{
+  if (ch >= '0' && ch <= '9')
+    return ch - '0';
+  if (ch >= 'a' && ch <= 'f')
+    return ch - 'a' + 10;
+  if (ch >= 'A' && ch <= 'F')
+    return ch - 'A' + 10;
+  return -1;
+}
 
+static gboolean
+json_parse_string (JsonCursor *cursor, gchar **out_string)
+{
+  if (out_string == NULL)
+    return FALSE;
+  *out_string = NULL;
+  json_skip_ws (cursor);
+  if (cursor->pos >= cursor->size || cursor->data[cursor->pos] != '"')
+    return FALSE;
+  cursor->pos++;
+
+  g_autoptr (GString) value = g_string_new (NULL);
+  while (cursor->pos < cursor->size) {
+    guchar ch = (guchar) cursor->data[cursor->pos++];
     if (ch == '"') {
-      in_string = TRUE;
+      *out_string = g_string_free (g_steal_pointer (&value), FALSE);
+      return TRUE;
+    }
+    if (ch < 0x20)
+      return FALSE;
+    if (ch != '\\') {
+      g_string_append_c (value, (gchar) ch);
       continue;
     }
-    if (g_ascii_isspace (ch) || ch == ',')
-      continue;
-    if (ch == '{') {
-      if (depth == 1)
-        count++;
-      depth++;
-      continue;
+    if (cursor->pos >= cursor->size)
+      return FALSE;
+    ch = (guchar) cursor->data[cursor->pos++];
+    switch (ch) {
+      case '"':
+      case '\\':
+      case '/':
+        g_string_append_c (value, (gchar) ch);
+        break;
+      case 'b':
+        g_string_append_c (value, '\b');
+        break;
+      case 'f':
+        g_string_append_c (value, '\f');
+        break;
+      case 'n':
+        g_string_append_c (value, '\n');
+        break;
+      case 'r':
+        g_string_append_c (value, '\r');
+        break;
+      case 't':
+        g_string_append_c (value, '\t');
+        break;
+      case 'u':
+      {
+        gunichar codepoint = 0;
+        for (guint i = 0; i < 4; i++) {
+          if (cursor->pos >= cursor->size)
+            return FALSE;
+          gint nibble = json_hex_value (cursor->data[cursor->pos++]);
+          if (nibble < 0)
+            return FALSE;
+          codepoint = (codepoint << 4) | (gunichar) nibble;
+        }
+        if (!g_unichar_validate (codepoint))
+          return FALSE;
+        g_string_append_unichar (value, codepoint);
+        break;
+      }
+      default:
+        return FALSE;
     }
-    if (ch == '}') {
-      depth--;
-      if (depth < 1)
-        return WYRELOG_E_IO;
-      continue;
-    }
-    if (ch == '[') {
-      depth++;
-      continue;
-    }
-    if (ch == ']') {
-      depth--;
-      if (depth != 0)
-        return WYRELOG_E_IO;
-      i++;
-      break;
-    }
-
-    if (depth == 1)
-      return WYRELOG_E_IO;
   }
 
-  while (i < size && g_ascii_isspace (data[i]))
-    i++;
-  if (depth != 0 || i != size || in_string || escaped)
+  return FALSE;
+}
+
+static gboolean
+json_parse_nullable_string (JsonCursor *cursor, gchar **out_string)
+{
+  if (out_string == NULL)
+    return FALSE;
+  *out_string = NULL;
+  json_skip_ws (cursor);
+  if (cursor->pos + 4 <= cursor->size
+      && memcmp (cursor->data + cursor->pos, "null", 4) == 0) {
+    cursor->pos += 4;
+    return TRUE;
+  }
+  return json_parse_string (cursor, out_string);
+}
+
+static gboolean
+json_parse_int64 (JsonCursor *cursor, gint64 *out_value)
+{
+  json_skip_ws (cursor);
+  if (cursor->pos >= cursor->size || out_value == NULL)
+    return FALSE;
+
+  gsize start = cursor->pos;
+  if (cursor->data[cursor->pos] == '-')
+    cursor->pos++;
+  if (cursor->pos >= cursor->size
+      || !g_ascii_isdigit (cursor->data[cursor->pos]))
+    return FALSE;
+  if (cursor->data[cursor->pos] == '0') {
+    cursor->pos++;
+  } else {
+    while (cursor->pos < cursor->size
+        && g_ascii_isdigit (cursor->data[cursor->pos]))
+      cursor->pos++;
+  }
+  g_autofree gchar *text =
+      g_strndup (cursor->data + start, cursor->pos - start);
+  gchar *end = NULL;
+  gint64 value = g_ascii_strtoll (text, &end, 10);
+  if (end == NULL || *end != '\0')
+    return FALSE;
+  *out_value = value;
+  return TRUE;
+}
+
+static wyrelog_error_t
+parse_audit_event_object (JsonCursor *cursor, WylAuditEvent **out_event)
+{
+  g_autofree gchar *id = NULL;
+  g_autofree gchar *subject_id = NULL;
+  g_autofree gchar *action = NULL;
+  g_autofree gchar *resource_id = NULL;
+  g_autofree gchar *deny_reason = NULL;
+  g_autofree gchar *deny_origin = NULL;
+  gint64 created_at_us = -1;
+  gint64 decision_raw = -1;
+  gboolean have_created_at = FALSE;
+  gboolean have_decision = FALSE;
+
+  if (out_event == NULL)
+    return WYRELOG_E_INVALID;
+  *out_event = NULL;
+  if (!json_consume (cursor, '{'))
     return WYRELOG_E_IO;
 
-  *out_count = count;
+  json_skip_ws (cursor);
+  if (cursor->pos < cursor->size && cursor->data[cursor->pos] == '}') {
+    cursor->pos++;
+    return WYRELOG_E_IO;
+  }
+
+  while (TRUE) {
+    g_autofree gchar *key = NULL;
+    if (!json_parse_string (cursor, &key) || !json_consume (cursor, ':'))
+      return WYRELOG_E_IO;
+
+    if (g_strcmp0 (key, "id") == 0) {
+      if (!json_parse_nullable_string (cursor, &id) || id == NULL)
+        return WYRELOG_E_IO;
+    } else if (g_strcmp0 (key, "created_at_us") == 0) {
+      if (!json_parse_int64 (cursor, &created_at_us))
+        return WYRELOG_E_IO;
+      have_created_at = TRUE;
+    } else if (g_strcmp0 (key, "subject_id") == 0) {
+      if (!json_parse_nullable_string (cursor, &subject_id))
+        return WYRELOG_E_IO;
+    } else if (g_strcmp0 (key, "action") == 0) {
+      if (!json_parse_nullable_string (cursor, &action))
+        return WYRELOG_E_IO;
+    } else if (g_strcmp0 (key, "resource_id") == 0) {
+      if (!json_parse_nullable_string (cursor, &resource_id))
+        return WYRELOG_E_IO;
+    } else if (g_strcmp0 (key, "deny_reason") == 0) {
+      if (!json_parse_nullable_string (cursor, &deny_reason))
+        return WYRELOG_E_IO;
+    } else if (g_strcmp0 (key, "deny_origin") == 0) {
+      if (!json_parse_nullable_string (cursor, &deny_origin))
+        return WYRELOG_E_IO;
+    } else if (g_strcmp0 (key, "decision") == 0) {
+      if (!json_parse_int64 (cursor, &decision_raw))
+        return WYRELOG_E_IO;
+      have_decision = TRUE;
+    } else {
+      return WYRELOG_E_IO;
+    }
+
+    json_skip_ws (cursor);
+    if (cursor->pos >= cursor->size)
+      return WYRELOG_E_IO;
+    if (cursor->data[cursor->pos] == ',') {
+      cursor->pos++;
+      continue;
+    }
+    if (cursor->data[cursor->pos] == '}') {
+      cursor->pos++;
+      break;
+    }
+    return WYRELOG_E_IO;
+  }
+
+  if (id == NULL || !have_created_at || !have_decision)
+    return WYRELOG_E_IO;
+
+  return wyl_audit_event_new_from_fields (id, created_at_us, subject_id,
+      action, resource_id, deny_reason, deny_origin,
+      (wyl_decision_t) decision_raw, out_event);
+}
+
+static wyrelog_error_t
+parse_audit_events_json (const gchar *data, gsize size, GPtrArray **out_events)
+{
+  if (data == NULL || out_events == NULL)
+    return WYRELOG_E_INVALID;
+  *out_events = NULL;
+
+  JsonCursor cursor = { data, size, 0 };
+  if (!json_consume (&cursor, '['))
+    return WYRELOG_E_IO;
+
+  g_autoptr (GPtrArray) events =
+      g_ptr_array_new_with_free_func (g_object_unref);
+  json_skip_ws (&cursor);
+  if (cursor.pos < cursor.size && cursor.data[cursor.pos] == ']') {
+    cursor.pos++;
+  } else {
+    while (TRUE) {
+      g_autoptr (WylAuditEvent) event = NULL;
+      wyrelog_error_t rc = parse_audit_event_object (&cursor, &event);
+      if (rc != WYRELOG_E_OK)
+        return rc == WYRELOG_E_INVALID ? WYRELOG_E_IO : rc;
+      g_ptr_array_add (events, g_steal_pointer (&event));
+
+      json_skip_ws (&cursor);
+      if (cursor.pos >= cursor.size)
+        return WYRELOG_E_IO;
+      if (cursor.data[cursor.pos] == ',') {
+        cursor.pos++;
+        continue;
+      }
+      if (cursor.data[cursor.pos] == ']') {
+        cursor.pos++;
+        break;
+      }
+      return WYRELOG_E_IO;
+    }
+  }
+
+  json_skip_ws (&cursor);
+  if (cursor.pos != cursor.size)
+    return WYRELOG_E_IO;
+
+  *out_events = g_steal_pointer (&events);
   return WYRELOG_E_OK;
 }
 
@@ -170,8 +396,10 @@ wyl_audit_iter_next (WylAuditIter *iter, gboolean *out_has_next)
   if (iter == NULL || !WYL_IS_AUDIT_ITER (iter) || out_has_next == NULL)
     return WYRELOG_E_INVALID;
 
-  if (iter->pending_events > 0) {
-    iter->pending_events--;
+  g_clear_object (&iter->current_event);
+  if (iter->events != NULL && iter->event_index < iter->events->len) {
+    iter->current_event =
+        g_object_ref (g_ptr_array_index (iter->events, iter->event_index++));
     *out_has_next = TRUE;
     return WYRELOG_E_OK;
   }
@@ -189,18 +417,20 @@ wyl_audit_iter_next (WylAuditIter *iter, gboolean *out_has_next)
 
   gsize body_size = 0;
   const gchar *body_data = g_bytes_get_data (body, &body_size);
-  guint event_count = 0;
-  rc = count_top_level_json_objects (body_data, body_size, &event_count);
+  g_clear_pointer (&iter->events, g_ptr_array_unref);
+  iter->event_index = 0;
+  rc = parse_audit_events_json (body_data, body_size, &iter->events);
   if (rc != WYRELOG_E_OK)
     return rc;
 
   iter->exhausted = TRUE;
-  if (event_count == 0) {
+  if (iter->events->len == 0) {
     *out_has_next = FALSE;
     return WYRELOG_E_OK;
   }
 
-  iter->pending_events = event_count - 1;
+  iter->current_event =
+      g_object_ref (g_ptr_array_index (iter->events, iter->event_index++));
   *out_has_next = TRUE;
   return WYRELOG_E_OK;
 }

--- a/wyrelog/client.h
+++ b/wyrelog/client.h
@@ -50,6 +50,7 @@ wyrelog_error_t wyl_client_audit_query (WylClient * client,
     const gchar * query_filter, WylAuditIter ** out_iter);
 gchar *wyl_audit_iter_dup_query_filter (const WylAuditIter * iter);
 gchar *wyl_audit_iter_dup_request_uri (const WylAuditIter * iter);
+WylAuditEvent *wyl_audit_iter_ref_event (const WylAuditIter * iter);
 wyrelog_error_t wyl_audit_iter_next (WylAuditIter * iter,
     gboolean * out_has_next);
 

--- a/wyrelog/client.h
+++ b/wyrelog/client.h
@@ -4,6 +4,7 @@
 #include <glib.h>
 #include <glib-object.h>
 
+#include "wyrelog/audit.h"
 #include "wyrelog/error.h"
 
 G_BEGIN_DECLS;

--- a/wyrelog/meson.build
+++ b/wyrelog/meson.build
@@ -90,7 +90,7 @@ if build_client
   libwyrelog_client = library('wyrelog-client',
     wyrelog_client_sources,
     include_directories : wyrelog_inc,
-    dependencies : [glib_dep, gio_dep, libsoup_dep],
+    dependencies : [wyrelog_dep, glib_dep, gio_dep, libsoup_dep],
     install : true,
     soversion : '0',
   )
@@ -100,7 +100,7 @@ if build_client
   wyrelog_client_dep = declare_dependency(
     link_with : libwyrelog_client,
     include_directories : wyrelog_inc,
-    dependencies : [glib_dep, gio_dep],
+    dependencies : [wyrelog_dep, glib_dep, gio_dep],
   )
 else
   wyrelog_client_dep = disabler()


### PR DESCRIPTION
## Summary

- expose the audit event type through the client API dependency chain
- add private event rehydration for persisted audit rows
- parse audit query responses into iterator-owned WylAuditEvent objects
- verify materialized event fields in client and daemon audit tests

## Validation

- meson test -C builddir --print-errorlogs client-smoke client-audit-daemon audit-event
- meson test -C builddir-audit --print-errorlogs client-smoke client-audit-daemon audit-event audit-emit wyrelogd-healthz
- meson test -C builddir-noclient --print-errorlogs wyrelogd-check