### PR TITLE
handle: pin role graph reload contract

### DIFF
--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -22,6 +22,13 @@ typedef struct
   guint matching;
 } DeltaExpect;
 
+typedef struct
+{
+  const gchar *expected_relation;
+  WylDeltaKind expected_kind;
+  guint matching;
+} DeltaRelationExpect;
+
 static void
 snapshot_expect_cb (const gchar *relation, const gint64 *row, guint ncols,
     gpointer user_data)
@@ -63,6 +70,22 @@ delta_expect_cb (const gchar *relation, const gint64 *row, guint ncols,
       && row[2] == expect->expected_row[2]) {
     expect->matching++;
   }
+}
+
+static void
+delta_relation_expect_cb (const gchar *relation, const gint64 *row,
+    guint ncols, WylDeltaKind kind, gpointer user_data)
+{
+  DeltaRelationExpect *expect = user_data;
+
+  (void) row;
+  (void) ncols;
+
+  if (g_strcmp0 (relation, expect->expected_relation) != 0)
+    return;
+  if (kind != expect->expected_kind)
+    return;
+  expect->matching++;
 }
 
 static wyrelog_error_t
@@ -580,6 +603,41 @@ check_snapshot_only_insert_skips_delta_engine (void)
     return 185;
   if (expect.matching != 0)
     return 186;
+  return 0;
+}
+
+static gint
+check_role_permission_insert_skips_delta_engine (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  gint64 row[2];
+  DeltaRelationExpect expect = {
+    "role_permission",
+    WYL_DELTA_INSERT,
+    0,
+  };
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 187;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 188;
+  if (wyl_handle_intern_engine_symbol (handle, "wr.snapshot-role", &row[0])
+      != WYRELOG_E_OK)
+    return 189;
+  if (wyl_handle_intern_engine_symbol (handle, "wr.snapshot-role.read",
+          &row[1]) != WYRELOG_E_OK)
+    return 190;
+  if (wyl_handle_engine_set_delta_callback (handle,
+          delta_relation_expect_cb, &expect) != WYRELOG_E_OK)
+    return 191;
+  if (wyl_handle_engine_insert (handle, "role_permission", row, 2)
+      != WYRELOG_E_OK)
+    return 192;
+  if (wyl_handle_engine_step_delta (handle) != WYRELOG_E_OK)
+    return 193;
+  if (expect.matching != 0)
+    return 194;
   return 0;
 }
 
@@ -1140,6 +1198,8 @@ main (void)
   if ((rc = check_insert_fanout_reaches_delta_engine ()) != 0)
     return rc;
   if ((rc = check_snapshot_only_insert_skips_delta_engine ()) != 0)
+    return rc;
+  if ((rc = check_role_permission_insert_skips_delta_engine ()) != 0)
     return rc;
   if ((rc = check_remove_fanout_reaches_read_engine ()) != 0)
     return rc;

--- a/wyrelog/daemon/wyrelogd.c
+++ b/wyrelog/daemon/wyrelogd.c
@@ -310,6 +310,92 @@ check_policy_snapshot_reload_ready (WylHandle *handle)
 }
 
 static wyrelog_error_t
+insert_symbol_row (WylHandle *handle, const gchar *relation,
+    const gchar *const *symbols, gsize ncols)
+{
+  gint64 row[4];
+
+  if (ncols == 0 || ncols > G_N_ELEMENTS (row))
+    return WYRELOG_E_INVALID;
+
+  for (gsize i = 0; i < ncols; i++) {
+    wyrelog_error_t rc =
+        wyl_handle_intern_engine_symbol (handle, symbols[i], &row[i]);
+    if (rc != WYRELOG_E_OK)
+      return rc;
+  }
+
+  return wyl_handle_engine_insert (handle, relation, row, ncols);
+}
+
+static wyrelog_error_t
+check_role_permission_snapshot_reload_ready (WylHandle *handle)
+{
+  g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
+  wyl_login_req_set_username (login, "wyrelogd-role-user");
+  wyl_login_req_set_skip_mfa (login, TRUE);
+
+  g_autoptr (WylSession) session = NULL;
+  wyrelog_error_t rc = wyl_session_login (handle, login, &session);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  g_autofree gchar *session_id = wyl_session_dup_id_string (session);
+  if (session_id == NULL)
+    return WYRELOG_E_INTERNAL;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  rc = wyl_policy_store_upsert_role (store, "wr.snapshot-role",
+      "snapshot role");
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_policy_store_upsert_permission (store, "wyrelogd.role.read",
+      "role read", "basic");
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_policy_store_grant_role_permission (store, "wr.snapshot-role",
+      "wyrelogd.role.read");
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_reload_engine_pair (handle);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  const gchar *member_row[] = {
+    "wyrelogd-role-user",
+    "wr.snapshot-role",
+    session_id,
+  };
+  rc = insert_symbol_row (handle, "member_of", member_row,
+      G_N_ELEMENTS (member_row));
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  const gchar *perm_state_row[] = {
+    "wyrelogd-role-user",
+    "wyrelogd.role.read",
+    session_id,
+    "armed",
+  };
+  rc = insert_symbol_row (handle, "perm_state", perm_state_row,
+      G_N_ELEMENTS (perm_state_row));
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  g_autoptr (wyl_decide_req_t) decide = wyl_decide_req_new ();
+  wyl_decide_req_set_subject_id (decide, "wyrelogd-role-user");
+  wyl_decide_req_set_action (decide, "wyrelogd.role.read");
+  wyl_decide_req_set_resource_id (decide, session_id);
+
+  g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
+  rc = wyl_decide (handle, decide, resp);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_decide_resp_get_decision (resp) == WYL_DECISION_ALLOW ?
+      WYRELOG_E_OK : WYRELOG_E_POLICY;
+}
+
+static wyrelog_error_t
 emit_daemon_start_event (WylHandle *handle)
 {
 #ifdef WYL_HAS_AUDIT
@@ -499,6 +585,12 @@ main (int argc, char **argv)
     rc = check_policy_snapshot_reload_ready (handle);
     if (rc != WYRELOG_E_OK) {
       g_printerr ("wyrelogd: policy snapshot reload check failed: %s\n",
+          wyrelog_error_string (rc));
+      return 1;
+    }
+    rc = check_role_permission_snapshot_reload_ready (handle);
+    if (rc != WYRELOG_E_OK) {
+      g_printerr ("wyrelogd: role permission reload check failed: %s\n",
           wyrelog_error_string (rc));
       return 1;
     }


### PR DESCRIPTION
## Summary

- keep role permission rows on the snapshot reload path instead of delta fanout
- cover the role permission no-delta contract in engine-pair tests
- extend daemon check to verify role graph updates after snapshot reload

## Validation

- git diff --check
- meson test -C builddir-audit --print-errorlogs handle-engine-pair wyrelogd-check
- meson test -C builddir --print-errorlogs handle-engine-pair wyrelogd-check
- meson test -C builddir-noclient --print-errorlogs handle-engine-pair wyrelogd-check
