### PR TITLE
policy: derive principal event facts

### DIFF
--- a/templates/access/fsm/principal.dl
+++ b/templates/access/fsm/principal.dl
@@ -23,7 +23,9 @@
 // side without the other will fail the build.
 
 .decl principal_transition(from: symbol, event: symbol, to: symbol)
+.decl principal_event(user: symbol, ev: symbol, from: symbol, to: symbol)
 .decl principal_step(from: symbol, event: symbol, to: symbol)
+.decl principal_fired(user: symbol, from: symbol, ev: symbol, to: symbol)
 
 principal_transition("unverified",    "login_ok",       "mfa_required").
 principal_transition("unverified",    "login_skip_mfa", "authenticated").
@@ -35,3 +37,7 @@ principal_transition("authenticated", "revoke",         "revoked").
 principal_transition("locked",        "unlock",         "unverified").
 
 principal_step(From, Ev, To) :- principal_transition(From, Ev, To).
+
+principal_fired(U, From, Ev, To) :-
+    principal_event(U, Ev, From, To),
+    principal_transition(From, Ev, To).

--- a/tests/test-fsm-bisim.c
+++ b/tests/test-fsm-bisim.c
@@ -88,7 +88,8 @@ parse_text_table (const gchar *path, const gchar *predicate,
     g_autofree gchar *trimmed = g_strdup (g_strchug (lines[i]));
     if (trimmed[0] == '%' || trimmed[0] == '\0'
         || g_str_has_prefix (trimmed, "//")
-        || g_str_has_prefix (trimmed, ".decl"))
+        || g_str_has_prefix (trimmed, ".decl")
+        || strstr (trimmed, ":-") != NULL || strchr (trimmed, '"') == NULL)
       continue;
     if (!g_str_has_prefix (trimmed, prefix))
       continue;

--- a/tests/test-fsm-principal.c
+++ b/tests/test-fsm-principal.c
@@ -201,7 +201,8 @@ check_text_mirror (void)
     g_autofree gchar *trimmed = g_strdup (g_strchug (lines[i]));
     if (trimmed[0] == '%' || trimmed[0] == '\0'
         || g_str_has_prefix (trimmed, "//")
-        || g_str_has_prefix (trimmed, ".decl"))
+        || g_str_has_prefix (trimmed, ".decl")
+        || strstr (trimmed, ":-") != NULL || strchr (trimmed, '"') == NULL)
       continue;
     if (!g_str_has_prefix (trimmed, "principal_transition"))
       continue;

--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -18,6 +18,14 @@ typedef struct
 {
   const gchar *expected_relation;
   const gint64 *expected_row;
+  guint ncols;
+  guint seen;
+} RelationSnapshotExpect;
+
+typedef struct
+{
+  const gchar *expected_relation;
+  const gint64 *expected_row;
   WylDeltaKind expected_kind;
   guint matching;
 } DeltaExpect;
@@ -54,6 +62,23 @@ snapshot_count_cb (const gchar *relation, const gint64 *row, guint ncols,
   (void) ncols;
 
   (*seen)++;
+}
+
+static void
+relation_snapshot_expect_cb (const gchar *relation, const gint64 *row,
+    guint ncols, gpointer user_data)
+{
+  RelationSnapshotExpect *expect = user_data;
+
+  if (g_strcmp0 (relation, expect->expected_relation) != 0)
+    return;
+  if (ncols != expect->ncols)
+    return;
+  for (guint i = 0; i < ncols; i++) {
+    if (row[i] != expect->expected_row[i])
+      return;
+  }
+  expect->seen++;
 }
 
 static void
@@ -102,6 +127,22 @@ intern3 (WylHandle *handle, const gchar *a, const gchar *b, const gchar *c,
 }
 
 static wyrelog_error_t
+intern4 (WylHandle *handle, const gchar *a, const gchar *b, const gchar *c,
+    const gchar *d, gint64 row[4])
+{
+  wyrelog_error_t rc = wyl_handle_intern_engine_symbol (handle, a, &row[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, b, &row[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, c, &row[2]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_intern_engine_symbol (handle, d, &row[3]);
+}
+
+static wyrelog_error_t
 insert1_symbol (WylHandle *handle, const gchar *relation, const gchar *a)
 {
   gint64 row[1];
@@ -142,16 +183,7 @@ insert4_symbol (WylHandle *handle, const gchar *relation, const gchar *a,
     const gchar *b, const gchar *c, const gchar *d)
 {
   gint64 row[4];
-  wyrelog_error_t rc = wyl_handle_intern_engine_symbol (handle, a, &row[0]);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  rc = wyl_handle_intern_engine_symbol (handle, b, &row[1]);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  rc = wyl_handle_intern_engine_symbol (handle, c, &row[2]);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  rc = wyl_handle_intern_engine_symbol (handle, d, &row[3]);
+  wyrelog_error_t rc = intern4 (handle, a, b, c, d, row);
   if (rc != WYRELOG_E_OK)
     return rc;
   return wyl_handle_engine_insert (handle, relation, row, 4);
@@ -1219,6 +1251,74 @@ check_policy_store_principal_states_require_engine_pair (void)
 }
 
 static gint
+check_policy_store_principal_events_autoload_on_open (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 390;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (wyl_policy_store_append_principal_event (store, "event-load-user",
+          "login_ok", "unverified", "mfa_required") != WYRELOG_E_OK)
+    return 391;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 392;
+
+  gint64 fired_row[4];
+  if (intern4 (handle, "event-load-user", "unverified", "login_ok",
+          "mfa_required", fired_row) != WYRELOG_E_OK)
+    return 393;
+  RelationSnapshotExpect fired_expect = {
+    .expected_relation = "principal_fired",
+    .expected_row = fired_row,
+    .ncols = 4,
+  };
+  if (wyl_engine_snapshot (wyl_handle_get_read_engine (handle),
+          "principal_fired", relation_snapshot_expect_cb, &fired_expect)
+      != WYRELOG_E_OK)
+    return 394;
+  if (fired_expect.seen != 1)
+    return 395;
+  return 0;
+}
+
+static gint
+check_policy_store_principal_events_reject_invalid_edges (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 400;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (wyl_policy_store_append_principal_event (store, "event-invalid-user",
+          "mfa_ok", "unverified", "authenticated") != WYRELOG_E_OK)
+    return 401;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_POLICY)
+    return 402;
+  return 0;
+}
+
+static gint
+check_policy_store_principal_events_require_engine_pair (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 410;
+  if (wyl_handle_load_policy_store_principal_events (NULL)
+      != WYRELOG_E_INVALID)
+    return 411;
+  if (wyl_handle_load_policy_store_principal_events (handle)
+      != WYRELOG_E_INVALID)
+    return 412;
+  return 0;
+}
+
+static gint
 check_policy_store_session_states_autoload_on_open (void)
 {
   g_autoptr (WylHandle) handle = NULL;
@@ -1357,6 +1457,12 @@ main (void)
   if ((rc = check_policy_store_principal_states_autoload_on_open ()) != 0)
     return rc;
   if ((rc = check_policy_store_principal_states_require_engine_pair ()) != 0)
+    return rc;
+  if ((rc = check_policy_store_principal_events_autoload_on_open ()) != 0)
+    return rc;
+  if ((rc = check_policy_store_principal_events_reject_invalid_edges ()) != 0)
+    return rc;
+  if ((rc = check_policy_store_principal_events_require_engine_pair ()) != 0)
     return rc;
   if ((rc = check_policy_store_session_states_autoload_on_open ()) != 0)
     return rc;

--- a/tests/test-session-username.c
+++ b/tests/test-session-username.c
@@ -85,6 +85,13 @@ typedef struct
   guint matches;
 } PrincipalEventExpect;
 
+typedef struct
+{
+  const gchar *relation;
+  const gint64 *row;
+  guint matches;
+} PrincipalEventFactExpect;
+
 static wyrelog_error_t
 principal_state_expect_cb (const gchar *subject_id, const gchar *state,
     gpointer user_data)
@@ -108,6 +115,51 @@ principal_event_expect_cb (const gchar *subject_id, const gchar *event,
       && g_strcmp0 (from_state, expect->from_state) == 0
       && g_strcmp0 (to_state, expect->to_state) == 0)
     expect->matches++;
+  return WYRELOG_E_OK;
+}
+
+static void
+principal_event_fact_expect_cb (const gchar *relation, const gint64 *row,
+    guint ncols, gpointer user_data)
+{
+  PrincipalEventFactExpect *expect = user_data;
+
+  if (g_strcmp0 (relation, expect->relation) != 0 || ncols != 4)
+    return;
+  if (row[0] == expect->row[0] && row[1] == expect->row[1]
+      && row[2] == expect->row[2] && row[3] == expect->row[3])
+    expect->matches++;
+}
+
+static wyrelog_error_t
+intern_principal_fired_row (WylHandle *handle, const gchar *subject_id,
+    const gchar *from_state, const gchar *event, const gchar *to_state,
+    gint64 row[4])
+{
+  wyrelog_error_t rc =
+      wyl_handle_intern_engine_symbol (handle, subject_id, &row[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, from_state, &row[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, event, &row[2]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_intern_engine_symbol (handle, to_state, &row[3]);
+}
+
+static wyrelog_error_t
+count_principal_event_fact (WylHandle *handle, const gchar *relation,
+    const gint64 row[4], guint *out_matches)
+{
+  PrincipalEventFactExpect expect = { relation, row, 0 };
+
+  wyrelog_error_t rc = wyl_engine_snapshot (wyl_handle_get_read_engine (handle),
+      relation, principal_event_fact_expect_cb, &expect);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  *out_matches = expect.matches;
   return WYRELOG_E_OK;
 }
 
@@ -510,6 +562,46 @@ check_login_skip_mfa_authenticates_principal (void)
   if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_ALLOW)
     return 159;
   return 0;
+}
+
+static gint
+check_login_skip_mfa_inserts_wirelog_principal_fired (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 162;
+
+  g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
+  wyl_login_req_set_username (login, "skip-mfa-fired-user");
+  wyl_login_req_set_skip_mfa (login, TRUE);
+  wyl_handle_set_login_skip_mfa_allowed (handle, TRUE);
+  g_autoptr (WylSession) session = NULL;
+  if (wyl_session_login (handle, login, &session) != WYRELOG_E_OK)
+    return 163;
+
+  gint64 row[4];
+  if (intern_principal_fired_row (handle, "skip-mfa-fired-user",
+          "unverified", "login_skip_mfa", "authenticated", row)
+      != WYRELOG_E_OK)
+    return 164;
+  guint matches = 0;
+  if (count_principal_event_fact (handle, "principal_fired", row, &matches)
+      != WYRELOG_E_OK)
+    return 165;
+  if (matches != 1)
+    return 166;
+
+  if (wyl_handle_reload_engine_pair (handle) != WYRELOG_E_OK)
+    return 167;
+  if (intern_principal_fired_row (handle, "skip-mfa-fired-user",
+          "unverified", "login_skip_mfa", "authenticated", row)
+      != WYRELOG_E_OK)
+    return 168;
+  matches = 0;
+  if (count_principal_event_fact (handle, "principal_fired", row, &matches)
+      != WYRELOG_E_OK)
+    return 169;
+  return matches == 1 ? 0 : 170;
 }
 
 static gint
@@ -1086,6 +1178,8 @@ main (void)
   if ((rc = check_login_skip_mfa_rejected_by_default ()) != 0)
     return rc;
   if ((rc = check_login_skip_mfa_authenticates_principal ()) != 0)
+    return rc;
+  if ((rc = check_login_skip_mfa_inserts_wirelog_principal_fired ()) != 0)
     return rc;
   if ((rc = check_login_skip_mfa_does_not_bypass_guarded_permission ()) != 0)
     return rc;

--- a/wyrelog/wyl-fsm-principal-private.h
+++ b/wyrelog/wyl-fsm-principal-private.h
@@ -73,5 +73,7 @@ const wyl_principal_transition_t *wyl_fsm_principal_table (gsize * out_len);
  * input. */
 const gchar *wyl_principal_state_name (wyl_principal_state_t s);
 const gchar *wyl_principal_event_name (wyl_principal_event_t ev);
+wyl_principal_state_t wyl_principal_state_from_name (const gchar * name);
+wyl_principal_event_t wyl_principal_event_from_name (const gchar * name);
 
 G_END_DECLS;

--- a/wyrelog/wyl-fsm-principal.c
+++ b/wyrelog/wyl-fsm-principal.c
@@ -84,3 +84,27 @@ wyl_principal_event_name (wyl_principal_event_t ev)
     return NULL;
   return event_names[ev];
 }
+
+wyl_principal_state_t
+wyl_principal_state_from_name (const gchar *name)
+{
+  if (name == NULL)
+    return WYL_PRINCIPAL_STATE_LAST_;
+  for (guint i = 0; i < WYL_PRINCIPAL_STATE_LAST_; i++) {
+    if (g_strcmp0 (name, state_names[i]) == 0)
+      return (wyl_principal_state_t) i;
+  }
+  return WYL_PRINCIPAL_STATE_LAST_;
+}
+
+wyl_principal_event_t
+wyl_principal_event_from_name (const gchar *name)
+{
+  if (name == NULL)
+    return WYL_PRINCIPAL_EVENT_LAST_;
+  for (guint i = 0; i < WYL_PRINCIPAL_EVENT_LAST_; i++) {
+    if (g_strcmp0 (name, event_names[i]) == 0)
+      return (wyl_principal_event_t) i;
+  }
+  return WYL_PRINCIPAL_EVENT_LAST_;
+}

--- a/wyrelog/wyl-handle-private.h
+++ b/wyrelog/wyl-handle-private.h
@@ -166,6 +166,14 @@ wyrelog_error_t wyl_handle_load_policy_store_principal_states (WylHandle *
     self);
 
 /*
+ * Loads principal_event rows from the handle-owned policy authority store into
+ * the attached read/delta engine pair as principal_event/4 facts. Rejected
+ * unless both the store and engine pair are available.
+ */
+wyrelog_error_t wyl_handle_load_policy_store_principal_events (WylHandle *
+    self);
+
+/*
  * Loads session_state rows from the handle-owned policy authority store into
  * the attached read/delta engine pair. Rejected unless both the store and
  * engine pair are available.

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -2,6 +2,7 @@
 #include "wyrelog/wyrelog.h"
 
 #include "wyrelog/engine.h"
+#include "wyl-fsm-principal-private.h"
 #include "wyl-handle-private.h"
 #include "wyl-id-private.h"
 #include "wyl-log-private.h"
@@ -108,6 +109,39 @@ wyl_handle_seed_session_active_states (WylHandle *self)
     if (rc != WYRELOG_E_OK)
       return rc;
     rc = wyl_handle_engine_insert (self, "session_active", row, 1);
+    if (rc != WYRELOG_E_OK)
+      return rc;
+  }
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+wyl_handle_seed_principal_transitions (WylHandle *self)
+{
+  gsize n = 0;
+  const wyl_principal_transition_t *table = wyl_fsm_principal_table (&n);
+
+  /* The .dl facts keep the source catalogue readable; this runtime seed makes
+   * the same catalogue available to wirelog snapshots and derived facts. */
+  for (gsize i = 0; i < n; i++) {
+    gint64 row[3];
+    const gchar *from_name = wyl_principal_state_name (table[i].from);
+    const gchar *event_name = wyl_principal_event_name (table[i].event);
+    const gchar *to_name = wyl_principal_state_name (table[i].to);
+    if (from_name == NULL || event_name == NULL || to_name == NULL)
+      return WYRELOG_E_INTERNAL;
+
+    wyrelog_error_t rc =
+        wyl_handle_intern_engine_symbol (self, from_name, &row[0]);
+    if (rc != WYRELOG_E_OK)
+      return rc;
+    rc = wyl_handle_intern_engine_symbol (self, event_name, &row[1]);
+    if (rc != WYRELOG_E_OK)
+      return rc;
+    rc = wyl_handle_intern_engine_symbol (self, to_name, &row[2]);
+    if (rc != WYRELOG_E_OK)
+      return rc;
+    rc = wyl_handle_engine_insert (self, "principal_transition", row, 3);
     if (rc != WYRELOG_E_OK)
       return rc;
   }
@@ -250,6 +284,9 @@ load_current_engine_pair (WylHandle *self)
   rc = wyl_handle_seed_session_active_states (self);
   if (rc != WYRELOG_E_OK)
     return rc;
+  rc = wyl_handle_seed_principal_transitions (self);
+  if (rc != WYRELOG_E_OK)
+    return rc;
   rc = wyl_handle_load_policy_store_role_permissions (self);
   if (rc != WYRELOG_E_OK)
     return rc;
@@ -260,6 +297,9 @@ load_current_engine_pair (WylHandle *self)
   if (rc != WYRELOG_E_OK)
     return rc;
   rc = wyl_handle_load_policy_store_principal_states (self);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_load_policy_store_principal_events (self);
   if (rc != WYRELOG_E_OK)
     return rc;
   return wyl_handle_load_policy_store_session_states (self);
@@ -605,6 +645,55 @@ wyl_handle_load_policy_store_principal_states (WylHandle *self)
 
   return wyl_policy_store_foreach_principal_state (self->policy_store,
       insert_policy_store_principal_state, self);
+}
+
+static wyrelog_error_t
+insert_policy_store_principal_event (const gchar *subject_id,
+    const gchar *event, const gchar *from_state, const gchar *to_state,
+    gpointer user_data)
+{
+  WylHandle *self = user_data;
+  gint64 row[4];
+  wyl_principal_state_t from = wyl_principal_state_from_name (from_state);
+  wyl_principal_event_t ev = wyl_principal_event_from_name (event);
+  wyl_principal_state_t to = wyl_principal_state_from_name (to_state);
+
+  if (from == WYL_PRINCIPAL_STATE_LAST_ || ev == WYL_PRINCIPAL_EVENT_LAST_
+      || to == WYL_PRINCIPAL_STATE_LAST_)
+    return WYRELOG_E_POLICY;
+  wyl_principal_state_t validated = WYL_PRINCIPAL_STATE_LAST_;
+  wyrelog_error_t rc = wyl_fsm_principal_step (from, ev, &validated);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if (validated != to)
+    return WYRELOG_E_POLICY;
+
+  rc = wyl_handle_intern_engine_symbol (self, subject_id, &row[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (self, event, &row[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (self, from_state, &row[2]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (self, to_state, &row[3]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_engine_insert (self, "principal_event", row, 4);
+}
+
+wyrelog_error_t
+wyl_handle_load_policy_store_principal_events (WylHandle *self)
+{
+  if (self == NULL || !WYL_IS_HANDLE (self))
+    return WYRELOG_E_INVALID;
+  if (self->policy_store == NULL || self->read_engine == NULL
+      || self->delta_engine == NULL)
+    return WYRELOG_E_INVALID;
+
+  return wyl_policy_store_foreach_principal_event (self->policy_store,
+      insert_policy_store_principal_event, self);
 }
 
 static wyrelog_error_t

--- a/wyrelog/wyl-session.c
+++ b/wyrelog/wyl-session.c
@@ -141,8 +141,36 @@ store_principal_event (WylHandle *handle, const gchar *username,
   if (old_state_name == NULL || event_name == NULL || new_state_name == NULL)
     return WYRELOG_E_INTERNAL;
 
-  return wyl_policy_store_append_principal_event (store, username, event_name,
-      old_state_name, new_state_name);
+  wyl_principal_state_t validated = WYL_PRINCIPAL_STATE_LAST_;
+  wyrelog_error_t validate_rc =
+      wyl_fsm_principal_step (old_state, event, &validated);
+  if (validate_rc != WYRELOG_E_OK)
+    return validate_rc;
+  if (validated != new_state)
+    return WYRELOG_E_POLICY;
+
+  wyrelog_error_t rc = wyl_policy_store_append_principal_event (store,
+      username, event_name, old_state_name, new_state_name);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  if (wyl_handle_get_read_engine (handle) == NULL)
+    return WYRELOG_E_OK;
+
+  gint64 row[4];
+  rc = wyl_handle_intern_engine_symbol (handle, username, &row[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, event_name, &row[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, old_state_name, &row[2]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, new_state_name, &row[3]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_engine_insert (handle, "principal_event", row, 4);
 }
 
 static wyrelog_error_t


### PR DESCRIPTION
## Summary

- seed principal transition facts into policy engine pairs
- replay validated principal event ledger rows into wirelog facts
- derive principal fired facts and cover runtime plus reload behavior

## Verification

- `git diff --check`
- `meson test -C builddir --print-errorlogs fsm-principal fsm-bisim handle-engine-pair session-username policy-store`
- `meson test -C builddir-audit --print-errorlogs fsm-principal fsm-bisim handle-engine-pair session-username audit-emit`
