### PR TITLE
policy: flatten role inheritance in snapshots

### DIFF
--- a/templates/access/sqlite-schema.sql
+++ b/templates/access/sqlite-schema.sql
@@ -52,6 +52,26 @@ CREATE INDEX IF NOT EXISTS idx_role_permissions_perm_id
     ON role_permissions (perm_id);
 
 -- ---------------------------------------------------------------------------
+-- Table: role_inheritances
+-- Mutable role graph edges flattened into role_permission/2 snapshots.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS role_inheritances (
+    child_role_id  TEXT    NOT NULL,
+    parent_role_id TEXT    NOT NULL,
+    granted_at     INTEGER,               -- Unix epoch (seconds)
+    granted_by     TEXT,                  -- Platform engineer identifier
+    PRIMARY KEY (child_role_id, parent_role_id),
+    FOREIGN KEY (child_role_id) REFERENCES roles (role_id),
+    FOREIGN KEY (parent_role_id) REFERENCES roles (role_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_role_inheritances_child
+    ON role_inheritances (child_role_id);
+
+CREATE INDEX IF NOT EXISTS idx_role_inheritances_parent
+    ON role_inheritances (parent_role_id);
+
+-- ---------------------------------------------------------------------------
 -- Table: direct_permissions
 -- Per-principal direct grants mirrored into direct_permission/3.
 -- ---------------------------------------------------------------------------

--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -967,6 +967,60 @@ check_policy_store_role_permissions_autoload_on_open (void)
 }
 
 static gint
+check_policy_store_role_inheritances_autoload_on_open (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 348;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (wyl_policy_store_upsert_role (store, "wr.inherit-child",
+          "inherit child") != WYRELOG_E_OK)
+    return 349;
+  if (wyl_policy_store_upsert_role (store, "wr.inherit-parent",
+          "inherit parent") != WYRELOG_E_OK)
+    return 350;
+  if (wyl_policy_store_upsert_permission (store, "wr.inherit.read",
+          "inherit read", "basic") != WYRELOG_E_OK)
+    return 351;
+  if (wyl_policy_store_grant_role_permission (store, "wr.inherit-parent",
+          "wr.inherit.read") != WYRELOG_E_OK)
+    return 352;
+  if (wyl_policy_store_grant_role_inheritance (store, "wr.inherit-child",
+          "wr.inherit-parent") != WYRELOG_E_OK)
+    return 353;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 354;
+
+  if (insert3_symbol (handle, "member_of", "inherit-user",
+          "wr.inherit-child", "inherit-scope") != WYRELOG_E_OK)
+    return 355;
+  if (insert2_symbol (handle, "principal_state", "inherit-user",
+          "authenticated") != WYRELOG_E_OK)
+    return 356;
+  if (insert2_symbol (handle, "session_state", "inherit-scope", "active")
+      != WYRELOG_E_OK)
+    return 357;
+  if (insert4_symbol (handle, "perm_state", "inherit-user",
+          "wr.inherit.read", "inherit-scope", "armed") != WYRELOG_E_OK)
+    return 358;
+
+  gint64 decision_row[3];
+  if (intern3 (handle, "inherit-user", "wr.inherit.read", "inherit-scope",
+          decision_row) != WYRELOG_E_OK)
+    return 359;
+  gboolean allowed = FALSE;
+  if (wyl_handle_engine_decide (handle, decision_row, &allowed)
+      != WYRELOG_E_OK)
+    return 360;
+  if (!allowed)
+    return 361;
+  return 0;
+}
+
+static gint
 check_policy_store_role_permissions_require_engine_pair (void)
 {
   g_autoptr (WylHandle) handle = NULL;
@@ -1224,6 +1278,8 @@ main (void)
   if ((rc = check_policy_store_role_permissions_load_into_engine ()) != 0)
     return rc;
   if ((rc = check_policy_store_role_permissions_autoload_on_open ()) != 0)
+    return rc;
+  if ((rc = check_policy_store_role_inheritances_autoload_on_open ()) != 0)
     return rc;
   if ((rc = check_policy_store_role_permissions_require_engine_pair ()) != 0)
     return rc;

--- a/tests/test-policy-store.c
+++ b/tests/test-policy-store.c
@@ -23,6 +23,7 @@ check_store_creates_authority_schema (void)
     "roles",
     "permissions",
     "role_permissions",
+    "role_inheritances",
     "direct_permissions",
     "direct_permission_events",
     "principal_events",
@@ -66,6 +67,7 @@ check_template_schema_creates_state_tables (void)
     "roles",
     "permissions",
     "role_permissions",
+    "role_inheritances",
     "direct_permissions",
     "direct_permission_events",
     "principal_events",
@@ -233,6 +235,13 @@ typedef struct
   guint matches;
 } RolePermissionExpect;
 
+typedef struct
+{
+  const gchar *child_role_id;
+  const gchar *parent_role_id;
+  guint matches;
+} RoleInheritanceExpect;
+
 static wyrelog_error_t
 role_permission_expect_cb (const gchar *role_id, const gchar *perm_id,
     gpointer user_data)
@@ -241,6 +250,18 @@ role_permission_expect_cb (const gchar *role_id, const gchar *perm_id,
 
   if (g_strcmp0 (role_id, expect->role_id) == 0
       && g_strcmp0 (perm_id, expect->perm_id) == 0)
+    expect->matches++;
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+role_inheritance_expect_cb (const gchar *child_role_id,
+    const gchar *parent_role_id, gpointer user_data)
+{
+  RoleInheritanceExpect *expect = user_data;
+
+  if (g_strcmp0 (child_role_id, expect->child_role_id) == 0
+      && g_strcmp0 (parent_role_id, expect->parent_role_id) == 0)
     expect->matches++;
   return WYRELOG_E_OK;
 }
@@ -276,6 +297,56 @@ check_store_grants_role_permission (void)
     return 46;
   if (expect.matches != 1)
     return 47;
+  return 0;
+}
+
+static gint
+check_store_grants_role_inheritance (void)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 48;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 49;
+  if (wyl_policy_store_upsert_role (store, "wr.child-role", "child role")
+      != WYRELOG_E_OK)
+    return 58;
+  if (wyl_policy_store_upsert_role (store, "wr.parent-role", "parent role")
+      != WYRELOG_E_OK)
+    return 59;
+  if (wyl_policy_store_grant_role_inheritance (store, "wr.child-role",
+          "wr.parent-role") != WYRELOG_E_OK)
+    return 60;
+  if (wyl_policy_store_grant_role_inheritance (store, "wr.child-role",
+          "wr.parent-role") != WYRELOG_E_OK)
+    return 61;
+  if (wyl_policy_store_upsert_permission (store, "wr.inherited.read",
+          "inherited read", "basic") != WYRELOG_E_OK)
+    return 62;
+  if (wyl_policy_store_grant_role_permission (store, "wr.parent-role",
+          "wr.inherited.read") != WYRELOG_E_OK)
+    return 63;
+
+  RoleInheritanceExpect expect = {
+    .child_role_id = "wr.child-role",
+    .parent_role_id = "wr.parent-role",
+  };
+  if (wyl_policy_store_foreach_role_inheritance (store,
+          role_inheritance_expect_cb, &expect) != WYRELOG_E_OK)
+    return 64;
+  if (expect.matches != 1)
+    return 65;
+
+  RolePermissionExpect permission_expect = {
+    .role_id = "wr.child-role",
+    .perm_id = "wr.inherited.read",
+  };
+  if (wyl_policy_store_foreach_role_permission (store,
+          role_permission_expect_cb, &permission_expect) != WYRELOG_E_OK)
+    return 66;
+  if (permission_expect.matches != 1)
+    return 67;
   return 0;
 }
 
@@ -494,6 +565,12 @@ check_store_rejects_bad_role_permission (void)
   if (wyl_policy_store_foreach_role_permission (store, NULL, NULL)
       != WYRELOG_E_INVALID)
     return 55;
+  if (wyl_policy_store_grant_role_inheritance (store, "missing-child",
+          "missing-parent") != WYRELOG_E_IO)
+    return 58;
+  if (wyl_policy_store_foreach_role_inheritance (store, NULL, NULL)
+      != WYRELOG_E_INVALID)
+    return 59;
   if (wyl_policy_store_set_principal_state (store, NULL, "authenticated")
       != WYRELOG_E_INVALID)
     return 56;
@@ -529,6 +606,8 @@ main (void)
   if ((rc = check_handle_owns_policy_store ()) != 0)
     return rc;
   if ((rc = check_store_grants_role_permission ()) != 0)
+    return rc;
+  if ((rc = check_store_grants_role_inheritance ()) != 0)
     return rc;
   if ((rc = check_store_grants_direct_permission ()) != 0)
     return rc;

--- a/wyrelog/daemon/wyrelogd.c
+++ b/wyrelog/daemon/wyrelogd.c
@@ -223,6 +223,7 @@ check_policy_store_ready (WylHandle *handle)
     "roles",
     "permissions",
     "role_permissions",
+    "role_inheritances",
     "direct_permissions",
     "direct_permission_events",
     "principal_events",
@@ -345,16 +346,24 @@ check_role_permission_snapshot_reload_ready (WylHandle *handle)
     return WYRELOG_E_INTERNAL;
 
   wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
-  rc = wyl_policy_store_upsert_role (store, "wr.snapshot-role",
-      "snapshot role");
+  rc = wyl_policy_store_upsert_role (store, "wr.snapshot-child",
+      "snapshot child");
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_policy_store_upsert_role (store, "wr.snapshot-parent",
+      "snapshot parent");
   if (rc != WYRELOG_E_OK)
     return rc;
   rc = wyl_policy_store_upsert_permission (store, "wyrelogd.role.read",
       "role read", "basic");
   if (rc != WYRELOG_E_OK)
     return rc;
-  rc = wyl_policy_store_grant_role_permission (store, "wr.snapshot-role",
+  rc = wyl_policy_store_grant_role_permission (store, "wr.snapshot-parent",
       "wyrelogd.role.read");
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_policy_store_grant_role_inheritance (store, "wr.snapshot-child",
+      "wr.snapshot-parent");
   if (rc != WYRELOG_E_OK)
     return rc;
   rc = wyl_handle_reload_engine_pair (handle);
@@ -363,7 +372,7 @@ check_role_permission_snapshot_reload_ready (WylHandle *handle)
 
   const gchar *member_row[] = {
     "wyrelogd-role-user",
-    "wr.snapshot-role",
+    "wr.snapshot-child",
     session_id,
   };
   rc = insert_symbol_row (handle, "member_of", member_row,

--- a/wyrelog/policy/store-private.h
+++ b/wyrelog/policy/store-private.h
@@ -12,6 +12,8 @@ typedef struct wyl_policy_store_t wyl_policy_store_t;
 
 typedef wyrelog_error_t (*wyl_policy_role_permission_cb) (const gchar * role_id,
     const gchar * perm_id, gpointer user_data);
+typedef wyrelog_error_t (*wyl_policy_role_inheritance_cb) (const gchar *
+    child_role_id, const gchar * parent_role_id, gpointer user_data);
 typedef wyrelog_error_t (*wyl_policy_direct_permission_cb) (const gchar *
     subject_id, const gchar * perm_id, const gchar * scope, gpointer user_data);
 typedef wyrelog_error_t (*wyl_policy_direct_permission_event_cb) (const gchar *
@@ -51,6 +53,10 @@ wyrelog_error_t wyl_policy_store_grant_role_permission (wyl_policy_store_t *
     store, const gchar * role_id, const gchar * perm_id);
 wyrelog_error_t wyl_policy_store_foreach_role_permission (wyl_policy_store_t *
     store, wyl_policy_role_permission_cb cb, gpointer user_data);
+wyrelog_error_t wyl_policy_store_grant_role_inheritance (wyl_policy_store_t *
+    store, const gchar * child_role_id, const gchar * parent_role_id);
+wyrelog_error_t wyl_policy_store_foreach_role_inheritance (wyl_policy_store_t *
+    store, wyl_policy_role_inheritance_cb cb, gpointer user_data);
 wyrelog_error_t wyl_policy_store_grant_direct_permission (wyl_policy_store_t *
     store, const gchar * subject_id, const gchar * perm_id,
     const gchar * scope);

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -115,6 +115,19 @@ wyl_policy_store_create_schema (wyl_policy_store_t *store)
       "  ON role_permissions (role_id);"
       "CREATE INDEX IF NOT EXISTS idx_role_permissions_perm_id "
       "  ON role_permissions (perm_id);"
+      "CREATE TABLE IF NOT EXISTS role_inheritances ("
+      "  child_role_id TEXT NOT NULL,"
+      "  parent_role_id TEXT NOT NULL,"
+      "  granted_at INTEGER,"
+      "  granted_by TEXT,"
+      "  PRIMARY KEY (child_role_id, parent_role_id),"
+      "  FOREIGN KEY (child_role_id) REFERENCES roles (role_id),"
+      "  FOREIGN KEY (parent_role_id) REFERENCES roles (role_id)"
+      ");"
+      "CREATE INDEX IF NOT EXISTS idx_role_inheritances_child "
+      "  ON role_inheritances (child_role_id);"
+      "CREATE INDEX IF NOT EXISTS idx_role_inheritances_parent "
+      "  ON role_inheritances (parent_role_id);"
       "CREATE TABLE IF NOT EXISTS direct_permissions ("
       "  subject_id TEXT NOT NULL,"
       "  perm_id TEXT NOT NULL,"
@@ -680,7 +693,15 @@ wyl_policy_store_foreach_role_permission (wyl_policy_store_t *store,
     return WYRELOG_E_INVALID;
 
   static const gchar *sql =
-      "SELECT role_id, perm_id FROM role_permissions "
+      "WITH RECURSIVE effective_role_permissions(role_id, perm_id) AS ("
+      "  SELECT role_id, perm_id FROM role_permissions"
+      "  UNION "
+      "  SELECT ri.child_role_id, erp.perm_id "
+      "  FROM role_inheritances ri "
+      "  JOIN effective_role_permissions erp "
+      "    ON erp.role_id = ri.parent_role_id"
+      ") "
+      "SELECT role_id, perm_id FROM effective_role_permissions "
       "ORDER BY role_id, perm_id;";
   wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
   if (rc != WYRELOG_E_OK)
@@ -691,6 +712,67 @@ wyl_policy_store_foreach_role_permission (wyl_policy_store_t *store,
     const gchar *role_id = (const gchar *) sqlite3_column_text (stmt, 0);
     const gchar *perm_id = (const gchar *) sqlite3_column_text (stmt, 1);
     rc = cb (role_id, perm_id, user_data);
+    if (rc != WYRELOG_E_OK) {
+      sqlite3_finalize (stmt);
+      return rc;
+    }
+  }
+
+  sqlite3_finalize (stmt);
+  return (step_rc == SQLITE_DONE) ? WYRELOG_E_OK : WYRELOG_E_IO;
+}
+
+wyrelog_error_t
+wyl_policy_store_grant_role_inheritance (wyl_policy_store_t *store,
+    const gchar *child_role_id, const gchar *parent_role_id)
+{
+  sqlite3_stmt *stmt = NULL;
+
+  if (store == NULL || store->db == NULL || child_role_id == NULL
+      || parent_role_id == NULL)
+    return WYRELOG_E_INVALID;
+
+  static const gchar *sql =
+      "INSERT INTO role_inheritances "
+      "  (child_role_id, parent_role_id, granted_at) "
+      "VALUES (?, ?, unixepoch()) "
+      "ON CONFLICT(child_role_id, parent_role_id) DO UPDATE SET "
+      "  granted_at = excluded.granted_at;";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if ((rc = bind_text (stmt, 1, child_role_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 2, parent_role_id)) != WYRELOG_E_OK) {
+    sqlite3_finalize (stmt);
+    return rc;
+  }
+
+  int step_rc = sqlite3_step (stmt);
+  sqlite3_finalize (stmt);
+  return (step_rc == SQLITE_DONE) ? WYRELOG_E_OK : WYRELOG_E_IO;
+}
+
+wyrelog_error_t
+wyl_policy_store_foreach_role_inheritance (wyl_policy_store_t *store,
+    wyl_policy_role_inheritance_cb cb, gpointer user_data)
+{
+  sqlite3_stmt *stmt = NULL;
+
+  if (store == NULL || store->db == NULL || cb == NULL)
+    return WYRELOG_E_INVALID;
+
+  static const gchar *sql =
+      "SELECT child_role_id, parent_role_id FROM role_inheritances "
+      "ORDER BY child_role_id, parent_role_id;";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  int step_rc;
+  while ((step_rc = sqlite3_step (stmt)) == SQLITE_ROW) {
+    const gchar *child_role_id = (const gchar *) sqlite3_column_text (stmt, 0);
+    const gchar *parent_role_id = (const gchar *) sqlite3_column_text (stmt, 1);
+    rc = cb (child_role_id, parent_role_id, user_data);
     if (rc != WYRELOG_E_OK) {
       sqlite3_finalize (stmt);
       return rc;

--- a/wyrelog/wyl-handle-private.h
+++ b/wyrelog/wyl-handle-private.h
@@ -79,9 +79,9 @@ wyrelog_error_t wyl_handle_engine_set_delta_callback (WylHandle * self,
     WylDeltaCallback cb, gpointer user_data);
 
 /*
- * Loads role_permission rows from the handle-owned policy authority store into
- * the attached read/delta engine pair. Rejected unless both the store and
- * engine pair are available.
+ * Loads effective role_permission rows from the handle-owned policy authority
+ * store into the attached read/delta engine pair. Role inheritance edges are
+ * flattened by the store iterator before they reach the engine.
  */
 wyrelog_error_t wyl_handle_load_policy_store_role_permissions (WylHandle *
     self);


### PR DESCRIPTION
## Summary
- persist role inheritance edges in the policy authority store
- expose inherited permissions as flattened role_permission snapshots
- cover store, handle autoload, and daemon readiness checks

## Tests
- git diff --check
- meson test -C builddir-audit --print-errorlogs policy-store handle-engine-pair wyrelogd-check
- meson test -C builddir --print-errorlogs policy-store handle-engine-pair wyrelogd-check
- meson test -C builddir-noclient --print-errorlogs policy-store handle-engine-pair wyrelogd-check