### PR TITLE
policy: carry guarded decision context

### DIFF
--- a/templates/access/fsm/permission_scope.dl
+++ b/templates/access/fsm/permission_scope.dl
@@ -53,6 +53,7 @@ perm_arm_rule("wr.svc.unfreeze",     "_v0_deferred").
 perm_arm_rule("wr.svc.grant_role",   "_v0_deferred").
 perm_arm_rule("wr.audit.read",       "_v0_deferred").
 perm_arm_rule("wr.audit.explain",    "_v0_deferred").
+perm_arm_rule("wr.stream.write_reserved", "_v0_deferred").
 
 // --- armed/3 derivation ----------------------------------------------
 

--- a/tests/test-decide-req.c
+++ b/tests/test-decide-req.c
@@ -4,6 +4,9 @@
 
 #include "wyrelog/wyrelog.h"
 
+static gboolean window_matcher (gint64 timestamp, const gchar * window_name,
+    gpointer user_data);
+
 static gint
 check_defaults_are_null (void)
 {
@@ -158,6 +161,7 @@ check_guard_context_clear_resets_fields (void)
 {
   g_autoptr (wyl_decide_req_t) req = wyl_decide_req_new ();
   wyl_decide_req_set_guard_context (req, 1234, "trusted", 42);
+  wyl_decide_req_set_guard_window_matcher (req, window_matcher, req);
   wyl_decide_req_clear_guard_context (req);
 
   if (wyl_decide_req_has_guard_context (req))
@@ -168,6 +172,8 @@ check_guard_context_clear_resets_fields (void)
     return 132;
   if (wyl_decide_req_get_guard_risk (req) != 0)
     return 133;
+  if (wyl_decide_req_get_guard_window_matcher (req, NULL) != NULL)
+    return 134;
   return 0;
 }
 
@@ -182,6 +188,38 @@ check_guard_context_get_null_request (void)
     return 142;
   if (wyl_decide_req_get_guard_risk (NULL) != 0)
     return 143;
+  return 0;
+}
+
+static gboolean
+window_matcher (gint64 timestamp, const gchar *window_name, gpointer user_data)
+{
+  (void) timestamp;
+  (void) window_name;
+  (void) user_data;
+  return TRUE;
+}
+
+static gint
+check_guard_window_matcher_round_trip (void)
+{
+  g_autoptr (wyl_decide_req_t) req = wyl_decide_req_new ();
+  gpointer marker = req;
+  wyl_decide_req_set_guard_window_matcher (req, window_matcher, marker);
+
+  gpointer user_data = NULL;
+  if (wyl_decide_req_get_guard_window_matcher (req, &user_data)
+      != window_matcher)
+    return 150;
+  if (user_data != marker)
+    return 151;
+
+  wyl_decide_req_set_guard_window_matcher (req, NULL, NULL);
+  user_data = marker;
+  if (wyl_decide_req_get_guard_window_matcher (req, &user_data) != NULL)
+    return 152;
+  if (user_data != NULL)
+    return 153;
   return 0;
 }
 
@@ -217,6 +255,8 @@ main (void)
   if ((rc = check_guard_context_clear_resets_fields ()) != 0)
     return rc;
   if ((rc = check_guard_context_get_null_request ()) != 0)
+    return rc;
+  if ((rc = check_guard_window_matcher_round_trip ()) != 0)
     return rc;
 
   return 0;

--- a/tests/test-decide.c
+++ b/tests/test-decide.c
@@ -116,6 +116,27 @@ insert_allow_fixture (WylHandle *handle, const gchar *subject,
   return insert_allow_fixture_state (handle, subject, action, resource, TRUE);
 }
 
+typedef struct
+{
+  const gchar *expected_window;
+  gint64 expected_timestamp;
+  gboolean answer;
+  guint calls;
+} WindowExpect;
+
+static gboolean
+window_expect_cb (gint64 timestamp, const gchar *window_name,
+    gpointer user_data)
+{
+  WindowExpect *expect = user_data;
+  expect->calls++;
+  if (timestamp != expect->expected_timestamp)
+    return FALSE;
+  if (g_strcmp0 (window_name, expect->expected_window) != 0)
+    return FALSE;
+  return expect->answer;
+}
+
 static gint
 check_guard_bridge_facts_absent (WylHandle *handle, const gchar *subject,
     const gchar *action, const gchar *resource, gint base_code)
@@ -148,6 +169,33 @@ check_guard_bridge_facts_absent (WylHandle *handle, const gchar *subject,
     return base_code + 6;
 
   return 0;
+}
+
+static wyrelog_error_t
+run_stream_window_decide (WylHandle *handle, gboolean install_matcher,
+    gboolean matcher_answer, wyl_decision_t *out_decision, guint *out_calls)
+{
+  WindowExpect expect = {
+    .expected_window = "off_hours",
+    .expected_timestamp = 4242,
+    .answer = matcher_answer,
+    .calls = 0,
+  };
+  g_autoptr (wyl_decide_req_t) req = wyl_decide_req_new ();
+  wyl_decide_req_set_subject_id (req, "window-user");
+  wyl_decide_req_set_action (req, "wr.stream.write_reserved");
+  wyl_decide_req_set_resource_id (req, "window-resource");
+  wyl_decide_req_set_guard_context (req, 4242, "trusted", 1);
+  if (install_matcher)
+    wyl_decide_req_set_guard_window_matcher (req, window_expect_cb, &expect);
+
+  g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
+  wyrelog_error_t rc = wyl_decide (handle, req, resp);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  *out_decision = wyl_decide_resp_get_decision (resp);
+  *out_calls = expect.calls;
+  return WYRELOG_E_OK;
 }
 
 static gint
@@ -208,6 +256,63 @@ check_decide_rejects_incomplete_req_as_deny (void)
   wyl_decide_req_set_action (req, "read");
   if (wyl_decide (handle, req, resp) != WYRELOG_E_INVALID)
     return 33;
+  return 0;
+}
+
+static gint
+check_decide_rejects_invalid_guard_context (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 34;
+
+  g_autoptr (wyl_decide_req_t) req = wyl_decide_req_new ();
+  wyl_decide_req_set_subject_id (req, "ctx-user");
+  wyl_decide_req_set_action (req, "read");
+  wyl_decide_req_set_resource_id (req, "ctx-resource");
+  g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
+
+  wyl_decide_resp_set_decision (resp, WYL_DECISION_ALLOW);
+  wyl_decide_req_set_guard_context (req, -1, "trusted", 1);
+  if (wyl_decide (handle, req, resp) != WYRELOG_E_INVALID)
+    return 35;
+  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_DENY)
+    return 36;
+
+  wyl_decide_resp_set_decision (resp, WYL_DECISION_ALLOW);
+  wyl_decide_req_set_guard_context (req, 1, "unknown", 1);
+  if (wyl_decide (handle, req, resp) != WYRELOG_E_INVALID)
+    return 37;
+  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_DENY)
+    return 38;
+
+  wyl_decide_resp_set_decision (resp, WYL_DECISION_ALLOW);
+  wyl_decide_req_set_guard_context (req, 1, NULL, 1);
+  if (wyl_decide (handle, req, resp) != WYRELOG_E_INVALID)
+    return 39;
+  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_DENY)
+    return 40;
+
+  wyl_decide_resp_set_decision (resp, WYL_DECISION_ALLOW);
+  wyl_decide_req_set_guard_context (req, 1, "trusted", -1);
+  if (wyl_decide (handle, req, resp) != WYRELOG_E_INVALID)
+    return 41;
+  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_DENY)
+    return 42;
+
+  wyl_decide_resp_set_decision (resp, WYL_DECISION_ALLOW);
+  wyl_decide_req_set_guard_context (req, 1, "trusted", 101);
+  if (wyl_decide (handle, req, resp) != WYRELOG_E_INVALID)
+    return 43;
+  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_DENY)
+    return 44;
+
+  wyl_decide_req_set_guard_context (req, 1, "semi_trusted", 100);
+  if (wyl_decide (handle, req, resp) != WYRELOG_E_OK)
+    return 45;
+  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_DENY)
+    return 46;
+
   return 0;
 }
 
@@ -374,6 +479,52 @@ check_decide_cleans_guard_facts_after_guarded_deny (void)
       "wr.audit.read", "decide-resource-e", 87);
 }
 
+static gint
+check_decide_evaluates_window_guard (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 90;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 91;
+  if (insert_allow_fixture_state (handle, "window-user",
+          "wr.stream.write_reserved", "window-resource", FALSE)
+      != WYRELOG_E_OK)
+    return 92;
+
+  wyl_decision_t decision = WYL_DECISION_ALLOW;
+  guint calls = 99;
+  if (run_stream_window_decide (handle, FALSE, FALSE, &decision, &calls)
+      != WYRELOG_E_OK)
+    return 93;
+  if (decision != WYL_DECISION_DENY || calls != 0)
+    return 94;
+  if (check_guard_bridge_facts_absent (handle, "window-user",
+          "wr.stream.write_reserved", "window-resource", 95) != 0)
+    return 102;
+
+  if (run_stream_window_decide (handle, TRUE, FALSE, &decision, &calls)
+      != WYRELOG_E_OK)
+    return 103;
+  if (decision != WYL_DECISION_DENY || calls != 1)
+    return 104;
+  if (check_guard_bridge_facts_absent (handle, "window-user",
+          "wr.stream.write_reserved", "window-resource", 105) != 0)
+    return 112;
+
+  if (run_stream_window_decide (handle, TRUE, TRUE, &decision, &calls)
+      != WYRELOG_E_OK)
+    return 113;
+  if (decision != WYL_DECISION_ALLOW || calls != 1)
+    return 114;
+  if (check_guard_bridge_facts_absent (handle, "window-user",
+          "wr.stream.write_reserved", "window-resource", 115) != 0)
+    return 122;
+
+  return 0;
+}
+
 int
 main (void)
 {
@@ -384,6 +535,8 @@ main (void)
     return rc;
   if ((rc = check_decide_rejects_incomplete_req_as_deny ()) != 0)
     return rc;
+  if ((rc = check_decide_rejects_invalid_guard_context ()) != 0)
+    return rc;
   if ((rc = check_decide_allows_engine_tuple ()) != 0)
     return rc;
   if ((rc = check_decide_denies_engine_miss ()) != 0)
@@ -393,6 +546,8 @@ main (void)
   if ((rc = check_decide_denies_guarded_permission_on_context_miss ()) != 0)
     return rc;
   if ((rc = check_decide_cleans_guard_facts_after_guarded_deny ()) != 0)
+    return rc;
+  if ((rc = check_decide_evaluates_window_guard ()) != 0)
     return rc;
   return 0;
 }

--- a/tests/test-fsm-permission-scope.c
+++ b/tests/test-fsm-permission-scope.c
@@ -51,7 +51,7 @@ check_stratification (void)
 static gint
 check_catalogue_invariants (void)
 {
-  if (wyl_perm_arm_rule_count () != 10)
+  if (wyl_perm_arm_rule_count () != 11)
     return 11;
   if (wyl_perm_arm_rule_lookup (NULL) != NULL)
     return 12;
@@ -136,6 +136,13 @@ check_catalogue_derivation (void)
     return 78;
   if (wyl_eval_guard (seal, &scope_public_low_risk))
     return 79;
+
+  const wyl_guard_expr_t *stream =
+      wyl_perm_arm_rule_lookup ("wr.stream.write_reserved");
+  if (stream == NULL)
+    return 80;
+  if (wyl_eval_guard (stream, &scope_trusted_low_risk))
+    return 81;
   return 0;
 }
 
@@ -264,6 +271,10 @@ check_in_window_callback (void)
       wyl_guard_cmp (WYL_GUARD_FIELD_TIMESTAMP, WYL_GUARD_OP_IN, "off_hours");
   if (g == NULL)
     return 110;
+  const wyl_guard_expr_t *stream =
+      wyl_perm_arm_rule_lookup ("wr.stream.write_reserved");
+  if (stream == NULL)
+    return 116;
 
   /* Without a callback, the timestamp-in test fails closed. */
   wyl_scope_t no_cb = {
@@ -272,6 +283,8 @@ check_in_window_callback (void)
   };
   if (wyl_eval_guard (g, &no_cb))
     return 111;
+  if (wyl_eval_guard (stream, &no_cb))
+    return 117;
 
   /* With a callback that says yes, eval returns TRUE. */
   window_stub_t st_yes = {
@@ -284,7 +297,9 @@ check_in_window_callback (void)
   };
   if (!wyl_eval_guard (g, &cb_yes))
     return 112;
-  if (st_yes.calls != 1)
+  if (!wyl_eval_guard (stream, &cb_yes))
+    return 118;
+  if (st_yes.calls != 2)
     return 113;
 
   /* Same callback, says no. */
@@ -298,7 +313,9 @@ check_in_window_callback (void)
   };
   if (wyl_eval_guard (g, &cb_no))
     return 114;
-  if (st_no.calls != 1)
+  if (wyl_eval_guard (stream, &cb_no))
+    return 119;
+  if (st_no.calls != 2)
     return 115;
   return 0;
 }

--- a/tests/test-session-username.c
+++ b/tests/test-session-username.c
@@ -27,6 +27,29 @@ grant_direct (WylHandle *handle, const gchar *subject_id,
   return wyl_perm_grant (handle, grant);
 }
 
+static wyrelog_error_t
+grant_role_permission (WylHandle *handle, const gchar *subject_id,
+    const gchar *role_id, const gchar *permission, const gchar *scope)
+{
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  wyrelog_error_t rc = wyl_policy_store_upsert_role (store, role_id, role_id);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_policy_store_upsert_permission (store, permission, permission,
+      "basic");
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_policy_store_grant_role_permission (store, role_id, permission);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  g_autoptr (wyl_role_grant_req_t) grant = wyl_role_grant_req_new ();
+  wyl_role_grant_req_set_subject_id (grant, subject_id);
+  wyl_role_grant_req_set_role_id (grant, role_id);
+  wyl_role_grant_req_set_scope (grant, scope);
+  return wyl_role_grant (handle, grant);
+}
+
 typedef struct
 {
   const gchar *session_id;
@@ -486,6 +509,50 @@ check_login_skip_mfa_authenticates_principal (void)
     return 158;
   if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_ALLOW)
     return 159;
+  return 0;
+}
+
+static gint
+check_login_skip_mfa_does_not_bypass_guarded_permission (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 166;
+
+  if (store_active_scope (handle, "skip-mfa-guarded-scope") != WYRELOG_E_OK)
+    return 167;
+  if (grant_role_permission (handle, "skip-mfa-guarded-user",
+          "wr.skip-mfa-guarded-role", "wr.audit.read",
+          "skip-mfa-guarded-scope") != WYRELOG_E_OK)
+    return 168;
+
+  g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
+  wyl_login_req_set_username (login, "skip-mfa-guarded-user");
+  wyl_login_req_set_skip_mfa (login, TRUE);
+  wyl_handle_set_login_skip_mfa_allowed (handle, TRUE);
+  g_autoptr (WylSession) session = NULL;
+  if (wyl_session_login (handle, login, &session) != WYRELOG_E_OK)
+    return 169;
+
+  g_autoptr (wyl_decide_req_t) decide = wyl_decide_req_new ();
+  wyl_decide_req_set_subject_id (decide, "skip-mfa-guarded-user");
+  wyl_decide_req_set_action (decide, "wr.audit.read");
+  wyl_decide_req_set_resource_id (decide, "skip-mfa-guarded-scope");
+
+  g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
+  if (wyl_decide (handle, decide, resp) != WYRELOG_E_OK)
+    return 170;
+  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_DENY)
+    return 171;
+  if (g_strcmp0 (wyl_decide_resp_get_deny_reason (resp), "not_armed") != 0)
+    return 172;
+
+  wyl_decide_req_set_guard_context (decide, 123, "public", 69);
+  if (wyl_decide (handle, decide, resp) != WYRELOG_E_OK)
+    return 173;
+  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_ALLOW)
+    return 174;
+
   return 0;
 }
 
@@ -1019,6 +1086,8 @@ main (void)
   if ((rc = check_login_skip_mfa_rejected_by_default ()) != 0)
     return rc;
   if ((rc = check_login_skip_mfa_authenticates_principal ()) != 0)
+    return rc;
+  if ((rc = check_login_skip_mfa_does_not_bypass_guarded_permission ()) != 0)
     return rc;
   if ((rc = check_session_close_persists_closed_state ()) != 0)
     return rc;

--- a/wyrelog/decide.h
+++ b/wyrelog/decide.h
@@ -30,6 +30,9 @@ typedef enum wyl_decision_t
 typedef struct _wyl_decide_req wyl_decide_req_t;
 typedef struct _wyl_decide_resp wyl_decide_resp_t;
 
+typedef gboolean (*wyl_guard_window_matcher_t) (gint64 timestamp,
+    const gchar * window_name, gpointer user_data);
+
 wyl_decide_req_t *wyl_decide_req_new (void);
 void wyl_decide_req_free (wyl_decide_req_t * req);
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (wyl_decide_req_t, wyl_decide_req_free);
@@ -56,6 +59,11 @@ const gchar *wyl_decide_req_get_resource_id (const wyl_decide_req_t * req);
  * Sets or clears request-time attributes used by guarded catalogue
  * permissions. When no guard context is set, guarded permissions remain
  * fail-closed. The location class string is duplicated by the request.
+ *
+ * wyl_decide validates the context before policy evaluation:
+ * timestamp must be non-negative, loc_class must be one of
+ * trusted/semi_trusted/public/untrusted, and risk must be in [0, 100].
+ * A window matcher is called synchronously by wyl_decide and is not retained.
  */
 void wyl_decide_req_set_guard_context (wyl_decide_req_t * req,
     gint64 timestamp, const gchar * loc_class, gint64 risk);
@@ -64,6 +72,10 @@ gboolean wyl_decide_req_has_guard_context (const wyl_decide_req_t * req);
 gint64 wyl_decide_req_get_guard_timestamp (const wyl_decide_req_t * req);
 const gchar *wyl_decide_req_get_guard_loc_class (const wyl_decide_req_t * req);
 gint64 wyl_decide_req_get_guard_risk (const wyl_decide_req_t * req);
+void wyl_decide_req_set_guard_window_matcher (wyl_decide_req_t * req,
+    wyl_guard_window_matcher_t matcher, gpointer user_data);
+wyl_guard_window_matcher_t wyl_decide_req_get_guard_window_matcher
+    (const wyl_decide_req_t * req, gpointer * out_user_data);
 
 wyl_decide_resp_t *wyl_decide_resp_new (void);
 void wyl_decide_resp_free (wyl_decide_resp_t * resp);

--- a/wyrelog/wyl-decide.c
+++ b/wyrelog/wyl-decide.c
@@ -14,6 +14,8 @@ struct _wyl_decide_req
   gint64 guard_timestamp;
   gchar *guard_loc_class;
   gint64 guard_risk;
+  wyl_guard_window_matcher_t guard_in_window;
+  gpointer guard_in_window_user_data;
 };
 
 struct _wyl_decide_resp
@@ -106,6 +108,8 @@ wyl_decide_req_clear_guard_context (wyl_decide_req_t *req)
   req->guard_timestamp = 0;
   g_clear_pointer (&req->guard_loc_class, g_free);
   req->guard_risk = 0;
+  req->guard_in_window = NULL;
+  req->guard_in_window_user_data = NULL;
 }
 
 gboolean
@@ -134,6 +138,25 @@ wyl_decide_req_get_guard_risk (const wyl_decide_req_t *req)
 {
   g_return_val_if_fail (req != NULL, 0);
   return req->guard_risk;
+}
+
+void
+wyl_decide_req_set_guard_window_matcher (wyl_decide_req_t *req,
+    wyl_guard_window_matcher_t matcher, gpointer user_data)
+{
+  g_return_if_fail (req != NULL);
+  req->guard_in_window = matcher;
+  req->guard_in_window_user_data = user_data;
+}
+
+wyl_guard_window_matcher_t
+wyl_decide_req_get_guard_window_matcher (const wyl_decide_req_t *req,
+    gpointer *out_user_data)
+{
+  g_return_val_if_fail (req != NULL, NULL);
+  if (out_user_data != NULL)
+    *out_user_data = req->guard_in_window_user_data;
+  return req->guard_in_window;
 }
 
 wyl_decide_resp_t *
@@ -195,6 +218,27 @@ wyl_decide_resp_get_deny_origin (const wyl_decide_resp_t *resp)
 }
 
 static gboolean
+is_valid_guard_loc_class (const gchar *loc_class)
+{
+  return g_strcmp0 (loc_class, "trusted") == 0 ||
+      g_strcmp0 (loc_class, "semi_trusted") == 0 ||
+      g_strcmp0 (loc_class, "public") == 0 ||
+      g_strcmp0 (loc_class, "untrusted") == 0;
+}
+
+static gboolean
+guard_context_is_valid (const wyl_decide_req_t *req)
+{
+  if (!req->has_guard_context)
+    return TRUE;
+  if (req->guard_timestamp < 0)
+    return FALSE;
+  if (!is_valid_guard_loc_class (req->guard_loc_class))
+    return FALSE;
+  return req->guard_risk >= 0 && req->guard_risk <= 100;
+}
+
+static gboolean
 guard_is_satisfied (const wyl_guard_expr_t *guard, const wyl_decide_req_t *req)
 {
   if (guard == NULL || !req->has_guard_context)
@@ -205,6 +249,8 @@ guard_is_satisfied (const wyl_guard_expr_t *guard, const wyl_decide_req_t *req)
     .timestamp = req->guard_timestamp,
     .loc_class = req->guard_loc_class,
     .risk = req->guard_risk,
+    .in_window = req->guard_in_window,
+    .in_window_user_data = req->guard_in_window_user_data,
   };
   return wyl_eval_guard (guard, &scope);
 }
@@ -306,6 +352,8 @@ wyl_decide (WylHandle *handle, const wyl_decide_req_t *req,
   if (wyl_decide_req_get_subject_id (req) == NULL
       || wyl_decide_req_get_action (req) == NULL
       || wyl_decide_req_get_resource_id (req) == NULL)
+    return WYRELOG_E_INVALID;
+  if (!guard_context_is_valid (req))
     return WYRELOG_E_INVALID;
 
   const gchar *deny_reason = NULL;

--- a/wyrelog/wyl-permission-scope.c
+++ b/wyrelog/wyl-permission-scope.c
@@ -74,6 +74,13 @@ build_audit_explain (void)
           "trusted"));
 }
 
+static wyl_guard_expr_t *
+build_stream_write_reserved (void)
+{
+  return wyl_guard_cmp (WYL_GUARD_FIELD_TIMESTAMP, WYL_GUARD_OP_IN,
+      "off_hours");
+}
+
 typedef struct catalogue_entry_t
 {
   const gchar *perm_id;
@@ -91,6 +98,7 @@ static const catalogue_entry_t catalogue[] = {
   {"wr.svc.grant_role", build_svc_grant_role},
   {"wr.audit.read", build_audit_read},
   {"wr.audit.explain", build_audit_explain},
+  {"wr.stream.write_reserved", build_stream_write_reserved},
 };
 
 /* The compiled trees are owned by this module for process


### PR DESCRIPTION
## Summary

- add a decide request window matcher for timestamp guards
- validate guard context before policy evaluation
- add a timestamp-window catalogue guard
- cover window guard decisions and skip-MFA guarded permissions

## Verification

- `git diff --check`
- `meson test -C builddir --print-errorlogs decide-req fsm-permission-scope decide session-username check-public-headers-no-novelty-tokens check-private-headers-not-installed`
- `meson test -C builddir-audit --print-errorlogs decide-req fsm-permission-scope decide session-username audit-emit check-public-headers-no-novelty-tokens check-private-headers-not-installed`
- `meson test -C builddir-noclient --print-errorlogs decide-req fsm-permission-scope decide session-username`
