### PR TITLE
ci: add codeql analysis workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+name: CodeQL
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    - cron: "27 3 * * 1"
+
+permissions:
+  contents: read
+  security-events: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  analyze:
+    name: analyze-c-cpp
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v5
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            meson ninja-build pkg-config \
+            libglib2.0-dev libsqlite3-dev libsoup-3.0-dev libsodium-dev \
+            libtss2-dev
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: c-cpp
+          build-mode: manual
+
+      - name: Configure
+        run: |
+          meson setup builddir \
+            -Denable_tpm=enabled \
+            -Denable_audit=enabled \
+            -Dduckdb_source=prebuilt
+
+      - name: Build
+        run: meson compile -C builddir
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
## Summary
- add a dedicated CodeQL workflow for C/C++ analysis
- run analysis on pull requests, main pushes, and a weekly schedule
- use a manual Meson build so CodeQL observes the compiled database

## Validation
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts f }' .github/workflows/codeql.yml .github/workflows/ci-pr.yml .github/workflows/ci-main.yml\n- gh api repos/github/codeql-action/git/ref/tags/v4 --jq '.ref + " " + .object.sha'\n- git diff --check HEAD