### PR TITLE
policy: add role membership admin api

### DIFF
--- a/templates/access/sqlite-schema.sql
+++ b/templates/access/sqlite-schema.sql
@@ -92,6 +92,26 @@ CREATE INDEX IF NOT EXISTS idx_role_memberships_subject_scope
     ON role_memberships (subject_id, scope);
 
 -- ---------------------------------------------------------------------------
+-- Table: role_membership_events
+-- Role membership grant/revoke history.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS role_membership_events (
+    event_id   INTEGER PRIMARY KEY AUTOINCREMENT,
+    subject_id TEXT NOT NULL,
+    role_id    TEXT NOT NULL,
+    scope      TEXT NOT NULL,
+    operation  TEXT NOT NULL CHECK (operation IN ('grant', 'revoke')),
+    created_at INTEGER NOT NULL,       -- Unix epoch (seconds)
+    FOREIGN KEY (role_id) REFERENCES roles (role_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_role_membership_events_subject
+    ON role_membership_events (subject_id);
+
+CREATE INDEX IF NOT EXISTS idx_role_membership_events_role
+    ON role_membership_events (role_id);
+
+-- ---------------------------------------------------------------------------
 -- Table: direct_permissions
 -- Per-principal direct grants mirrored into direct_permission/3.
 -- ---------------------------------------------------------------------------

--- a/tests/test-audit-emit.c
+++ b/tests/test-audit-emit.c
@@ -971,6 +971,162 @@ check_permission_revoke_emits_audit_row (void)
 }
 
 static gint
+seed_audit_role_permission (WylHandle *handle, const gchar *role_id,
+    const gchar *perm_id)
+{
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+
+  if (wyl_policy_store_upsert_role (store, role_id, role_id) != WYRELOG_E_OK)
+    return 1;
+  if (wyl_policy_store_upsert_permission (store, perm_id, perm_id, "basic")
+      != WYRELOG_E_OK)
+    return 2;
+  if (wyl_policy_store_grant_role_permission (store, role_id, perm_id)
+      != WYRELOG_E_OK)
+    return 3;
+  if (wyl_handle_reload_engine_pair (handle) != WYRELOG_E_OK)
+    return 4;
+  return 0;
+}
+
+static gint
+check_role_grant_emits_audit_row (void)
+{
+  WylHandle *handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 140;
+  if (seed_audit_role_permission (handle, "wr.audit-role-grant",
+          "wr.audit-role-grant.read") != 0) {
+    g_object_unref (handle);
+    return 141;
+  }
+
+  g_autoptr (wyl_role_grant_req_t) grant = wyl_role_grant_req_new ();
+  wyl_role_grant_req_set_subject_id (grant, "audit-role-grant-user");
+  wyl_role_grant_req_set_role_id (grant, "wr.audit-role-grant");
+  wyl_role_grant_req_set_scope (grant, "audit-role-grant-scope");
+  if (wyl_role_grant (handle, grant) != WYRELOG_E_OK) {
+    g_object_unref (handle);
+    return 142;
+  }
+
+  duckdb_connection conn =
+      wyl_audit_conn_get_connection (wyl_handle_get_audit_conn (handle));
+  duckdb_result result;
+  if (duckdb_query (conn,
+          "SELECT subject_id, action, resource_id, deny_origin, decision "
+          "FROM audit_events WHERE action = 'role_grant';", &result)
+      != DuckDBSuccess) {
+    duckdb_destroy_result (&result);
+    g_object_unref (handle);
+    return 143;
+  }
+  if (duckdb_row_count (&result) != 1) {
+    duckdb_destroy_result (&result);
+    g_object_unref (handle);
+    return 144;
+  }
+
+  gint rc = 0;
+  const gchar *subject = duckdb_value_varchar (&result, 0, 0);
+  const gchar *action = duckdb_value_varchar (&result, 1, 0);
+  const gchar *resource = duckdb_value_varchar (&result, 2, 0);
+  const gchar *role = duckdb_value_varchar (&result, 3, 0);
+  gint16 decision = (gint16) duckdb_value_int64 (&result, 4, 0);
+  if (g_strcmp0 (subject, "audit-role-grant-user") != 0)
+    rc = 145;
+  else if (g_strcmp0 (action, "role_grant") != 0)
+    rc = 146;
+  else if (g_strcmp0 (resource, "audit-role-grant-scope") != 0)
+    rc = 147;
+  else if (g_strcmp0 (role, "wr.audit-role-grant") != 0)
+    rc = 148;
+  else if (decision != WYL_DECISION_ALLOW)
+    rc = 149;
+
+  duckdb_free ((void *) subject);
+  duckdb_free ((void *) action);
+  duckdb_free ((void *) resource);
+  duckdb_free ((void *) role);
+  duckdb_destroy_result (&result);
+  g_object_unref (handle);
+  return rc;
+}
+
+static gint
+check_role_revoke_emits_audit_row (void)
+{
+  WylHandle *handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 150;
+  if (seed_audit_role_permission (handle, "wr.audit-role-revoke",
+          "wr.audit-role-revoke.read") != 0) {
+    g_object_unref (handle);
+    return 151;
+  }
+
+  g_autoptr (wyl_role_grant_req_t) grant = wyl_role_grant_req_new ();
+  wyl_role_grant_req_set_subject_id (grant, "audit-role-revoke-user");
+  wyl_role_grant_req_set_role_id (grant, "wr.audit-role-revoke");
+  wyl_role_grant_req_set_scope (grant, "audit-role-revoke-scope");
+  if (wyl_role_grant (handle, grant) != WYRELOG_E_OK) {
+    g_object_unref (handle);
+    return 152;
+  }
+
+  g_autoptr (wyl_role_revoke_req_t) revoke = wyl_role_revoke_req_new ();
+  wyl_role_revoke_req_set_subject_id (revoke, "audit-role-revoke-user");
+  wyl_role_revoke_req_set_role_id (revoke, "wr.audit-role-revoke");
+  wyl_role_revoke_req_set_scope (revoke, "audit-role-revoke-scope");
+  if (wyl_role_revoke (handle, revoke) != WYRELOG_E_OK) {
+    g_object_unref (handle);
+    return 153;
+  }
+
+  duckdb_connection conn =
+      wyl_audit_conn_get_connection (wyl_handle_get_audit_conn (handle));
+  duckdb_result result;
+  if (duckdb_query (conn,
+          "SELECT subject_id, action, resource_id, deny_origin, decision "
+          "FROM audit_events WHERE action = 'role_revoke';", &result)
+      != DuckDBSuccess) {
+    duckdb_destroy_result (&result);
+    g_object_unref (handle);
+    return 154;
+  }
+  if (duckdb_row_count (&result) != 1) {
+    duckdb_destroy_result (&result);
+    g_object_unref (handle);
+    return 155;
+  }
+
+  gint rc = 0;
+  const gchar *subject = duckdb_value_varchar (&result, 0, 0);
+  const gchar *action = duckdb_value_varchar (&result, 1, 0);
+  const gchar *resource = duckdb_value_varchar (&result, 2, 0);
+  const gchar *role = duckdb_value_varchar (&result, 3, 0);
+  gint16 decision = (gint16) duckdb_value_int64 (&result, 4, 0);
+  if (g_strcmp0 (subject, "audit-role-revoke-user") != 0)
+    rc = 156;
+  else if (g_strcmp0 (action, "role_revoke") != 0)
+    rc = 157;
+  else if (g_strcmp0 (resource, "audit-role-revoke-scope") != 0)
+    rc = 158;
+  else if (g_strcmp0 (role, "wr.audit-role-revoke") != 0)
+    rc = 159;
+  else if (decision != WYL_DECISION_ALLOW)
+    rc = 160;
+
+  duckdb_free ((void *) subject);
+  duckdb_free ((void *) action);
+  duckdb_free ((void *) resource);
+  duckdb_free ((void *) role);
+  duckdb_destroy_result (&result);
+  g_object_unref (handle);
+  return rc;
+}
+
+static gint
 check_emit_rejects_null_args (void)
 {
   WylHandle *handle = NULL;
@@ -1020,6 +1176,10 @@ main (void)
   if ((rc = check_permission_grant_emits_audit_row ()) != 0)
     return rc;
   if ((rc = check_permission_revoke_emits_audit_row ()) != 0)
+    return rc;
+  if ((rc = check_role_grant_emits_audit_row ()) != 0)
+    return rc;
+  if ((rc = check_role_revoke_emits_audit_row ()) != 0)
     return rc;
   if ((rc = check_emit_rejects_null_args ()) != 0)
     return rc;

--- a/tests/test-perm.c
+++ b/tests/test-perm.c
@@ -25,6 +25,15 @@ typedef struct
   guint matches;
 } DirectPermissionEventExpect;
 
+typedef struct
+{
+  const gchar *subject_id;
+  const gchar *role_id;
+  const gchar *scope;
+  const gchar *operation;
+  guint matches;
+} RoleMembershipEventExpect;
+
 static wyrelog_error_t
 direct_permission_event_expect_cb (const gchar *subject_id,
     const gchar *perm_id, const gchar *scope, const gchar *operation,
@@ -38,6 +47,65 @@ direct_permission_event_expect_cb (const gchar *subject_id,
       && g_strcmp0 (operation, expect->operation) == 0)
     expect->matches++;
   return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+role_membership_event_expect_cb (const gchar *subject_id,
+    const gchar *role_id, const gchar *scope, const gchar *operation,
+    gpointer user_data)
+{
+  RoleMembershipEventExpect *expect = user_data;
+
+  if (g_strcmp0 (subject_id, expect->subject_id) == 0
+      && g_strcmp0 (role_id, expect->role_id) == 0
+      && g_strcmp0 (scope, expect->scope) == 0
+      && g_strcmp0 (operation, expect->operation) == 0)
+    expect->matches++;
+  return WYRELOG_E_OK;
+}
+
+static gint
+seed_role_permission (WylHandle *handle, const gchar *role_id,
+    const gchar *perm_id)
+{
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+
+  if (wyl_policy_store_upsert_role (store, role_id, role_id) != WYRELOG_E_OK)
+    return 1;
+  if (wyl_policy_store_upsert_permission (store, perm_id, perm_id, "basic")
+      != WYRELOG_E_OK)
+    return 2;
+  if (wyl_policy_store_grant_role_permission (store, role_id, perm_id)
+      != WYRELOG_E_OK)
+    return 3;
+  if (wyl_handle_get_read_engine (handle) != NULL
+      && wyl_handle_reload_engine_pair (handle) != WYRELOG_E_OK)
+    return 4;
+  return 0;
+}
+
+static gint
+insert_perm_state (WylHandle *handle, const gchar *subject_id,
+    const gchar *perm_id, const gchar *scope, const gchar *state)
+{
+  gint64 row[4];
+
+  if (wyl_handle_intern_engine_symbol (handle, subject_id, &row[0])
+      != WYRELOG_E_OK)
+    return 1;
+  if (wyl_handle_intern_engine_symbol (handle, perm_id, &row[1])
+      != WYRELOG_E_OK)
+    return 2;
+  if (wyl_handle_intern_engine_symbol (handle, scope, &row[2])
+      != WYRELOG_E_OK)
+    return 3;
+  if (wyl_handle_intern_engine_symbol (handle, state, &row[3])
+      != WYRELOG_E_OK)
+    return 4;
+  if (wyl_handle_engine_insert (handle, "perm_state", row, 4)
+      != WYRELOG_E_OK)
+    return 5;
+  return 0;
 }
 
 static gint
@@ -141,6 +209,88 @@ check_revoke_rejects_incomplete_req (void)
 }
 
 static gint
+check_role_grant_rejects_null_args (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 90;
+
+  g_autoptr (wyl_role_grant_req_t) req = wyl_role_grant_req_new ();
+
+  if (wyl_role_grant (NULL, req) != WYRELOG_E_INVALID)
+    return 91;
+  if (wyl_role_grant (handle, NULL) != WYRELOG_E_INVALID)
+    return 92;
+  return 0;
+}
+
+static gint
+check_role_grant_rejects_incomplete_req (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 95;
+
+  g_autoptr (wyl_role_grant_req_t) req = wyl_role_grant_req_new ();
+  if (wyl_role_grant (handle, req) != WYRELOG_E_INVALID)
+    return 96;
+  wyl_role_grant_req_set_subject_id (req, "alice");
+  wyl_role_grant_req_set_role_id (req, "wr.role");
+  if (wyl_role_grant (handle, req) != WYRELOG_E_INVALID)
+    return 97;
+  return 0;
+}
+
+static gint
+check_role_revoke_rejects_null_args (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 98;
+
+  g_autoptr (wyl_role_revoke_req_t) req = wyl_role_revoke_req_new ();
+
+  if (wyl_role_revoke (NULL, req) != WYRELOG_E_INVALID)
+    return 99;
+  if (wyl_role_revoke (handle, NULL) != WYRELOG_E_INVALID)
+    return 100;
+  return 0;
+}
+
+static gint
+check_role_revoke_rejects_incomplete_req (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 101;
+
+  g_autoptr (wyl_role_revoke_req_t) req = wyl_role_revoke_req_new ();
+  if (wyl_role_revoke (handle, req) != WYRELOG_E_INVALID)
+    return 102;
+  wyl_role_revoke_req_set_subject_id (req, "alice");
+  wyl_role_revoke_req_set_role_id (req, "wr.role");
+  if (wyl_role_revoke (handle, req) != WYRELOG_E_INVALID)
+    return 103;
+  return 0;
+}
+
+static gint
+check_role_grant_requires_existing_role (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 104;
+
+  g_autoptr (wyl_role_grant_req_t) req = wyl_role_grant_req_new ();
+  wyl_role_grant_req_set_subject_id (req, "missing-role-user");
+  wyl_role_grant_req_set_role_id (req, "wr.missing-role");
+  wyl_role_grant_req_set_scope (req, "missing-role-scope");
+  if (wyl_role_grant (handle, req) != WYRELOG_E_IO)
+    return 105;
+  return 0;
+}
+
+static gint
 check_grant_allows_engine_decide (void)
 {
   g_autoptr (WylHandle) handle = NULL;
@@ -187,6 +337,62 @@ check_grant_allows_engine_decide (void)
     return 57;
   if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_ALLOW)
     return 58;
+  return 0;
+}
+
+static gint
+check_role_grant_allows_engine_decide (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 110;
+  if (seed_role_permission (handle, "wr.role-grant-role",
+          "wr.role-grant-permission") != 0)
+    return 111;
+
+  g_autoptr (wyl_role_grant_req_t) grant = wyl_role_grant_req_new ();
+  wyl_role_grant_req_set_subject_id (grant, "role-grant-user");
+  wyl_role_grant_req_set_role_id (grant, "wr.role-grant-role");
+  wyl_role_grant_req_set_scope (grant, "role-grant-scope");
+  if (wyl_role_grant (handle, grant) != WYRELOG_E_OK)
+    return 112;
+
+  g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
+  wyl_login_req_set_username (login, "role-grant-user");
+  g_autoptr (WylSession) session = NULL;
+  if (wyl_session_login (handle, login, &session) != WYRELOG_E_OK)
+    return 113;
+  if (wyl_session_mfa_verify (handle, session) != WYRELOG_E_OK)
+    return 114;
+
+  gint64 active_row[1];
+  if (wyl_handle_intern_engine_symbol (handle, "active", &active_row[0])
+      != WYRELOG_E_OK)
+    return 115;
+  if (wyl_handle_engine_insert (handle, "session_active", active_row, 1)
+      != WYRELOG_E_OK)
+    return 116;
+  gint64 session_row[2];
+  if (wyl_handle_intern_engine_symbol (handle, "role-grant-scope",
+          &session_row[0]) != WYRELOG_E_OK)
+    return 117;
+  session_row[1] = active_row[0];
+  if (wyl_handle_engine_insert (handle, "session_state", session_row, 2)
+      != WYRELOG_E_OK)
+    return 118;
+  if (insert_perm_state (handle, "role-grant-user",
+          "wr.role-grant-permission", "role-grant-scope", "armed") != 0)
+    return 119;
+
+  g_autoptr (wyl_decide_req_t) decide = wyl_decide_req_new ();
+  wyl_decide_req_set_subject_id (decide, "role-grant-user");
+  wyl_decide_req_set_action (decide, "wr.role-grant-permission");
+  wyl_decide_req_set_resource_id (decide, "role-grant-scope");
+  g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
+  if (wyl_decide (handle, decide, resp) != WYRELOG_E_OK)
+    return 120;
+  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_ALLOW)
+    return 121;
   return 0;
 }
 
@@ -300,6 +506,92 @@ check_revoke_removes_store_grant (void)
 }
 
 static gint
+check_role_grant_persists_membership (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 121;
+  if (seed_role_permission (handle, "wr.store-role", "wr.store-role.read")
+      != 0)
+    return 122;
+
+  g_autoptr (wyl_role_grant_req_t) req = wyl_role_grant_req_new ();
+  wyl_role_grant_req_set_subject_id (req, "store-role-user");
+  wyl_role_grant_req_set_role_id (req, "wr.store-role");
+  wyl_role_grant_req_set_scope (req, "store-role-scope");
+  if (wyl_role_grant (handle, req) != WYRELOG_E_OK)
+    return 123;
+
+  gboolean exists = FALSE;
+  if (wyl_policy_store_role_membership_exists (wyl_handle_get_policy_store
+          (handle), "store-role-user", "wr.store-role", "store-role-scope",
+          &exists) != WYRELOG_E_OK)
+    return 124;
+  if (!exists)
+    return 125;
+
+  RoleMembershipEventExpect expect = {
+    .subject_id = "store-role-user",
+    .role_id = "wr.store-role",
+    .scope = "store-role-scope",
+    .operation = "grant",
+  };
+  if (wyl_policy_store_foreach_role_membership_event
+      (wyl_handle_get_policy_store (handle), role_membership_event_expect_cb,
+          &expect) != WYRELOG_E_OK)
+    return 126;
+  if (expect.matches != 1)
+    return 127;
+  return 0;
+}
+
+static gint
+check_role_revoke_removes_store_membership (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 128;
+  if (seed_role_permission (handle, "wr.store-revoke-role",
+          "wr.store-revoke-role.read") != 0)
+    return 129;
+
+  g_autoptr (wyl_role_grant_req_t) grant = wyl_role_grant_req_new ();
+  wyl_role_grant_req_set_subject_id (grant, "store-role-revoke-user");
+  wyl_role_grant_req_set_role_id (grant, "wr.store-revoke-role");
+  wyl_role_grant_req_set_scope (grant, "store-role-revoke-scope");
+  if (wyl_role_grant (handle, grant) != WYRELOG_E_OK)
+    return 130;
+
+  g_autoptr (wyl_role_revoke_req_t) revoke = wyl_role_revoke_req_new ();
+  wyl_role_revoke_req_set_subject_id (revoke, "store-role-revoke-user");
+  wyl_role_revoke_req_set_role_id (revoke, "wr.store-revoke-role");
+  wyl_role_revoke_req_set_scope (revoke, "store-role-revoke-scope");
+  if (wyl_role_revoke (handle, revoke) != WYRELOG_E_OK)
+    return 131;
+
+  gboolean exists = TRUE;
+  if (wyl_policy_store_role_membership_exists (wyl_handle_get_policy_store
+          (handle), "store-role-revoke-user", "wr.store-revoke-role",
+          "store-role-revoke-scope", &exists) != WYRELOG_E_OK)
+    return 132;
+  if (exists)
+    return 133;
+  RoleMembershipEventExpect revoke_expect = {
+    .subject_id = "store-role-revoke-user",
+    .role_id = "wr.store-revoke-role",
+    .scope = "store-role-revoke-scope",
+    .operation = "revoke",
+  };
+  if (wyl_policy_store_foreach_role_membership_event
+      (wyl_handle_get_policy_store (handle), role_membership_event_expect_cb,
+          &revoke_expect) != WYRELOG_E_OK)
+    return 134;
+  if (revoke_expect.matches != 1)
+    return 135;
+  return 0;
+}
+
+static gint
 check_revoke_removes_engine_grant (void)
 {
   g_autoptr (WylHandle) handle = NULL;
@@ -338,6 +630,51 @@ check_revoke_removes_engine_grant (void)
   return 0;
 }
 
+static gint
+check_role_revoke_removes_engine_membership (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 140;
+  if (seed_role_permission (handle, "wr.role-revoke-role",
+          "wr.role-revoke-permission") != 0)
+    return 141;
+
+  g_autoptr (wyl_role_grant_req_t) grant = wyl_role_grant_req_new ();
+  wyl_role_grant_req_set_subject_id (grant, "role-revoke-user");
+  wyl_role_grant_req_set_role_id (grant, "wr.role-revoke-role");
+  wyl_role_grant_req_set_scope (grant, "role-revoke-scope");
+  if (wyl_role_grant (handle, grant) != WYRELOG_E_OK)
+    return 142;
+
+  g_autoptr (wyl_role_revoke_req_t) revoke = wyl_role_revoke_req_new ();
+  wyl_role_revoke_req_set_subject_id (revoke, "role-revoke-user");
+  wyl_role_revoke_req_set_role_id (revoke, "wr.role-revoke-role");
+  wyl_role_revoke_req_set_scope (revoke, "role-revoke-scope");
+  if (wyl_role_revoke (handle, revoke) != WYRELOG_E_OK)
+    return 143;
+  if (insert_perm_state (handle, "role-revoke-user",
+          "wr.role-revoke-permission", "role-revoke-scope", "armed") != 0)
+    return 149;
+
+  gint64 row[3];
+  if (wyl_handle_intern_engine_symbol (handle, "role-revoke-user", &row[0])
+      != WYRELOG_E_OK)
+    return 144;
+  if (wyl_handle_intern_engine_symbol (handle, "wr.role-revoke-permission",
+          &row[1]) != WYRELOG_E_OK)
+    return 145;
+  if (wyl_handle_intern_engine_symbol (handle, "role-revoke-scope", &row[2])
+      != WYRELOG_E_OK)
+    return 146;
+  gboolean allowed = TRUE;
+  if (wyl_handle_engine_decide (handle, row, &allowed) != WYRELOG_E_OK)
+    return 147;
+  if (allowed)
+    return 148;
+  return 0;
+}
+
 int
 main (void)
 {
@@ -354,15 +691,33 @@ main (void)
     return rc;
   if ((rc = check_revoke_rejects_incomplete_req ()) != 0)
     return rc;
+  if ((rc = check_role_grant_rejects_null_args ()) != 0)
+    return rc;
+  if ((rc = check_role_grant_rejects_incomplete_req ()) != 0)
+    return rc;
+  if ((rc = check_role_revoke_rejects_null_args ()) != 0)
+    return rc;
+  if ((rc = check_role_revoke_rejects_incomplete_req ()) != 0)
+    return rc;
+  if ((rc = check_role_grant_requires_existing_role ()) != 0)
+    return rc;
   if ((rc = check_grant_allows_engine_decide ()) != 0)
+    return rc;
+  if ((rc = check_role_grant_allows_engine_decide ()) != 0)
     return rc;
   if ((rc = check_gated_grant_is_rejected_by_engine_path ()) != 0)
     return rc;
   if ((rc = check_grant_persists_direct_permission ()) != 0)
     return rc;
+  if ((rc = check_role_grant_persists_membership ()) != 0)
+    return rc;
   if ((rc = check_revoke_removes_store_grant ()) != 0)
     return rc;
+  if ((rc = check_role_revoke_removes_store_membership ()) != 0)
+    return rc;
   if ((rc = check_revoke_removes_engine_grant ()) != 0)
+    return rc;
+  if ((rc = check_role_revoke_removes_engine_membership ()) != 0)
     return rc;
   return 0;
 }

--- a/tests/test-policy-store.c
+++ b/tests/test-policy-store.c
@@ -25,6 +25,7 @@ check_store_creates_authority_schema (void)
     "role_permissions",
     "role_inheritances",
     "role_memberships",
+    "role_membership_events",
     "direct_permissions",
     "direct_permission_events",
     "principal_events",
@@ -71,6 +72,7 @@ check_template_schema_creates_state_tables (void)
     "role_permissions",
     "role_inheritances",
     "role_memberships",
+    "role_membership_events",
     "direct_permissions",
     "direct_permission_events",
     "principal_events",
@@ -254,6 +256,15 @@ typedef struct
   guint matches;
 } RoleMembershipExpect;
 
+typedef struct
+{
+  const gchar *subject_id;
+  const gchar *role_id;
+  const gchar *scope;
+  const gchar *operation;
+  guint matches;
+} RoleMembershipEventExpect;
+
 static wyrelog_error_t
 role_permission_expect_cb (const gchar *role_id, const gchar *perm_id,
     gpointer user_data)
@@ -287,6 +298,21 @@ role_membership_expect_cb (const gchar *subject_id, const gchar *role_id,
   if (g_strcmp0 (subject_id, expect->subject_id) == 0
       && g_strcmp0 (role_id, expect->role_id) == 0
       && g_strcmp0 (scope, expect->scope) == 0)
+    expect->matches++;
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+role_membership_event_expect_cb (const gchar *subject_id,
+    const gchar *role_id, const gchar *scope, const gchar *operation,
+    gpointer user_data)
+{
+  RoleMembershipEventExpect *expect = user_data;
+
+  if (g_strcmp0 (subject_id, expect->subject_id) == 0
+      && g_strcmp0 (role_id, expect->role_id) == 0
+      && g_strcmp0 (scope, expect->scope) == 0
+      && g_strcmp0 (operation, expect->operation) == 0)
     expect->matches++;
   return WYRELOG_E_OK;
 }
@@ -390,6 +416,9 @@ check_store_grants_role_membership (void)
   if (wyl_policy_store_grant_role_membership (store, "member-user",
           "wr.member-role", "member-scope") != WYRELOG_E_OK)
     return 71;
+  if (wyl_policy_store_append_role_membership_event (store, "member-user",
+          "wr.member-role", "member-scope", "grant") != WYRELOG_E_OK)
+    return 100;
   if (wyl_policy_store_grant_role_membership (store, "member-user",
           "wr.member-role", "member-scope") != WYRELOG_E_OK)
     return 72;
@@ -404,6 +433,36 @@ check_store_grants_role_membership (void)
     return 73;
   if (expect.matches != 1)
     return 74;
+  gboolean exists = FALSE;
+  if (wyl_policy_store_role_membership_exists (store, "member-user",
+          "wr.member-role", "member-scope", &exists) != WYRELOG_E_OK)
+    return 101;
+  if (!exists)
+    return 102;
+
+  RoleMembershipEventExpect event_expect = {
+    .subject_id = "member-user",
+    .role_id = "wr.member-role",
+    .scope = "member-scope",
+    .operation = "grant",
+  };
+  if (wyl_policy_store_foreach_role_membership_event (store,
+          role_membership_event_expect_cb, &event_expect) != WYRELOG_E_OK)
+    return 103;
+  if (event_expect.matches != 1)
+    return 104;
+  if (wyl_policy_store_revoke_role_membership (store, "member-user",
+          "wr.member-role", "member-scope") != WYRELOG_E_OK)
+    return 105;
+  if (wyl_policy_store_append_role_membership_event (store, "member-user",
+          "wr.member-role", "member-scope", "revoke") != WYRELOG_E_OK)
+    return 106;
+  exists = TRUE;
+  if (wyl_policy_store_role_membership_exists (store, "member-user",
+          "wr.member-role", "member-scope", &exists) != WYRELOG_E_OK)
+    return 107;
+  if (exists)
+    return 108;
   return 0;
 }
 
@@ -687,9 +746,25 @@ check_store_rejects_bad_role_permission (void)
   if (wyl_policy_store_grant_role_membership (store, NULL, "missing-role",
           "role-scope") != WYRELOG_E_INVALID)
     return 98;
+  if (wyl_policy_store_revoke_role_membership (store, NULL, "missing-role",
+          "role-scope") != WYRELOG_E_INVALID)
+    return 100;
+  gboolean exists = TRUE;
+  if (wyl_policy_store_role_membership_exists (store, NULL, "missing-role",
+          "role-scope", &exists) != WYRELOG_E_INVALID)
+    return 101;
   if (wyl_policy_store_foreach_role_membership (store, NULL, NULL)
       != WYRELOG_E_INVALID)
     return 99;
+  if (wyl_policy_store_append_role_membership_event (store, "role-user",
+          "missing-role", "role-scope", "grant") != WYRELOG_E_IO)
+    return 102;
+  if (wyl_policy_store_append_role_membership_event (store, "role-user",
+          "missing-role", "role-scope", "invalid") != WYRELOG_E_IO)
+    return 103;
+  if (wyl_policy_store_foreach_role_membership_event (store, NULL, NULL)
+      != WYRELOG_E_INVALID)
+    return 104;
   if (wyl_policy_store_set_principal_state (store, NULL, "authenticated")
       != WYRELOG_E_INVALID)
     return 56;

--- a/wyrelog/daemon/wyrelogd.c
+++ b/wyrelog/daemon/wyrelogd.c
@@ -225,6 +225,7 @@ check_policy_store_ready (WylHandle *handle)
     "role_permissions",
     "role_inheritances",
     "role_memberships",
+    "role_membership_events",
     "direct_permissions",
     "direct_permission_events",
     "principal_events",

--- a/wyrelog/perm.h
+++ b/wyrelog/perm.h
@@ -17,6 +17,8 @@ G_BEGIN_DECLS;
  */
 typedef struct _wyl_grant_req wyl_grant_req_t;
 typedef struct _wyl_revoke_req wyl_revoke_req_t;
+typedef struct _wyl_role_grant_req wyl_role_grant_req_t;
+typedef struct _wyl_role_revoke_req wyl_role_revoke_req_t;
 
 wyl_grant_req_t *wyl_grant_req_new (void);
 void wyl_grant_req_free (wyl_grant_req_t * req);
@@ -66,5 +68,45 @@ wyrelog_error_t wyl_perm_grant (WylHandle * handle,
     const wyl_grant_req_t * req);
 wyrelog_error_t wyl_perm_revoke (WylHandle * handle,
     const wyl_revoke_req_t * req);
+
+wyl_role_grant_req_t *wyl_role_grant_req_new (void);
+void wyl_role_grant_req_free (wyl_role_grant_req_t * req);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (wyl_role_grant_req_t, wyl_role_grant_req_free);
+
+void wyl_role_grant_req_set_subject_id (wyl_role_grant_req_t * req,
+    const gchar * subject_id);
+const gchar *wyl_role_grant_req_get_subject_id (const wyl_role_grant_req_t *
+    req);
+
+void wyl_role_grant_req_set_role_id (wyl_role_grant_req_t * req,
+    const gchar * role_id);
+const gchar *wyl_role_grant_req_get_role_id (const wyl_role_grant_req_t * req);
+
+void wyl_role_grant_req_set_scope (wyl_role_grant_req_t * req,
+    const gchar * scope);
+const gchar *wyl_role_grant_req_get_scope (const wyl_role_grant_req_t * req);
+
+wyl_role_revoke_req_t *wyl_role_revoke_req_new (void);
+void wyl_role_revoke_req_free (wyl_role_revoke_req_t * req);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (wyl_role_revoke_req_t, wyl_role_revoke_req_free);
+
+void wyl_role_revoke_req_set_subject_id (wyl_role_revoke_req_t * req,
+    const gchar * subject_id);
+const gchar *wyl_role_revoke_req_get_subject_id (const wyl_role_revoke_req_t *
+    req);
+
+void wyl_role_revoke_req_set_role_id (wyl_role_revoke_req_t * req,
+    const gchar * role_id);
+const gchar *wyl_role_revoke_req_get_role_id (const wyl_role_revoke_req_t *
+    req);
+
+void wyl_role_revoke_req_set_scope (wyl_role_revoke_req_t * req,
+    const gchar * scope);
+const gchar *wyl_role_revoke_req_get_scope (const wyl_role_revoke_req_t * req);
+
+wyrelog_error_t wyl_role_grant (WylHandle * handle,
+    const wyl_role_grant_req_t * req);
+wyrelog_error_t wyl_role_revoke (WylHandle * handle,
+    const wyl_role_revoke_req_t * req);
 
 G_END_DECLS;

--- a/wyrelog/policy/store-private.h
+++ b/wyrelog/policy/store-private.h
@@ -17,6 +17,9 @@ typedef wyrelog_error_t (*wyl_policy_role_inheritance_cb) (const gchar *
     child_role_id, const gchar * parent_role_id, gpointer user_data);
 typedef wyrelog_error_t (*wyl_policy_role_membership_cb) (const gchar *
     subject_id, const gchar * role_id, const gchar * scope, gpointer user_data);
+typedef wyrelog_error_t (*wyl_policy_role_membership_event_cb) (const gchar *
+    subject_id, const gchar * role_id, const gchar * scope,
+    const gchar * operation, gpointer user_data);
 typedef wyrelog_error_t (*wyl_policy_direct_permission_cb) (const gchar *
     subject_id, const gchar * perm_id, const gchar * scope, gpointer user_data);
 typedef wyrelog_error_t (*wyl_policy_direct_permission_event_cb) (const gchar *
@@ -63,8 +66,21 @@ wyrelog_error_t wyl_policy_store_foreach_role_inheritance (wyl_policy_store_t *
 wyrelog_error_t wyl_policy_store_grant_role_membership (wyl_policy_store_t *
     store, const gchar * subject_id, const gchar * role_id,
     const gchar * scope);
+wyrelog_error_t wyl_policy_store_revoke_role_membership (wyl_policy_store_t *
+    store, const gchar * subject_id, const gchar * role_id,
+    const gchar * scope);
+wyrelog_error_t wyl_policy_store_role_membership_exists (wyl_policy_store_t *
+    store, const gchar * subject_id, const gchar * role_id,
+    const gchar * scope, gboolean * out_exists);
 wyrelog_error_t wyl_policy_store_foreach_role_membership (wyl_policy_store_t *
     store, wyl_policy_role_membership_cb cb, gpointer user_data);
+wyrelog_error_t
+wyl_policy_store_append_role_membership_event (wyl_policy_store_t * store,
+    const gchar * subject_id, const gchar * role_id, const gchar * scope,
+    const gchar * operation);
+wyrelog_error_t
+wyl_policy_store_foreach_role_membership_event (wyl_policy_store_t * store,
+    wyl_policy_role_membership_event_cb cb, gpointer user_data);
 wyrelog_error_t wyl_policy_store_grant_direct_permission (wyl_policy_store_t *
     store, const gchar * subject_id, const gchar * perm_id,
     const gchar * scope);

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -152,6 +152,19 @@ wyl_policy_store_create_schema (wyl_policy_store_t *store)
       "  ON role_memberships (role_id);"
       "CREATE INDEX IF NOT EXISTS idx_role_memberships_subject_scope "
       "  ON role_memberships (subject_id, scope);"
+      "CREATE TABLE IF NOT EXISTS role_membership_events ("
+      "  event_id INTEGER PRIMARY KEY AUTOINCREMENT,"
+      "  subject_id TEXT NOT NULL,"
+      "  role_id TEXT NOT NULL,"
+      "  scope TEXT NOT NULL,"
+      "  operation TEXT NOT NULL CHECK (operation IN ('grant', 'revoke')),"
+      "  created_at INTEGER NOT NULL,"
+      "  FOREIGN KEY (role_id) REFERENCES roles (role_id)"
+      ");"
+      "CREATE INDEX IF NOT EXISTS idx_role_membership_events_subject "
+      "  ON role_membership_events (subject_id);"
+      "CREATE INDEX IF NOT EXISTS idx_role_membership_events_role "
+      "  ON role_membership_events (role_id);"
       "CREATE TABLE IF NOT EXISTS direct_permissions ("
       "  subject_id TEXT NOT NULL,"
       "  perm_id TEXT NOT NULL,"
@@ -859,6 +872,71 @@ wyl_policy_store_grant_role_membership (wyl_policy_store_t *store,
 }
 
 wyrelog_error_t
+wyl_policy_store_revoke_role_membership (wyl_policy_store_t *store,
+    const gchar *subject_id, const gchar *role_id, const gchar *scope)
+{
+  sqlite3_stmt *stmt = NULL;
+
+  if (store == NULL || store->db == NULL || subject_id == NULL
+      || role_id == NULL || scope == NULL)
+    return WYRELOG_E_INVALID;
+
+  static const gchar *sql =
+      "DELETE FROM role_memberships "
+      "WHERE subject_id = ? AND role_id = ? AND scope = ?;";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if ((rc = bind_text (stmt, 1, subject_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 2, role_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 3, scope)) != WYRELOG_E_OK) {
+    sqlite3_finalize (stmt);
+    return rc;
+  }
+
+  int step_rc = sqlite3_step (stmt);
+  sqlite3_finalize (stmt);
+  return (step_rc == SQLITE_DONE) ? WYRELOG_E_OK : WYRELOG_E_IO;
+}
+
+wyrelog_error_t
+wyl_policy_store_role_membership_exists (wyl_policy_store_t *store,
+    const gchar *subject_id, const gchar *role_id, const gchar *scope,
+    gboolean *out_exists)
+{
+  sqlite3_stmt *stmt = NULL;
+
+  if (store == NULL || store->db == NULL || subject_id == NULL
+      || role_id == NULL || scope == NULL || out_exists == NULL)
+    return WYRELOG_E_INVALID;
+
+  *out_exists = FALSE;
+  static const gchar *sql =
+      "SELECT 1 FROM role_memberships "
+      "WHERE subject_id = ? AND role_id = ? AND scope = ?;";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if ((rc = bind_text (stmt, 1, subject_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 2, role_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 3, scope)) != WYRELOG_E_OK) {
+    sqlite3_finalize (stmt);
+    return rc;
+  }
+
+  int step_rc = sqlite3_step (stmt);
+  if (step_rc == SQLITE_ROW)
+    *out_exists = TRUE;
+  else if (step_rc != SQLITE_DONE) {
+    sqlite3_finalize (stmt);
+    return WYRELOG_E_IO;
+  }
+
+  sqlite3_finalize (stmt);
+  return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
 wyl_policy_store_foreach_role_membership (wyl_policy_store_t *store,
     wyl_policy_role_membership_cb cb, gpointer user_data)
 {
@@ -880,6 +958,70 @@ wyl_policy_store_foreach_role_membership (wyl_policy_store_t *store,
     const gchar *role_id = (const gchar *) sqlite3_column_text (stmt, 1);
     const gchar *scope = (const gchar *) sqlite3_column_text (stmt, 2);
     rc = cb (subject_id, role_id, scope, user_data);
+    if (rc != WYRELOG_E_OK) {
+      sqlite3_finalize (stmt);
+      return rc;
+    }
+  }
+
+  sqlite3_finalize (stmt);
+  return (step_rc == SQLITE_DONE) ? WYRELOG_E_OK : WYRELOG_E_IO;
+}
+
+wyrelog_error_t
+wyl_policy_store_append_role_membership_event (wyl_policy_store_t *store,
+    const gchar *subject_id, const gchar *role_id, const gchar *scope,
+    const gchar *operation)
+{
+  sqlite3_stmt *stmt = NULL;
+
+  if (store == NULL || store->db == NULL || subject_id == NULL
+      || role_id == NULL || scope == NULL || operation == NULL)
+    return WYRELOG_E_INVALID;
+
+  static const gchar *sql =
+      "INSERT INTO role_membership_events "
+      "  (subject_id, role_id, scope, operation, created_at) "
+      "VALUES (?, ?, ?, ?, unixepoch());";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if ((rc = bind_text (stmt, 1, subject_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 2, role_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 3, scope)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 4, operation)) != WYRELOG_E_OK) {
+    sqlite3_finalize (stmt);
+    return rc;
+  }
+
+  int step_rc = sqlite3_step (stmt);
+  sqlite3_finalize (stmt);
+  return (step_rc == SQLITE_DONE) ? WYRELOG_E_OK : WYRELOG_E_IO;
+}
+
+wyrelog_error_t
+wyl_policy_store_foreach_role_membership_event (wyl_policy_store_t *store,
+    wyl_policy_role_membership_event_cb cb, gpointer user_data)
+{
+  sqlite3_stmt *stmt = NULL;
+
+  if (store == NULL || store->db == NULL || cb == NULL)
+    return WYRELOG_E_INVALID;
+
+  static const gchar *sql =
+      "SELECT subject_id, role_id, scope, operation "
+      "FROM role_membership_events ORDER BY event_id;";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  int step_rc;
+  while ((step_rc = sqlite3_step (stmt)) == SQLITE_ROW) {
+    const gchar *subject_id = (const gchar *) sqlite3_column_text (stmt, 0);
+    const gchar *role_id = (const gchar *) sqlite3_column_text (stmt, 1);
+    const gchar *scope = (const gchar *) sqlite3_column_text (stmt, 2);
+    const gchar *operation = (const gchar *) sqlite3_column_text (stmt, 3);
+    rc = cb (subject_id, role_id, scope, operation, user_data);
     if (rc != WYRELOG_E_OK) {
       sqlite3_finalize (stmt);
       return rc;

--- a/wyrelog/wyl-perm.c
+++ b/wyrelog/wyl-perm.c
@@ -24,6 +24,20 @@ struct _wyl_revoke_req
   gchar *resource_id;
 };
 
+struct _wyl_role_grant_req
+{
+  gchar *subject_id;
+  gchar *role_id;
+  gchar *scope;
+};
+
+struct _wyl_role_revoke_req
+{
+  gchar *subject_id;
+  gchar *role_id;
+  gchar *scope;
+};
+
 wyl_login_req_t *
 wyl_login_req_new (void)
 {
@@ -192,6 +206,133 @@ wyl_revoke_req_get_resource_id (const wyl_revoke_req_t *req)
   return req->resource_id;
 }
 
+wyl_role_grant_req_t *
+wyl_role_grant_req_new (void)
+{
+  return g_new0 (wyl_role_grant_req_t, 1);
+}
+
+void
+wyl_role_grant_req_free (wyl_role_grant_req_t *req)
+{
+  if (req == NULL)
+    return;
+  g_free (req->subject_id);
+  g_free (req->role_id);
+  g_free (req->scope);
+  g_free (req);
+}
+
+void
+wyl_role_grant_req_set_subject_id (wyl_role_grant_req_t *req,
+    const gchar *subject_id)
+{
+  g_return_if_fail (req != NULL);
+  g_free (req->subject_id);
+  req->subject_id = g_strdup (subject_id);
+}
+
+const gchar *
+wyl_role_grant_req_get_subject_id (const wyl_role_grant_req_t *req)
+{
+  g_return_val_if_fail (req != NULL, NULL);
+  return req->subject_id;
+}
+
+void
+wyl_role_grant_req_set_role_id (wyl_role_grant_req_t *req, const gchar *role_id)
+{
+  g_return_if_fail (req != NULL);
+  g_free (req->role_id);
+  req->role_id = g_strdup (role_id);
+}
+
+const gchar *
+wyl_role_grant_req_get_role_id (const wyl_role_grant_req_t *req)
+{
+  g_return_val_if_fail (req != NULL, NULL);
+  return req->role_id;
+}
+
+void
+wyl_role_grant_req_set_scope (wyl_role_grant_req_t *req, const gchar *scope)
+{
+  g_return_if_fail (req != NULL);
+  g_free (req->scope);
+  req->scope = g_strdup (scope);
+}
+
+const gchar *
+wyl_role_grant_req_get_scope (const wyl_role_grant_req_t *req)
+{
+  g_return_val_if_fail (req != NULL, NULL);
+  return req->scope;
+}
+
+wyl_role_revoke_req_t *
+wyl_role_revoke_req_new (void)
+{
+  return g_new0 (wyl_role_revoke_req_t, 1);
+}
+
+void
+wyl_role_revoke_req_free (wyl_role_revoke_req_t *req)
+{
+  if (req == NULL)
+    return;
+  g_free (req->subject_id);
+  g_free (req->role_id);
+  g_free (req->scope);
+  g_free (req);
+}
+
+void
+wyl_role_revoke_req_set_subject_id (wyl_role_revoke_req_t *req,
+    const gchar *subject_id)
+{
+  g_return_if_fail (req != NULL);
+  g_free (req->subject_id);
+  req->subject_id = g_strdup (subject_id);
+}
+
+const gchar *
+wyl_role_revoke_req_get_subject_id (const wyl_role_revoke_req_t *req)
+{
+  g_return_val_if_fail (req != NULL, NULL);
+  return req->subject_id;
+}
+
+void
+wyl_role_revoke_req_set_role_id (wyl_role_revoke_req_t *req,
+    const gchar *role_id)
+{
+  g_return_if_fail (req != NULL);
+  g_free (req->role_id);
+  req->role_id = g_strdup (role_id);
+}
+
+const gchar *
+wyl_role_revoke_req_get_role_id (const wyl_role_revoke_req_t *req)
+{
+  g_return_val_if_fail (req != NULL, NULL);
+  return req->role_id;
+}
+
+void
+wyl_role_revoke_req_set_scope (wyl_role_revoke_req_t *req, const gchar *scope)
+{
+  g_return_if_fail (req != NULL);
+  g_free (req->scope);
+  req->scope = g_strdup (scope);
+}
+
+const gchar *
+wyl_role_revoke_req_get_scope (const wyl_role_revoke_req_t *req)
+{
+  g_return_val_if_fail (req != NULL, NULL);
+  return req->scope;
+}
+
 static wyrelog_error_t
 update_direct_permission_store (WylHandle *handle, const gchar *subject_id,
     const gchar *action, const gchar *resource_id, gboolean insert)
@@ -222,7 +363,26 @@ update_direct_permission_store (WylHandle *handle, const gchar *subject_id,
 }
 
 static wyrelog_error_t
-reload_direct_permission_snapshot (WylHandle *handle)
+update_role_membership_store (WylHandle *handle, const gchar *subject_id,
+    const gchar *role_id, const gchar *scope, gboolean insert)
+{
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (store == NULL)
+    return WYRELOG_E_INVALID;
+
+  wyrelog_error_t rc = insert
+      ? wyl_policy_store_grant_role_membership (store, subject_id, role_id,
+      scope)
+      : wyl_policy_store_revoke_role_membership (store, subject_id, role_id,
+      scope);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_policy_store_append_role_membership_event (store, subject_id,
+      role_id, scope, insert ? "grant" : "revoke");
+}
+
+static wyrelog_error_t
+reload_policy_snapshot (WylHandle *handle)
 {
   if (wyl_handle_get_read_engine (handle) == NULL)
     return WYRELOG_E_OK;
@@ -247,7 +407,7 @@ wyl_perm_grant (WylHandle *handle, const wyl_grant_req_t *req)
       wyl_grant_req_get_resource_id (req), TRUE);
   if (rc != WYRELOG_E_OK)
     return rc;
-  rc = reload_direct_permission_snapshot (handle);
+  rc = reload_policy_snapshot (handle);
   if (rc != WYRELOG_E_OK)
     return rc;
 
@@ -283,7 +443,7 @@ wyl_perm_revoke (WylHandle *handle, const wyl_revoke_req_t *req)
       wyl_revoke_req_get_resource_id (req), FALSE);
   if (rc != WYRELOG_E_OK)
     return rc;
-  rc = reload_direct_permission_snapshot (handle);
+  rc = reload_policy_snapshot (handle);
   if (rc != WYRELOG_E_OK)
     return rc;
 
@@ -295,6 +455,72 @@ wyl_perm_revoke (WylHandle *handle, const wyl_revoke_req_t *req)
   wyl_audit_event_set_action (ev, "permission_revoke");
   wyl_audit_event_set_resource_id (ev, wyl_revoke_req_get_resource_id (req));
   wyl_audit_event_set_deny_origin (ev, wyl_revoke_req_get_action (req));
+  wyl_audit_event_set_decision (ev, WYL_DECISION_ALLOW);
+  (void) wyl_audit_emit (handle, ev);
+#endif
+
+  return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
+wyl_role_grant (WylHandle *handle, const wyl_role_grant_req_t *req)
+{
+  if (handle == NULL || req == NULL)
+    return WYRELOG_E_INVALID;
+  if (wyl_role_grant_req_get_subject_id (req) == NULL
+      || wyl_role_grant_req_get_role_id (req) == NULL
+      || wyl_role_grant_req_get_scope (req) == NULL)
+    return WYRELOG_E_INVALID;
+
+  wyrelog_error_t rc = update_role_membership_store (handle,
+      wyl_role_grant_req_get_subject_id (req),
+      wyl_role_grant_req_get_role_id (req), wyl_role_grant_req_get_scope (req),
+      TRUE);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = reload_policy_snapshot (handle);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+#ifdef WYL_HAS_AUDIT
+  g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
+  wyl_audit_event_set_subject_id (ev, wyl_role_grant_req_get_subject_id (req));
+  wyl_audit_event_set_action (ev, "role_grant");
+  wyl_audit_event_set_resource_id (ev, wyl_role_grant_req_get_scope (req));
+  wyl_audit_event_set_deny_origin (ev, wyl_role_grant_req_get_role_id (req));
+  wyl_audit_event_set_decision (ev, WYL_DECISION_ALLOW);
+  (void) wyl_audit_emit (handle, ev);
+#endif
+
+  return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
+wyl_role_revoke (WylHandle *handle, const wyl_role_revoke_req_t *req)
+{
+  if (handle == NULL || req == NULL)
+    return WYRELOG_E_INVALID;
+  if (wyl_role_revoke_req_get_subject_id (req) == NULL
+      || wyl_role_revoke_req_get_role_id (req) == NULL
+      || wyl_role_revoke_req_get_scope (req) == NULL)
+    return WYRELOG_E_INVALID;
+
+  wyrelog_error_t rc = update_role_membership_store (handle,
+      wyl_role_revoke_req_get_subject_id (req),
+      wyl_role_revoke_req_get_role_id (req),
+      wyl_role_revoke_req_get_scope (req), FALSE);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = reload_policy_snapshot (handle);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+#ifdef WYL_HAS_AUDIT
+  g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
+  wyl_audit_event_set_subject_id (ev, wyl_role_revoke_req_get_subject_id (req));
+  wyl_audit_event_set_action (ev, "role_revoke");
+  wyl_audit_event_set_resource_id (ev, wyl_role_revoke_req_get_scope (req));
+  wyl_audit_event_set_deny_origin (ev, wyl_role_revoke_req_get_role_id (req));
   wyl_audit_event_set_decision (ev, WYL_DECISION_ALLOW);
   (void) wyl_audit_emit (handle, ev);
 #endif


### PR DESCRIPTION
## Summary
- add public role grant and revoke request carriers and APIs
- persist role membership grant/revoke history in the policy store
- reload policy snapshots after role membership admin changes
- mirror accepted role membership operations into audit events
- cover store, decision, audit, and daemon readiness behavior

## Verification
- git diff --check
- sqlite3 :memory: < templates/access/sqlite-schema.sql
- meson test -C builddir-audit --print-errorlogs policy-store perm audit-emit wyrelogd-check
- meson test -C builddir --print-errorlogs policy-store perm wyrelogd-check
- meson test -C builddir-noclient --print-errorlogs policy-store perm wyrelogd-check
- meson test -C builddir --print-errorlogs check-public-headers-no-novelty-tokens check-private-headers-not-installed
- meson test -C builddir-audit --print-errorlogs check-public-headers-no-novelty-tokens check-private-headers-not-installed
