### PR TITLE
policy: derive session event facts

### DIFF
--- a/templates/access/fsm/session.dl
+++ b/templates/access/fsm/session.dl
@@ -28,6 +28,8 @@
 // `session_transition(` token may appear inside comments.
 
 .decl session_transition(from: symbol, event: symbol, to: symbol)
+.decl session_event(session: symbol, event: symbol, from: symbol, to: symbol)
+.decl session_fired(session: symbol, from: symbol, event: symbol, to: symbol)
 .decl session_step(from: symbol, event: symbol, to: symbol)
 
 session_transition("idle",     "request",       "active").
@@ -45,3 +47,6 @@ session_transition("expiring", "expiry",        "closed").
 session_transition("expiring", "logout",        "closed").
 
 session_step(From, Ev, To) :- session_transition(From, Ev, To).
+session_fired(S, From, Ev, To) :-
+    session_event(S, Ev, From, To),
+    session_transition(From, Ev, To).

--- a/templates/access/sqlite-schema.sql
+++ b/templates/access/sqlite-schema.sql
@@ -196,6 +196,26 @@ CREATE INDEX IF NOT EXISTS idx_session_states_state
     ON session_states (state);
 
 -- ---------------------------------------------------------------------------
+-- Table: session_events
+-- Append-only session FSM transition ledger. Current state is kept in
+-- session_states; this table preserves the event edge that produced it.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS session_events (
+    event_id   INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT    NOT NULL,
+    event      TEXT    NOT NULL,
+    from_state TEXT    NOT NULL,
+    to_state   TEXT    NOT NULL,
+    created_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_session_events_session_id
+    ON session_events (session_id);
+
+CREATE INDEX IF NOT EXISTS idx_session_events_event
+    ON session_events (event);
+
+-- ---------------------------------------------------------------------------
 -- Table: audit_events
 -- Append-only audit sink mirrored from runtime audit emission.
 -- ---------------------------------------------------------------------------

--- a/tests/test-fsm-session.c
+++ b/tests/test-fsm-session.c
@@ -80,18 +80,32 @@ static gint
 check_name_roundtrip (void)
 {
   for (guint s = 0; s < WYL_SESSION_STATE_LAST_; s++) {
-    if (wyl_session_state_name ((wyl_session_state_t) s) == NULL)
+    const gchar *name = wyl_session_state_name ((wyl_session_state_t) s);
+    if (name == NULL)
       return 3;
+    if (wyl_session_state_from_name (name) != (wyl_session_state_t) s)
+      return 7;
   }
   if (wyl_session_state_name (WYL_SESSION_STATE_LAST_) != NULL)
     return 4;
+  if (wyl_session_state_from_name (NULL) != WYL_SESSION_STATE_LAST_)
+    return 8;
+  if (wyl_session_state_from_name ("missing") != WYL_SESSION_STATE_LAST_)
+    return 9;
 
   for (guint e = 0; e < WYL_SESSION_EVENT_LAST_; e++) {
-    if (wyl_session_event_name ((wyl_session_event_t) e) == NULL)
+    const gchar *name = wyl_session_event_name ((wyl_session_event_t) e);
+    if (name == NULL)
       return 5;
+    if (wyl_session_event_from_name (name) != (wyl_session_event_t) e)
+      return 10;
   }
   if (wyl_session_event_name (WYL_SESSION_EVENT_LAST_) != NULL)
     return 6;
+  if (wyl_session_event_from_name (NULL) != WYL_SESSION_EVENT_LAST_)
+    return 11;
+  if (wyl_session_event_from_name ("missing") != WYL_SESSION_EVENT_LAST_)
+    return 12;
   return 0;
 }
 
@@ -268,6 +282,8 @@ check_text_mirror (void)
         || g_str_has_prefix (trimmed, ".decl"))
       continue;
     if (!g_str_has_prefix (trimmed, "session_transition"))
+      continue;
+    if (strstr (trimmed, ":-") != NULL || strchr (trimmed, '"') == NULL)
       continue;
 
     g_autofree gchar *from = NULL;

--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -1379,6 +1379,97 @@ check_policy_store_session_states_require_engine_pair (void)
   return 0;
 }
 
+static gint
+check_policy_store_session_events_autoload_on_open (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 420;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (wyl_policy_store_append_session_event (store, "session-event-load",
+          "elevate_grant", "active", "elevated") != WYRELOG_E_OK)
+    return 421;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 422;
+
+  gint64 fired_row[4];
+  if (intern4 (handle, "session-event-load", "active", "elevate_grant",
+          "elevated", fired_row) != WYRELOG_E_OK)
+    return 423;
+  RelationSnapshotExpect fired_expect = {
+    .expected_relation = "session_fired",
+    .expected_row = fired_row,
+    .ncols = 4,
+  };
+  if (wyl_engine_snapshot (wyl_handle_get_read_engine (handle),
+          "session_fired", relation_snapshot_expect_cb, &fired_expect)
+      != WYRELOG_E_OK)
+    return 424;
+  if (fired_expect.seen != 1)
+    return 425;
+  return 0;
+}
+
+static gint
+check_policy_store_session_events_reject_invalid_edges (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 430;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (wyl_policy_store_append_session_event (store, "session-event-invalid",
+          "request", "expiring", "active") != WYRELOG_E_OK)
+    return 431;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_POLICY)
+    return 432;
+  return 0;
+}
+
+static gint
+check_policy_store_session_events_reload_failure_preserves_pair (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 433;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 434;
+  WylEngine *read_engine = wyl_handle_get_read_engine (handle);
+  WylEngine *delta_engine = wyl_handle_get_delta_engine (handle);
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (wyl_policy_store_append_session_event (store, "session-event-invalid",
+          "request", "expiring", "active") != WYRELOG_E_OK)
+    return 435;
+  if (wyl_handle_reload_engine_pair (handle) != WYRELOG_E_POLICY)
+    return 436;
+  if (wyl_handle_get_read_engine (handle) != read_engine)
+    return 437;
+  return wyl_handle_get_delta_engine (handle) == delta_engine ? 0 : 438;
+}
+
+static gint
+check_policy_store_session_events_require_engine_pair (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 440;
+  if (wyl_handle_load_policy_store_session_events (NULL) != WYRELOG_E_INVALID)
+    return 441;
+  if (wyl_handle_load_policy_store_session_events (handle)
+      != WYRELOG_E_INVALID)
+    return 442;
+  return 0;
+}
+
 int
 main (void)
 {
@@ -1467,6 +1558,15 @@ main (void)
   if ((rc = check_policy_store_session_states_autoload_on_open ()) != 0)
     return rc;
   if ((rc = check_policy_store_session_states_require_engine_pair ()) != 0)
+    return rc;
+  if ((rc = check_policy_store_session_events_autoload_on_open ()) != 0)
+    return rc;
+  if ((rc = check_policy_store_session_events_reject_invalid_edges ()) != 0)
+    return rc;
+  if ((rc = check_policy_store_session_events_reload_failure_preserves_pair ())
+      != 0)
+    return rc;
+  if ((rc = check_policy_store_session_events_require_engine_pair ()) != 0)
     return rc;
 
   return 0;

--- a/tests/test-policy-store.c
+++ b/tests/test-policy-store.c
@@ -31,6 +31,7 @@ check_store_creates_authority_schema (void)
     "principal_events",
     "principal_states",
     "session_states",
+    "session_events",
     "audit_events",
     "policy_signatures",
   };
@@ -78,6 +79,7 @@ check_template_schema_creates_state_tables (void)
     "principal_events",
     "principal_states",
     "session_states",
+    "session_events",
     "audit_events",
     "policy_signatures",
   };
@@ -222,6 +224,15 @@ typedef struct
   guint matches;
 } SessionStateExpect;
 
+typedef struct
+{
+  const gchar *session_id;
+  const gchar *event;
+  const gchar *from_state;
+  const gchar *to_state;
+  guint matches;
+} SessionEventExpect;
+
 static wyrelog_error_t
 session_state_expect_cb (const gchar *session_id, const gchar *state,
     gpointer user_data)
@@ -230,6 +241,20 @@ session_state_expect_cb (const gchar *session_id, const gchar *state,
 
   if (g_strcmp0 (session_id, expect->session_id) == 0
       && g_strcmp0 (state, expect->state) == 0)
+    expect->matches++;
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+session_event_expect_cb (const gchar *session_id, const gchar *event,
+    const gchar *from_state, const gchar *to_state, gpointer user_data)
+{
+  SessionEventExpect *expect = user_data;
+
+  if (g_strcmp0 (session_id, expect->session_id) == 0
+      && g_strcmp0 (event, expect->event) == 0
+      && g_strcmp0 (from_state, expect->from_state) == 0
+      && g_strcmp0 (to_state, expect->to_state) == 0)
     expect->matches++;
   return WYRELOG_E_OK;
 }
@@ -623,6 +648,33 @@ check_store_appends_principal_event (void)
 }
 
 static gint
+check_store_appends_session_event (void)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 97;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 98;
+  if (wyl_policy_store_append_session_event (store, "session/1",
+          "elevate_grant", "active", "elevated") != WYRELOG_E_OK)
+    return 99;
+
+  SessionEventExpect expect = {
+    .session_id = "session/1",
+    .event = "elevate_grant",
+    .from_state = "active",
+    .to_state = "elevated",
+  };
+  if (wyl_policy_store_foreach_session_event (store, session_event_expect_cb,
+          &expect) != WYRELOG_E_OK)
+    return 100;
+  if (expect.matches != 1)
+    return 101;
+  return 0;
+}
+
+static gint
 check_store_appends_audit_event (void)
 {
   g_autoptr (wyl_policy_store_t) store = NULL;
@@ -783,6 +835,12 @@ check_store_rejects_bad_role_permission (void)
   if (wyl_policy_store_foreach_session_state (store, NULL, NULL)
       != WYRELOG_E_INVALID)
     return 59;
+  if (wyl_policy_store_append_session_event (store, NULL, "request", "idle",
+          "active") != WYRELOG_E_INVALID)
+    return 60;
+  if (wyl_policy_store_foreach_session_event (store, NULL, NULL)
+      != WYRELOG_E_INVALID)
+    return 61;
   if (wyl_policy_store_append_audit_event (store, NULL, 0, NULL, NULL, NULL,
           NULL, NULL, WYL_DECISION_ALLOW) != WYRELOG_E_INVALID)
     return 94;
@@ -823,6 +881,8 @@ main (void)
   if ((rc = check_store_sets_session_state ()) != 0)
     return rc;
   if ((rc = check_store_appends_principal_event ()) != 0)
+    return rc;
+  if ((rc = check_store_appends_session_event ()) != 0)
     return rc;
   if ((rc = check_store_appends_audit_event ()) != 0)
     return rc;

--- a/tests/test-session-username.c
+++ b/tests/test-session-username.c
@@ -57,6 +57,15 @@ typedef struct
   guint matches;
 } SessionStateExpect;
 
+typedef struct
+{
+  const gchar *session_id;
+  const gchar *event;
+  const gchar *from_state;
+  const gchar *to_state;
+  guint matches;
+} SessionEventExpect;
+
 static wyrelog_error_t
 session_state_expect_cb (const gchar *session_id, const gchar *state,
     gpointer user_data)
@@ -65,6 +74,20 @@ session_state_expect_cb (const gchar *session_id, const gchar *state,
 
   if (g_strcmp0 (session_id, expect->session_id) == 0
       && g_strcmp0 (state, expect->state) == 0)
+    expect->matches++;
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+session_event_expect_cb (const gchar *session_id, const gchar *event,
+    const gchar *from_state, const gchar *to_state, gpointer user_data)
+{
+  SessionEventExpect *expect = user_data;
+
+  if (g_strcmp0 (session_id, expect->session_id) == 0
+      && g_strcmp0 (event, expect->event) == 0
+      && g_strcmp0 (from_state, expect->from_state) == 0
+      && g_strcmp0 (to_state, expect->to_state) == 0)
     expect->matches++;
   return WYRELOG_E_OK;
 }
@@ -150,6 +173,24 @@ intern_principal_fired_row (WylHandle *handle, const gchar *subject_id,
 }
 
 static wyrelog_error_t
+intern_session_fired_row (WylHandle *handle, const gchar *session_id,
+    const gchar *from_state, const gchar *event, const gchar *to_state,
+    gint64 row[4])
+{
+  wyrelog_error_t rc =
+      wyl_handle_intern_engine_symbol (handle, session_id, &row[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, from_state, &row[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, event, &row[2]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_intern_engine_symbol (handle, to_state, &row[3]);
+}
+
+static wyrelog_error_t
 count_principal_event_fact (WylHandle *handle, const gchar *relation,
     const gint64 row[4], guint *out_matches)
 {
@@ -161,6 +202,46 @@ count_principal_event_fact (WylHandle *handle, const gchar *relation,
     return rc;
   *out_matches = expect.matches;
   return WYRELOG_E_OK;
+}
+
+static gint
+expect_session_transition (WylHandle *handle, const gchar *session_id,
+    const gchar *from_state, const gchar *event, const gchar *to_state,
+    gint base_code)
+{
+  SessionEventExpect event_expect = {
+    .session_id = session_id,
+    .event = event,
+    .from_state = from_state,
+    .to_state = to_state,
+  };
+  if (wyl_policy_store_foreach_session_event (wyl_handle_get_policy_store
+          (handle), session_event_expect_cb, &event_expect) != WYRELOG_E_OK)
+    return base_code;
+  if (event_expect.matches != 1)
+    return base_code + 1;
+
+  gint64 row[4];
+  if (intern_session_fired_row (handle, session_id, from_state, event,
+          to_state, row) != WYRELOG_E_OK)
+    return base_code + 2;
+  guint matches = 0;
+  if (count_principal_event_fact (handle, "session_fired", row, &matches)
+      != WYRELOG_E_OK)
+    return base_code + 3;
+  if (matches != 1)
+    return base_code + 4;
+
+  if (wyl_handle_reload_engine_pair (handle) != WYRELOG_E_OK)
+    return base_code + 5;
+  if (intern_session_fired_row (handle, session_id, from_state, event,
+          to_state, row) != WYRELOG_E_OK)
+    return base_code + 6;
+  matches = 0;
+  if (count_principal_event_fact (handle, "session_fired", row, &matches)
+      != WYRELOG_E_OK)
+    return base_code + 7;
+  return matches == 1 ? 0 : base_code + 8;
 }
 
 static WylSession *
@@ -445,6 +526,26 @@ check_login_persists_active_session_state (void)
 }
 
 static gint
+check_login_inserts_wirelog_session_fired (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 136;
+
+  g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
+  wyl_login_req_set_username (login, "session-fired-login-user");
+  g_autoptr (WylSession) session = NULL;
+  if (wyl_session_login (handle, login, &session) != WYRELOG_E_OK)
+    return 137;
+
+  g_autofree gchar *session_id = wyl_session_dup_id_string (session);
+  if (session_id == NULL)
+    return 138;
+  return expect_session_transition (handle, session_id, "idle", "request",
+      "active", 139);
+}
+
+static gint
 check_login_session_id_is_active_decision_scope (void)
 {
   g_autoptr (WylHandle) handle = NULL;
@@ -679,6 +780,27 @@ check_session_close_persists_closed_state (void)
 }
 
 static gint
+check_session_close_inserts_wirelog_session_fired (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 166;
+
+  g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
+  wyl_login_req_set_username (login, "session-fired-close-user");
+  g_autoptr (WylSession) session = NULL;
+  if (wyl_session_login (handle, login, &session) != WYRELOG_E_OK)
+    return 167;
+  g_autofree gchar *session_id = wyl_session_dup_id_string (session);
+  if (session_id == NULL)
+    return 168;
+  if (wyl_session_close (handle, session) != WYRELOG_E_OK)
+    return 169;
+  return expect_session_transition (handle, session_id, "active", "logout",
+      "closed", 175);
+}
+
+static gint
 check_session_close_deactivates_decision_scope (void)
 {
   g_autoptr (WylHandle) handle = NULL;
@@ -760,6 +882,40 @@ check_session_elevate_persists_elevated_state (void)
   if (expect.matches != 1)
     return 205;
   return 0;
+}
+
+static gint
+check_session_transitions_insert_wirelog_session_fired (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 206;
+
+  g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
+  wyl_login_req_set_username (login, "session-fired-user");
+  g_autoptr (WylSession) session = NULL;
+  if (wyl_session_login (handle, login, &session) != WYRELOG_E_OK)
+    return 207;
+
+  g_autofree gchar *session_id = wyl_session_dup_id_string (session);
+  if (session_id == NULL)
+    return 208;
+  if (wyl_session_elevate (handle, session) != WYRELOG_E_OK)
+    return 209;
+  gint rc = expect_session_transition (handle, session_id, "active",
+      "elevate_grant", "elevated", 210);
+  if (rc != 0)
+    return rc;
+  if (wyl_session_drop_elevation (handle, session) != WYRELOG_E_OK)
+    return 219;
+  rc = expect_session_transition (handle, session_id, "elevated",
+      "elevate_drop", "active", 220);
+  if (rc != 0)
+    return rc;
+  if (wyl_session_idle_timeout (handle, session) != WYRELOG_E_OK)
+    return 229;
+  return expect_session_transition (handle, session_id, "active",
+      "idle_timeout", "idle", 230);
 }
 
 static gint
@@ -1087,6 +1243,33 @@ check_expiring_session_expire_persists_closed_state (void)
 }
 
 static gint
+check_session_expiry_inserts_wirelog_session_fired (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 327;
+
+  g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
+  wyl_login_req_set_username (login, "session-fired-expiry-user");
+  g_autoptr (WylSession) session = NULL;
+  if (wyl_session_login (handle, login, &session) != WYRELOG_E_OK)
+    return 328;
+  g_autofree gchar *session_id = wyl_session_dup_id_string (session);
+  if (session_id == NULL)
+    return 329;
+  if (wyl_session_expire (handle, session) != WYRELOG_E_OK)
+    return 337;
+  gint rc = expect_session_transition (handle, session_id, "active",
+      "expiry", "expiring", 338);
+  if (rc != 0)
+    return rc;
+  if (wyl_session_expire (handle, session) != WYRELOG_E_OK)
+    return 347;
+  return expect_session_transition (handle, session_id, "expiring",
+      "expiry", "closed", 348);
+}
+
+static gint
 check_elevated_session_expire_persists_expiring_state (void)
 {
   g_autoptr (WylHandle) handle = NULL;
@@ -1173,6 +1356,8 @@ main (void)
     return rc;
   if ((rc = check_login_persists_active_session_state ()) != 0)
     return rc;
+  if ((rc = check_login_inserts_wirelog_session_fired ()) != 0)
+    return rc;
   if ((rc = check_login_session_id_is_active_decision_scope ()) != 0)
     return rc;
   if ((rc = check_login_skip_mfa_rejected_by_default ()) != 0)
@@ -1185,11 +1370,15 @@ main (void)
     return rc;
   if ((rc = check_session_close_persists_closed_state ()) != 0)
     return rc;
+  if ((rc = check_session_close_inserts_wirelog_session_fired ()) != 0)
+    return rc;
   if ((rc = check_session_close_deactivates_decision_scope ()) != 0)
     return rc;
   if ((rc = check_session_close_rejects_invalid_args ()) != 0)
     return rc;
   if ((rc = check_session_elevate_persists_elevated_state ()) != 0)
+    return rc;
+  if ((rc = check_session_transitions_insert_wirelog_session_fired ()) != 0)
     return rc;
   if ((rc = check_session_drop_elevation_persists_active_state ()) != 0)
     return rc;
@@ -1208,6 +1397,8 @@ main (void)
   if ((rc = check_expiring_session_deactivates_decision_scope ()) != 0)
     return rc;
   if ((rc = check_expiring_session_expire_persists_closed_state ()) != 0)
+    return rc;
+  if ((rc = check_session_expiry_inserts_wirelog_session_fired ()) != 0)
     return rc;
   if ((rc = check_elevated_session_expire_persists_expiring_state ()) != 0)
     return rc;

--- a/wyrelog/daemon/wyrelogd.c
+++ b/wyrelog/daemon/wyrelogd.c
@@ -231,6 +231,7 @@ check_policy_store_ready (WylHandle *handle)
     "principal_events",
     "principal_states",
     "session_states",
+    "session_events",
     "audit_events",
     "policy_signatures",
   };

--- a/wyrelog/policy/store-private.h
+++ b/wyrelog/policy/store-private.h
@@ -32,6 +32,9 @@ typedef wyrelog_error_t (*wyl_policy_principal_event_cb) (const gchar *
     const gchar * to_state, gpointer user_data);
 typedef wyrelog_error_t (*wyl_policy_session_state_cb) (const gchar *
     session_id, const gchar * state, gpointer user_data);
+typedef wyrelog_error_t (*wyl_policy_session_event_cb) (const gchar *
+    session_id, const gchar * event, const gchar * from_state,
+    const gchar * to_state, gpointer user_data);
 
 /*
  * Policy authority store lifecycle wrapper.
@@ -112,6 +115,11 @@ wyrelog_error_t wyl_policy_store_set_session_state (wyl_policy_store_t * store,
     const gchar * session_id, const gchar * state);
 wyrelog_error_t wyl_policy_store_foreach_session_state (wyl_policy_store_t *
     store, wyl_policy_session_state_cb cb, gpointer user_data);
+wyrelog_error_t wyl_policy_store_append_session_event (wyl_policy_store_t *
+    store, const gchar * session_id, const gchar * event,
+    const gchar * from_state, const gchar * to_state);
+wyrelog_error_t wyl_policy_store_foreach_session_event (wyl_policy_store_t *
+    store, wyl_policy_session_event_cb cb, gpointer user_data);
 wyrelog_error_t wyl_policy_store_append_audit_event (wyl_policy_store_t *
     store, const gchar * id, gint64 created_at_us, const gchar * subject_id,
     const gchar * action, const gchar * resource_id, const gchar * deny_reason,

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -216,6 +216,18 @@ wyl_policy_store_create_schema (wyl_policy_store_t *store)
       ");"
       "CREATE INDEX IF NOT EXISTS idx_session_states_state "
       "  ON session_states (state);"
+      "CREATE TABLE IF NOT EXISTS session_events ("
+      "  event_id INTEGER PRIMARY KEY AUTOINCREMENT,"
+      "  session_id TEXT NOT NULL,"
+      "  event TEXT NOT NULL,"
+      "  from_state TEXT NOT NULL,"
+      "  to_state TEXT NOT NULL,"
+      "  created_at INTEGER NOT NULL"
+      ");"
+      "CREATE INDEX IF NOT EXISTS idx_session_events_session_id "
+      "  ON session_events (session_id);"
+      "CREATE INDEX IF NOT EXISTS idx_session_events_event "
+      "  ON session_events (event);"
       "CREATE TABLE IF NOT EXISTS audit_events ("
       "  id TEXT PRIMARY KEY,"
       "  created_at_us INTEGER NOT NULL,"
@@ -672,6 +684,70 @@ wyl_policy_store_foreach_session_state (wyl_policy_store_t *store,
     const gchar *session_id = (const gchar *) sqlite3_column_text (stmt, 0);
     const gchar *state = (const gchar *) sqlite3_column_text (stmt, 1);
     rc = cb (session_id, state, user_data);
+    if (rc != WYRELOG_E_OK) {
+      sqlite3_finalize (stmt);
+      return rc;
+    }
+  }
+
+  sqlite3_finalize (stmt);
+  return (step_rc == SQLITE_DONE) ? WYRELOG_E_OK : WYRELOG_E_IO;
+}
+
+wyrelog_error_t
+wyl_policy_store_append_session_event (wyl_policy_store_t *store,
+    const gchar *session_id, const gchar *event, const gchar *from_state,
+    const gchar *to_state)
+{
+  sqlite3_stmt *stmt = NULL;
+
+  if (store == NULL || store->db == NULL || session_id == NULL
+      || event == NULL || from_state == NULL || to_state == NULL)
+    return WYRELOG_E_INVALID;
+
+  static const gchar *sql =
+      "INSERT INTO session_events "
+      "  (session_id, event, from_state, to_state, created_at) "
+      "VALUES (?, ?, ?, ?, unixepoch());";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if ((rc = bind_text (stmt, 1, session_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 2, event)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 3, from_state)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 4, to_state)) != WYRELOG_E_OK) {
+    sqlite3_finalize (stmt);
+    return rc;
+  }
+
+  int step_rc = sqlite3_step (stmt);
+  sqlite3_finalize (stmt);
+  return (step_rc == SQLITE_DONE) ? WYRELOG_E_OK : WYRELOG_E_IO;
+}
+
+wyrelog_error_t
+wyl_policy_store_foreach_session_event (wyl_policy_store_t *store,
+    wyl_policy_session_event_cb cb, gpointer user_data)
+{
+  sqlite3_stmt *stmt = NULL;
+
+  if (store == NULL || store->db == NULL || cb == NULL)
+    return WYRELOG_E_INVALID;
+
+  static const gchar *sql =
+      "SELECT session_id, event, from_state, to_state "
+      "FROM session_events ORDER BY event_id;";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  int step_rc;
+  while ((step_rc = sqlite3_step (stmt)) == SQLITE_ROW) {
+    const gchar *session_id = (const gchar *) sqlite3_column_text (stmt, 0);
+    const gchar *event = (const gchar *) sqlite3_column_text (stmt, 1);
+    const gchar *from_state = (const gchar *) sqlite3_column_text (stmt, 2);
+    const gchar *to_state = (const gchar *) sqlite3_column_text (stmt, 3);
+    rc = cb (session_id, event, from_state, to_state, user_data);
     if (rc != WYRELOG_E_OK) {
       sqlite3_finalize (stmt);
       return rc;

--- a/wyrelog/wyl-fsm-session-private.h
+++ b/wyrelog/wyl-fsm-session-private.h
@@ -76,5 +76,7 @@ const wyl_session_transition_t *wyl_fsm_session_table (gsize * out_len);
  * input. */
 const gchar *wyl_session_state_name (wyl_session_state_t s);
 const gchar *wyl_session_event_name (wyl_session_event_t ev);
+wyl_session_state_t wyl_session_state_from_name (const gchar * name);
+wyl_session_event_t wyl_session_event_from_name (const gchar * name);
 
 G_END_DECLS;

--- a/wyrelog/wyl-fsm-session.c
+++ b/wyrelog/wyl-fsm-session.c
@@ -93,3 +93,27 @@ wyl_session_event_name (wyl_session_event_t ev)
     return NULL;
   return event_names[ev];
 }
+
+wyl_session_state_t
+wyl_session_state_from_name (const gchar *name)
+{
+  if (name == NULL)
+    return WYL_SESSION_STATE_LAST_;
+  for (guint i = 0; i < WYL_SESSION_STATE_LAST_; i++) {
+    if (g_strcmp0 (name, state_names[i]) == 0)
+      return (wyl_session_state_t) i;
+  }
+  return WYL_SESSION_STATE_LAST_;
+}
+
+wyl_session_event_t
+wyl_session_event_from_name (const gchar *name)
+{
+  if (name == NULL)
+    return WYL_SESSION_EVENT_LAST_;
+  for (guint i = 0; i < WYL_SESSION_EVENT_LAST_; i++) {
+    if (g_strcmp0 (name, event_names[i]) == 0)
+      return (wyl_session_event_t) i;
+  }
+  return WYL_SESSION_EVENT_LAST_;
+}

--- a/wyrelog/wyl-handle-private.h
+++ b/wyrelog/wyl-handle-private.h
@@ -181,6 +181,13 @@ wyrelog_error_t wyl_handle_load_policy_store_principal_events (WylHandle *
 wyrelog_error_t wyl_handle_load_policy_store_session_states (WylHandle * self);
 
 /*
+ * Loads session_event rows from the handle-owned policy authority store into
+ * the attached read/delta engine pair as session_event/4 facts. Rejected
+ * unless both the store and engine pair are available.
+ */
+wyrelog_error_t wyl_handle_load_policy_store_session_events (WylHandle * self);
+
+/*
  * Probes the read engine for an exact EDB/IDB row match. Rejected unless the
  * engine pair is already open.
  */

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -3,6 +3,7 @@
 
 #include "wyrelog/engine.h"
 #include "wyl-fsm-principal-private.h"
+#include "wyl-fsm-session-private.h"
 #include "wyl-handle-private.h"
 #include "wyl-id-private.h"
 #include "wyl-log-private.h"
@@ -148,6 +149,37 @@ wyl_handle_seed_principal_transitions (WylHandle *self)
   return WYRELOG_E_OK;
 }
 
+static wyrelog_error_t
+wyl_handle_seed_session_transitions (WylHandle *self)
+{
+  gsize n = 0;
+  const wyl_session_transition_t *table = wyl_fsm_session_table (&n);
+
+  for (gsize i = 0; i < n; i++) {
+    gint64 row[3];
+    const gchar *from_name = wyl_session_state_name (table[i].from);
+    const gchar *event_name = wyl_session_event_name (table[i].event);
+    const gchar *to_name = wyl_session_state_name (table[i].to);
+    if (from_name == NULL || event_name == NULL || to_name == NULL)
+      return WYRELOG_E_INTERNAL;
+
+    wyrelog_error_t rc =
+        wyl_handle_intern_engine_symbol (self, from_name, &row[0]);
+    if (rc != WYRELOG_E_OK)
+      return rc;
+    rc = wyl_handle_intern_engine_symbol (self, event_name, &row[1]);
+    if (rc != WYRELOG_E_OK)
+      return rc;
+    rc = wyl_handle_intern_engine_symbol (self, to_name, &row[2]);
+    if (rc != WYRELOG_E_OK)
+      return rc;
+    rc = wyl_handle_engine_insert (self, "session_transition", row, 3);
+    if (rc != WYRELOG_E_OK)
+      return rc;
+  }
+  return WYRELOG_E_OK;
+}
+
 wyrelog_error_t
 wyl_init (const gchar *config_path, WylHandle **out_handle)
 {
@@ -287,6 +319,9 @@ load_current_engine_pair (WylHandle *self)
   rc = wyl_handle_seed_principal_transitions (self);
   if (rc != WYRELOG_E_OK)
     return rc;
+  rc = wyl_handle_seed_session_transitions (self);
+  if (rc != WYRELOG_E_OK)
+    return rc;
   rc = wyl_handle_load_policy_store_role_permissions (self);
   if (rc != WYRELOG_E_OK)
     return rc;
@@ -302,7 +337,10 @@ load_current_engine_pair (WylHandle *self)
   rc = wyl_handle_load_policy_store_principal_events (self);
   if (rc != WYRELOG_E_OK)
     return rc;
-  return wyl_handle_load_policy_store_session_states (self);
+  rc = wyl_handle_load_policy_store_session_states (self);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_load_policy_store_session_events (self);
 }
 
 static wyrelog_error_t
@@ -724,6 +762,55 @@ wyl_handle_load_policy_store_session_states (WylHandle *self)
 
   return wyl_policy_store_foreach_session_state (self->policy_store,
       insert_policy_store_session_state, self);
+}
+
+static wyrelog_error_t
+insert_policy_store_session_event (const gchar *session_id,
+    const gchar *event, const gchar *from_state, const gchar *to_state,
+    gpointer user_data)
+{
+  WylHandle *self = user_data;
+  gint64 row[4];
+  wyl_session_state_t from = wyl_session_state_from_name (from_state);
+  wyl_session_event_t ev = wyl_session_event_from_name (event);
+  wyl_session_state_t to = wyl_session_state_from_name (to_state);
+
+  if (from == WYL_SESSION_STATE_LAST_ || ev == WYL_SESSION_EVENT_LAST_
+      || to == WYL_SESSION_STATE_LAST_)
+    return WYRELOG_E_POLICY;
+  wyl_session_state_t validated = WYL_SESSION_STATE_LAST_;
+  wyrelog_error_t rc = wyl_fsm_session_step (from, ev, &validated);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if (validated != to)
+    return WYRELOG_E_POLICY;
+
+  rc = wyl_handle_intern_engine_symbol (self, session_id, &row[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (self, event, &row[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (self, from_state, &row[2]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (self, to_state, &row[3]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_engine_insert (self, "session_event", row, 4);
+}
+
+wyrelog_error_t
+wyl_handle_load_policy_store_session_events (WylHandle *self)
+{
+  if (self == NULL || !WYL_IS_HANDLE (self))
+    return WYRELOG_E_INVALID;
+  if (self->policy_store == NULL || self->read_engine == NULL
+      || self->delta_engine == NULL)
+    return WYRELOG_E_INVALID;
+
+  return wyl_policy_store_foreach_session_event (self->policy_store,
+      insert_policy_store_session_event, self);
 }
 
 typedef struct

--- a/wyrelog/wyl-session.c
+++ b/wyrelog/wyl-session.c
@@ -303,6 +303,56 @@ store_session_state (WylHandle *handle, const gchar *session_id,
   return wyl_policy_store_set_session_state (store, session_id, state);
 }
 
+static wyrelog_error_t
+store_session_event (WylHandle *handle, const gchar *session_id,
+    wyl_session_state_t old_state, wyl_session_event_t event,
+    wyl_session_state_t new_state)
+{
+  if (session_id == NULL)
+    return WYRELOG_E_OK;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (store == NULL)
+    return WYRELOG_E_OK;
+
+  const gchar *old_state_name = wyl_session_state_name (old_state);
+  const gchar *event_name = wyl_session_event_name (event);
+  const gchar *new_state_name = wyl_session_state_name (new_state);
+  if (old_state_name == NULL || event_name == NULL || new_state_name == NULL)
+    return WYRELOG_E_INTERNAL;
+
+  wyl_session_state_t validated = WYL_SESSION_STATE_LAST_;
+  wyrelog_error_t validate_rc =
+      wyl_fsm_session_step (old_state, event, &validated);
+  if (validate_rc != WYRELOG_E_OK)
+    return validate_rc;
+  if (validated != new_state)
+    return WYRELOG_E_POLICY;
+
+  wyrelog_error_t rc = wyl_policy_store_append_session_event (store,
+      session_id, event_name, old_state_name, new_state_name);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  if (wyl_handle_get_read_engine (handle) == NULL)
+    return WYRELOG_E_OK;
+
+  gint64 row[4];
+  rc = wyl_handle_intern_engine_symbol (handle, session_id, &row[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, event_name, &row[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, old_state_name, &row[2]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, new_state_name, &row[3]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_engine_insert (handle, "session_event", row, 4);
+}
+
 #ifdef WYL_HAS_AUDIT
 static void
 emit_session_state_audit (WylHandle *handle, const gchar *session_id,
@@ -333,7 +383,8 @@ set_session_state (WylHandle *handle, WylSession *session, const gchar *state)
 
 static wyrelog_error_t
 transition_session_state (WylHandle *handle, WylSession *session,
-    wyl_session_state_t old_state, wyl_session_state_t new_state)
+    wyl_session_state_t old_state, wyl_session_event_t event,
+    wyl_session_state_t new_state)
 {
   g_autofree gchar *session_id = wyl_session_dup_id_string (session);
   const gchar *old_state_name = wyl_session_state_name (old_state);
@@ -349,6 +400,9 @@ transition_session_state (WylHandle *handle, WylSession *session,
   if (rc != WYRELOG_E_OK)
     return rc;
   rc = store_session_state (handle, session_id, new_state_name);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = store_session_event (handle, session_id, old_state, event, new_state);
   if (rc != WYRELOG_E_OK)
     return rc;
   rc = reload_session_snapshot (handle);
@@ -423,8 +477,14 @@ wyl_session_login (WylHandle *handle, const wyl_login_req_t *req,
     g_object_unref (session);
     return rc;
   }
-#ifdef WYL_HAS_AUDIT
   g_autofree gchar *session_id = wyl_session_dup_id_string (session);
+  rc = store_session_event (handle, session_id, WYL_SESSION_STATE_IDLE,
+      WYL_SESSION_EVENT_REQUEST, WYL_SESSION_STATE_ACTIVE);
+  if (rc != WYRELOG_E_OK) {
+    g_object_unref (session);
+    return rc;
+  }
+#ifdef WYL_HAS_AUDIT
   emit_session_state_audit (handle, session_id,
       wyl_session_state_name (session->state), "active");
 #endif
@@ -464,7 +524,8 @@ wyl_session_close (WylHandle *handle, WylSession *session)
   if (rc != WYRELOG_E_OK || state != WYL_SESSION_STATE_CLOSED)
     return (rc == WYRELOG_E_OK) ? WYRELOG_E_INTERNAL : rc;
 
-  return transition_session_state (handle, session, session->state, state);
+  return transition_session_state (handle, session, session->state,
+      WYL_SESSION_EVENT_LOGOUT, state);
 }
 
 wyrelog_error_t
@@ -479,7 +540,8 @@ wyl_session_elevate (WylHandle *handle, WylSession *session)
   if (rc != WYRELOG_E_OK || state != WYL_SESSION_STATE_ELEVATED)
     return (rc == WYRELOG_E_OK) ? WYRELOG_E_INTERNAL : rc;
 
-  return transition_session_state (handle, session, session->state, state);
+  return transition_session_state (handle, session, session->state,
+      WYL_SESSION_EVENT_ELEVATE_GRANT, state);
 }
 
 wyrelog_error_t
@@ -494,7 +556,8 @@ wyl_session_drop_elevation (WylHandle *handle, WylSession *session)
   if (rc != WYRELOG_E_OK || state != WYL_SESSION_STATE_ACTIVE)
     return (rc == WYRELOG_E_OK) ? WYRELOG_E_INTERNAL : rc;
 
-  return transition_session_state (handle, session, session->state, state);
+  return transition_session_state (handle, session, session->state,
+      WYL_SESSION_EVENT_ELEVATE_DROP, state);
 }
 
 wyrelog_error_t
@@ -509,7 +572,8 @@ wyl_session_idle_timeout (WylHandle *handle, WylSession *session)
   if (rc != WYRELOG_E_OK || state != WYL_SESSION_STATE_IDLE)
     return (rc == WYRELOG_E_OK) ? WYRELOG_E_INTERNAL : rc;
 
-  return transition_session_state (handle, session, session->state, state);
+  return transition_session_state (handle, session, session->state,
+      WYL_SESSION_EVENT_IDLE_TIMEOUT, state);
 }
 
 wyrelog_error_t
@@ -524,7 +588,8 @@ wyl_session_expire (WylHandle *handle, WylSession *session)
   if (rc != WYRELOG_E_OK)
     return rc;
 
-  return transition_session_state (handle, session, session->state, state);
+  return transition_session_state (handle, session, session->state,
+      WYL_SESSION_EVENT_EXPIRY, state);
 }
 
 wyrelog_error_t


### PR DESCRIPTION
## Summary

- add durable session event storage and replay into policy engines
- derive session_fired facts from validated session event edges
- cover runtime transitions, reload behavior, and invalid replay cases

## Verification

- `git diff --check HEAD~1..HEAD`
- `git diff --check`
- `meson test -C builddir --print-errorlogs fsm-session fsm-bisim handle-engine-pair session-username policy-store dl-static`
- `meson test -C builddir-audit --print-errorlogs fsm-session fsm-bisim handle-engine-pair session-username policy-store audit-emit`
