### PR TITLE
policy: attach guard context facts

### DIFF
--- a/templates/access/fsm/permission_scope.dl
+++ b/templates/access/fsm/permission_scope.dl
@@ -8,8 +8,9 @@
 // IDB rule set with no transition lifecycle: the host must inject
 // perm_state(user, perm, scope, "armed") for unguarded permissions
 // that are ready to participate in allow/3. Guarded permissions are
-// armed only when the host injects the request-local context_now/2
-// and eval_guard/3 bridge facts for a satisfied guard expression.
+// armed only when the host injects request-local context_now/3,
+// guard_context/6, and eval_guard/4 bridge facts for a satisfied
+// guard expression.
 //
 // EDB schemas (host-populated, no clauses below):
 //   perm_state(user, perm, scope, state)        -- v0 row count = 0
@@ -17,9 +18,11 @@
 //                                                   bootstrap.dl
 //   perm_arm_rule(perm, guard_handle)            -- compound guard
 //                                                   payload key
-//   context_now(user, scope)                     -- request context
+//   context_now(user, scope, ctx)                -- request context
 //                                                   activation
-//   eval_guard(user, perm, scope)                -- host guard result
+//   guard_context(ctx, user, scope, timestamp,   -- structured request
+//                 loc_class, risk)                  context payload
+//   eval_guard(user, perm, scope, ctx)           -- host guard result
 //
 // Row order in any future perm_arm_rule block will be load-bearing:
 // the test harness compares the perm-id list line by line against
@@ -28,8 +31,10 @@
 
 .decl perm_state(user: symbol, perm: symbol, scope: symbol, state: symbol)
 .decl perm_arm_rule(perm: symbol, guard_handle: symbol)
-.decl context_now(user: symbol, scope: symbol)
-.decl eval_guard(user: symbol, perm: symbol, scope: symbol)
+.decl context_now(user: symbol, scope: symbol, ctx: symbol)
+.decl guard_context(ctx: symbol, user: symbol, scope: symbol,
+    timestamp: int64, loc_class: symbol, risk: int64)
+.decl eval_guard(user: symbol, perm: symbol, scope: symbol, ctx: symbol)
 .decl armed(user: symbol, perm: symbol, scope: symbol)
 
 // --- perm_arm_rule catalogue mirror ----------------------------------
@@ -41,7 +46,7 @@
 // the compound-term guard payload itself lives in the C catalogue,
 // keyed by perm-id; the `_v0_deferred` placeholder pins the row count
 // while the host bridge exposes satisfied guard decisions as
-// eval_guard/3 facts.
+// eval_guard/4 facts tied to a structured guard_context/6 row.
 
 perm_arm_rule("wr.sys.admin",        "_v0_deferred").
 perm_arm_rule("wr.sys.key_rotate",   "_v0_deferred").
@@ -66,10 +71,11 @@ armed(U, P, S) :-
 
 // rule-3: gated permission with compound-term guard payload. The
 // payload tree remains in the C catalogue for now, keyed by P; the
-// host evaluates it against request context and injects eval_guard/3
+// host evaluates it against request context and injects eval_guard/4
 // only when the guard is satisfied.
 armed(U, P, S) :-
     has_permission(U, P, S),
-    context_now(U, S),
+    context_now(U, S, C),
+    guard_context(C, U, S, _, _, _),
     perm_arm_rule(P, _),
-    eval_guard(U, P, S).
+    eval_guard(U, P, S, C).

--- a/tests/test-decide.c
+++ b/tests/test-decide.c
@@ -124,6 +124,12 @@ typedef struct
   guint calls;
 } WindowExpect;
 
+typedef struct
+{
+  const gint64 *row;
+  guint matches;
+} GuardFactExpect;
+
 static gboolean
 window_expect_cb (gint64 timestamp, const gchar *window_name,
     gpointer user_data)
@@ -135,6 +141,37 @@ window_expect_cb (gint64 timestamp, const gchar *window_name,
   if (g_strcmp0 (window_name, expect->expected_window) != 0)
     return FALSE;
   return expect->answer;
+}
+
+static void
+count_context_now_cb (const gchar *relation, const gint64 *row, guint ncols,
+    gpointer user_data)
+{
+  (void) relation;
+  GuardFactExpect *expect = user_data;
+  if (ncols == 3 && row[0] == expect->row[0] && row[1] == expect->row[2])
+    expect->matches++;
+}
+
+static void
+count_eval_guard_cb (const gchar *relation, const gint64 *row, guint ncols,
+    gpointer user_data)
+{
+  (void) relation;
+  GuardFactExpect *expect = user_data;
+  if (ncols == 4 && row[0] == expect->row[0] && row[1] == expect->row[1]
+      && row[2] == expect->row[2])
+    expect->matches++;
+}
+
+static void
+count_guard_context_cb (const gchar *relation, const gint64 *row, guint ncols,
+    gpointer user_data)
+{
+  (void) relation;
+  GuardFactExpect *expect = user_data;
+  if (ncols == 6 && row[1] == expect->row[0] && row[2] == expect->row[2])
+    expect->matches++;
 }
 
 static gint
@@ -152,21 +189,29 @@ check_guard_bridge_facts_absent (WylHandle *handle, const gchar *subject,
   if (rc != WYRELOG_E_OK)
     return base_code + 2;
 
-  gint64 context_row[2] = { row[0], row[2] };
-  gboolean found = TRUE;
-  rc = wyl_handle_engine_contains (handle, "context_now", context_row, 2,
-      &found);
+  GuardFactExpect expect = { row, 0 };
+  rc = wyl_engine_snapshot (wyl_handle_get_read_engine (handle),
+      "context_now", count_context_now_cb, &expect);
   if (rc != WYRELOG_E_OK)
     return base_code + 3;
-  if (found)
+  if (expect.matches != 0)
     return base_code + 4;
 
-  found = TRUE;
-  rc = wyl_handle_engine_contains (handle, "eval_guard", row, 3, &found);
+  expect.matches = 0;
+  rc = wyl_engine_snapshot (wyl_handle_get_read_engine (handle),
+      "eval_guard", count_eval_guard_cb, &expect);
   if (rc != WYRELOG_E_OK)
     return base_code + 5;
-  if (found)
+  if (expect.matches != 0)
     return base_code + 6;
+
+  expect.matches = 0;
+  rc = wyl_engine_snapshot (wyl_handle_get_read_engine (handle),
+      "guard_context", count_guard_context_cb, &expect);
+  if (rc != WYRELOG_E_OK)
+    return base_code + 7;
+  if (expect.matches != 0)
+    return base_code + 8;
 
   return 0;
 }

--- a/tests/test-fsm-permission-scope.c
+++ b/tests/test-fsm-permission-scope.c
@@ -18,8 +18,9 @@
  * into wyl_dl_rule_t form and asserts the program is stratified.
  * The negation edge in the state-driven rule references
  * \+ perm_arm_rule, and the guarded rule goes through eval_guard /
- * context_now. No edge can close a cycle because perm_arm_rule,
- * perm_state, has_permission, context_now and eval_guard are
+ * context_now / guard_context. No edge can close a cycle because
+ * perm_arm_rule, perm_state, has_permission, context_now,
+ * guard_context and eval_guard are
  * EDB-only — none of them appears as a head predicate in the
  * lifted rule set.
  */
@@ -33,6 +34,7 @@ check_stratification (void)
   static const wyl_dl_body_atom_t rule3_body[] = {
     {.predicate = "has_permission",.negated = FALSE},
     {.predicate = "context_now",.negated = FALSE},
+    {.predicate = "guard_context",.negated = FALSE},
     {.predicate = "perm_arm_rule",.negated = FALSE},
     {.predicate = "eval_guard",.negated = FALSE},
   };

--- a/wyrelog/wyl-decide.c
+++ b/wyrelog/wyl-decide.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <string.h>
+
 #include "wyrelog/wyrelog.h"
 
 #include "access/decision-private.h"
@@ -24,6 +26,16 @@ struct _wyl_decide_resp
   gchar *deny_reason;
   gchar *deny_origin;
 };
+
+typedef struct guard_eval_facts_t
+{
+  gint64 context_now[3];
+  gint64 guard_context[6];
+  gint64 eval_guard[4];
+  gboolean context_now_inserted;
+  gboolean guard_context_inserted;
+  gboolean eval_guard_inserted;
+} guard_eval_facts_t;
 
 wyl_decide_req_t *
 wyl_decide_req_new (void)
@@ -255,33 +267,99 @@ guard_is_satisfied (const wyl_guard_expr_t *guard, const wyl_decide_req_t *req)
   return wyl_eval_guard (guard, &scope);
 }
 
-static wyrelog_error_t
-insert_guard_eval_facts (WylHandle *handle, const gint64 row[3])
+static gchar *
+build_guard_context_symbol (const wyl_decide_req_t *req)
 {
-  gint64 context_row[2] = { row[0], row[2] };
-  wyrelog_error_t rc =
-      wyl_handle_engine_insert (handle, "context_now", context_row, 2);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-
-  rc = wyl_handle_engine_insert (handle, "eval_guard", row, 3);
-  if (rc != WYRELOG_E_OK) {
-    (void) wyl_handle_engine_remove (handle, "context_now", context_row, 2);
-    return rc;
-  }
-
-  return WYRELOG_E_OK;
+  static gint next_id = 0;
+  gint id = g_atomic_int_add (&next_id, 1) + 1;
+  return g_strdup_printf ("scope(metadata(%" G_GINT64_FORMAT ",%s,%"
+      G_GINT64_FORMAT "),request(%d))", req->guard_timestamp,
+      req->guard_loc_class, req->guard_risk, id);
 }
 
 static wyrelog_error_t
-remove_guard_eval_facts (WylHandle *handle, const gint64 row[3])
+remove_guard_eval_facts (WylHandle *handle, const guard_eval_facts_t *facts)
 {
-  gint64 context_row[2] = { row[0], row[2] };
-  wyrelog_error_t rc = wyl_handle_engine_remove (handle, "eval_guard", row, 3);
+  wyrelog_error_t first_rc = WYRELOG_E_OK;
+
+  if (facts->eval_guard_inserted) {
+    wyrelog_error_t rc =
+        wyl_handle_engine_remove (handle, "eval_guard", facts->eval_guard, 4);
+    if (first_rc == WYRELOG_E_OK)
+      first_rc = rc;
+  }
+  if (facts->context_now_inserted) {
+    wyrelog_error_t rc =
+        wyl_handle_engine_remove (handle, "context_now", facts->context_now, 3);
+    if (first_rc == WYRELOG_E_OK)
+      first_rc = rc;
+  }
+  if (facts->guard_context_inserted) {
+    wyrelog_error_t rc = wyl_handle_engine_remove (handle, "guard_context",
+        facts->guard_context, 6);
+    if (first_rc == WYRELOG_E_OK)
+      first_rc = rc;
+  }
+
+  return first_rc;
+}
+
+static wyrelog_error_t
+insert_guard_eval_facts (WylHandle *handle, const gint64 row[3],
+    const wyl_decide_req_t *req, guard_eval_facts_t *facts)
+{
+  memset (facts, 0, sizeof (*facts));
+
+  g_autofree gchar *context_symbol = build_guard_context_symbol (req);
+  gint64 context_id = 0;
+  wyrelog_error_t rc =
+      wyl_handle_intern_engine_symbol (handle, context_symbol, &context_id);
   if (rc != WYRELOG_E_OK)
     return rc;
 
-  return wyl_handle_engine_remove (handle, "context_now", context_row, 2);
+  gint64 loc_class_id = 0;
+  rc = wyl_handle_intern_engine_symbol (handle, req->guard_loc_class,
+      &loc_class_id);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  facts->guard_context[0] = context_id;
+  facts->guard_context[1] = row[0];
+  facts->guard_context[2] = row[2];
+  facts->guard_context[3] = req->guard_timestamp;
+  facts->guard_context[4] = loc_class_id;
+  facts->guard_context[5] = req->guard_risk;
+
+  facts->context_now[0] = row[0];
+  facts->context_now[1] = row[2];
+  facts->context_now[2] = context_id;
+
+  facts->eval_guard[0] = row[0];
+  facts->eval_guard[1] = row[1];
+  facts->eval_guard[2] = row[2];
+  facts->eval_guard[3] = context_id;
+
+  rc = wyl_handle_engine_insert (handle, "guard_context",
+      facts->guard_context, 6);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  facts->guard_context_inserted = TRUE;
+
+  rc = wyl_handle_engine_insert (handle, "context_now", facts->context_now, 3);
+  if (rc != WYRELOG_E_OK) {
+    (void) remove_guard_eval_facts (handle, facts);
+    return rc;
+  }
+  facts->context_now_inserted = TRUE;
+
+  rc = wyl_handle_engine_insert (handle, "eval_guard", facts->eval_guard, 4);
+  if (rc != WYRELOG_E_OK) {
+    (void) remove_guard_eval_facts (handle, facts);
+    return rc;
+  }
+  facts->eval_guard_inserted = TRUE;
+
+  return WYRELOG_E_OK;
 }
 
 static wyrelog_error_t
@@ -379,7 +457,7 @@ wyl_decide (WylHandle *handle, const wyl_decide_req_t *req,
       return rc;
 
     gboolean allowed = FALSE;
-    gboolean guard_facts_inserted = FALSE;
+    guard_eval_facts_t guard_facts = { 0 };
     const wyl_guard_expr_t *guard =
         wyl_perm_arm_rule_lookup (wyl_decide_req_get_action (req));
     if (guard != NULL) {
@@ -394,16 +472,15 @@ wyl_decide (WylHandle *handle, const wyl_decide_req_t *req,
         wyl_decide_resp_set_deny_tags (resp, deny_reason, deny_origin);
         goto emit_audit;
       }
-      rc = insert_guard_eval_facts (handle, row);
+      rc = insert_guard_eval_facts (handle, row, req, &guard_facts);
       if (rc != WYRELOG_E_OK)
         return rc;
-      guard_facts_inserted = TRUE;
     }
 
     rc = wyl_handle_engine_decide (handle, row, &allowed);
     if (rc != WYRELOG_E_OK) {
-      if (guard_facts_inserted)
-        (void) remove_guard_eval_facts (handle, row);
+      if (guard_facts.eval_guard_inserted)
+        (void) remove_guard_eval_facts (handle, &guard_facts);
       return rc;
     }
     if (allowed) {
@@ -412,15 +489,15 @@ wyl_decide (WylHandle *handle, const wyl_decide_req_t *req,
       wyl_deny_reason_code_t code = WYL_DENY_REASON_LAST_;
       rc = find_deny_reason (handle, row, reason_names, reason_origins, &code);
       if (rc != WYRELOG_E_OK) {
-        if (guard_facts_inserted)
-          (void) remove_guard_eval_facts (handle, row);
+        if (guard_facts.eval_guard_inserted)
+          (void) remove_guard_eval_facts (handle, &guard_facts);
         return rc;
       }
       deny_reason = wyl_deny_reason_name (code);
       deny_origin = wyl_deny_reason_origin (code);
     }
-    if (guard_facts_inserted) {
-      rc = remove_guard_eval_facts (handle, row);
+    if (guard_facts.eval_guard_inserted) {
+      rc = remove_guard_eval_facts (handle, &guard_facts);
       if (rc != WYRELOG_E_OK) {
         wyl_decide_resp_set_decision (resp, WYL_DECISION_DENY);
         wyl_decide_resp_set_deny_tags (resp, "guard_cleanup_failed",

--- a/wyrelog/wyl-permission-scope-private.h
+++ b/wyrelog/wyl-permission-scope-private.h
@@ -15,13 +15,14 @@ G_BEGIN_DECLS;
  * <datadir>/wyrelog/access/fsm/permission_scope.dl. This module
  * mirrors the catalogue rows on the C side and provides a guard
  * evaluator the decision layer can call before it exposes a
- * request-local eval_guard/3 bridge fact to wirelog.
+ * request-local eval_guard/4 bridge fact to wirelog.
  *
- * The version-0 Datalog bridge is intentionally flat:
- * context_now(user, scope) and eval_guard(user, perm, scope).
- * Richer scope metadata remains in wyl_scope_t and in the C guard
- * catalogue until wirelog compound declarations can carry the
- * canonical scope payload directly.
+ * The version-0 Datalog bridge carries a request-local context
+ * handle: context_now(user, scope, ctx), guard_context(ctx, user,
+ * scope, timestamp, loc_class, risk), and eval_guard(user, perm,
+ * scope, ctx). The guard expression payload remains in the C
+ * catalogue until wirelog compound declarations can carry it
+ * directly.
  *
  * Evaluation contract: every uncertain or undefined branch
  * returns FALSE (fail-closed). This includes a NULL expression, a


### PR DESCRIPTION
## Summary

- attach guarded decisions to a shared request context handle
- add structured wirelog-side rows for timestamp, location class, and risk
- join guarded activation and guard results through the same context handle
- clean tracked request-local bridge rows as one lifecycle

## Verification

- `git diff --check`
- `meson test -C builddir --print-errorlogs fsm-permission-scope access-decision decide session-username check-public-headers-no-novelty-tokens check-private-headers-not-installed`
- `meson test -C builddir-audit --print-errorlogs fsm-permission-scope access-decision decide session-username audit-emit check-public-headers-no-novelty-tokens check-private-headers-not-installed`
- `meson test -C builddir-noclient --print-errorlogs fsm-permission-scope access-decision decide session-username`
