### PR TITLE
ci: run codeql outside pull requests

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,8 +2,6 @@
 name: CodeQL
 
 on:
-  pull_request:
-    branches: [main]
   push:
     branches: [main]
   schedule:


### PR DESCRIPTION
## Summary
- remove the CodeQL pull_request trigger
- keep CodeQL on push to main and the existing weekly schedule

## Verification
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/codeql.yml"); puts "ok"'
