### PR TITLE
ci: filter vendored CodeQL results

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -54,3 +54,19 @@ jobs:
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@v4
+        with:
+          output: sarif-results
+          upload: failure-only
+
+      - name: Filter vendored SARIF results
+        uses: advanced-security/filter-sarif@v1
+        with:
+          patterns: |
+            -subprojects/**/*
+          input: sarif-results/cpp.sarif
+          output: sarif-results/cpp.sarif
+
+      - name: Upload CodeQL SARIF
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: sarif-results/cpp.sarif


### PR DESCRIPTION
## Summary

- emit CodeQL results as SARIF before upload
- filter SARIF alerts reported from vendored subproject paths
- upload the filtered SARIF file to code scanning

## Validation

- python3 YAML parse for .github/workflows/codeql.yml
- git diff --check
