### PR TITLE
session: gate login skip mfa ingress

### DIFF
--- a/tests/test-audit-emit.c
+++ b/tests/test-audit-emit.c
@@ -788,6 +788,7 @@ check_login_skip_mfa_emits_principal_state_audit_row (void)
   g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
   wyl_login_req_set_username (login, "audit-skip-mfa-user");
   wyl_login_req_set_skip_mfa (login, TRUE);
+  wyl_handle_set_login_skip_mfa_allowed (handle, TRUE);
   g_autoptr (WylSession) session = NULL;
   if (wyl_session_login (handle, login, &session) != WYRELOG_E_OK) {
     g_object_unref (handle);

--- a/tests/test-session-username.c
+++ b/tests/test-session-username.c
@@ -405,6 +405,36 @@ check_login_session_id_is_active_decision_scope (void)
 }
 
 static gint
+check_login_skip_mfa_rejected_by_default (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 149;
+
+  if (wyl_handle_get_login_skip_mfa_allowed (handle))
+    return 150;
+
+  g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
+  wyl_login_req_set_username (login, "skip-mfa-denied-user");
+  wyl_login_req_set_skip_mfa (login, TRUE);
+
+  g_autoptr (WylSession) session = NULL;
+  if (wyl_session_login (handle, login, &session) != WYRELOG_E_POLICY)
+    return 151;
+  if (session != NULL)
+    return 152;
+
+  PrincipalStateExpect expect = {
+    .subject_id = "skip-mfa-denied-user",
+    .state = "authenticated",
+  };
+  if (wyl_policy_store_foreach_principal_state (wyl_handle_get_policy_store
+          (handle), principal_state_expect_cb, &expect) != WYRELOG_E_OK)
+    return 153;
+  return expect.matches == 0 ? 0 : 154;
+}
+
+static gint
 check_login_skip_mfa_authenticates_principal (void)
 {
   g_autoptr (WylHandle) handle = NULL;
@@ -420,6 +450,7 @@ check_login_skip_mfa_authenticates_principal (void)
   g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
   wyl_login_req_set_username (login, "skip-mfa-user");
   wyl_login_req_set_skip_mfa (login, TRUE);
+  wyl_handle_set_login_skip_mfa_allowed (handle, TRUE);
   g_autoptr (WylSession) session = NULL;
   if (wyl_session_login (handle, login, &session) != WYRELOG_E_OK)
     return 155;
@@ -498,6 +529,7 @@ check_session_close_deactivates_decision_scope (void)
   g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
   wyl_login_req_set_username (login, "close-user");
   wyl_login_req_set_skip_mfa (login, TRUE);
+  wyl_handle_set_login_skip_mfa_allowed (handle, TRUE);
   g_autoptr (WylSession) session = NULL;
   if (wyl_session_login (handle, login, &session) != WYRELOG_E_OK)
     return 172;
@@ -613,6 +645,7 @@ check_elevated_session_remains_active_decision_scope (void)
   g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
   wyl_login_req_set_username (login, "elevate-user");
   wyl_login_req_set_skip_mfa (login, TRUE);
+  wyl_handle_set_login_skip_mfa_allowed (handle, TRUE);
   g_autoptr (WylSession) session = NULL;
   if (wyl_session_login (handle, login, &session) != WYRELOG_E_OK)
     return 222;
@@ -648,6 +681,7 @@ check_elevated_session_close_deactivates_decision_scope (void)
   g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
   wyl_login_req_set_username (login, "elevated-close-user");
   wyl_login_req_set_skip_mfa (login, TRUE);
+  wyl_handle_set_login_skip_mfa_allowed (handle, TRUE);
   g_autoptr (WylSession) session = NULL;
   if (wyl_session_login (handle, login, &session) != WYRELOG_E_OK)
     return 232;
@@ -719,6 +753,7 @@ check_idle_session_deactivates_decision_scope (void)
   g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
   wyl_login_req_set_username (login, "idle-user");
   wyl_login_req_set_skip_mfa (login, TRUE);
+  wyl_handle_set_login_skip_mfa_allowed (handle, TRUE);
   g_autoptr (WylSession) session = NULL;
   if (wyl_session_login (handle, login, &session) != WYRELOG_E_OK)
     return 272;
@@ -758,6 +793,7 @@ check_elevated_session_idle_timeout_deactivates_scope (void)
   g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
   wyl_login_req_set_username (login, "elevated-idle-user");
   wyl_login_req_set_skip_mfa (login, TRUE);
+  wyl_handle_set_login_skip_mfa_allowed (handle, TRUE);
   g_autoptr (WylSession) session = NULL;
   if (wyl_session_login (handle, login, &session) != WYRELOG_E_OK)
     return 282;
@@ -829,6 +865,7 @@ check_expiring_session_deactivates_decision_scope (void)
   g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
   wyl_login_req_set_username (login, "expiry-user");
   wyl_login_req_set_skip_mfa (login, TRUE);
+  wyl_handle_set_login_skip_mfa_allowed (handle, TRUE);
   g_autoptr (WylSession) session = NULL;
   if (wyl_session_login (handle, login, &session) != WYRELOG_E_OK)
     return 312;
@@ -978,6 +1015,8 @@ main (void)
   if ((rc = check_login_persists_active_session_state ()) != 0)
     return rc;
   if ((rc = check_login_session_id_is_active_decision_scope ()) != 0)
+    return rc;
+  if ((rc = check_login_skip_mfa_rejected_by_default ()) != 0)
     return rc;
   if ((rc = check_login_skip_mfa_authenticates_principal ()) != 0)
     return rc;

--- a/wyrelog/daemon/wyrelogd.c
+++ b/wyrelog/daemon/wyrelogd.c
@@ -282,7 +282,11 @@ check_policy_snapshot_reload_ready (WylHandle *handle)
   wyl_login_req_set_skip_mfa (login, TRUE);
 
   g_autoptr (WylSession) session = NULL;
+  gboolean skip_mfa_was_allowed =
+      wyl_handle_get_login_skip_mfa_allowed (handle);
+  wyl_handle_set_login_skip_mfa_allowed (handle, TRUE);
   wyrelog_error_t rc = wyl_session_login (handle, login, &session);
+  wyl_handle_set_login_skip_mfa_allowed (handle, skip_mfa_was_allowed);
   if (rc != WYRELOG_E_OK)
     return rc;
 
@@ -338,7 +342,11 @@ check_role_permission_snapshot_reload_ready (WylHandle *handle)
   wyl_login_req_set_skip_mfa (login, TRUE);
 
   g_autoptr (WylSession) session = NULL;
+  gboolean skip_mfa_was_allowed =
+      wyl_handle_get_login_skip_mfa_allowed (handle);
+  wyl_handle_set_login_skip_mfa_allowed (handle, TRUE);
   wyrelog_error_t rc = wyl_session_login (handle, login, &session);
+  wyl_handle_set_login_skip_mfa_allowed (handle, skip_mfa_was_allowed);
   if (rc != WYRELOG_E_OK)
     return rc;
 

--- a/wyrelog/session.h
+++ b/wyrelog/session.h
@@ -52,10 +52,11 @@ void wyl_login_req_set_username (wyl_login_req_t * req, const gchar * username);
 const gchar *wyl_login_req_get_username (const wyl_login_req_t * req);
 
 /*
- * Marks the request as already satisfying the MFA requirement. When
- * TRUE, wyl_session_login drives the principal FSM through the
- * login_skip_mfa event and records the principal as authenticated.
- * The default for a fresh request is FALSE.
+ * Marks the request as already satisfying the MFA requirement. When TRUE,
+ * wyl_session_login may drive the principal FSM through the login_skip_mfa
+ * event and record the principal as authenticated. The host-side ingress
+ * policy must explicitly allow this path for the WylHandle; otherwise login
+ * fails with WYRELOG_E_POLICY. The default for a fresh request is FALSE.
  */
 void wyl_login_req_set_skip_mfa (wyl_login_req_t * req, gboolean skip_mfa);
 gboolean wyl_login_req_get_skip_mfa (const wyl_login_req_t * req);

--- a/wyrelog/wyl-handle-private.h
+++ b/wyrelog/wyl-handle-private.h
@@ -31,6 +31,14 @@ wyl_audit_conn_t *wyl_handle_get_audit_conn (WylHandle * self);
 wyl_policy_store_t *wyl_handle_get_policy_store (WylHandle * self);
 
 /*
+ * Host-side ingress guard for login requests that carry skip_mfa. The default
+ * is FALSE; callers that model a trusted non-production path must opt in
+ * explicitly before passing such requests to wyl_session_login.
+ */
+void wyl_handle_set_login_skip_mfa_allowed (WylHandle * self, gboolean allowed);
+gboolean wyl_handle_get_login_skip_mfa_allowed (WylHandle * self);
+
+/*
  * Opens the handle-owned policy engine pair from @template_dir.
  * Rejected if the pair is already present. On failure the handle is left
  * without policy engines.

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -22,6 +22,7 @@ struct _WylHandle
   GHashTable *engine_symbols_by_id;
   gchar *template_dir;
   wyl_policy_store_t *policy_store;
+  gboolean login_skip_mfa_allowed;
 #ifdef WYL_HAS_AUDIT
   wyl_audit_conn_t *audit_conn;
 #endif
@@ -216,6 +217,20 @@ wyl_handle_get_policy_store (WylHandle *self)
 {
   g_return_val_if_fail (WYL_IS_HANDLE (self), NULL);
   return self->policy_store;
+}
+
+void
+wyl_handle_set_login_skip_mfa_allowed (WylHandle *self, gboolean allowed)
+{
+  g_return_if_fail (WYL_IS_HANDLE (self));
+  self->login_skip_mfa_allowed = allowed;
+}
+
+gboolean
+wyl_handle_get_login_skip_mfa_allowed (WylHandle *self)
+{
+  g_return_val_if_fail (WYL_IS_HANDLE (self), FALSE);
+  return self->login_skip_mfa_allowed;
 }
 
 static GHashTable *

--- a/wyrelog/wyl-session.c
+++ b/wyrelog/wyl-session.c
@@ -330,6 +330,10 @@ wyl_session_login (WylHandle *handle, const wyl_login_req_t *req,
   if (handle == NULL)
     return WYRELOG_E_INVALID;
 
+  if (req != NULL && wyl_login_req_get_skip_mfa (req) &&
+      !wyl_handle_get_login_skip_mfa_allowed (handle))
+    return WYRELOG_E_POLICY;
+
   WylSession *session = g_object_new (WYL_TYPE_SESSION, NULL);
   const gchar *username = NULL;
   if (req != NULL) {


### PR DESCRIPTION
## Summary
- add a handle-owned ingress guard for skip_mfa login requests
- keep the default path closed with a policy error
- make daemon readiness probes and tests opt in explicitly
- add coverage for default-deny skip_mfa behavior

## Verification
- git diff --check
- meson test -C builddir-audit --print-errorlogs session-username audit-emit wyrelogd-check
- meson test -C builddir --print-errorlogs session-username wyrelogd-check
- meson test -C builddir-noclient --print-errorlogs session-username wyrelogd-check
