### PR TITLE
ci: refresh vcpkg cache path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build-posix:
     name: build-${{ matrix.os }}
@@ -74,13 +77,10 @@ jobs:
   build-windows:
     name: build-windows
     runs-on: windows-latest
-    permissions:
-      contents: read
-      packages: write
     env:
       VCPKG_ROOT: ${{ github.workspace }}\vcpkg
       VCPKG_INSTALLED_DIR: ${{ github.workspace }}\vcpkg\installed\x64-windows
-      VCPKG_BINARY_SOURCES: "clear;nuget,https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json,readwrite"
+      VCPKG_DEFAULT_BINARY_CACHE: ${{ github.workspace }}\vcpkg-binary-cache
     steps:
       - name: Check out source
         uses: actions/checkout@v5
@@ -96,18 +96,17 @@ jobs:
           git clone --depth 1 --branch 2026.04.27 https://github.com/microsoft/vcpkg.git "%VCPKG_ROOT%"
           call "%VCPKG_ROOT%\bootstrap-vcpkg.bat" -disableMetrics
 
-      - name: Register NuGet source
-        shell: pwsh
-        run: |
-          $nuget = & "$env:VCPKG_ROOT\vcpkg.exe" fetch nuget | Select-Object -Last 1
-          $feed  = "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
-          & $nuget sources add `
-            -Source $feed `
-            -StorePasswordInClearText `
-            -Name GitHubPackages `
-            -UserName "${{ github.repository_owner }}" `
-            -Password "${{ secrets.GITHUB_TOKEN }}"
-          & $nuget setapikey "${{ secrets.GITHUB_TOKEN }}" -Source $feed
+      - name: Cache vcpkg binary packages
+        uses: actions/cache@v5
+        with:
+          path: ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
+          key: vcpkg-windows-${{ hashFiles('.github/workflows/ci.yml') }}
+          restore-keys: |
+            vcpkg-windows-
+
+      - name: Create vcpkg binary cache
+        shell: cmd
+        run: if not exist "%VCPKG_DEFAULT_BINARY_CACHE%" mkdir "%VCPKG_DEFAULT_BINARY_CACHE%"
 
       - name: Install meson and ninja
         shell: cmd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,7 @@ jobs:
       VCPKG_ROOT: ${{ github.workspace }}\vcpkg
       VCPKG_INSTALLED_DIR: ${{ github.workspace }}\vcpkg\installed\x64-windows
       VCPKG_DEFAULT_BINARY_CACHE: ${{ github.workspace }}\vcpkg-binary-cache
+      VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}\\vcpkg-binary-cache,readwrite"
     steps:
       - name: Check out source
         uses: actions/checkout@v5


### PR DESCRIPTION
## Summary

- opt the workflow into the Node 24 JavaScript action runtime
- replace Windows NuGet package-cache wiring with a local vcpkg cache path
- keep CI on full Meson suite execution across configured platforms

## Validation

- git diff --check
- PR GitHub Actions gate