### PR TITLE
policy: persist role memberships

### DIFF
--- a/templates/access/sqlite-schema.sql
+++ b/templates/access/sqlite-schema.sql
@@ -72,6 +72,26 @@ CREATE INDEX IF NOT EXISTS idx_role_inheritances_parent
     ON role_inheritances (parent_role_id);
 
 -- ---------------------------------------------------------------------------
+-- Table: role_memberships
+-- Per-principal role grants mirrored into member_of/3 snapshots.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS role_memberships (
+    subject_id TEXT NOT NULL,
+    role_id    TEXT NOT NULL,
+    scope      TEXT NOT NULL,
+    granted_at INTEGER,               -- Unix epoch (seconds)
+    granted_by TEXT,                  -- Platform engineer identifier
+    PRIMARY KEY (subject_id, role_id, scope),
+    FOREIGN KEY (role_id) REFERENCES roles (role_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_role_memberships_role_id
+    ON role_memberships (role_id);
+
+CREATE INDEX IF NOT EXISTS idx_role_memberships_subject_scope
+    ON role_memberships (subject_id, scope);
+
+-- ---------------------------------------------------------------------------
 -- Table: direct_permissions
 -- Per-principal direct grants mirrored into direct_permission/3.
 -- ---------------------------------------------------------------------------

--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -1037,6 +1037,69 @@ check_policy_store_role_permissions_require_engine_pair (void)
 }
 
 static gint
+check_policy_store_role_memberships_autoload_on_open (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 333;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (wyl_policy_store_upsert_role (store, "wr.member-load-role",
+          "member load role") != WYRELOG_E_OK)
+    return 334;
+  if (wyl_policy_store_upsert_permission (store, "wr.member-load.read",
+          "member load read", "basic") != WYRELOG_E_OK)
+    return 335;
+  if (wyl_policy_store_grant_role_permission (store, "wr.member-load-role",
+          "wr.member-load.read") != WYRELOG_E_OK)
+    return 336;
+  if (wyl_policy_store_grant_role_membership (store, "member-load-user",
+          "wr.member-load-role", "member-load-scope") != WYRELOG_E_OK)
+    return 337;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 338;
+
+  if (insert2_symbol (handle, "principal_state", "member-load-user",
+          "authenticated") != WYRELOG_E_OK)
+    return 339;
+  if (insert2_symbol (handle, "session_state", "member-load-scope",
+          "active") != WYRELOG_E_OK)
+    return 340;
+  if (insert4_symbol (handle, "perm_state", "member-load-user",
+          "wr.member-load.read", "member-load-scope", "armed")
+      != WYRELOG_E_OK)
+    return 341;
+
+  gint64 decision_row[3];
+  if (intern3 (handle, "member-load-user", "wr.member-load.read",
+          "member-load-scope", decision_row) != WYRELOG_E_OK)
+    return 342;
+  gboolean allowed = FALSE;
+  if (wyl_handle_engine_decide (handle, decision_row, &allowed)
+      != WYRELOG_E_OK)
+    return 343;
+  return allowed ? 0 : 344;
+}
+
+static gint
+check_policy_store_role_memberships_require_engine_pair (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 345;
+  if (wyl_handle_load_policy_store_role_memberships (NULL)
+      != WYRELOG_E_INVALID)
+    return 346;
+  if (wyl_handle_load_policy_store_role_memberships (handle)
+      != WYRELOG_E_INVALID)
+    return 347;
+  return 0;
+}
+
+static gint
 check_policy_store_direct_permissions_autoload_on_open (void)
 {
   g_autoptr (WylHandle) handle = NULL;
@@ -1282,6 +1345,10 @@ main (void)
   if ((rc = check_policy_store_role_inheritances_autoload_on_open ()) != 0)
     return rc;
   if ((rc = check_policy_store_role_permissions_require_engine_pair ()) != 0)
+    return rc;
+  if ((rc = check_policy_store_role_memberships_autoload_on_open ()) != 0)
+    return rc;
+  if ((rc = check_policy_store_role_memberships_require_engine_pair ()) != 0)
     return rc;
   if ((rc = check_policy_store_direct_permissions_autoload_on_open ()) != 0)
     return rc;

--- a/tests/test-policy-store.c
+++ b/tests/test-policy-store.c
@@ -24,6 +24,7 @@ check_store_creates_authority_schema (void)
     "permissions",
     "role_permissions",
     "role_inheritances",
+    "role_memberships",
     "direct_permissions",
     "direct_permission_events",
     "principal_events",
@@ -69,6 +70,7 @@ check_template_schema_creates_state_tables (void)
     "permissions",
     "role_permissions",
     "role_inheritances",
+    "role_memberships",
     "direct_permissions",
     "direct_permission_events",
     "principal_events",
@@ -244,6 +246,14 @@ typedef struct
   guint matches;
 } RoleInheritanceExpect;
 
+typedef struct
+{
+  const gchar *subject_id;
+  const gchar *role_id;
+  const gchar *scope;
+  guint matches;
+} RoleMembershipExpect;
+
 static wyrelog_error_t
 role_permission_expect_cb (const gchar *role_id, const gchar *perm_id,
     gpointer user_data)
@@ -264,6 +274,19 @@ role_inheritance_expect_cb (const gchar *child_role_id,
 
   if (g_strcmp0 (child_role_id, expect->child_role_id) == 0
       && g_strcmp0 (parent_role_id, expect->parent_role_id) == 0)
+    expect->matches++;
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+role_membership_expect_cb (const gchar *subject_id, const gchar *role_id,
+    const gchar *scope, gpointer user_data)
+{
+  RoleMembershipExpect *expect = user_data;
+
+  if (g_strcmp0 (subject_id, expect->subject_id) == 0
+      && g_strcmp0 (role_id, expect->role_id) == 0
+      && g_strcmp0 (scope, expect->scope) == 0)
     expect->matches++;
   return WYRELOG_E_OK;
 }
@@ -349,6 +372,38 @@ check_store_grants_role_inheritance (void)
     return 66;
   if (permission_expect.matches != 1)
     return 67;
+  return 0;
+}
+
+static gint
+check_store_grants_role_membership (void)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 68;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 69;
+  if (wyl_policy_store_upsert_role (store, "wr.member-role", "member role")
+      != WYRELOG_E_OK)
+    return 70;
+  if (wyl_policy_store_grant_role_membership (store, "member-user",
+          "wr.member-role", "member-scope") != WYRELOG_E_OK)
+    return 71;
+  if (wyl_policy_store_grant_role_membership (store, "member-user",
+          "wr.member-role", "member-scope") != WYRELOG_E_OK)
+    return 72;
+
+  RoleMembershipExpect expect = {
+    .subject_id = "member-user",
+    .role_id = "wr.member-role",
+    .scope = "member-scope",
+  };
+  if (wyl_policy_store_foreach_role_membership (store,
+          role_membership_expect_cb, &expect) != WYRELOG_E_OK)
+    return 73;
+  if (expect.matches != 1)
+    return 74;
   return 0;
 }
 
@@ -626,6 +681,15 @@ check_store_rejects_bad_role_permission (void)
   if (wyl_policy_store_foreach_role_inheritance (store, NULL, NULL)
       != WYRELOG_E_INVALID)
     return 59;
+  if (wyl_policy_store_grant_role_membership (store, "role-user",
+          "missing-role", "role-scope") != WYRELOG_E_IO)
+    return 97;
+  if (wyl_policy_store_grant_role_membership (store, NULL, "missing-role",
+          "role-scope") != WYRELOG_E_INVALID)
+    return 98;
+  if (wyl_policy_store_foreach_role_membership (store, NULL, NULL)
+      != WYRELOG_E_INVALID)
+    return 99;
   if (wyl_policy_store_set_principal_state (store, NULL, "authenticated")
       != WYRELOG_E_INVALID)
     return 56;
@@ -672,6 +736,8 @@ main (void)
   if ((rc = check_store_grants_role_permission ()) != 0)
     return rc;
   if ((rc = check_store_grants_role_inheritance ()) != 0)
+    return rc;
+  if ((rc = check_store_grants_role_membership ()) != 0)
     return rc;
   if ((rc = check_store_grants_direct_permission ()) != 0)
     return rc;

--- a/wyrelog/daemon/wyrelogd.c
+++ b/wyrelog/daemon/wyrelogd.c
@@ -224,6 +224,7 @@ check_policy_store_ready (WylHandle *handle)
     "permissions",
     "role_permissions",
     "role_inheritances",
+    "role_memberships",
     "direct_permissions",
     "direct_permission_events",
     "principal_events",

--- a/wyrelog/policy/store-private.h
+++ b/wyrelog/policy/store-private.h
@@ -15,6 +15,8 @@ typedef wyrelog_error_t (*wyl_policy_role_permission_cb) (const gchar * role_id,
     const gchar * perm_id, gpointer user_data);
 typedef wyrelog_error_t (*wyl_policy_role_inheritance_cb) (const gchar *
     child_role_id, const gchar * parent_role_id, gpointer user_data);
+typedef wyrelog_error_t (*wyl_policy_role_membership_cb) (const gchar *
+    subject_id, const gchar * role_id, const gchar * scope, gpointer user_data);
 typedef wyrelog_error_t (*wyl_policy_direct_permission_cb) (const gchar *
     subject_id, const gchar * perm_id, const gchar * scope, gpointer user_data);
 typedef wyrelog_error_t (*wyl_policy_direct_permission_event_cb) (const gchar *
@@ -58,6 +60,11 @@ wyrelog_error_t wyl_policy_store_grant_role_inheritance (wyl_policy_store_t *
     store, const gchar * child_role_id, const gchar * parent_role_id);
 wyrelog_error_t wyl_policy_store_foreach_role_inheritance (wyl_policy_store_t *
     store, wyl_policy_role_inheritance_cb cb, gpointer user_data);
+wyrelog_error_t wyl_policy_store_grant_role_membership (wyl_policy_store_t *
+    store, const gchar * subject_id, const gchar * role_id,
+    const gchar * scope);
+wyrelog_error_t wyl_policy_store_foreach_role_membership (wyl_policy_store_t *
+    store, wyl_policy_role_membership_cb cb, gpointer user_data);
 wyrelog_error_t wyl_policy_store_grant_direct_permission (wyl_policy_store_t *
     store, const gchar * subject_id, const gchar * perm_id,
     const gchar * scope);

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -139,6 +139,19 @@ wyl_policy_store_create_schema (wyl_policy_store_t *store)
       "  ON role_inheritances (child_role_id);"
       "CREATE INDEX IF NOT EXISTS idx_role_inheritances_parent "
       "  ON role_inheritances (parent_role_id);"
+      "CREATE TABLE IF NOT EXISTS role_memberships ("
+      "  subject_id TEXT NOT NULL,"
+      "  role_id TEXT NOT NULL,"
+      "  scope TEXT NOT NULL,"
+      "  granted_at INTEGER,"
+      "  granted_by TEXT,"
+      "  PRIMARY KEY (subject_id, role_id, scope),"
+      "  FOREIGN KEY (role_id) REFERENCES roles (role_id)"
+      ");"
+      "CREATE INDEX IF NOT EXISTS idx_role_memberships_role_id "
+      "  ON role_memberships (role_id);"
+      "CREATE INDEX IF NOT EXISTS idx_role_memberships_subject_scope "
+      "  ON role_memberships (subject_id, scope);"
       "CREATE TABLE IF NOT EXISTS direct_permissions ("
       "  subject_id TEXT NOT NULL,"
       "  perm_id TEXT NOT NULL,"
@@ -804,6 +817,69 @@ wyl_policy_store_foreach_role_inheritance (wyl_policy_store_t *store,
     const gchar *child_role_id = (const gchar *) sqlite3_column_text (stmt, 0);
     const gchar *parent_role_id = (const gchar *) sqlite3_column_text (stmt, 1);
     rc = cb (child_role_id, parent_role_id, user_data);
+    if (rc != WYRELOG_E_OK) {
+      sqlite3_finalize (stmt);
+      return rc;
+    }
+  }
+
+  sqlite3_finalize (stmt);
+  return (step_rc == SQLITE_DONE) ? WYRELOG_E_OK : WYRELOG_E_IO;
+}
+
+wyrelog_error_t
+wyl_policy_store_grant_role_membership (wyl_policy_store_t *store,
+    const gchar *subject_id, const gchar *role_id, const gchar *scope)
+{
+  sqlite3_stmt *stmt = NULL;
+
+  if (store == NULL || store->db == NULL || subject_id == NULL
+      || role_id == NULL || scope == NULL)
+    return WYRELOG_E_INVALID;
+
+  static const gchar *sql =
+      "INSERT INTO role_memberships "
+      "  (subject_id, role_id, scope, granted_at) "
+      "VALUES (?, ?, ?, unixepoch()) "
+      "ON CONFLICT(subject_id, role_id, scope) DO UPDATE SET "
+      "  granted_at = excluded.granted_at;";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if ((rc = bind_text (stmt, 1, subject_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 2, role_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 3, scope)) != WYRELOG_E_OK) {
+    sqlite3_finalize (stmt);
+    return rc;
+  }
+
+  int step_rc = sqlite3_step (stmt);
+  sqlite3_finalize (stmt);
+  return (step_rc == SQLITE_DONE) ? WYRELOG_E_OK : WYRELOG_E_IO;
+}
+
+wyrelog_error_t
+wyl_policy_store_foreach_role_membership (wyl_policy_store_t *store,
+    wyl_policy_role_membership_cb cb, gpointer user_data)
+{
+  sqlite3_stmt *stmt = NULL;
+
+  if (store == NULL || store->db == NULL || cb == NULL)
+    return WYRELOG_E_INVALID;
+
+  static const gchar *sql =
+      "SELECT subject_id, role_id, scope FROM role_memberships "
+      "ORDER BY subject_id, role_id, scope;";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  int step_rc;
+  while ((step_rc = sqlite3_step (stmt)) == SQLITE_ROW) {
+    const gchar *subject_id = (const gchar *) sqlite3_column_text (stmt, 0);
+    const gchar *role_id = (const gchar *) sqlite3_column_text (stmt, 1);
+    const gchar *scope = (const gchar *) sqlite3_column_text (stmt, 2);
+    rc = cb (subject_id, role_id, scope, user_data);
     if (rc != WYRELOG_E_OK) {
       sqlite3_finalize (stmt);
       return rc;

--- a/wyrelog/wyl-handle-private.h
+++ b/wyrelog/wyl-handle-private.h
@@ -95,6 +95,13 @@ wyrelog_error_t wyl_handle_load_policy_store_role_permissions (WylHandle *
     self);
 
 /*
+ * Loads role_membership rows from the handle-owned policy authority store into
+ * the attached read/delta engine pair as member_of/3 facts.
+ */
+wyrelog_error_t wyl_handle_load_policy_store_role_memberships (WylHandle *
+    self);
+
+/*
  * Loads direct_permission rows from the handle-owned policy authority store
  * into the attached read/delta engine pair, together with their "armed"
  * perm_state rows. Rejected unless both the store and engine pair are

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -251,6 +251,9 @@ load_current_engine_pair (WylHandle *self)
   rc = wyl_handle_load_policy_store_role_permissions (self);
   if (rc != WYRELOG_E_OK)
     return rc;
+  rc = wyl_handle_load_policy_store_role_memberships (self);
+  if (rc != WYRELOG_E_OK)
+    return rc;
   rc = wyl_handle_load_policy_store_direct_permissions (self);
   if (rc != WYRELOG_E_OK)
     return rc;
@@ -478,6 +481,39 @@ wyl_handle_load_policy_store_role_permissions (WylHandle *self)
 
   return wyl_policy_store_foreach_role_permission (self->policy_store,
       insert_policy_store_role_permission, self);
+}
+
+static wyrelog_error_t
+insert_policy_store_role_membership (const gchar *subject_id,
+    const gchar *role_id, const gchar *scope, gpointer user_data)
+{
+  WylHandle *self = user_data;
+  gint64 row[3];
+
+  wyrelog_error_t rc =
+      wyl_handle_intern_engine_symbol (self, subject_id, &row[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (self, role_id, &row[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (self, scope, &row[2]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_engine_insert (self, "member_of", row, 3);
+}
+
+wyrelog_error_t
+wyl_handle_load_policy_store_role_memberships (WylHandle *self)
+{
+  if (self == NULL || !WYL_IS_HANDLE (self))
+    return WYRELOG_E_INVALID;
+  if (self->policy_store == NULL || self->read_engine == NULL
+      || self->delta_engine == NULL)
+    return WYRELOG_E_INVALID;
+
+  return wyl_policy_store_foreach_role_membership (self->policy_store,
+      insert_policy_store_role_membership, self);
 }
 
 static wyrelog_error_t


### PR DESCRIPTION
## Summary
- add role_memberships to the policy store schema and template schema
- expose private grant/foreach APIs for role membership rows
- autoload role memberships into engine snapshots as member_of facts
- cover store validation and snapshot decision behavior

## Verification
- git diff --check
- sqlite3 :memory: < templates/access/sqlite-schema.sql
- meson test -C builddir-audit --print-errorlogs policy-store handle-engine-pair wyrelogd-check
- meson test -C builddir --print-errorlogs policy-store handle-engine-pair wyrelogd-check
- meson test -C builddir-noclient --print-errorlogs policy-store handle-engine-pair wyrelogd-check
