### PR TITLE
policy: fan out fsm event deltas

### DIFF
--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -37,6 +37,15 @@ typedef struct
   guint matching;
 } DeltaRelationExpect;
 
+typedef struct
+{
+  const gchar *expected_relation;
+  const gint64 *expected_row;
+  guint ncols;
+  WylDeltaKind expected_kind;
+  guint matching;
+} DeltaRowExpect;
+
 static void
 snapshot_expect_cb (const gchar *relation, const gint64 *row, guint ncols,
     gpointer user_data)
@@ -110,6 +119,23 @@ delta_relation_expect_cb (const gchar *relation, const gint64 *row,
     return;
   if (kind != expect->expected_kind)
     return;
+  expect->matching++;
+}
+
+static void
+delta_row_expect_cb (const gchar *relation, const gint64 *row, guint ncols,
+    WylDeltaKind kind, gpointer user_data)
+{
+  DeltaRowExpect *expect = user_data;
+
+  if (g_strcmp0 (relation, expect->expected_relation) != 0)
+    return;
+  if (ncols != expect->ncols || kind != expect->expected_kind)
+    return;
+  for (guint i = 0; i < ncols; i++) {
+    if (row[i] != expect->expected_row[i])
+      return;
+  }
   expect->matching++;
 }
 
@@ -603,6 +629,121 @@ check_insert_fanout_reaches_delta_engine (void)
   if (expect.matching == 0)
     return 105;
   return 0;
+}
+
+static gint
+check_principal_event_fanout_derives_delta (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  gint64 event_row[4];
+  gint64 fired_row[4];
+  DeltaRowExpect expect = {
+    "principal_fired",
+    fired_row,
+    4,
+    WYL_DELTA_INSERT,
+    0,
+  };
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 106;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 107;
+  if (intern4 (handle, "delta-principal-user", "login_ok", "unverified",
+          "mfa_required", event_row) != WYRELOG_E_OK)
+    return 108;
+  if (intern4 (handle, "delta-principal-user", "unverified", "login_ok",
+          "mfa_required", fired_row) != WYRELOG_E_OK)
+    return 109;
+  if (wyl_handle_engine_set_delta_callback (handle, delta_row_expect_cb,
+          &expect) != WYRELOG_E_OK)
+    return 117;
+  if (wyl_handle_engine_insert (handle, "principal_event", event_row, 4)
+      != WYRELOG_E_OK)
+    return 118;
+  if (expect.matching != 1)
+    return 119;
+  if (wyl_handle_engine_insert (handle, "principal_event", event_row, 4)
+      != WYRELOG_E_OK)
+    return 150;
+  return expect.matching == 1 ? 0 : 151;
+}
+
+static gint
+check_session_event_fanout_derives_delta (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  gint64 event_row[4];
+  gint64 fired_row[4];
+  DeltaRowExpect expect = {
+    "session_fired",
+    fired_row,
+    4,
+    WYL_DELTA_INSERT,
+    0,
+  };
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 125;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 126;
+  if (intern4 (handle, "delta-session", "elevate_grant", "active",
+          "elevated", event_row) != WYRELOG_E_OK)
+    return 127;
+  if (intern4 (handle, "delta-session", "active", "elevate_grant",
+          "elevated", fired_row) != WYRELOG_E_OK)
+    return 128;
+  if (wyl_handle_engine_set_delta_callback (handle, delta_row_expect_cb,
+          &expect) != WYRELOG_E_OK)
+    return 129;
+  if (wyl_handle_engine_insert (handle, "session_event", event_row, 4)
+      != WYRELOG_E_OK)
+    return 135;
+  return expect.matching == 1 ? 0 : 136;
+}
+
+static gint
+check_delta_callback_survives_reload (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  gint64 live_event_row[4];
+  gint64 fired_row[4];
+  DeltaRowExpect expect = {
+    "session_fired",
+    fired_row,
+    4,
+    WYL_DELTA_INSERT,
+    0,
+  };
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 137;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 138;
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (wyl_policy_store_append_session_event (store, "delta-replay-session",
+          "elevate_grant", "active", "elevated") != WYRELOG_E_OK)
+    return 139;
+  if (intern4 (handle, "delta-reload-session", "idle_timeout", "active",
+          "idle", live_event_row) != WYRELOG_E_OK)
+    return 146;
+  if (intern4 (handle, "delta-reload-session", "active", "idle_timeout",
+          "idle", fired_row) != WYRELOG_E_OK)
+    return 146;
+  if (wyl_handle_engine_set_delta_callback (handle, delta_row_expect_cb,
+          &expect) != WYRELOG_E_OK)
+    return 147;
+  if (wyl_handle_reload_engine_pair (handle) != WYRELOG_E_OK)
+    return 148;
+  if (expect.matching != 0)
+    return 152;
+  if (wyl_handle_engine_insert (handle, "session_event", live_event_row, 4)
+      != WYRELOG_E_OK)
+    return 149;
+  return expect.matching == 1 ? 0 : 156;
 }
 
 static gint
@@ -1504,6 +1645,12 @@ main (void)
   if ((rc = check_insert_fanout_reaches_read_engine ()) != 0)
     return rc;
   if ((rc = check_insert_fanout_reaches_delta_engine ()) != 0)
+    return rc;
+  if ((rc = check_principal_event_fanout_derives_delta ()) != 0)
+    return rc;
+  if ((rc = check_session_event_fanout_derives_delta ()) != 0)
+    return rc;
+  if ((rc = check_delta_callback_survives_reload ()) != 0)
     return rc;
   if ((rc = check_snapshot_only_insert_skips_delta_engine ()) != 0)
     return rc;

--- a/tests/test-session-username.c
+++ b/tests/test-session-username.c
@@ -115,6 +115,15 @@ typedef struct
   guint matches;
 } PrincipalEventFactExpect;
 
+typedef struct
+{
+  const gchar *relation;
+  const gint64 *row;
+  guint ncols;
+  WylDeltaKind kind;
+  guint matches;
+} DeltaFactExpect;
+
 static wyrelog_error_t
 principal_state_expect_cb (const gchar *subject_id, const gchar *state,
     gpointer user_data)
@@ -152,6 +161,35 @@ principal_event_fact_expect_cb (const gchar *relation, const gint64 *row,
   if (row[0] == expect->row[0] && row[1] == expect->row[1]
       && row[2] == expect->row[2] && row[3] == expect->row[3])
     expect->matches++;
+}
+
+static void
+delta_fact_expect_cb (const gchar *relation, const gint64 *row, guint ncols,
+    WylDeltaKind kind, gpointer user_data)
+{
+  DeltaFactExpect *expect = user_data;
+
+  if (g_strcmp0 (relation, expect->relation) != 0 || ncols != expect->ncols
+      || kind != expect->kind)
+    return;
+  for (guint i = 0; i < ncols; i++) {
+    if (row[i] != expect->row[i])
+      return;
+  }
+  expect->matches++;
+}
+
+static void
+delta_relation_count_cb (const gchar *relation, const gint64 *row,
+    guint ncols, WylDeltaKind kind, gpointer user_data)
+{
+  guint *matches = user_data;
+
+  (void) row;
+
+  if (g_strcmp0 (relation, "session_fired") == 0 && ncols == 4
+      && kind == WYL_DELTA_INSERT)
+    (*matches)++;
 }
 
 static wyrelog_error_t
@@ -426,6 +464,37 @@ check_mfa_verify_authenticates_engine_principal (void)
 }
 
 static gint
+check_mfa_delta_callback_survives_state_reload (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 91;
+
+  g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
+  wyl_login_req_set_username (login, "mfa-delta-user");
+  g_autoptr (WylSession) session = NULL;
+  if (wyl_session_login (handle, login, &session) != WYRELOG_E_OK)
+    return 92;
+
+  gint64 row[4];
+  if (intern_principal_fired_row (handle, "mfa-delta-user", "mfa_required",
+          "mfa_ok", "authenticated", row) != WYRELOG_E_OK)
+    return 93;
+  DeltaFactExpect expect = {
+    .relation = "principal_fired",
+    .row = row,
+    .ncols = 4,
+    .kind = WYL_DELTA_INSERT,
+  };
+  if (wyl_handle_engine_set_delta_callback (handle, delta_fact_expect_cb,
+          &expect) != WYRELOG_E_OK)
+    return 94;
+  if (wyl_session_mfa_verify (handle, session) != WYRELOG_E_OK)
+    return 95;
+  return expect.matches == 1 ? 0 : 96;
+}
+
+static gint
 check_mfa_verify_rejects_invalid_args (void)
 {
   g_autoptr (WylHandle) handle = NULL;
@@ -543,6 +612,47 @@ check_login_inserts_wirelog_session_fired (void)
     return 138;
   return expect_session_transition (handle, session_id, "idle", "request",
       "active", 139);
+}
+
+static gint
+check_login_delta_callback_survives_state_reload (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 141;
+
+  gint64 row[4];
+  if (intern_principal_fired_row (handle, "login-delta-user", "unverified",
+          "login_ok", "mfa_required", row) != WYRELOG_E_OK)
+    return 142;
+  DeltaFactExpect principal_expect = {
+    .relation = "principal_fired",
+    .row = row,
+    .ncols = 4,
+    .kind = WYL_DELTA_INSERT,
+  };
+  if (wyl_handle_engine_set_delta_callback (handle, delta_fact_expect_cb,
+          &principal_expect) != WYRELOG_E_OK)
+    return 143;
+
+  g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
+  wyl_login_req_set_username (login, "login-delta-user");
+  g_autoptr (WylSession) session = NULL;
+  if (wyl_session_login (handle, login, &session) != WYRELOG_E_OK)
+    return 144;
+  if (principal_expect.matches != 1)
+    return 145;
+
+  guint session_fired = 0;
+  if (wyl_handle_engine_set_delta_callback (handle, delta_relation_count_cb,
+          &session_fired) != WYRELOG_E_OK)
+    return 146;
+  g_autoptr (wyl_login_req_t) second_login = wyl_login_req_new ();
+  wyl_login_req_set_username (second_login, "login-delta-session-user");
+  g_autoptr (WylSession) second_session = NULL;
+  if (wyl_session_login (handle, second_login, &second_session) != WYRELOG_E_OK)
+    return 147;
+  return session_fired == 1 ? 0 : 148;
 }
 
 static gint
@@ -1348,6 +1458,8 @@ main (void)
     return rc;
   if ((rc = check_mfa_verify_authenticates_engine_principal ()) != 0)
     return rc;
+  if ((rc = check_mfa_delta_callback_survives_state_reload ()) != 0)
+    return rc;
   if ((rc = check_mfa_verify_rejects_invalid_args ()) != 0)
     return rc;
   if ((rc = check_login_persists_mfa_required_state ()) != 0)
@@ -1357,6 +1469,8 @@ main (void)
   if ((rc = check_login_persists_active_session_state ()) != 0)
     return rc;
   if ((rc = check_login_inserts_wirelog_session_fired ()) != 0)
+    return rc;
+  if ((rc = check_login_delta_callback_survives_state_reload ()) != 0)
     return rc;
   if ((rc = check_login_session_id_is_active_decision_scope ()) != 0)
     return rc;

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -23,6 +23,8 @@ struct _WylHandle
   WylEngine *delta_engine;
   GHashTable *engine_symbols_by_id;
   gchar *template_dir;
+  WylDeltaCallback delta_callback;
+  gpointer delta_callback_user_data;
   wyl_policy_store_t *policy_store;
   gboolean login_skip_mfa_allowed;
 #ifdef WYL_HAS_AUDIT
@@ -380,6 +382,21 @@ replace_engine_pair (WylHandle *self, const gchar *template_dir)
     self->template_dir = old_template_dir;
     return rc;
   }
+  if (self->delta_callback != NULL) {
+    rc = wyl_engine_set_delta_callback (self->delta_engine,
+        self->delta_callback, self->delta_callback_user_data);
+    if (rc != WYRELOG_E_OK) {
+      g_clear_object (&self->read_engine);
+      g_clear_object (&self->delta_engine);
+      g_clear_pointer (&self->engine_symbols_by_id, g_hash_table_unref);
+      g_clear_pointer (&self->template_dir, g_free);
+      self->read_engine = old_read_engine;
+      self->delta_engine = old_delta_engine;
+      self->engine_symbols_by_id = old_symbols;
+      self->template_dir = old_template_dir;
+      return rc;
+    }
+  }
 
   g_clear_object (&old_read_engine);
   g_clear_object (&old_delta_engine);
@@ -464,7 +481,11 @@ wyl_handle_dup_engine_symbol (WylHandle *self, gint64 id)
 static gboolean
 relation_fans_out_to_delta (const gchar *relation)
 {
-  return g_strcmp0 (relation, "member_of") == 0;
+  return g_strcmp0 (relation, "member_of") == 0
+      || g_strcmp0 (relation, "principal_transition") == 0
+      || g_strcmp0 (relation, "session_transition") == 0
+      || g_strcmp0 (relation, "principal_event") == 0
+      || g_strcmp0 (relation, "session_event") == 0;
 }
 
 wyrelog_error_t
@@ -545,7 +566,14 @@ wyl_handle_engine_set_delta_callback (WylHandle *self, WylDeltaCallback cb,
   if (self->delta_engine == NULL)
     return WYRELOG_E_INVALID;
 
-  return wyl_engine_set_delta_callback (self->delta_engine, cb, user_data);
+  wyrelog_error_t rc =
+      wyl_engine_set_delta_callback (self->delta_engine, cb, user_data);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  self->delta_callback = cb;
+  self->delta_callback_user_data = user_data;
+  return WYRELOG_E_OK;
 }
 
 static wyrelog_error_t


### PR DESCRIPTION
## Summary

- fan out FSM transition and event facts into the delta engine
- preserve handle delta callbacks across successful engine reloads
- cover fired relation deltas, reload callback behavior, and duplicate fact semantics

## Verification

- `git diff --check HEAD~1..HEAD`
- `git diff --check`
- `meson test -C builddir --print-errorlogs handle-engine-pair session-username policy-store fsm-principal fsm-session dl-static`
- `meson test -C builddir-audit --print-errorlogs handle-engine-pair session-username policy-store fsm-principal fsm-session audit-emit`
