### PR TITLE
policy: persist LoBAC event ledgers

### DIFF
--- a/templates/access/sqlite-schema.sql
+++ b/templates/access/sqlite-schema.sql
@@ -84,6 +84,26 @@ CREATE INDEX IF NOT EXISTS idx_principal_states_state
     ON principal_states (state);
 
 -- ---------------------------------------------------------------------------
+-- Table: principal_events
+-- Append-only principal FSM transition ledger. Current state is kept in
+-- principal_states; this table preserves the event edge that produced it.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS principal_events (
+    event_id   INTEGER PRIMARY KEY AUTOINCREMENT,
+    subject_id TEXT    NOT NULL,
+    event      TEXT    NOT NULL,
+    from_state TEXT    NOT NULL,
+    to_state   TEXT    NOT NULL,
+    created_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_principal_events_subject_id
+    ON principal_events (subject_id);
+
+CREATE INDEX IF NOT EXISTS idx_principal_events_event
+    ON principal_events (event);
+
+-- ---------------------------------------------------------------------------
 -- Table: session_states
 -- Durable session lifecycle state mirrored into session_state/2.
 -- ---------------------------------------------------------------------------

--- a/templates/access/sqlite-schema.sql
+++ b/templates/access/sqlite-schema.sql
@@ -71,6 +71,25 @@ CREATE INDEX IF NOT EXISTS idx_direct_permissions_subject_scope
     ON direct_permissions (subject_id, scope);
 
 -- ---------------------------------------------------------------------------
+-- Table: direct_permission_events
+-- Append-only grant/revoke ledger for direct_permission/3 changes.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS direct_permission_events (
+    event_id   INTEGER PRIMARY KEY AUTOINCREMENT,
+    subject_id TEXT    NOT NULL,
+    perm_id    TEXT    NOT NULL,
+    scope      TEXT    NOT NULL,
+    operation  TEXT    NOT NULL CHECK (operation IN ('grant', 'revoke')),
+    created_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_direct_permission_events_subject
+    ON direct_permission_events (subject_id);
+
+CREATE INDEX IF NOT EXISTS idx_direct_permission_events_perm
+    ON direct_permission_events (perm_id);
+
+-- ---------------------------------------------------------------------------
 -- Table: principal_states
 -- Durable principal authentication state mirrored into principal_state/2.
 -- ---------------------------------------------------------------------------

--- a/tests/test-audit-emit.c
+++ b/tests/test-audit-emit.c
@@ -604,7 +604,8 @@ check_principal_transition_emits_audit_row (void)
       wyl_audit_conn_get_connection (wyl_handle_get_audit_conn (handle));
   duckdb_result result;
   if (duckdb_query (conn,
-          "SELECT subject_id, action, resource_id, deny_origin, decision "
+          "SELECT subject_id, action, resource_id, deny_reason, "
+          "deny_origin, decision "
           "FROM audit_events WHERE action = 'principal_state' "
           "AND deny_origin = 'mfa_required';", &result)
       != DuckDBSuccess) {
@@ -622,22 +623,26 @@ check_principal_transition_emits_audit_row (void)
   const gchar *subject = duckdb_value_varchar (&result, 0, 0);
   const gchar *action = duckdb_value_varchar (&result, 1, 0);
   const gchar *resource = duckdb_value_varchar (&result, 2, 0);
-  const gchar *old_state = duckdb_value_varchar (&result, 3, 0);
-  gint16 decision = (gint16) duckdb_value_int64 (&result, 4, 0);
+  const gchar *event = duckdb_value_varchar (&result, 3, 0);
+  const gchar *old_state = duckdb_value_varchar (&result, 4, 0);
+  gint16 decision = (gint16) duckdb_value_int64 (&result, 5, 0);
   if (g_strcmp0 (subject, "audit-principal-user") != 0)
     rc = 85;
   else if (g_strcmp0 (action, "principal_state") != 0)
     rc = 86;
   else if (g_strcmp0 (resource, "authenticated") != 0)
     rc = 87;
-  else if (g_strcmp0 (old_state, "mfa_required") != 0)
+  else if (g_strcmp0 (event, "mfa_ok") != 0)
     rc = 88;
-  else if (decision != WYL_DECISION_ALLOW)
+  else if (g_strcmp0 (old_state, "mfa_required") != 0)
     rc = 89;
+  else if (decision != WYL_DECISION_ALLOW)
+    rc = 90;
 
   duckdb_free ((void *) subject);
   duckdb_free ((void *) action);
   duckdb_free ((void *) resource);
+  duckdb_free ((void *) event);
   duckdb_free ((void *) old_state);
   duckdb_destroy_result (&result);
   g_object_unref (handle);
@@ -663,7 +668,8 @@ check_login_principal_state_emits_audit_row (void)
       wyl_audit_conn_get_connection (wyl_handle_get_audit_conn (handle));
   duckdb_result result;
   if (duckdb_query (conn,
-          "SELECT subject_id, action, resource_id, deny_origin, decision "
+          "SELECT subject_id, action, resource_id, deny_reason, "
+          "deny_origin, decision "
           "FROM audit_events WHERE action = 'principal_state';", &result)
       != DuckDBSuccess) {
     duckdb_destroy_result (&result);
@@ -680,22 +686,26 @@ check_login_principal_state_emits_audit_row (void)
   const gchar *subject = duckdb_value_varchar (&result, 0, 0);
   const gchar *action = duckdb_value_varchar (&result, 1, 0);
   const gchar *resource = duckdb_value_varchar (&result, 2, 0);
-  const gchar *old_state = duckdb_value_varchar (&result, 3, 0);
-  gint16 decision = (gint16) duckdb_value_int64 (&result, 4, 0);
+  const gchar *event = duckdb_value_varchar (&result, 3, 0);
+  const gchar *old_state = duckdb_value_varchar (&result, 4, 0);
+  gint16 decision = (gint16) duckdb_value_int64 (&result, 5, 0);
   if (g_strcmp0 (subject, "audit-login-user") != 0)
     rc = 94;
   else if (g_strcmp0 (action, "principal_state") != 0)
     rc = 95;
   else if (g_strcmp0 (resource, "mfa_required") != 0)
     rc = 96;
-  else if (g_strcmp0 (old_state, "unverified") != 0)
+  else if (g_strcmp0 (event, "login_ok") != 0)
     rc = 97;
-  else if (decision != WYL_DECISION_ALLOW)
+  else if (g_strcmp0 (old_state, "unverified") != 0)
     rc = 98;
+  else if (decision != WYL_DECISION_ALLOW)
+    rc = 99;
 
   duckdb_free ((void *) subject);
   duckdb_free ((void *) action);
   duckdb_free ((void *) resource);
+  duckdb_free ((void *) event);
   duckdb_free ((void *) old_state);
   duckdb_destroy_result (&result);
   g_object_unref (handle);
@@ -722,7 +732,8 @@ check_login_skip_mfa_emits_principal_state_audit_row (void)
       wyl_audit_conn_get_connection (wyl_handle_get_audit_conn (handle));
   duckdb_result result;
   if (duckdb_query (conn,
-          "SELECT subject_id, action, resource_id, deny_origin, decision "
+          "SELECT subject_id, action, resource_id, deny_reason, "
+          "deny_origin, decision "
           "FROM audit_events WHERE action = 'principal_state';", &result)
       != DuckDBSuccess) {
     duckdb_destroy_result (&result);
@@ -739,22 +750,26 @@ check_login_skip_mfa_emits_principal_state_audit_row (void)
   const gchar *subject = duckdb_value_varchar (&result, 0, 0);
   const gchar *action = duckdb_value_varchar (&result, 1, 0);
   const gchar *resource = duckdb_value_varchar (&result, 2, 0);
-  const gchar *old_state = duckdb_value_varchar (&result, 3, 0);
-  gint16 decision = (gint16) duckdb_value_int64 (&result, 4, 0);
+  const gchar *event = duckdb_value_varchar (&result, 3, 0);
+  const gchar *old_state = duckdb_value_varchar (&result, 4, 0);
+  gint16 decision = (gint16) duckdb_value_int64 (&result, 5, 0);
   if (g_strcmp0 (subject, "audit-skip-mfa-user") != 0)
     rc = 104;
   else if (g_strcmp0 (action, "principal_state") != 0)
     rc = 105;
   else if (g_strcmp0 (resource, "authenticated") != 0)
     rc = 106;
-  else if (g_strcmp0 (old_state, "unverified") != 0)
+  else if (g_strcmp0 (event, "login_skip_mfa") != 0)
     rc = 107;
-  else if (decision != WYL_DECISION_ALLOW)
+  else if (g_strcmp0 (old_state, "unverified") != 0)
     rc = 108;
+  else if (decision != WYL_DECISION_ALLOW)
+    rc = 109;
 
   duckdb_free ((void *) subject);
   duckdb_free ((void *) action);
   duckdb_free ((void *) resource);
+  duckdb_free ((void *) event);
   duckdb_free ((void *) old_state);
   duckdb_destroy_result (&result);
   g_object_unref (handle);

--- a/tests/test-perm.c
+++ b/tests/test-perm.c
@@ -16,6 +16,30 @@
  * enabled, and return WYRELOG_E_OK.
  */
 
+typedef struct
+{
+  const gchar *subject_id;
+  const gchar *perm_id;
+  const gchar *scope;
+  const gchar *operation;
+  guint matches;
+} DirectPermissionEventExpect;
+
+static wyrelog_error_t
+direct_permission_event_expect_cb (const gchar *subject_id,
+    const gchar *perm_id, const gchar *scope, const gchar *operation,
+    gpointer user_data)
+{
+  DirectPermissionEventExpect *expect = user_data;
+
+  if (g_strcmp0 (subject_id, expect->subject_id) == 0
+      && g_strcmp0 (perm_id, expect->perm_id) == 0
+      && g_strcmp0 (scope, expect->scope) == 0
+      && g_strcmp0 (operation, expect->operation) == 0)
+    expect->matches++;
+  return WYRELOG_E_OK;
+}
+
 static gint
 check_grant_returns_ok (void)
 {
@@ -203,6 +227,19 @@ check_grant_persists_direct_permission (void)
     return 72;
   if (!exists)
     return 73;
+
+  DirectPermissionEventExpect expect = {
+    .subject_id = "store-user",
+    .perm_id = "wr.store-direct",
+    .scope = "store-scope",
+    .operation = "grant",
+  };
+  if (wyl_policy_store_foreach_direct_permission_event
+      (wyl_handle_get_policy_store (handle), direct_permission_event_expect_cb,
+          &expect) != WYRELOG_E_OK)
+    return 74;
+  if (expect.matches != 1)
+    return 75;
   return 0;
 }
 
@@ -235,6 +272,30 @@ check_revoke_removes_store_grant (void)
     return 83;
   if (exists)
     return 84;
+  DirectPermissionEventExpect grant_expect = {
+    .subject_id = "store-revoke-user",
+    .perm_id = "wr.store-revoke",
+    .scope = "store-revoke-scope",
+    .operation = "grant",
+  };
+  if (wyl_policy_store_foreach_direct_permission_event
+      (wyl_handle_get_policy_store (handle), direct_permission_event_expect_cb,
+          &grant_expect) != WYRELOG_E_OK)
+    return 85;
+  if (grant_expect.matches != 1)
+    return 86;
+  DirectPermissionEventExpect revoke_expect = {
+    .subject_id = "store-revoke-user",
+    .perm_id = "wr.store-revoke",
+    .scope = "store-revoke-scope",
+    .operation = "revoke",
+  };
+  if (wyl_policy_store_foreach_direct_permission_event
+      (wyl_handle_get_policy_store (handle), direct_permission_event_expect_cb,
+          &revoke_expect) != WYRELOG_E_OK)
+    return 87;
+  if (revoke_expect.matches != 1)
+    return 88;
   return 0;
 }
 

--- a/tests/test-policy-store.c
+++ b/tests/test-policy-store.c
@@ -24,6 +24,7 @@ check_store_creates_authority_schema (void)
     "permissions",
     "role_permissions",
     "direct_permissions",
+    "principal_events",
     "principal_states",
     "session_states",
     "policy_signatures",
@@ -65,6 +66,7 @@ check_template_schema_creates_state_tables (void)
     "permissions",
     "role_permissions",
     "direct_permissions",
+    "principal_events",
     "principal_states",
     "session_states",
     "policy_signatures",
@@ -152,6 +154,15 @@ typedef struct
   guint matches;
 } PrincipalStateExpect;
 
+typedef struct
+{
+  const gchar *subject_id;
+  const gchar *event;
+  const gchar *from_state;
+  const gchar *to_state;
+  guint matches;
+} PrincipalEventExpect;
+
 static wyrelog_error_t
 principal_state_expect_cb (const gchar *subject_id, const gchar *state,
     gpointer user_data)
@@ -160,6 +171,20 @@ principal_state_expect_cb (const gchar *subject_id, const gchar *state,
 
   if (g_strcmp0 (subject_id, expect->subject_id) == 0
       && g_strcmp0 (state, expect->state) == 0)
+    expect->matches++;
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+principal_event_expect_cb (const gchar *subject_id, const gchar *event,
+    const gchar *from_state, const gchar *to_state, gpointer user_data)
+{
+  PrincipalEventExpect *expect = user_data;
+
+  if (g_strcmp0 (subject_id, expect->subject_id) == 0
+      && g_strcmp0 (event, expect->event) == 0
+      && g_strcmp0 (from_state, expect->from_state) == 0
+      && g_strcmp0 (to_state, expect->to_state) == 0)
     expect->matches++;
   return WYRELOG_E_OK;
 }
@@ -339,6 +364,33 @@ check_store_sets_session_state (void)
 }
 
 static gint
+check_store_appends_principal_event (void)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 92;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 93;
+  if (wyl_policy_store_append_principal_event (store, "principal-user",
+          "login_skip_mfa", "unverified", "authenticated") != WYRELOG_E_OK)
+    return 94;
+
+  PrincipalEventExpect expect = {
+    .subject_id = "principal-user",
+    .event = "login_skip_mfa",
+    .from_state = "unverified",
+    .to_state = "authenticated",
+  };
+  if (wyl_policy_store_foreach_principal_event (store,
+          principal_event_expect_cb, &expect) != WYRELOG_E_OK)
+    return 95;
+  if (expect.matches != 1)
+    return 96;
+  return 0;
+}
+
+static gint
 check_store_rejects_bad_direct_permission (void)
 {
   g_autoptr (wyl_policy_store_t) store = NULL;
@@ -397,6 +449,12 @@ check_store_rejects_bad_role_permission (void)
   if (wyl_policy_store_foreach_principal_state (store, NULL, NULL)
       != WYRELOG_E_INVALID)
     return 57;
+  if (wyl_policy_store_append_principal_event (store, NULL, "login_ok",
+          "unverified", "mfa_required") != WYRELOG_E_INVALID)
+    return 92;
+  if (wyl_policy_store_foreach_principal_event (store, NULL, NULL)
+      != WYRELOG_E_INVALID)
+    return 93;
   if (wyl_policy_store_set_session_state (store, NULL, "active")
       != WYRELOG_E_INVALID)
     return 58;
@@ -426,6 +484,8 @@ main (void)
   if ((rc = check_store_sets_principal_state ()) != 0)
     return rc;
   if ((rc = check_store_sets_session_state ()) != 0)
+    return rc;
+  if ((rc = check_store_appends_principal_event ()) != 0)
     return rc;
   if ((rc = check_store_rejects_bad_direct_permission ()) != 0)
     return rc;

--- a/tests/test-policy-store.c
+++ b/tests/test-policy-store.c
@@ -24,6 +24,7 @@ check_store_creates_authority_schema (void)
     "permissions",
     "role_permissions",
     "direct_permissions",
+    "direct_permission_events",
     "principal_events",
     "principal_states",
     "session_states",
@@ -66,6 +67,7 @@ check_template_schema_creates_state_tables (void)
     "permissions",
     "role_permissions",
     "direct_permissions",
+    "direct_permission_events",
     "principal_events",
     "principal_states",
     "session_states",
@@ -131,6 +133,7 @@ typedef struct
   const gchar *subject_id;
   const gchar *perm_id;
   const gchar *scope;
+  const gchar *operation;
   guint matches;
 } DirectPermissionExpect;
 
@@ -143,6 +146,21 @@ direct_permission_expect_cb (const gchar *subject_id, const gchar *perm_id,
   if (g_strcmp0 (subject_id, expect->subject_id) == 0
       && g_strcmp0 (perm_id, expect->perm_id) == 0
       && g_strcmp0 (scope, expect->scope) == 0)
+    expect->matches++;
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+direct_permission_event_expect_cb (const gchar *subject_id,
+    const gchar *perm_id, const gchar *scope, const gchar *operation,
+    gpointer user_data)
+{
+  DirectPermissionExpect *expect = user_data;
+
+  if (g_strcmp0 (subject_id, expect->subject_id) == 0
+      && g_strcmp0 (perm_id, expect->perm_id) == 0
+      && g_strcmp0 (scope, expect->scope) == 0
+      && g_strcmp0 (operation, expect->operation) == 0)
     expect->matches++;
   return WYRELOG_E_OK;
 }
@@ -308,6 +326,33 @@ check_store_grants_direct_permission (void)
 }
 
 static gint
+check_store_appends_direct_permission_event (void)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 92;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 93;
+  if (wyl_policy_store_append_direct_permission_event (store, "direct-user",
+          "wr.direct.read", "direct-scope", "grant") != WYRELOG_E_OK)
+    return 94;
+
+  DirectPermissionExpect expect = {
+    .subject_id = "direct-user",
+    .perm_id = "wr.direct.read",
+    .scope = "direct-scope",
+    .operation = "grant",
+  };
+  if (wyl_policy_store_foreach_direct_permission_event (store,
+          direct_permission_event_expect_cb, &expect) != WYRELOG_E_OK)
+    return 95;
+  if (expect.matches != 1)
+    return 96;
+  return 0;
+}
+
+static gint
 check_store_sets_principal_state (void)
 {
   g_autoptr (wyl_policy_store_t) store = NULL;
@@ -415,6 +460,12 @@ check_store_rejects_bad_direct_permission (void)
   if (wyl_policy_store_foreach_direct_permission (store, NULL, NULL)
       != WYRELOG_E_INVALID)
     return 78;
+  if (wyl_policy_store_append_direct_permission_event (store, NULL,
+          "missing-perm", "direct-scope", "grant") != WYRELOG_E_INVALID)
+    return 79;
+  if (wyl_policy_store_foreach_direct_permission_event (store, NULL, NULL)
+      != WYRELOG_E_INVALID)
+    return 80;
   if (wyl_policy_store_direct_permission_exists (store, "direct-user",
           "missing-perm", "direct-scope", &exists) != WYRELOG_E_OK)
     return 76;
@@ -480,6 +531,8 @@ main (void)
   if ((rc = check_store_grants_role_permission ()) != 0)
     return rc;
   if ((rc = check_store_grants_direct_permission ()) != 0)
+    return rc;
+  if ((rc = check_store_appends_direct_permission_event ()) != 0)
     return rc;
   if ((rc = check_store_sets_principal_state ()) != 0)
     return rc;

--- a/tests/test-session-username.c
+++ b/tests/test-session-username.c
@@ -103,6 +103,15 @@ typedef struct
   guint matches;
 } PrincipalStateExpect;
 
+typedef struct
+{
+  const gchar *subject_id;
+  const gchar *event;
+  const gchar *from_state;
+  const gchar *to_state;
+  guint matches;
+} PrincipalEventExpect;
+
 static wyrelog_error_t
 principal_state_expect_cb (const gchar *subject_id, const gchar *state,
     gpointer user_data)
@@ -111,6 +120,20 @@ principal_state_expect_cb (const gchar *subject_id, const gchar *state,
 
   if (g_strcmp0 (subject_id, expect->subject_id) == 0
       && g_strcmp0 (state, expect->state) == 0)
+    expect->matches++;
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+principal_event_expect_cb (const gchar *subject_id, const gchar *event,
+    const gchar *from_state, const gchar *to_state, gpointer user_data)
+{
+  PrincipalEventExpect *expect = user_data;
+
+  if (g_strcmp0 (subject_id, expect->subject_id) == 0
+      && g_strcmp0 (event, expect->event) == 0
+      && g_strcmp0 (from_state, expect->from_state) == 0
+      && g_strcmp0 (to_state, expect->to_state) == 0)
     expect->matches++;
   return WYRELOG_E_OK;
 }
@@ -492,6 +515,17 @@ check_login_skip_mfa_authenticates_principal (void)
     return 156;
   if (expect.matches != 1)
     return 157;
+  PrincipalEventExpect event_expect = {
+    .subject_id = "skip-mfa-user",
+    .event = "login_skip_mfa",
+    .from_state = "unverified",
+    .to_state = "authenticated",
+  };
+  if (wyl_policy_store_foreach_principal_event (wyl_handle_get_policy_store
+          (handle), principal_event_expect_cb, &event_expect) != WYRELOG_E_OK)
+    return 160;
+  if (event_expect.matches != 1)
+    return 161;
 
   g_autoptr (wyl_decide_req_t) decide = wyl_decide_req_new ();
   wyl_decide_req_set_subject_id (decide, "skip-mfa-user");

--- a/wyrelog/daemon/wyrelogd.c
+++ b/wyrelog/daemon/wyrelogd.c
@@ -224,6 +224,9 @@ check_policy_store_ready (WylHandle *handle)
     "permissions",
     "role_permissions",
     "direct_permissions",
+    "principal_events",
+    "principal_states",
+    "session_states",
     "policy_signatures",
   };
 

--- a/wyrelog/daemon/wyrelogd.c
+++ b/wyrelog/daemon/wyrelogd.c
@@ -224,6 +224,7 @@ check_policy_store_ready (WylHandle *handle)
     "permissions",
     "role_permissions",
     "direct_permissions",
+    "direct_permission_events",
     "principal_events",
     "principal_states",
     "session_states",

--- a/wyrelog/policy/store-private.h
+++ b/wyrelog/policy/store-private.h
@@ -14,6 +14,9 @@ typedef wyrelog_error_t (*wyl_policy_role_permission_cb) (const gchar * role_id,
     const gchar * perm_id, gpointer user_data);
 typedef wyrelog_error_t (*wyl_policy_direct_permission_cb) (const gchar *
     subject_id, const gchar * perm_id, const gchar * scope, gpointer user_data);
+typedef wyrelog_error_t (*wyl_policy_direct_permission_event_cb) (const gchar *
+    subject_id, const gchar * perm_id, const gchar * scope,
+    const gchar * operation, gpointer user_data);
 typedef wyrelog_error_t (*wyl_policy_principal_state_cb) (const gchar *
     subject_id, const gchar * state, gpointer user_data);
 typedef wyrelog_error_t (*wyl_policy_principal_event_cb) (const gchar *
@@ -59,6 +62,13 @@ wyrelog_error_t wyl_policy_store_direct_permission_exists (wyl_policy_store_t *
     gboolean * out_exists);
 wyrelog_error_t wyl_policy_store_foreach_direct_permission (wyl_policy_store_t *
     store, wyl_policy_direct_permission_cb cb, gpointer user_data);
+wyrelog_error_t
+wyl_policy_store_append_direct_permission_event (wyl_policy_store_t * store,
+    const gchar * subject_id, const gchar * perm_id, const gchar * scope,
+    const gchar * operation);
+wyrelog_error_t
+wyl_policy_store_foreach_direct_permission_event (wyl_policy_store_t * store,
+    wyl_policy_direct_permission_event_cb cb, gpointer user_data);
 wyrelog_error_t wyl_policy_store_set_principal_state (wyl_policy_store_t *
     store, const gchar * subject_id, const gchar * state);
 wyrelog_error_t wyl_policy_store_foreach_principal_state (wyl_policy_store_t *

--- a/wyrelog/policy/store-private.h
+++ b/wyrelog/policy/store-private.h
@@ -16,6 +16,9 @@ typedef wyrelog_error_t (*wyl_policy_direct_permission_cb) (const gchar *
     subject_id, const gchar * perm_id, const gchar * scope, gpointer user_data);
 typedef wyrelog_error_t (*wyl_policy_principal_state_cb) (const gchar *
     subject_id, const gchar * state, gpointer user_data);
+typedef wyrelog_error_t (*wyl_policy_principal_event_cb) (const gchar *
+    subject_id, const gchar * event, const gchar * from_state,
+    const gchar * to_state, gpointer user_data);
 typedef wyrelog_error_t (*wyl_policy_session_state_cb) (const gchar *
     session_id, const gchar * state, gpointer user_data);
 
@@ -60,6 +63,11 @@ wyrelog_error_t wyl_policy_store_set_principal_state (wyl_policy_store_t *
     store, const gchar * subject_id, const gchar * state);
 wyrelog_error_t wyl_policy_store_foreach_principal_state (wyl_policy_store_t *
     store, wyl_policy_principal_state_cb cb, gpointer user_data);
+wyrelog_error_t wyl_policy_store_append_principal_event (wyl_policy_store_t *
+    store, const gchar * subject_id, const gchar * event,
+    const gchar * from_state, const gchar * to_state);
+wyrelog_error_t wyl_policy_store_foreach_principal_event (wyl_policy_store_t *
+    store, wyl_policy_principal_event_cb cb, gpointer user_data);
 wyrelog_error_t wyl_policy_store_set_session_state (wyl_policy_store_t * store,
     const gchar * session_id, const gchar * state);
 wyrelog_error_t wyl_policy_store_foreach_session_state (wyl_policy_store_t *

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -127,6 +127,19 @@ wyl_policy_store_create_schema (wyl_policy_store_t *store)
       "  ON direct_permissions (perm_id);"
       "CREATE INDEX IF NOT EXISTS idx_direct_permissions_subject_scope "
       "  ON direct_permissions (subject_id, scope);"
+      "CREATE TABLE IF NOT EXISTS direct_permission_events ("
+      "  event_id INTEGER PRIMARY KEY AUTOINCREMENT,"
+      "  subject_id TEXT NOT NULL,"
+      "  perm_id TEXT NOT NULL,"
+      "  scope TEXT NOT NULL,"
+      "  operation TEXT NOT NULL CHECK "
+      "    (operation IN ('grant', 'revoke')),"
+      "  created_at INTEGER NOT NULL"
+      ");"
+      "CREATE INDEX IF NOT EXISTS idx_direct_permission_events_subject "
+      "  ON direct_permission_events (subject_id);"
+      "CREATE INDEX IF NOT EXISTS idx_direct_permission_events_perm "
+      "  ON direct_permission_events (perm_id);"
       "CREATE TABLE IF NOT EXISTS principal_states ("
       "  subject_id TEXT PRIMARY KEY,"
       "  state TEXT NOT NULL,"
@@ -345,6 +358,70 @@ wyl_policy_store_foreach_direct_permission (wyl_policy_store_t *store,
     const gchar *perm_id = (const gchar *) sqlite3_column_text (stmt, 1);
     const gchar *scope = (const gchar *) sqlite3_column_text (stmt, 2);
     rc = cb (subject_id, perm_id, scope, user_data);
+    if (rc != WYRELOG_E_OK) {
+      sqlite3_finalize (stmt);
+      return rc;
+    }
+  }
+
+  sqlite3_finalize (stmt);
+  return (step_rc == SQLITE_DONE) ? WYRELOG_E_OK : WYRELOG_E_IO;
+}
+
+wyrelog_error_t
+wyl_policy_store_append_direct_permission_event (wyl_policy_store_t *store,
+    const gchar *subject_id, const gchar *perm_id, const gchar *scope,
+    const gchar *operation)
+{
+  sqlite3_stmt *stmt = NULL;
+
+  if (store == NULL || store->db == NULL || subject_id == NULL
+      || perm_id == NULL || scope == NULL || operation == NULL)
+    return WYRELOG_E_INVALID;
+
+  static const gchar *sql =
+      "INSERT INTO direct_permission_events "
+      "  (subject_id, perm_id, scope, operation, created_at) "
+      "VALUES (?, ?, ?, ?, unixepoch());";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if ((rc = bind_text (stmt, 1, subject_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 2, perm_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 3, scope)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 4, operation)) != WYRELOG_E_OK) {
+    sqlite3_finalize (stmt);
+    return rc;
+  }
+
+  int step_rc = sqlite3_step (stmt);
+  sqlite3_finalize (stmt);
+  return (step_rc == SQLITE_DONE) ? WYRELOG_E_OK : WYRELOG_E_IO;
+}
+
+wyrelog_error_t
+wyl_policy_store_foreach_direct_permission_event (wyl_policy_store_t *store,
+    wyl_policy_direct_permission_event_cb cb, gpointer user_data)
+{
+  sqlite3_stmt *stmt = NULL;
+
+  if (store == NULL || store->db == NULL || cb == NULL)
+    return WYRELOG_E_INVALID;
+
+  static const gchar *sql =
+      "SELECT subject_id, perm_id, scope, operation "
+      "FROM direct_permission_events ORDER BY event_id;";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  int step_rc;
+  while ((step_rc = sqlite3_step (stmt)) == SQLITE_ROW) {
+    const gchar *subject_id = (const gchar *) sqlite3_column_text (stmt, 0);
+    const gchar *perm_id = (const gchar *) sqlite3_column_text (stmt, 1);
+    const gchar *scope = (const gchar *) sqlite3_column_text (stmt, 2);
+    const gchar *operation = (const gchar *) sqlite3_column_text (stmt, 3);
+    rc = cb (subject_id, perm_id, scope, operation, user_data);
     if (rc != WYRELOG_E_OK) {
       sqlite3_finalize (stmt);
       return rc;

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -134,6 +134,18 @@ wyl_policy_store_create_schema (wyl_policy_store_t *store)
       ");"
       "CREATE INDEX IF NOT EXISTS idx_principal_states_state "
       "  ON principal_states (state);"
+      "CREATE TABLE IF NOT EXISTS principal_events ("
+      "  event_id INTEGER PRIMARY KEY AUTOINCREMENT,"
+      "  subject_id TEXT NOT NULL,"
+      "  event TEXT NOT NULL,"
+      "  from_state TEXT NOT NULL,"
+      "  to_state TEXT NOT NULL,"
+      "  created_at INTEGER NOT NULL"
+      ");"
+      "CREATE INDEX IF NOT EXISTS idx_principal_events_subject_id "
+      "  ON principal_events (subject_id);"
+      "CREATE INDEX IF NOT EXISTS idx_principal_events_event "
+      "  ON principal_events (event);"
       "CREATE TABLE IF NOT EXISTS session_states ("
       "  session_id TEXT PRIMARY KEY,"
       "  state TEXT NOT NULL,"
@@ -391,6 +403,70 @@ wyl_policy_store_foreach_principal_state (wyl_policy_store_t *store,
     const gchar *subject_id = (const gchar *) sqlite3_column_text (stmt, 0);
     const gchar *state = (const gchar *) sqlite3_column_text (stmt, 1);
     rc = cb (subject_id, state, user_data);
+    if (rc != WYRELOG_E_OK) {
+      sqlite3_finalize (stmt);
+      return rc;
+    }
+  }
+
+  sqlite3_finalize (stmt);
+  return (step_rc == SQLITE_DONE) ? WYRELOG_E_OK : WYRELOG_E_IO;
+}
+
+wyrelog_error_t
+wyl_policy_store_append_principal_event (wyl_policy_store_t *store,
+    const gchar *subject_id, const gchar *event, const gchar *from_state,
+    const gchar *to_state)
+{
+  sqlite3_stmt *stmt = NULL;
+
+  if (store == NULL || store->db == NULL || subject_id == NULL
+      || event == NULL || from_state == NULL || to_state == NULL)
+    return WYRELOG_E_INVALID;
+
+  static const gchar *sql =
+      "INSERT INTO principal_events "
+      "  (subject_id, event, from_state, to_state, created_at) "
+      "VALUES (?, ?, ?, ?, unixepoch());";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if ((rc = bind_text (stmt, 1, subject_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 2, event)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 3, from_state)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 4, to_state)) != WYRELOG_E_OK) {
+    sqlite3_finalize (stmt);
+    return rc;
+  }
+
+  int step_rc = sqlite3_step (stmt);
+  sqlite3_finalize (stmt);
+  return (step_rc == SQLITE_DONE) ? WYRELOG_E_OK : WYRELOG_E_IO;
+}
+
+wyrelog_error_t
+wyl_policy_store_foreach_principal_event (wyl_policy_store_t *store,
+    wyl_policy_principal_event_cb cb, gpointer user_data)
+{
+  sqlite3_stmt *stmt = NULL;
+
+  if (store == NULL || store->db == NULL || cb == NULL)
+    return WYRELOG_E_INVALID;
+
+  static const gchar *sql =
+      "SELECT subject_id, event, from_state, to_state "
+      "FROM principal_events ORDER BY event_id;";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  int step_rc;
+  while ((step_rc = sqlite3_step (stmt)) == SQLITE_ROW) {
+    const gchar *subject_id = (const gchar *) sqlite3_column_text (stmt, 0);
+    const gchar *event = (const gchar *) sqlite3_column_text (stmt, 1);
+    const gchar *from_state = (const gchar *) sqlite3_column_text (stmt, 2);
+    const gchar *to_state = (const gchar *) sqlite3_column_text (stmt, 3);
+    rc = cb (subject_id, event, from_state, to_state, user_data);
     if (rc != WYRELOG_E_OK) {
       sqlite3_finalize (stmt);
       return rc;

--- a/wyrelog/wyl-perm.c
+++ b/wyrelog/wyl-perm.c
@@ -205,12 +205,20 @@ update_direct_permission_store (WylHandle *handle, const gchar *subject_id,
         wyl_policy_store_upsert_permission (store, action, action, "basic");
     if (rc != WYRELOG_E_OK)
       return rc;
-    return wyl_policy_store_grant_direct_permission (store, subject_id,
+    rc = wyl_policy_store_grant_direct_permission (store, subject_id,
         action, resource_id);
+    if (rc != WYRELOG_E_OK)
+      return rc;
+    return wyl_policy_store_append_direct_permission_event (store, subject_id,
+        action, resource_id, "grant");
   }
 
-  return wyl_policy_store_revoke_direct_permission (store, subject_id,
-      action, resource_id);
+  wyrelog_error_t rc = wyl_policy_store_revoke_direct_permission (store,
+      subject_id, action, resource_id);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_policy_store_append_direct_permission_event (store, subject_id,
+      action, resource_id, "revoke");
 }
 
 static wyrelog_error_t

--- a/wyrelog/wyl-session.c
+++ b/wyrelog/wyl-session.c
@@ -116,6 +116,28 @@ store_principal_state (WylHandle *handle, const gchar *username,
 }
 
 static wyrelog_error_t
+store_principal_event (WylHandle *handle, const gchar *username,
+    wyl_principal_state_t old_state, wyl_principal_event_t event,
+    wyl_principal_state_t new_state)
+{
+  if (username == NULL)
+    return WYRELOG_E_OK;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (store == NULL)
+    return WYRELOG_E_OK;
+
+  const gchar *old_state_name = wyl_principal_state_name (old_state);
+  const gchar *event_name = wyl_principal_event_name (event);
+  const gchar *new_state_name = wyl_principal_state_name (new_state);
+  if (old_state_name == NULL || event_name == NULL || new_state_name == NULL)
+    return WYRELOG_E_INTERNAL;
+
+  return wyl_policy_store_append_principal_event (store, username, event_name,
+      old_state_name, new_state_name);
+}
+
+static wyrelog_error_t
 set_principal_state (WylHandle *handle, const gchar *username,
     wyl_principal_state_t state)
 {
@@ -157,6 +179,10 @@ transition_principal_state (WylHandle *handle, const gchar *username,
   if (rc != WYRELOG_E_OK)
     return rc;
   rc = store_principal_state (handle, username, new_state);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = store_principal_event (handle, username, old_state,
+      WYL_PRINCIPAL_EVENT_MFA_OK, new_state);
   if (rc != WYRELOG_E_OK)
     return rc;
 #ifdef WYL_HAS_AUDIT
@@ -306,6 +332,12 @@ wyl_session_login (WylHandle *handle, const wyl_login_req_t *req,
       return (rc == WYRELOG_E_OK) ? WYRELOG_E_INTERNAL : rc;
     }
     rc = set_principal_state (handle, username, state);
+    if (rc != WYRELOG_E_OK) {
+      g_object_unref (session);
+      return rc;
+    }
+    rc = store_principal_event (handle, username,
+        WYL_PRINCIPAL_STATE_UNVERIFIED, event, state);
     if (rc != WYRELOG_E_OK) {
       g_object_unref (session);
       return rc;

--- a/wyrelog/wyl-session.c
+++ b/wyrelog/wyl-session.c
@@ -128,12 +128,13 @@ set_principal_state (WylHandle *handle, const gchar *username,
 #ifdef WYL_HAS_AUDIT
 static void
 emit_principal_state_audit (WylHandle *handle, const gchar *username,
-    const gchar *old_state, const gchar *new_state)
+    const gchar *old_state, const gchar *new_state, const gchar *event)
 {
   g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
   wyl_audit_event_set_subject_id (ev, username);
   wyl_audit_event_set_action (ev, "principal_state");
   wyl_audit_event_set_resource_id (ev, new_state);
+  wyl_audit_event_set_deny_reason (ev, event);
   wyl_audit_event_set_deny_origin (ev, old_state);
   wyl_audit_event_set_decision (ev, WYL_DECISION_ALLOW);
   (void) wyl_audit_emit (handle, ev);
@@ -159,7 +160,8 @@ transition_principal_state (WylHandle *handle, const gchar *username,
   if (rc != WYRELOG_E_OK)
     return rc;
 #ifdef WYL_HAS_AUDIT
-  emit_principal_state_audit (handle, username, old_state_name, new_state_name);
+  emit_principal_state_audit (handle, username, old_state_name, new_state_name,
+      wyl_principal_event_name (WYL_PRINCIPAL_EVENT_MFA_OK));
 #endif
   return WYRELOG_E_OK;
 }
@@ -311,7 +313,7 @@ wyl_session_login (WylHandle *handle, const wyl_login_req_t *req,
 #ifdef WYL_HAS_AUDIT
     emit_principal_state_audit (handle, username,
         wyl_principal_state_name (WYL_PRINCIPAL_STATE_UNVERIFIED),
-        wyl_principal_state_name (state));
+        wyl_principal_state_name (state), wyl_principal_event_name (event));
 #endif
   }
 


### PR DESCRIPTION
## Summary

- records principal FSM event names on principal-state audit rows
- adds append-only policy-store ledgers for principal transitions and direct permission changes
- wires login, MFA, grant, and revoke paths to persist event edges alongside current state

## Validation

- `meson test -C builddir-audit --print-errorlogs policy-store perm session-username audit-emit wyrelogd-check`
- `meson test -C builddir --print-errorlogs policy-store perm session-username wyrelogd-check`
- `meson test -C builddir-noclient --print-errorlogs policy-store perm session-username wyrelogd-check`
- `git diff --check HEAD`
