### PR TITLE
policy: scope guard bridge facts to decisions

### DIFF
--- a/tests/test-decide.c
+++ b/tests/test-decide.c
@@ -117,6 +117,40 @@ insert_allow_fixture (WylHandle *handle, const gchar *subject,
 }
 
 static gint
+check_guard_bridge_facts_absent (WylHandle *handle, const gchar *subject,
+    const gchar *action, const gchar *resource, gint base_code)
+{
+  gint64 row[3];
+  wyrelog_error_t rc = intern_symbol (handle, subject, &row[0]);
+  if (rc != WYRELOG_E_OK)
+    return base_code;
+  rc = intern_symbol (handle, action, &row[1]);
+  if (rc != WYRELOG_E_OK)
+    return base_code + 1;
+  rc = intern_symbol (handle, resource, &row[2]);
+  if (rc != WYRELOG_E_OK)
+    return base_code + 2;
+
+  gint64 context_row[2] = { row[0], row[2] };
+  gboolean found = TRUE;
+  rc = wyl_handle_engine_contains (handle, "context_now", context_row, 2,
+      &found);
+  if (rc != WYRELOG_E_OK)
+    return base_code + 3;
+  if (found)
+    return base_code + 4;
+
+  found = TRUE;
+  rc = wyl_handle_engine_contains (handle, "eval_guard", row, 3, &found);
+  if (rc != WYRELOG_E_OK)
+    return base_code + 5;
+  if (found)
+    return base_code + 6;
+
+  return 0;
+}
+
+static gint
 check_decide_returns_ok_and_deny (void)
 {
   g_autoptr (WylHandle) handle = NULL;
@@ -257,6 +291,10 @@ check_decide_allows_guarded_permission_with_context (void)
     return 63;
   if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_ALLOW)
     return 64;
+  gint guard_rc = check_guard_bridge_facts_absent (handle, "decide-user-c",
+      "wr.audit.read", "decide-resource-c", 67);
+  if (guard_rc != 0)
+    return guard_rc;
 
   wyl_decide_req_clear_guard_context (req);
   wyl_decide_resp_set_decision (resp, WYL_DECISION_ALLOW);
@@ -301,6 +339,41 @@ check_decide_denies_guarded_permission_on_context_miss (void)
   return 0;
 }
 
+static gint
+check_decide_cleans_guard_facts_after_guarded_deny (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 80;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 81;
+  if (insert_allow_fixture_state (handle, "decide-user-e", "wr.audit.read",
+          "decide-resource-e", FALSE) != WYRELOG_E_OK)
+    return 82;
+  if (insert_symbol_row1 (handle, "frozen", "decide-resource-e")
+      != WYRELOG_E_OK)
+    return 83;
+
+  g_autoptr (wyl_decide_req_t) req = wyl_decide_req_new ();
+  wyl_decide_req_set_subject_id (req, "decide-user-e");
+  wyl_decide_req_set_action (req, "wr.audit.read");
+  wyl_decide_req_set_resource_id (req, "decide-resource-e");
+  wyl_decide_req_set_guard_context (req, 123, "public", 69);
+
+  g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
+  wyl_decide_resp_set_decision (resp, WYL_DECISION_ALLOW);
+  if (wyl_decide (handle, req, resp) != WYRELOG_E_OK)
+    return 84;
+  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_DENY)
+    return 85;
+  if (g_strcmp0 (wyl_decide_resp_get_deny_reason (resp), "frozen") != 0)
+    return 86;
+
+  return check_guard_bridge_facts_absent (handle, "decide-user-e",
+      "wr.audit.read", "decide-resource-e", 87);
+}
+
 int
 main (void)
 {
@@ -318,6 +391,8 @@ main (void)
   if ((rc = check_decide_allows_guarded_permission_with_context ()) != 0)
     return rc;
   if ((rc = check_decide_denies_guarded_permission_on_context_miss ()) != 0)
+    return rc;
+  if ((rc = check_decide_cleans_guard_facts_after_guarded_deny ()) != 0)
     return rc;
   return 0;
 }

--- a/wyrelog/wyl-decide.c
+++ b/wyrelog/wyl-decide.c
@@ -218,7 +218,24 @@ insert_guard_eval_facts (WylHandle *handle, const gint64 row[3])
   if (rc != WYRELOG_E_OK)
     return rc;
 
-  return wyl_handle_engine_insert (handle, "eval_guard", row, 3);
+  rc = wyl_handle_engine_insert (handle, "eval_guard", row, 3);
+  if (rc != WYRELOG_E_OK) {
+    (void) wyl_handle_engine_remove (handle, "context_now", context_row, 2);
+    return rc;
+  }
+
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+remove_guard_eval_facts (WylHandle *handle, const gint64 row[3])
+{
+  gint64 context_row[2] = { row[0], row[2] };
+  wyrelog_error_t rc = wyl_handle_engine_remove (handle, "eval_guard", row, 3);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  return wyl_handle_engine_remove (handle, "context_now", context_row, 2);
 }
 
 static wyrelog_error_t
@@ -314,6 +331,7 @@ wyl_decide (WylHandle *handle, const wyl_decide_req_t *req,
       return rc;
 
     gboolean allowed = FALSE;
+    gboolean guard_facts_inserted = FALSE;
     const wyl_guard_expr_t *guard =
         wyl_perm_arm_rule_lookup (wyl_decide_req_get_action (req));
     if (guard != NULL) {
@@ -331,20 +349,36 @@ wyl_decide (WylHandle *handle, const wyl_decide_req_t *req,
       rc = insert_guard_eval_facts (handle, row);
       if (rc != WYRELOG_E_OK)
         return rc;
+      guard_facts_inserted = TRUE;
     }
 
     rc = wyl_handle_engine_decide (handle, row, &allowed);
-    if (rc != WYRELOG_E_OK)
+    if (rc != WYRELOG_E_OK) {
+      if (guard_facts_inserted)
+        (void) remove_guard_eval_facts (handle, row);
       return rc;
+    }
     if (allowed) {
       wyl_decide_resp_set_decision (resp, WYL_DECISION_ALLOW);
     } else {
       wyl_deny_reason_code_t code = WYL_DENY_REASON_LAST_;
       rc = find_deny_reason (handle, row, reason_names, reason_origins, &code);
-      if (rc != WYRELOG_E_OK)
+      if (rc != WYRELOG_E_OK) {
+        if (guard_facts_inserted)
+          (void) remove_guard_eval_facts (handle, row);
         return rc;
+      }
       deny_reason = wyl_deny_reason_name (code);
       deny_origin = wyl_deny_reason_origin (code);
+    }
+    if (guard_facts_inserted) {
+      rc = remove_guard_eval_facts (handle, row);
+      if (rc != WYRELOG_E_OK) {
+        wyl_decide_resp_set_decision (resp, WYL_DECISION_DENY);
+        wyl_decide_resp_set_deny_tags (resp, "guard_cleanup_failed",
+            "eval_guard");
+        return rc;
+      }
     }
   }
   wyl_decide_resp_set_deny_tags (resp, deny_reason, deny_origin);

--- a/wyrelog/wyl-permission-scope-private.h
+++ b/wyrelog/wyl-permission-scope-private.h
@@ -14,14 +14,14 @@ G_BEGIN_DECLS;
  * The Datalog source of truth lives at
  * <datadir>/wyrelog/access/fsm/permission_scope.dl. This module
  * mirrors the catalogue rows on the C side and provides a guard
- * evaluator the engine can call to resolve eval_guard/2 against a
- * request scope.
+ * evaluator the decision layer can call before it exposes a
+ * request-local eval_guard/3 bridge fact to wirelog.
  *
- * scope/4 in the .dl is laid out as (user, timestamp, loc_class,
- * risk). The fourth slot is `risk` rather than `tenant` because
- * the version-0 catalogue exercises `risk` heavily and `tenant`
- * not at all; the tenant slot is reserved for tenant-scoped policy
- * wiring in a follow-up commit.
+ * The version-0 Datalog bridge is intentionally flat:
+ * context_now(user, scope) and eval_guard(user, perm, scope).
+ * Richer scope metadata remains in wyl_scope_t and in the C guard
+ * catalogue until wirelog compound declarations can carry the
+ * canonical scope payload directly.
  *
  * Evaluation contract: every uncertain or undefined branch
  * returns FALSE (fail-closed). This includes a NULL expression, a


### PR DESCRIPTION
## Summary

- remove request-local guard bridge facts after guarded decisions
- fail closed if guard bridge cleanup cannot complete
- cover guarded allow and guarded deny cleanup paths
- align private permission-scope comments with the flat v0 bridge

## Verification

- git diff --check
- meson test -C builddir --print-errorlogs decide fsm-permission-scope guard-expr access-decision handle-engine-pair
- meson test -C builddir-audit --print-errorlogs decide audit-emit audit-conn fsm-permission-scope guard-expr access-decision handle-engine-pair
- meson test -C builddir-noclient --print-errorlogs decide fsm-permission-scope guard-expr access-decision handle-engine-pair
