### PR TITLE
daemon: audit wirelog member deltas

### DIFF
--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -366,6 +366,30 @@ check_symbol_intern_is_stable (void)
 }
 
 static gint
+check_symbol_intern_can_be_reversed (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  gint64 id = -1;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 28;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 29;
+  if (wyl_handle_intern_engine_symbol (handle, "reverse-symbol", &id)
+      != WYRELOG_E_OK)
+    return 30;
+  g_autofree gchar *symbol = wyl_handle_dup_engine_symbol (handle, id);
+  if (g_strcmp0 (symbol, "reverse-symbol") != 0)
+    return 31;
+  if (wyl_handle_dup_engine_symbol (handle, -42) != NULL)
+    return 32;
+  if (wyl_handle_dup_engine_symbol (NULL, id) != NULL)
+    return 33;
+  return 0;
+}
+
+static gint
 check_symbol_intern_rejects_missing_pair (void)
 {
   g_autoptr (WylHandle) handle = NULL;
@@ -1027,6 +1051,8 @@ main (void)
   if ((rc = check_symbol_intern_reaches_both_engines ()) != 0)
     return rc;
   if ((rc = check_symbol_intern_is_stable ()) != 0)
+    return rc;
+  if ((rc = check_symbol_intern_can_be_reversed ()) != 0)
     return rc;
   if ((rc = check_symbol_intern_rejects_missing_pair ()) != 0)
     return rc;

--- a/wyrelog/daemon/wyrelogd.c
+++ b/wyrelog/daemon/wyrelogd.c
@@ -28,6 +28,7 @@ typedef struct
 
 typedef struct
 {
+  WylHandle *handle;
   guint64 inserted;
   guint64 removed;
   gboolean expect_effective_member;
@@ -35,6 +36,57 @@ typedef struct
   gboolean matched_expected_insert;
   gboolean matched_expected_remove;
 } WylDaemonRuntime;
+
+#ifdef WYL_HAS_AUDIT
+static void
+emit_wirelog_effective_member_audit (WylDaemonRuntime *runtime,
+    const gint64 row[3], WylDeltaKind kind)
+{
+  if (runtime == NULL || runtime->handle == NULL)
+    return;
+
+  g_autofree gchar *user =
+      wyl_handle_dup_engine_symbol (runtime->handle, row[0]);
+  g_autofree gchar *role =
+      wyl_handle_dup_engine_symbol (runtime->handle, row[1]);
+  g_autofree gchar *scope =
+      wyl_handle_dup_engine_symbol (runtime->handle, row[2]);
+  if (user == NULL || role == NULL || scope == NULL)
+    return;
+
+  g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
+  wyl_audit_event_set_subject_id (ev, user);
+  wyl_audit_event_set_action (ev, "effective_member_delta");
+  wyl_audit_event_set_resource_id (ev, role);
+  wyl_audit_event_set_deny_reason (ev,
+      kind == WYL_DELTA_INSERT ? "insert" : "remove");
+  wyl_audit_event_set_deny_origin (ev, scope);
+  wyl_audit_event_set_decision (ev, WYL_DECISION_ALLOW);
+  (void) wyl_audit_emit (runtime->handle, ev);
+}
+
+static wyrelog_error_t
+check_wirelog_delta_audit_rows (WylHandle *handle)
+{
+  duckdb_connection conn =
+      wyl_audit_conn_get_connection (wyl_handle_get_audit_conn (handle));
+  duckdb_result result;
+  if (duckdb_query (conn,
+          "SELECT COUNT(*) FROM audit_events "
+          "WHERE action = 'effective_member_delta' "
+          "AND subject_id = 'wyrelogd-check-user' "
+          "AND resource_id = 'wr.viewer' "
+          "AND deny_origin = 'wyrelogd-check-scope';", &result)
+      != DuckDBSuccess) {
+    duckdb_destroy_result (&result);
+    return WYRELOG_E_IO;
+  }
+
+  gint64 rows = duckdb_value_int64 (&result, 0, 0);
+  duckdb_destroy_result (&result);
+  return rows == 2 ? WYRELOG_E_OK : WYRELOG_E_POLICY;
+}
+#endif
 
 static gboolean
 parse_options (gint *argc, gchar ***argv, WylDaemonOptions *opts,
@@ -246,11 +298,16 @@ daemon_delta_cb (const gchar *relation, const gint64 *row, guint ncols,
     runtime->removed++;
   }
 
-  if (!runtime->expect_effective_member)
-    return;
   if (g_strcmp0 (relation, "effective_member") != 0)
     return;
   if ((kind != WYL_DELTA_INSERT && kind != WYL_DELTA_REMOVE) || ncols != 3)
+    return;
+
+#ifdef WYL_HAS_AUDIT
+  emit_wirelog_effective_member_audit (runtime, row, kind);
+#endif
+
+  if (!runtime->expect_effective_member)
     return;
   if (row[0] == runtime->expected_row[0]
       && row[1] == runtime->expected_row[1]
@@ -273,6 +330,7 @@ static wyrelog_error_t
 check_wirelog_delta_ready (WylHandle *handle)
 {
   WylDaemonRuntime runtime = {
+    .handle = handle,
     .expect_effective_member = TRUE,
   };
 
@@ -303,6 +361,11 @@ check_wirelog_delta_ready (WylHandle *handle)
     return rc;
   if (runtime.removed == 0 || !runtime.matched_expected_remove)
     return WYRELOG_E_POLICY;
+#ifdef WYL_HAS_AUDIT
+  rc = check_wirelog_delta_audit_rows (handle);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+#endif
   return wyl_handle_engine_set_delta_callback (handle, NULL, NULL);
 }
 
@@ -401,7 +464,9 @@ main (int argc, char **argv)
     return 0;
   }
 
-  WylDaemonRuntime runtime = { 0 };
+  WylDaemonRuntime runtime = {
+    .handle = handle,
+  };
   rc = start_wirelog_delta_callbacks (handle, &runtime);
   if (rc != WYRELOG_E_OK) {
     g_printerr ("wyrelogd: delta callback setup failed: %s\n",

--- a/wyrelog/wyl-handle-private.h
+++ b/wyrelog/wyl-handle-private.h
@@ -44,6 +44,7 @@ wyrelog_error_t wyl_handle_open_engine_pair (WylHandle * self,
  */
 wyrelog_error_t wyl_handle_intern_engine_symbol (WylHandle * self,
     const gchar * symbol, gint64 * out_id);
+gchar *wyl_handle_dup_engine_symbol (WylHandle * self, gint64 id);
 
 /*
  * Applies an EDB row update to both handle-owned policy engines. Rejected

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -19,6 +19,7 @@ struct _WylHandle
   gint64 created_at_us;
   WylEngine *read_engine;
   WylEngine *delta_engine;
+  GHashTable *engine_symbols_by_id;
   wyl_policy_store_t *policy_store;
 #ifdef WYL_HAS_AUDIT
   wyl_audit_conn_t *audit_conn;
@@ -34,6 +35,7 @@ wyl_handle_finalize (GObject *object)
 
   g_clear_object (&self->read_engine);
   g_clear_object (&self->delta_engine);
+  g_clear_pointer (&self->engine_symbols_by_id, g_hash_table_unref);
   g_clear_pointer (&self->policy_store, wyl_policy_store_close);
 #ifdef WYL_HAS_AUDIT
   /* NULL-safe: if wyl_shutdown already closed the conn the pointer
@@ -65,6 +67,8 @@ wyl_handle_init (WylHandle *self)
   if (wyl_id_new (&self->id) != WYRELOG_E_OK)
     g_error ("wyl_handle_init: failed to mint identifier");
   self->created_at_us = g_get_real_time ();
+  self->engine_symbols_by_id =
+      g_hash_table_new_full (g_int64_hash, g_int64_equal, g_free, g_free);
 }
 
 static wyrelog_error_t
@@ -173,6 +177,7 @@ wyl_shutdown (WylHandle *handle)
   g_clear_pointer (&handle->policy_store, wyl_policy_store_close);
   g_clear_object (&handle->read_engine);
   g_clear_object (&handle->delta_engine);
+  g_hash_table_remove_all (handle->engine_symbols_by_id);
 }
 
 gchar *
@@ -298,8 +303,26 @@ wyl_handle_intern_engine_symbol (WylHandle *self, const gchar *symbol,
   if (read_id != delta_id)
     return WYRELOG_E_INTERNAL;
 
+  gint64 *key = g_new (gint64, 1);
+  *key = read_id;
+  g_hash_table_replace (self->engine_symbols_by_id, key, g_strdup (symbol));
+
   *out_id = read_id;
   return WYRELOG_E_OK;
+}
+
+gchar *
+wyl_handle_dup_engine_symbol (WylHandle *self, gint64 id)
+{
+  if (self == NULL || !WYL_IS_HANDLE (self))
+    return NULL;
+  if (self->engine_symbols_by_id == NULL)
+    return NULL;
+
+  const gchar *symbol = g_hash_table_lookup (self->engine_symbols_by_id, &id);
+  if (symbol == NULL)
+    return NULL;
+  return g_strdup (symbol);
 }
 
 static gboolean


### PR DESCRIPTION
## Summary

- keep a handle-owned reverse map for symbols interned into policy engines
- use that map to turn effective_member delta rows into audit events
- extend daemon readiness checks to verify the audited delta path

## Validation

- meson test -C builddir --print-errorlogs handle-engine-pair wyrelogd-check
- meson test -C builddir-audit --print-errorlogs handle-engine-pair wyrelogd-check wyrelogd-healthz client-audit-daemon audit-emit
- meson test -C builddir-noclient --print-errorlogs wyrelogd-check