### PR TITLE
session: audit denied skip mfa logins

### DIFF
--- a/tests/test-audit-emit.c
+++ b/tests/test-audit-emit.c
@@ -844,6 +844,74 @@ check_login_skip_mfa_emits_principal_state_audit_row (void)
 }
 
 static gint
+check_denied_login_skip_mfa_emits_audit_row (void)
+{
+  WylHandle *handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 110;
+
+  g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
+  wyl_login_req_set_username (login, "audit-skip-mfa-denied-user");
+  wyl_login_req_set_skip_mfa (login, TRUE);
+  g_autoptr (WylSession) session = NULL;
+  if (wyl_session_login (handle, login, &session) != WYRELOG_E_POLICY) {
+    g_object_unref (handle);
+    return 111;
+  }
+  if (session != NULL) {
+    g_object_unref (handle);
+    return 112;
+  }
+
+  duckdb_connection conn =
+      wyl_audit_conn_get_connection (wyl_handle_get_audit_conn (handle));
+  duckdb_result result;
+  if (duckdb_query (conn,
+          "SELECT subject_id, action, resource_id, deny_reason, "
+          "deny_origin, decision "
+          "FROM audit_events WHERE action = 'login_skip_mfa';", &result)
+      != DuckDBSuccess) {
+    duckdb_destroy_result (&result);
+    g_object_unref (handle);
+    return 113;
+  }
+  if (duckdb_row_count (&result) != 1) {
+    duckdb_destroy_result (&result);
+    g_object_unref (handle);
+    return 114;
+  }
+
+  gint rc = 0;
+  const gchar *subject = duckdb_value_varchar (&result, 0, 0);
+  const gchar *action = duckdb_value_varchar (&result, 1, 0);
+  const gchar *resource = duckdb_value_varchar (&result, 2, 0);
+  const gchar *reason = duckdb_value_varchar (&result, 3, 0);
+  const gchar *origin = duckdb_value_varchar (&result, 4, 0);
+  gint16 decision = (gint16) duckdb_value_int64 (&result, 5, 0);
+  if (g_strcmp0 (subject, "audit-skip-mfa-denied-user") != 0)
+    rc = 115;
+  else if (g_strcmp0 (action, "login_skip_mfa") != 0)
+    rc = 116;
+  else if (g_strcmp0 (resource, "principal_state") != 0)
+    rc = 117;
+  else if (g_strcmp0 (reason, "skip_mfa_not_allowed") != 0)
+    rc = 118;
+  else if (g_strcmp0 (origin, "login_ingress") != 0)
+    rc = 119;
+  else if (decision != WYL_DECISION_DENY)
+    rc = 120;
+
+  duckdb_free ((void *) subject);
+  duckdb_free ((void *) action);
+  duckdb_free ((void *) resource);
+  duckdb_free ((void *) reason);
+  duckdb_free ((void *) origin);
+  duckdb_destroy_result (&result);
+  g_object_unref (handle);
+  return rc;
+}
+
+static gint
 check_permission_grant_emits_audit_row (void)
 {
   WylHandle *handle = NULL;
@@ -1172,6 +1240,8 @@ main (void)
   if ((rc = check_login_principal_state_emits_audit_row ()) != 0)
     return rc;
   if ((rc = check_login_skip_mfa_emits_principal_state_audit_row ()) != 0)
+    return rc;
+  if ((rc = check_denied_login_skip_mfa_emits_audit_row ()) != 0)
     return rc;
   if ((rc = check_permission_grant_emits_audit_row ()) != 0)
     return rc;

--- a/wyrelog/wyl-session.c
+++ b/wyrelog/wyl-session.c
@@ -160,6 +160,19 @@ set_principal_state (WylHandle *handle, const gchar *username,
 
 #ifdef WYL_HAS_AUDIT
 static void
+emit_login_skip_mfa_denied_audit (WylHandle *handle, const gchar *username)
+{
+  g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
+  wyl_audit_event_set_subject_id (ev, username);
+  wyl_audit_event_set_action (ev, "login_skip_mfa");
+  wyl_audit_event_set_resource_id (ev, "principal_state");
+  wyl_audit_event_set_deny_reason (ev, "skip_mfa_not_allowed");
+  wyl_audit_event_set_deny_origin (ev, "login_ingress");
+  wyl_audit_event_set_decision (ev, WYL_DECISION_DENY);
+  (void) wyl_audit_emit (handle, ev);
+}
+
+static void
 emit_principal_state_audit (WylHandle *handle, const gchar *username,
     const gchar *old_state, const gchar *new_state, const gchar *event)
 {
@@ -331,8 +344,12 @@ wyl_session_login (WylHandle *handle, const wyl_login_req_t *req,
     return WYRELOG_E_INVALID;
 
   if (req != NULL && wyl_login_req_get_skip_mfa (req) &&
-      !wyl_handle_get_login_skip_mfa_allowed (handle))
+      !wyl_handle_get_login_skip_mfa_allowed (handle)) {
+#ifdef WYL_HAS_AUDIT
+    emit_login_skip_mfa_denied_audit (handle, wyl_login_req_get_username (req));
+#endif
     return WYRELOG_E_POLICY;
+  }
 
   WylSession *session = g_object_new (WYL_TYPE_SESSION, NULL);
   const gchar *username = NULL;


### PR DESCRIPTION
## Summary

- emit a denied audit row for blocked login skip-MFA attempts
- keep denied skip-MFA before session allocation and state mutation
- cover the denied audit row shape in audit-enabled tests

## Verification

- `git diff --check`
- `meson test -C builddir --print-errorlogs fsm-principal policy-store session-username`
- `meson test -C builddir-audit --print-errorlogs fsm-principal policy-store session-username audit-emit`
