### PR TITLE
handle: reload policy engine snapshot

### DIFF
--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -104,6 +104,17 @@ insert2_symbol (WylHandle *handle, const gchar *relation, const gchar *a,
 }
 
 static wyrelog_error_t
+insert3_symbol (WylHandle *handle, const gchar *relation, const gchar *a,
+    const gchar *b, const gchar *c)
+{
+  gint64 row[3];
+  wyrelog_error_t rc = intern3 (handle, a, b, c, row);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_engine_insert (handle, relation, row, 3);
+}
+
+static wyrelog_error_t
 insert4_symbol (WylHandle *handle, const gchar *relation, const gchar *a,
     const gchar *b, const gchar *c, const gchar *d)
 {
@@ -308,6 +319,70 @@ check_second_open_is_rejected (void)
   if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
       != WYRELOG_E_INVALID)
     return 52;
+  return 0;
+}
+
+static gint
+check_reload_rejects_missing_pair (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 55;
+  if (wyl_handle_reload_engine_pair (NULL) != WYRELOG_E_INVALID)
+    return 56;
+  if (wyl_handle_reload_engine_pair (handle) != WYRELOG_E_INVALID)
+    return 57;
+  return 0;
+}
+
+static gint
+check_reload_loads_policy_store_snapshot (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 58;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 59;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (wyl_policy_store_upsert_role (store, "wr.reload-role", "reload role")
+      != WYRELOG_E_OK)
+    return 53;
+  if (wyl_policy_store_upsert_permission (store, "wr.reload.read",
+          "reload read", "basic") != WYRELOG_E_OK)
+    return 54;
+  if (wyl_policy_store_grant_role_permission (store, "wr.reload-role",
+          "wr.reload.read") != WYRELOG_E_OK)
+    return 45;
+  if (wyl_handle_reload_engine_pair (handle) != WYRELOG_E_OK)
+    return 46;
+
+  if (insert3_symbol (handle, "member_of", "reload-user", "wr.reload-role",
+          "reload-scope") != WYRELOG_E_OK)
+    return 47;
+  if (insert2_symbol (handle, "principal_state", "reload-user",
+          "authenticated") != WYRELOG_E_OK)
+    return 48;
+  if (insert2_symbol (handle, "session_state", "reload-scope", "active")
+      != WYRELOG_E_OK)
+    return 49;
+  if (insert4_symbol (handle, "perm_state", "reload-user", "wr.reload.read",
+          "reload-scope", "armed") != WYRELOG_E_OK)
+    return 44;
+
+  gint64 decision_row[3];
+  if (intern3 (handle, "reload-user", "wr.reload.read", "reload-scope",
+          decision_row) != WYRELOG_E_OK)
+    return 33;
+  gboolean allowed = FALSE;
+  if (wyl_handle_engine_decide (handle, decision_row, &allowed)
+      != WYRELOG_E_OK)
+    return 34;
+  if (!allowed)
+    return 37;
   return 0;
 }
 
@@ -1047,6 +1122,10 @@ main (void)
   if ((rc = check_shutdown_clears_engine_pair ()) != 0)
     return rc;
   if ((rc = check_second_open_is_rejected ()) != 0)
+    return rc;
+  if ((rc = check_reload_rejects_missing_pair ()) != 0)
+    return rc;
+  if ((rc = check_reload_loads_policy_store_snapshot ()) != 0)
     return rc;
   if ((rc = check_symbol_intern_reaches_both_engines ()) != 0)
     return rc;

--- a/wyrelog/wyl-handle-private.h
+++ b/wyrelog/wyl-handle-private.h
@@ -39,6 +39,13 @@ wyrelog_error_t wyl_handle_open_engine_pair (WylHandle * self,
     const gchar * template_dir);
 
 /*
+ * Replaces the handle-owned policy engine pair with a freshly opened pair
+ * loaded from the same template directory and current policy store snapshot.
+ * On failure, the existing pair remains installed.
+ */
+wyrelog_error_t wyl_handle_reload_engine_pair (WylHandle * self);
+
+/*
  * Interns @symbol into both handle-owned policy engines and returns the shared
  * integer id. Rejected unless the engine pair is already open.
  */

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -20,6 +20,7 @@ struct _WylHandle
   WylEngine *read_engine;
   WylEngine *delta_engine;
   GHashTable *engine_symbols_by_id;
+  gchar *template_dir;
   wyl_policy_store_t *policy_store;
 #ifdef WYL_HAS_AUDIT
   wyl_audit_conn_t *audit_conn;
@@ -36,6 +37,7 @@ wyl_handle_finalize (GObject *object)
   g_clear_object (&self->read_engine);
   g_clear_object (&self->delta_engine);
   g_clear_pointer (&self->engine_symbols_by_id, g_hash_table_unref);
+  g_clear_pointer (&self->template_dir, g_free);
   g_clear_pointer (&self->policy_store, wyl_policy_store_close);
 #ifdef WYL_HAS_AUDIT
   /* NULL-safe: if wyl_shutdown already closed the conn the pointer
@@ -177,6 +179,7 @@ wyl_shutdown (WylHandle *handle)
   g_clear_pointer (&handle->policy_store, wyl_policy_store_close);
   g_clear_object (&handle->read_engine);
   g_clear_object (&handle->delta_engine);
+  g_clear_pointer (&handle->template_dir, g_free);
   g_hash_table_remove_all (handle->engine_symbols_by_id);
 }
 
@@ -215,6 +218,79 @@ wyl_handle_get_policy_store (WylHandle *self)
   return self->policy_store;
 }
 
+static GHashTable *
+new_engine_symbol_map (void)
+{
+  return g_hash_table_new_full (g_int64_hash, g_int64_equal, g_free, g_free);
+}
+
+static wyrelog_error_t
+load_current_engine_pair (WylHandle *self)
+{
+  wyrelog_error_t rc = wyl_handle_seed_perm_arm_rules (self);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_seed_session_active_states (self);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_load_policy_store_role_permissions (self);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_load_policy_store_direct_permissions (self);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_load_policy_store_principal_states (self);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_load_policy_store_session_states (self);
+}
+
+static wyrelog_error_t
+replace_engine_pair (WylHandle *self, const gchar *template_dir)
+{
+  WylEngine *old_read_engine = self->read_engine;
+  WylEngine *old_delta_engine = self->delta_engine;
+  GHashTable *old_symbols = self->engine_symbols_by_id;
+  gchar *old_template_dir = self->template_dir;
+
+  WylEngine *new_read_engine = NULL;
+  wyrelog_error_t rc = wyl_engine_open (template_dir, 1, &new_read_engine);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  WylEngine *new_delta_engine = NULL;
+  rc = wyl_engine_open (template_dir, 1, &new_delta_engine);
+  if (rc != WYRELOG_E_OK) {
+    g_object_unref (new_read_engine);
+    return rc;
+  }
+
+  self->read_engine = new_read_engine;
+  self->delta_engine = new_delta_engine;
+  self->engine_symbols_by_id = new_engine_symbol_map ();
+  self->template_dir = g_strdup (template_dir);
+
+  rc = load_current_engine_pair (self);
+  if (rc != WYRELOG_E_OK) {
+    g_clear_object (&self->read_engine);
+    g_clear_object (&self->delta_engine);
+    g_clear_pointer (&self->engine_symbols_by_id, g_hash_table_unref);
+    g_clear_pointer (&self->template_dir, g_free);
+    self->read_engine = old_read_engine;
+    self->delta_engine = old_delta_engine;
+    self->engine_symbols_by_id = old_symbols;
+    self->template_dir = old_template_dir;
+    return rc;
+  }
+
+  g_clear_object (&old_read_engine);
+  g_clear_object (&old_delta_engine);
+  if (old_symbols != NULL)
+    g_hash_table_unref (old_symbols);
+  g_free (old_template_dir);
+  return WYRELOG_E_OK;
+}
+
 wyrelog_error_t
 wyl_handle_open_engine_pair (WylHandle *self, const gchar *template_dir)
 {
@@ -225,57 +301,19 @@ wyl_handle_open_engine_pair (WylHandle *self, const gchar *template_dir)
   if (self->read_engine != NULL || self->delta_engine != NULL)
     return WYRELOG_E_INVALID;
 
-  WylEngine *read_engine = NULL;
-  wyrelog_error_t rc = wyl_engine_open (template_dir, 1, &read_engine);
-  if (rc != WYRELOG_E_OK)
-    return rc;
+  return replace_engine_pair (self, template_dir);
+}
 
-  WylEngine *delta_engine = NULL;
-  rc = wyl_engine_open (template_dir, 1, &delta_engine);
-  if (rc != WYRELOG_E_OK) {
-    g_object_unref (read_engine);
-    return rc;
-  }
+wyrelog_error_t
+wyl_handle_reload_engine_pair (WylHandle *self)
+{
+  if (self == NULL || !WYL_IS_HANDLE (self))
+    return WYRELOG_E_INVALID;
+  if (self->template_dir == NULL)
+    return WYRELOG_E_INVALID;
 
-  self->read_engine = read_engine;
-  self->delta_engine = delta_engine;
-  rc = wyl_handle_seed_perm_arm_rules (self);
-  if (rc != WYRELOG_E_OK) {
-    g_clear_object (&self->read_engine);
-    g_clear_object (&self->delta_engine);
-    return rc;
-  }
-  rc = wyl_handle_seed_session_active_states (self);
-  if (rc != WYRELOG_E_OK) {
-    g_clear_object (&self->read_engine);
-    g_clear_object (&self->delta_engine);
-    return rc;
-  }
-  rc = wyl_handle_load_policy_store_role_permissions (self);
-  if (rc != WYRELOG_E_OK) {
-    g_clear_object (&self->read_engine);
-    g_clear_object (&self->delta_engine);
-    return rc;
-  }
-  rc = wyl_handle_load_policy_store_direct_permissions (self);
-  if (rc != WYRELOG_E_OK) {
-    g_clear_object (&self->read_engine);
-    g_clear_object (&self->delta_engine);
-    return rc;
-  }
-  rc = wyl_handle_load_policy_store_principal_states (self);
-  if (rc != WYRELOG_E_OK) {
-    g_clear_object (&self->read_engine);
-    g_clear_object (&self->delta_engine);
-    return rc;
-  }
-  rc = wyl_handle_load_policy_store_session_states (self);
-  if (rc != WYRELOG_E_OK) {
-    g_clear_object (&self->read_engine);
-    g_clear_object (&self->delta_engine);
-    return rc;
-  }
-  return WYRELOG_E_OK;
+  g_autofree gchar *template_dir = g_strdup (self->template_dir);
+  return replace_engine_pair (self, template_dir);
 }
 
 wyrelog_error_t


### PR DESCRIPTION
## Summary
- add a handle-private policy engine reload path for the stored template directory
- load the current policy-store snapshot into a fresh engine pair before swapping
- keep the existing engine pair installed when reload setup fails

## Validation
- git diff --check HEAD
- meson test -C builddir-audit --print-errorlogs handle-engine-pair wyrelogd-check
- meson test -C builddir --print-errorlogs handle-engine-pair wyrelogd-check
- meson test -C builddir-noclient --print-errorlogs handle-engine-pair wyrelogd-check