### PR TITLE
audit: mirror events into policy store

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -102,6 +102,7 @@ jobs:
           key: vcpkg-windows-v2-2026.04.27-glib-sqlite3-libsodium
           restore-keys: |
             vcpkg-windows-v2-
+            vcpkg-windows-
 
       - name: Create vcpkg binary cache
         shell: cmd

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -99,9 +99,9 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
-          key: vcpkg-windows-2026.04.27-glib-sqlite3-libsodium
+          key: vcpkg-windows-v2-2026.04.27-glib-sqlite3-libsodium
           restore-keys: |
-            vcpkg-windows-
+            vcpkg-windows-v2-
 
       - name: Create vcpkg binary cache
         shell: cmd

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -103,6 +103,7 @@ jobs:
           key: vcpkg-windows-v2-2026.04.27-glib-sqlite3-libsodium
           restore-keys: |
             vcpkg-windows-v2-
+            vcpkg-windows-
 
       - name: Create vcpkg binary cache
         shell: cmd

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -96,12 +96,13 @@ jobs:
           call "%VCPKG_ROOT%\bootstrap-vcpkg.bat" -disableMetrics
 
       - name: Restore vcpkg binary packages
+        id: vcpkg-cache
         uses: actions/cache/restore@v5
         with:
           path: ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
-          key: vcpkg-windows-2026.04.27-glib-sqlite3-libsodium
+          key: vcpkg-windows-v2-2026.04.27-glib-sqlite3-libsodium
           restore-keys: |
-            vcpkg-windows-
+            vcpkg-windows-v2-
 
       - name: Create vcpkg binary cache
         shell: cmd
@@ -121,7 +122,16 @@ jobs:
           @echo off
           "%VCPKG_ROOT%\vcpkg.exe" install glib:x64-windows sqlite3:x64-windows libsodium:x64-windows --x-abi-tools-use-exact-versions
 
+      - name: Save vcpkg binary packages
+        if: steps.vcpkg-cache.outputs.cache-hit != 'true'
+        continue-on-error: true
+        uses: actions/cache/save@v5
+        with:
+          path: ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
+          key: ${{ steps.vcpkg-cache.outputs.cache-primary-key }}
+
       - name: Restore meson packagecache
+        id: meson-packagecache
         uses: actions/cache/restore@v5
         with:
           path: subprojects/packagecache
@@ -137,6 +147,14 @@ jobs:
           set PKG_CONFIG_PATH=%VCPKG_INSTALLED_DIR%\lib\pkgconfig
           set CC=clang-cl
           meson setup builddir -Denable_tpm=disabled -Denable_client=disabled -Ddefault_library=static -Denable_audit=enabled -Dduckdb_source=prebuilt
+
+      - name: Save meson packagecache
+        if: steps.meson-packagecache.outputs.cache-hit != 'true'
+        continue-on-error: true
+        uses: actions/cache/save@v5
+        with:
+          path: subprojects/packagecache
+          key: ${{ steps.meson-packagecache.outputs.cache-primary-key }}
 
       - name: Build and test (clang-cl)
         shell: cmd

--- a/templates/access/sqlite-schema.sql
+++ b/templates/access/sqlite-schema.sql
@@ -156,6 +156,36 @@ CREATE INDEX IF NOT EXISTS idx_session_states_state
     ON session_states (state);
 
 -- ---------------------------------------------------------------------------
+-- Table: audit_events
+-- Append-only audit sink mirrored from runtime audit emission.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS audit_events (
+    id            TEXT    PRIMARY KEY,
+    created_at_us INTEGER NOT NULL,
+    subject_id    TEXT,
+    action        TEXT,
+    resource_id   TEXT,
+    deny_reason   TEXT,
+    deny_origin   TEXT,
+    decision      INTEGER NOT NULL CHECK (decision IN (0, 1))
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_events_created_at_us
+    ON audit_events (created_at_us);
+
+CREATE INDEX IF NOT EXISTS idx_audit_events_subject_id
+    ON audit_events (subject_id);
+
+CREATE INDEX IF NOT EXISTS idx_audit_events_action
+    ON audit_events (action);
+
+CREATE INDEX IF NOT EXISTS idx_audit_events_decision
+    ON audit_events (decision);
+
+CREATE INDEX IF NOT EXISTS idx_audit_events_deny_reason
+    ON audit_events (deny_reason);
+
+-- ---------------------------------------------------------------------------
 -- Table: policy_signatures
 -- Ed25519 signatures over policy snapshots, authored by security_officer.
 -- Each policy version is immutably signed; versions are monotonically

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -399,7 +399,7 @@ if get_option('enable_audit').allowed()
       '-DWYL_HAS_AUDIT',
       '-DWYL_TEST_TEMPLATE_DIR="' + meson.project_source_root() / 'templates' / 'access' + '"',
     ],
-    dependencies : [wyrelog_dep, duckdb_dep],
+    dependencies : [wyrelog_dep, duckdb_dep, sqlite_dep],
   )
 
   test('audit-emit', test_audit_emit, env : audit_conn_test_env)

--- a/tests/test-audit-emit.c
+++ b/tests/test-audit-emit.c
@@ -4,6 +4,7 @@
 
 #include "wyrelog/wyrelog.h"
 #include "wyrelog/audit/conn-private.h"
+#include "wyrelog/policy/store-private.h"
 #include "wyrelog/wyl-handle-private.h"
 
 #ifndef WYL_TEST_TEMPLATE_DIR
@@ -345,6 +346,71 @@ check_query_events_json_filters_rows (void)
 
   g_object_unref (handle);
   return 0;
+}
+
+static gint
+check_emit_mirrors_policy_store_row (void)
+{
+  WylHandle *handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 160;
+
+  g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
+  wyl_audit_event_set_subject_id (ev, "policy-audit-user");
+  wyl_audit_event_set_action (ev, "audit.write");
+  wyl_audit_event_set_resource_id (ev, "audit-log");
+  wyl_audit_event_set_deny_reason (ev, "allowed");
+  wyl_audit_event_set_deny_origin (ev, "test");
+  wyl_audit_event_set_decision (ev, WYL_DECISION_ALLOW);
+  g_autofree gchar *expected_id = wyl_audit_event_dup_id_string (ev);
+
+  if (wyl_audit_emit (handle, ev) != WYRELOG_E_OK) {
+    g_object_unref (handle);
+    return 161;
+  }
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  sqlite3_stmt *stmt = NULL;
+  static const gchar *sql =
+      "SELECT subject_id, action, resource_id, deny_reason, deny_origin, "
+      "decision FROM audit_events WHERE id = ?;";
+  if (sqlite3_prepare_v2 (wyl_policy_store_get_db (store), sql, -1, &stmt,
+          NULL) != SQLITE_OK) {
+    g_object_unref (handle);
+    return 162;
+  }
+  if (sqlite3_bind_text (stmt, 1, expected_id, -1, SQLITE_TRANSIENT)
+      != SQLITE_OK) {
+    sqlite3_finalize (stmt);
+    g_object_unref (handle);
+    return 163;
+  }
+
+  int step_rc = sqlite3_step (stmt);
+  gint rc = 0;
+  if (step_rc != SQLITE_ROW)
+    rc = 164;
+  else if (g_strcmp0 ((const gchar *) sqlite3_column_text (stmt, 0),
+          "policy-audit-user") != 0)
+    rc = 165;
+  else if (g_strcmp0 ((const gchar *) sqlite3_column_text (stmt, 1),
+          "audit.write") != 0)
+    rc = 166;
+  else if (g_strcmp0 ((const gchar *) sqlite3_column_text (stmt, 2),
+          "audit-log") != 0)
+    rc = 167;
+  else if (g_strcmp0 ((const gchar *) sqlite3_column_text (stmt, 3),
+          "allowed") != 0)
+    rc = 168;
+  else if (g_strcmp0 ((const gchar *) sqlite3_column_text (stmt, 4),
+          "test") != 0)
+    rc = 169;
+  else if (sqlite3_column_int (stmt, 5) != WYL_DECISION_ALLOW)
+    rc = 170;
+
+  sqlite3_finalize (stmt);
+  g_object_unref (handle);
+  return rc;
 }
 
 static gint
@@ -933,6 +999,8 @@ main (void)
   if ((rc = check_emit_persists_event_fields ()) != 0)
     return rc;
   if ((rc = check_query_events_json_filters_rows ()) != 0)
+    return rc;
+  if ((rc = check_emit_mirrors_policy_store_row ()) != 0)
     return rc;
   if ((rc = check_decide_persists_representative_deny_reason ()) != 0)
     return rc;

--- a/tests/test-policy-store.c
+++ b/tests/test-policy-store.c
@@ -29,6 +29,7 @@ check_store_creates_authority_schema (void)
     "principal_events",
     "principal_states",
     "session_states",
+    "audit_events",
     "policy_signatures",
   };
   for (gsize i = 0; i < G_N_ELEMENTS (tables); i++) {
@@ -73,6 +74,7 @@ check_template_schema_creates_state_tables (void)
     "principal_events",
     "principal_states",
     "session_states",
+    "audit_events",
     "policy_signatures",
   };
   for (gsize i = 0; i < G_N_ELEMENTS (tables); i++) {
@@ -507,6 +509,59 @@ check_store_appends_principal_event (void)
 }
 
 static gint
+check_store_appends_audit_event (void)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 120;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 121;
+  if (wyl_policy_store_append_audit_event (store, "audit-store-id", 123,
+          "audit-user", "read", "doc/1", "not_armed", "perm_state",
+          WYL_DECISION_DENY) != WYRELOG_E_OK)
+    return 122;
+
+  sqlite3_stmt *stmt = NULL;
+  static const gchar *sql =
+      "SELECT subject_id, action, resource_id, deny_reason, deny_origin, "
+      "decision FROM audit_events WHERE id = ?;";
+  if (sqlite3_prepare_v2 (wyl_policy_store_get_db (store), sql, -1, &stmt,
+          NULL) != SQLITE_OK)
+    return 123;
+  if (sqlite3_bind_text (stmt, 1, "audit-store-id", -1, SQLITE_TRANSIENT)
+      != SQLITE_OK) {
+    sqlite3_finalize (stmt);
+    return 124;
+  }
+
+  int step_rc = sqlite3_step (stmt);
+  gint rc = 0;
+  if (step_rc != SQLITE_ROW)
+    rc = 125;
+  else if (g_strcmp0 ((const gchar *) sqlite3_column_text (stmt, 0),
+          "audit-user") != 0)
+    rc = 126;
+  else if (g_strcmp0 ((const gchar *) sqlite3_column_text (stmt, 1),
+          "read") != 0)
+    rc = 127;
+  else if (g_strcmp0 ((const gchar *) sqlite3_column_text (stmt, 2),
+          "doc/1") != 0)
+    rc = 128;
+  else if (g_strcmp0 ((const gchar *) sqlite3_column_text (stmt, 3),
+          "not_armed") != 0)
+    rc = 129;
+  else if (g_strcmp0 ((const gchar *) sqlite3_column_text (stmt, 4),
+          "perm_state") != 0)
+    rc = 130;
+  else if (sqlite3_column_int (stmt, 5) != WYL_DECISION_DENY)
+    rc = 131;
+
+  sqlite3_finalize (stmt);
+  return rc;
+}
+
+static gint
 check_store_rejects_bad_direct_permission (void)
 {
   g_autoptr (wyl_policy_store_t) store = NULL;
@@ -589,6 +644,15 @@ check_store_rejects_bad_role_permission (void)
   if (wyl_policy_store_foreach_session_state (store, NULL, NULL)
       != WYRELOG_E_INVALID)
     return 59;
+  if (wyl_policy_store_append_audit_event (store, NULL, 0, NULL, NULL, NULL,
+          NULL, NULL, WYL_DECISION_ALLOW) != WYRELOG_E_INVALID)
+    return 94;
+  if (wyl_policy_store_append_audit_event (store, "audit-bad", -1, NULL,
+          NULL, NULL, NULL, NULL, WYL_DECISION_ALLOW) != WYRELOG_E_INVALID)
+    return 95;
+  if (wyl_policy_store_append_audit_event (store, "audit-bad", 0, NULL,
+          NULL, NULL, NULL, NULL, (wyl_decision_t) 9) != WYRELOG_E_INVALID)
+    return 96;
   return 0;
 }
 
@@ -618,6 +682,8 @@ main (void)
   if ((rc = check_store_sets_session_state ()) != 0)
     return rc;
   if ((rc = check_store_appends_principal_event ()) != 0)
+    return rc;
+  if ((rc = check_store_appends_audit_event ()) != 0)
     return rc;
   if ((rc = check_store_rejects_bad_direct_permission ()) != 0)
     return rc;

--- a/wyrelog/audit/event.c
+++ b/wyrelog/audit/event.c
@@ -8,6 +8,7 @@
 #include <duckdb.h>
 
 #include "audit/conn-private.h"
+#include "policy/store-private.h"
 #include "wyl-handle-private.h"
 #endif
 
@@ -289,7 +290,29 @@ wyl_audit_emit (WylHandle *handle, const WylAuditEvent *event)
   duckdb_destroy_result (&result);
   duckdb_destroy_prepare (&stmt);
 
-  return (rc == DuckDBSuccess) ? WYRELOG_E_OK : WYRELOG_E_IO;
+  if (rc != DuckDBSuccess)
+    return WYRELOG_E_IO;
+
+  wyrelog_error_t store_rc =
+      wyl_policy_store_append_audit_event (wyl_handle_get_policy_store (handle),
+      id_buf, event->created_at_us,
+      event->subject_id, event->action, event->resource_id,
+      event->deny_reason, event->deny_origin, event->decision);
+  if (store_rc != WYRELOG_E_OK) {
+    duckdb_prepared_statement delete_stmt = NULL;
+    duckdb_result delete_result = { 0 };
+
+    static const gchar *delete_sql = "DELETE FROM audit_events WHERE id = ?;";
+    if (duckdb_prepare (conn, delete_sql, &delete_stmt) == DuckDBSuccess) {
+      duckdb_bind_varchar (delete_stmt, 1, id_buf);
+      duckdb_execute_prepared (delete_stmt, &delete_result);
+      duckdb_destroy_result (&delete_result);
+    }
+    duckdb_destroy_prepare (&delete_stmt);
+    return store_rc;
+  }
+
+  return WYRELOG_E_OK;
 #else
   (void) handle;
   (void) event;

--- a/wyrelog/daemon/wyrelogd.c
+++ b/wyrelog/daemon/wyrelogd.c
@@ -229,6 +229,7 @@ check_policy_store_ready (WylHandle *handle)
     "principal_events",
     "principal_states",
     "session_states",
+    "audit_events",
     "policy_signatures",
   };
 

--- a/wyrelog/policy/store-private.h
+++ b/wyrelog/policy/store-private.h
@@ -4,6 +4,7 @@
 #include <glib.h>
 #include <sqlite3.h>
 
+#include "wyrelog/decide.h"
 #include "wyrelog/error.h"
 
 G_BEGIN_DECLS;
@@ -88,5 +89,9 @@ wyrelog_error_t wyl_policy_store_set_session_state (wyl_policy_store_t * store,
     const gchar * session_id, const gchar * state);
 wyrelog_error_t wyl_policy_store_foreach_session_state (wyl_policy_store_t *
     store, wyl_policy_session_state_cb cb, gpointer user_data);
+wyrelog_error_t wyl_policy_store_append_audit_event (wyl_policy_store_t *
+    store, const gchar * id, gint64 created_at_us, const gchar * subject_id,
+    const gchar * action, const gchar * resource_id, const gchar * deny_reason,
+    const gchar * deny_origin, wyl_decision_t decision);
 
 G_END_DECLS;

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -35,6 +35,17 @@ bind_text (sqlite3_stmt *stmt, int index, const gchar *value)
   return WYRELOG_E_OK;
 }
 
+static wyrelog_error_t
+bind_nullable_text (sqlite3_stmt *stmt, int index, const gchar *value)
+{
+  if (value == NULL) {
+    if (sqlite3_bind_null (stmt, index) != SQLITE_OK)
+      return WYRELOG_E_IO;
+    return WYRELOG_E_OK;
+  }
+  return bind_text (stmt, index, value);
+}
+
 wyrelog_error_t
 wyl_policy_store_open (const gchar *path, wyl_policy_store_t **out_store)
 {
@@ -179,6 +190,26 @@ wyl_policy_store_create_schema (wyl_policy_store_t *store)
       ");"
       "CREATE INDEX IF NOT EXISTS idx_session_states_state "
       "  ON session_states (state);"
+      "CREATE TABLE IF NOT EXISTS audit_events ("
+      "  id TEXT PRIMARY KEY,"
+      "  created_at_us INTEGER NOT NULL,"
+      "  subject_id TEXT,"
+      "  action TEXT,"
+      "  resource_id TEXT,"
+      "  deny_reason TEXT,"
+      "  deny_origin TEXT,"
+      "  decision INTEGER NOT NULL CHECK (decision IN (0, 1))"
+      ");"
+      "CREATE INDEX IF NOT EXISTS idx_audit_events_created_at_us "
+      "  ON audit_events (created_at_us);"
+      "CREATE INDEX IF NOT EXISTS idx_audit_events_subject_id "
+      "  ON audit_events (subject_id);"
+      "CREATE INDEX IF NOT EXISTS idx_audit_events_action "
+      "  ON audit_events (action);"
+      "CREATE INDEX IF NOT EXISTS idx_audit_events_decision "
+      "  ON audit_events (decision);"
+      "CREATE INDEX IF NOT EXISTS idx_audit_events_deny_reason "
+      "  ON audit_events (deny_reason);"
       "CREATE TABLE IF NOT EXISTS policy_signatures ("
       "  policy_version INTEGER PRIMARY KEY,"
       "  policy_hash BLOB NOT NULL,"
@@ -779,6 +810,44 @@ wyl_policy_store_foreach_role_inheritance (wyl_policy_store_t *store,
     }
   }
 
+  sqlite3_finalize (stmt);
+  return (step_rc == SQLITE_DONE) ? WYRELOG_E_OK : WYRELOG_E_IO;
+}
+
+wyrelog_error_t
+wyl_policy_store_append_audit_event (wyl_policy_store_t *store,
+    const gchar *id, gint64 created_at_us, const gchar *subject_id,
+    const gchar *action, const gchar *resource_id, const gchar *deny_reason,
+    const gchar *deny_origin, wyl_decision_t decision)
+{
+  sqlite3_stmt *stmt = NULL;
+
+  if (store == NULL || store->db == NULL || id == NULL || created_at_us < 0)
+    return WYRELOG_E_INVALID;
+  if (decision != WYL_DECISION_DENY && decision != WYL_DECISION_ALLOW)
+    return WYRELOG_E_INVALID;
+
+  static const gchar *sql =
+      "INSERT INTO audit_events "
+      "  (id, created_at_us, subject_id, action, resource_id, "
+      "   deny_reason, deny_origin, decision) "
+      "VALUES (?, ?, ?, ?, ?, ?, ?, ?);";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if ((rc = bind_text (stmt, 1, id)) != WYRELOG_E_OK
+      || sqlite3_bind_int64 (stmt, 2, created_at_us) != SQLITE_OK
+      || (rc = bind_nullable_text (stmt, 3, subject_id)) != WYRELOG_E_OK
+      || (rc = bind_nullable_text (stmt, 4, action)) != WYRELOG_E_OK
+      || (rc = bind_nullable_text (stmt, 5, resource_id)) != WYRELOG_E_OK
+      || (rc = bind_nullable_text (stmt, 6, deny_reason)) != WYRELOG_E_OK
+      || (rc = bind_nullable_text (stmt, 7, deny_origin)) != WYRELOG_E_OK
+      || sqlite3_bind_int (stmt, 8, (int) decision) != SQLITE_OK) {
+    sqlite3_finalize (stmt);
+    return WYRELOG_E_IO;
+  }
+
+  int step_rc = sqlite3_step (stmt);
   sqlite3_finalize (stmt);
   return (step_rc == SQLITE_DONE) ? WYRELOG_E_OK : WYRELOG_E_IO;
 }


### PR DESCRIPTION
## Summary
- add a policy-store audit_events table and schema checks
- mirror emitted audit rows into the policy store after DuckDB accepts them
- let PR Windows builds save a refreshed vcpkg cache generation

## Tests
- git diff --check
- meson test -C builddir-audit --print-errorlogs policy-store audit-emit wyrelogd-check
- meson test -C builddir --print-errorlogs policy-store wyrelogd-check
- meson test -C builddir-noclient --print-errorlogs policy-store wyrelogd-check
- GitHub PR checks: CodeQL, Ubuntu, macOS, Windows