### PR TITLE
daemon: audit fsm fired deltas

### DIFF
--- a/wyrelog/daemon/checks.c
+++ b/wyrelog/daemon/checks.c
@@ -1,0 +1,239 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "daemon/checks.h"
+
+#include "wyrelog/wyl-handle-private.h"
+
+wyrelog_error_t
+wyl_daemon_check_wirelog_policy_ready (WylHandle *handle)
+{
+  gint64 row[1];
+  wyrelog_error_t rc =
+      wyl_handle_intern_engine_symbol (handle, "wr.audit.read", &row[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  gboolean found = FALSE;
+  rc = wyl_handle_engine_contains (handle, "guarded_perm", row, 1, &found);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if (!found)
+    return WYRELOG_E_POLICY;
+  return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
+wyl_daemon_check_policy_store_ready (WylHandle *handle)
+{
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  const gchar *tables[] = {
+    "roles",
+    "permissions",
+    "role_permissions",
+    "role_inheritances",
+    "role_memberships",
+    "role_membership_events",
+    "direct_permissions",
+    "direct_permission_events",
+    "principal_events",
+    "principal_states",
+    "session_states",
+    "session_events",
+    "audit_events",
+    "policy_signatures",
+  };
+
+  for (gsize i = 0; i < G_N_ELEMENTS (tables); i++) {
+    gboolean found = FALSE;
+    wyrelog_error_t rc =
+        wyl_policy_store_table_exists (store, tables[i], &found);
+    if (rc != WYRELOG_E_OK)
+      return rc;
+    if (!found)
+      return WYRELOG_E_POLICY;
+  }
+
+  return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
+wyl_daemon_check_audit_sink_ready (WylHandle *handle)
+{
+#ifdef WYL_HAS_AUDIT
+  wyl_audit_conn_t *conn = wyl_handle_get_audit_conn (handle);
+  gboolean found = FALSE;
+
+  wyrelog_error_t rc =
+      wyl_audit_conn_table_exists (conn, "audit_events", &found);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if (!found)
+    return WYRELOG_E_IO;
+
+  g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
+  wyl_audit_event_set_subject_id (ev, "wyrelogd");
+  wyl_audit_event_set_action (ev, "daemon_check");
+  wyl_audit_event_set_resource_id (ev, "audit_events");
+  wyl_audit_event_set_decision (ev, WYL_DECISION_ALLOW);
+  rc = wyl_audit_emit (handle, ev);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+#else
+  (void) handle;
+#endif
+  return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
+wyl_daemon_check_policy_snapshot_reload_ready (WylHandle *handle)
+{
+  g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
+  wyl_login_req_set_username (login, "wyrelogd-snapshot-user");
+  wyl_login_req_set_skip_mfa (login, TRUE);
+
+  g_autoptr (WylSession) session = NULL;
+  gboolean skip_mfa_was_allowed =
+      wyl_handle_get_login_skip_mfa_allowed (handle);
+  wyl_handle_set_login_skip_mfa_allowed (handle, TRUE);
+  wyrelog_error_t rc = wyl_session_login (handle, login, &session);
+  wyl_handle_set_login_skip_mfa_allowed (handle, skip_mfa_was_allowed);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  g_autofree gchar *session_id = wyl_session_dup_id_string (session);
+  if (session_id == NULL)
+    return WYRELOG_E_INTERNAL;
+
+  g_autoptr (wyl_grant_req_t) grant = wyl_grant_req_new ();
+  wyl_grant_req_set_subject_id (grant, "wyrelogd-snapshot-user");
+  wyl_grant_req_set_action (grant, "wyrelogd.snapshot.read");
+  wyl_grant_req_set_resource_id (grant, session_id);
+  rc = wyl_perm_grant (handle, grant);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  g_autoptr (wyl_decide_req_t) decide = wyl_decide_req_new ();
+  wyl_decide_req_set_subject_id (decide, "wyrelogd-snapshot-user");
+  wyl_decide_req_set_action (decide, "wyrelogd.snapshot.read");
+  wyl_decide_req_set_resource_id (decide, session_id);
+
+  g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
+  rc = wyl_decide (handle, decide, resp);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_decide_resp_get_decision (resp) == WYL_DECISION_ALLOW ?
+      WYRELOG_E_OK : WYRELOG_E_POLICY;
+}
+
+static wyrelog_error_t
+insert_symbol_row (WylHandle *handle, const gchar *relation,
+    const gchar *const *symbols, gsize ncols)
+{
+  gint64 row[4];
+
+  if (ncols == 0 || ncols > G_N_ELEMENTS (row))
+    return WYRELOG_E_INVALID;
+
+  for (gsize i = 0; i < ncols; i++) {
+    wyrelog_error_t rc =
+        wyl_handle_intern_engine_symbol (handle, symbols[i], &row[i]);
+    if (rc != WYRELOG_E_OK)
+      return rc;
+  }
+
+  return wyl_handle_engine_insert (handle, relation, row, ncols);
+}
+
+wyrelog_error_t
+wyl_daemon_check_role_permission_snapshot_reload_ready (WylHandle *handle)
+{
+  g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
+  wyl_login_req_set_username (login, "wyrelogd-role-user");
+  wyl_login_req_set_skip_mfa (login, TRUE);
+
+  g_autoptr (WylSession) session = NULL;
+  gboolean skip_mfa_was_allowed =
+      wyl_handle_get_login_skip_mfa_allowed (handle);
+  wyl_handle_set_login_skip_mfa_allowed (handle, TRUE);
+  wyrelog_error_t rc = wyl_session_login (handle, login, &session);
+  wyl_handle_set_login_skip_mfa_allowed (handle, skip_mfa_was_allowed);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  g_autofree gchar *session_id = wyl_session_dup_id_string (session);
+  if (session_id == NULL)
+    return WYRELOG_E_INTERNAL;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  rc = wyl_policy_store_upsert_role (store, "wr.snapshot-child",
+      "snapshot child");
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_policy_store_upsert_role (store, "wr.snapshot-parent",
+      "snapshot parent");
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_policy_store_upsert_permission (store, "wyrelogd.role.read",
+      "role read", "basic");
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_policy_store_grant_role_permission (store, "wr.snapshot-parent",
+      "wyrelogd.role.read");
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_policy_store_grant_role_inheritance (store, "wr.snapshot-child",
+      "wr.snapshot-parent");
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_reload_engine_pair (handle);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  const gchar *member_row[] = {
+    "wyrelogd-role-user",
+    "wr.snapshot-child",
+    session_id,
+  };
+  rc = insert_symbol_row (handle, "member_of", member_row,
+      G_N_ELEMENTS (member_row));
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  const gchar *perm_state_row[] = {
+    "wyrelogd-role-user",
+    "wyrelogd.role.read",
+    session_id,
+    "armed",
+  };
+  rc = insert_symbol_row (handle, "perm_state", perm_state_row,
+      G_N_ELEMENTS (perm_state_row));
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  g_autoptr (wyl_decide_req_t) decide = wyl_decide_req_new ();
+  wyl_decide_req_set_subject_id (decide, "wyrelogd-role-user");
+  wyl_decide_req_set_action (decide, "wyrelogd.role.read");
+  wyl_decide_req_set_resource_id (decide, session_id);
+
+  g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
+  rc = wyl_decide (handle, decide, resp);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_decide_resp_get_decision (resp) == WYL_DECISION_ALLOW ?
+      WYRELOG_E_OK : WYRELOG_E_POLICY;
+}
+
+wyrelog_error_t
+wyl_daemon_emit_start_event (WylHandle *handle)
+{
+#ifdef WYL_HAS_AUDIT
+  g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
+  wyl_audit_event_set_subject_id (ev, "wyrelogd");
+  wyl_audit_event_set_action (ev, "daemon_start");
+  wyl_audit_event_set_resource_id (ev, "audit_events");
+  wyl_audit_event_set_decision (ev, WYL_DECISION_ALLOW);
+  return wyl_audit_emit (handle, ev);
+#else
+  (void) handle;
+  return WYRELOG_E_OK;
+#endif
+}

--- a/wyrelog/daemon/checks.h
+++ b/wyrelog/daemon/checks.h
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+
+#include "wyrelog/wyrelog.h"
+
+wyrelog_error_t wyl_daemon_check_wirelog_policy_ready (WylHandle * handle);
+wyrelog_error_t wyl_daemon_check_policy_store_ready (WylHandle * handle);
+wyrelog_error_t wyl_daemon_check_audit_sink_ready (WylHandle * handle);
+wyrelog_error_t wyl_daemon_check_policy_snapshot_reload_ready (WylHandle *
+    handle);
+wyrelog_error_t
+wyl_daemon_check_role_permission_snapshot_reload_ready (WylHandle * handle);
+wyrelog_error_t wyl_daemon_emit_start_event (WylHandle * handle);

--- a/wyrelog/daemon/delta.c
+++ b/wyrelog/daemon/delta.c
@@ -1,0 +1,354 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "daemon/delta.h"
+
+#include "wyrelog/wyl-handle-private.h"
+
+#ifdef WYL_HAS_AUDIT
+static void
+emit_wirelog_effective_member_audit (WylDaemonRuntime *runtime,
+    const gint64 row[3], WylDeltaKind kind)
+{
+  if (runtime == NULL || runtime->handle == NULL)
+    return;
+
+  g_autofree gchar *user =
+      wyl_handle_dup_engine_symbol (runtime->handle, row[0]);
+  g_autofree gchar *role =
+      wyl_handle_dup_engine_symbol (runtime->handle, row[1]);
+  g_autofree gchar *scope =
+      wyl_handle_dup_engine_symbol (runtime->handle, row[2]);
+  if (user == NULL || role == NULL || scope == NULL)
+    return;
+
+  g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
+  wyl_audit_event_set_subject_id (ev, user);
+  wyl_audit_event_set_action (ev, "effective_member_delta");
+  wyl_audit_event_set_resource_id (ev, role);
+  wyl_audit_event_set_deny_reason (ev,
+      kind == WYL_DELTA_INSERT ? "insert" : "remove");
+  wyl_audit_event_set_deny_origin (ev, scope);
+  wyl_audit_event_set_decision (ev, WYL_DECISION_ALLOW);
+  (void) wyl_audit_emit (runtime->handle, ev);
+}
+
+static void
+emit_wirelog_fsm_fired_audit (WylDaemonRuntime *runtime, const gchar *relation,
+    const gint64 row[4], WylDeltaKind kind)
+{
+  if (runtime == NULL || runtime->handle == NULL)
+    return;
+
+  g_autofree gchar *entity =
+      wyl_handle_dup_engine_symbol (runtime->handle, row[0]);
+  g_autofree gchar *from_state =
+      wyl_handle_dup_engine_symbol (runtime->handle, row[1]);
+  g_autofree gchar *event =
+      wyl_handle_dup_engine_symbol (runtime->handle, row[2]);
+  g_autofree gchar *to_state =
+      wyl_handle_dup_engine_symbol (runtime->handle, row[3]);
+  if (entity == NULL || from_state == NULL || event == NULL || to_state == NULL)
+    return;
+
+  g_autofree gchar *action = g_strdup_printf ("%s_delta_%s", relation,
+      kind == WYL_DELTA_INSERT ? "insert" : "remove");
+  g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
+  wyl_audit_event_set_subject_id (ev, entity);
+  wyl_audit_event_set_action (ev, action);
+  wyl_audit_event_set_resource_id (ev, to_state);
+  wyl_audit_event_set_deny_reason (ev, event);
+  wyl_audit_event_set_deny_origin (ev, from_state);
+  wyl_audit_event_set_decision (ev, WYL_DECISION_ALLOW);
+  (void) wyl_audit_emit (runtime->handle, ev);
+}
+
+static wyrelog_error_t
+check_wirelog_delta_audit_rows (WylHandle *handle)
+{
+  duckdb_connection conn =
+      wyl_audit_conn_get_connection (wyl_handle_get_audit_conn (handle));
+  duckdb_result result;
+  if (duckdb_query (conn,
+          "SELECT "
+          "SUM(CASE WHEN action = 'effective_member_delta' "
+          "AND subject_id = 'wyrelogd-check-user' "
+          "AND resource_id = 'wr.viewer' "
+          "AND deny_origin = 'wyrelogd-check-scope' "
+          "AND deny_reason = 'insert' "
+          "AND decision = 1 THEN 1 ELSE 0 END), "
+          "SUM(CASE WHEN action = 'effective_member_delta' "
+          "AND subject_id = 'wyrelogd-check-user' "
+          "AND resource_id = 'wr.viewer' "
+          "AND deny_origin = 'wyrelogd-check-scope' "
+          "AND deny_reason = 'remove' "
+          "AND decision = 1 THEN 1 ELSE 0 END) " "FROM audit_events;", &result)
+      != DuckDBSuccess) {
+    duckdb_destroy_result (&result);
+    return WYRELOG_E_IO;
+  }
+
+  gint64 inserts = duckdb_value_int64 (&result, 0, 0);
+  gint64 removes = duckdb_value_int64 (&result, 1, 0);
+  duckdb_destroy_result (&result);
+  return inserts == 1 && removes == 1 ? WYRELOG_E_OK : WYRELOG_E_POLICY;
+}
+
+static wyrelog_error_t
+check_wirelog_fsm_audit_rows (WylHandle *handle)
+{
+  duckdb_connection conn =
+      wyl_audit_conn_get_connection (wyl_handle_get_audit_conn (handle));
+  duckdb_result result;
+  if (duckdb_query (conn,
+          "SELECT "
+          "SUM(CASE WHEN action = 'principal_fired_delta_insert' "
+          "AND subject_id = 'wyrelogd-principal-user' "
+          "AND resource_id = 'mfa_required' "
+          "AND deny_reason = 'login_ok' "
+          "AND deny_origin = 'unverified' "
+          "AND decision = 1 THEN 1 ELSE 0 END), "
+          "SUM(CASE WHEN action = 'session_fired_delta_insert' "
+          "AND subject_id = 'wyrelogd-session' "
+          "AND resource_id = 'elevated' "
+          "AND deny_reason = 'elevate_grant' "
+          "AND deny_origin = 'active' "
+          "AND decision = 1 THEN 1 ELSE 0 END), "
+          "SUM(CASE WHEN action = 'principal_fired_delta_remove' "
+          "AND subject_id = 'wyrelogd-principal-user' "
+          "AND resource_id = 'mfa_required' "
+          "AND deny_reason = 'login_ok' "
+          "AND deny_origin = 'unverified' "
+          "AND decision = 1 THEN 1 ELSE 0 END), "
+          "SUM(CASE WHEN action = 'session_fired_delta_remove' "
+          "AND subject_id = 'wyrelogd-session' "
+          "AND resource_id = 'elevated' "
+          "AND deny_reason = 'elevate_grant' "
+          "AND deny_origin = 'active' "
+          "AND decision = 1 THEN 1 ELSE 0 END) " "FROM audit_events;", &result)
+      != DuckDBSuccess) {
+    duckdb_destroy_result (&result);
+    return WYRELOG_E_IO;
+  }
+
+  gint64 principal_inserts = duckdb_value_int64 (&result, 0, 0);
+  gint64 session_inserts = duckdb_value_int64 (&result, 1, 0);
+  gint64 principal_removes = duckdb_value_int64 (&result, 2, 0);
+  gint64 session_removes = duckdb_value_int64 (&result, 3, 0);
+  duckdb_destroy_result (&result);
+  return principal_inserts == 1 && session_inserts == 1
+      && principal_removes == 1 && session_removes == 1 ?
+      WYRELOG_E_OK : WYRELOG_E_POLICY;
+}
+#endif
+
+static void
+daemon_delta_cb (const gchar *relation, const gint64 *row, guint ncols,
+    WylDeltaKind kind, gpointer user_data)
+{
+  WylDaemonRuntime *runtime = user_data;
+
+  if (runtime == NULL)
+    return;
+  if (kind == WYL_DELTA_INSERT) {
+    runtime->inserted++;
+  } else if (kind == WYL_DELTA_REMOVE) {
+    runtime->removed++;
+  }
+
+  if (g_strcmp0 (relation, "effective_member") != 0)
+    goto fsm_relations;
+  if ((kind != WYL_DELTA_INSERT && kind != WYL_DELTA_REMOVE) || ncols != 3)
+    return;
+
+#ifdef WYL_HAS_AUDIT
+  emit_wirelog_effective_member_audit (runtime, row, kind);
+#endif
+
+  if (!runtime->expect_effective_member)
+    return;
+  if (row[0] == runtime->expected_row[0]
+      && row[1] == runtime->expected_row[1]
+      && row[2] == runtime->expected_row[2]) {
+    if (kind == WYL_DELTA_INSERT)
+      runtime->matched_expected_insert = TRUE;
+    else if (kind == WYL_DELTA_REMOVE)
+      runtime->matched_expected_remove = TRUE;
+  }
+  return;
+
+fsm_relations:
+  if ((g_strcmp0 (relation, "principal_fired") != 0
+          && g_strcmp0 (relation, "session_fired") != 0)
+      || (kind != WYL_DELTA_INSERT && kind != WYL_DELTA_REMOVE) || ncols != 4)
+    return;
+
+#ifdef WYL_HAS_AUDIT
+  emit_wirelog_fsm_fired_audit (runtime, relation, row, kind);
+#endif
+
+  if (runtime->expect_principal_fired
+      && g_strcmp0 (relation, "principal_fired") == 0
+      && row[0] == runtime->expected_principal_fired[0]
+      && row[1] == runtime->expected_principal_fired[1]
+      && row[2] == runtime->expected_principal_fired[2]
+      && row[3] == runtime->expected_principal_fired[3]) {
+    if (kind == WYL_DELTA_INSERT)
+      runtime->matched_principal_fired_insert = TRUE;
+    else if (kind == WYL_DELTA_REMOVE)
+      runtime->matched_principal_fired_remove = TRUE;
+  }
+  if (runtime->expect_session_fired
+      && g_strcmp0 (relation, "session_fired") == 0
+      && row[0] == runtime->expected_session_fired[0]
+      && row[1] == runtime->expected_session_fired[1]
+      && row[2] == runtime->expected_session_fired[2]
+      && row[3] == runtime->expected_session_fired[3]) {
+    if (kind == WYL_DELTA_INSERT)
+      runtime->matched_session_fired_insert = TRUE;
+    else if (kind == WYL_DELTA_REMOVE)
+      runtime->matched_session_fired_remove = TRUE;
+  }
+}
+
+wyrelog_error_t
+wyl_daemon_start_delta_callbacks (WylHandle *handle, WylDaemonRuntime *runtime)
+{
+  return wyl_handle_engine_set_delta_callback (handle, daemon_delta_cb,
+      runtime);
+}
+
+wyrelog_error_t
+wyl_daemon_check_delta_ready (WylHandle *handle)
+{
+  WylDaemonRuntime runtime = {
+    .handle = handle,
+    .expect_effective_member = TRUE,
+    .expect_principal_fired = TRUE,
+    .expect_session_fired = TRUE,
+  };
+
+  wyrelog_error_t rc =
+      wyl_handle_intern_engine_symbol (handle, "wyrelogd-check-user",
+      &runtime.expected_row[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, "wr.viewer",
+      &runtime.expected_row[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, "wyrelogd-check-scope",
+      &runtime.expected_row[2]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, "wyrelogd-principal-user",
+      &runtime.expected_principal_fired[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, "unverified",
+      &runtime.expected_principal_fired[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, "login_ok",
+      &runtime.expected_principal_fired[2]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, "mfa_required",
+      &runtime.expected_principal_fired[3]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, "wyrelogd-session",
+      &runtime.expected_session_fired[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, "active",
+      &runtime.expected_session_fired[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, "elevate_grant",
+      &runtime.expected_session_fired[2]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, "elevated",
+      &runtime.expected_session_fired[3]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  rc = wyl_daemon_start_delta_callbacks (handle, &runtime);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  gint64 principal_event[4] = {
+    runtime.expected_principal_fired[0],
+    runtime.expected_principal_fired[2],
+    runtime.expected_principal_fired[1],
+    runtime.expected_principal_fired[3],
+  };
+  gint64 session_event[4] = {
+    runtime.expected_session_fired[0],
+    runtime.expected_session_fired[2],
+    runtime.expected_session_fired[1],
+    runtime.expected_session_fired[3],
+  };
+
+  rc = wyl_handle_engine_insert (handle, "member_of", runtime.expected_row, 3);
+  if (rc != WYRELOG_E_OK)
+    goto cleanup;
+  if (runtime.inserted == 0 || !runtime.matched_expected_insert) {
+    rc = WYRELOG_E_POLICY;
+    goto cleanup;
+  }
+
+  rc = wyl_handle_engine_insert (handle, "principal_event", principal_event, 4);
+  if (rc != WYRELOG_E_OK)
+    goto cleanup;
+  if (!runtime.matched_principal_fired_insert) {
+    rc = WYRELOG_E_POLICY;
+    goto cleanup;
+  }
+
+  rc = wyl_handle_engine_insert (handle, "session_event", session_event, 4);
+  if (rc != WYRELOG_E_OK)
+    goto cleanup;
+  if (!runtime.matched_session_fired_insert) {
+    rc = WYRELOG_E_POLICY;
+    goto cleanup;
+  }
+
+  rc = wyl_handle_engine_remove (handle, "principal_event", principal_event, 4);
+  if (rc != WYRELOG_E_OK)
+    goto cleanup;
+  if (!runtime.matched_principal_fired_remove) {
+    rc = WYRELOG_E_POLICY;
+    goto cleanup;
+  }
+
+  rc = wyl_handle_engine_remove (handle, "session_event", session_event, 4);
+  if (rc != WYRELOG_E_OK)
+    goto cleanup;
+  if (!runtime.matched_session_fired_remove) {
+    rc = WYRELOG_E_POLICY;
+    goto cleanup;
+  }
+
+  rc = wyl_handle_engine_remove (handle, "member_of", runtime.expected_row, 3);
+  if (rc != WYRELOG_E_OK)
+    goto cleanup;
+  if (runtime.removed == 0 || !runtime.matched_expected_remove) {
+    rc = WYRELOG_E_POLICY;
+    goto cleanup;
+  }
+#ifdef WYL_HAS_AUDIT
+  rc = check_wirelog_delta_audit_rows (handle);
+  if (rc != WYRELOG_E_OK)
+    goto cleanup;
+  rc = check_wirelog_fsm_audit_rows (handle);
+  if (rc != WYRELOG_E_OK)
+    goto cleanup;
+#endif
+
+cleanup:
+  wyrelog_error_t cleanup_rc =
+      wyl_handle_engine_set_delta_callback (handle, NULL, NULL);
+  if (rc == WYRELOG_E_OK)
+    rc = cleanup_rc;
+  return rc;
+}

--- a/wyrelog/daemon/delta.h
+++ b/wyrelog/daemon/delta.h
@@ -1,0 +1,27 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+
+#include "wyrelog/wyrelog.h"
+
+typedef struct
+{
+  WylHandle *handle;
+  guint64 inserted;
+  guint64 removed;
+  gboolean expect_effective_member;
+  gint64 expected_row[3];
+  gboolean matched_expected_insert;
+  gboolean matched_expected_remove;
+  gboolean expect_principal_fired;
+  gboolean expect_session_fired;
+  gint64 expected_principal_fired[4];
+  gint64 expected_session_fired[4];
+  gboolean matched_principal_fired_insert;
+  gboolean matched_session_fired_insert;
+  gboolean matched_principal_fired_remove;
+  gboolean matched_session_fired_remove;
+} WylDaemonRuntime;
+
+wyrelog_error_t wyl_daemon_start_delta_callbacks (WylHandle * handle,
+    WylDaemonRuntime * runtime);
+wyrelog_error_t wyl_daemon_check_delta_ready (WylHandle * handle);

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -1,0 +1,90 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "daemon/http.h"
+
+#ifdef WYL_HAS_DAEMON_HTTP
+#include <string.h>
+
+#include "wyrelog/wyl-handle-private.h"
+
+static void
+healthz_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
+    GHashTable *query, gpointer user_data)
+{
+  (void) server;
+  (void) path;
+  (void) query;
+  (void) user_data;
+
+  const gchar *body = "ok\n";
+  soup_server_message_set_status (msg, 200, NULL);
+  soup_server_message_set_response (msg, "text/plain", SOUP_MEMORY_COPY, body,
+      strlen (body));
+}
+
+static void
+audit_events_handler (SoupServer *server, SoupServerMessage *msg,
+    const char *path, GHashTable *query, gpointer user_data)
+{
+  (void) server;
+  (void) path;
+
+#ifdef WYL_HAS_AUDIT
+  const gchar *filter = NULL;
+  if (query != NULL)
+    filter = g_hash_table_lookup (query, "filter");
+
+  WylHandle *handle = user_data;
+  g_autofree gchar *body = NULL;
+  wyrelog_error_t rc =
+      wyl_audit_conn_query_events_json (wyl_handle_get_audit_conn (handle),
+      filter, &body);
+  if (rc == WYRELOG_E_INVALID) {
+    const gchar *error_body = "{\"error\":\"invalid_filter\"}";
+    soup_server_message_set_status (msg, 400, NULL);
+    soup_server_message_set_response (msg, "application/json",
+        SOUP_MEMORY_COPY, error_body, strlen (error_body));
+    return;
+  }
+  if (rc != WYRELOG_E_OK) {
+    const gchar *error_body = "{\"error\":\"audit_query_failed\"}";
+    soup_server_message_set_status (msg, 500, NULL);
+    soup_server_message_set_response (msg, "application/json",
+        SOUP_MEMORY_COPY, error_body, strlen (error_body));
+    return;
+  }
+#else
+  (void) query;
+  (void) user_data;
+  const gchar *body = "[]";
+#endif
+
+  soup_server_message_set_status (msg, 200, NULL);
+  soup_server_message_set_response (msg, "application/json",
+      SOUP_MEMORY_COPY, body, strlen (body));
+}
+
+SoupServer *
+wyl_daemon_start_http_server (const WylDaemonOptions *opts, WylHandle *handle,
+    GError **error)
+{
+  g_return_val_if_fail (opts != NULL, NULL);
+  g_return_val_if_fail (WYL_IS_HANDLE (handle), NULL);
+
+  if (opts->listen_port < 0 || opts->listen_port > 65535) {
+    g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_BAD_VALUE,
+        "listen port must be between 0 and 65535");
+    return NULL;
+  }
+
+  SoupServer *server = soup_server_new (NULL, NULL);
+  soup_server_add_handler (server, "/healthz", healthz_handler, NULL, NULL);
+  soup_server_add_handler (server, "/audit/events", audit_events_handler,
+      handle, NULL);
+  if (!soup_server_listen_local (server, (guint) opts->listen_port, 0, error)) {
+    g_object_unref (server);
+    return NULL;
+  }
+
+  return server;
+}
+#endif

--- a/wyrelog/daemon/http.h
+++ b/wyrelog/daemon/http.h
@@ -1,0 +1,14 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+
+#include <glib.h>
+
+#include "daemon/options.h"
+#include "wyrelog/wyrelog.h"
+
+#ifdef WYL_HAS_DAEMON_HTTP
+#include <libsoup/soup.h>
+
+SoupServer *wyl_daemon_start_http_server (const WylDaemonOptions * opts,
+    WylHandle * handle, GError ** error);
+#endif

--- a/wyrelog/daemon/options.h
+++ b/wyrelog/daemon/options.h
@@ -1,0 +1,12 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+
+#include <glib.h>
+
+typedef struct
+{
+  const gchar *template_dir;
+  gint listen_port;
+  gboolean check_only;
+  gboolean show_version;
+} WylDaemonOptions;

--- a/wyrelog/daemon/wyrelogd.c
+++ b/wyrelog/daemon/wyrelogd.c
@@ -2,90 +2,18 @@
 #include <glib.h>
 #include <signal.h>
 
-#ifdef WYL_HAS_DAEMON_HTTP
-#include <libsoup/soup.h>
-#include <string.h>
-#endif
-
 #ifdef G_OS_UNIX
 #include <glib-unix.h>
 #endif
 
+#include "daemon/checks.h"
+#include "daemon/delta.h"
+#include "daemon/http.h"
+#include "daemon/options.h"
 #include "wyrelog/wyrelog.h"
-#include "wyrelog/wyl-handle-private.h"
 
 #ifndef WYL_DEFAULT_TEMPLATE_DIR
 #error "WYL_DEFAULT_TEMPLATE_DIR must be defined by the build."
-#endif
-
-typedef struct
-{
-  const gchar *template_dir;
-  gint listen_port;
-  gboolean check_only;
-  gboolean show_version;
-} WylDaemonOptions;
-
-typedef struct
-{
-  WylHandle *handle;
-  guint64 inserted;
-  guint64 removed;
-  gboolean expect_effective_member;
-  gint64 expected_row[3];
-  gboolean matched_expected_insert;
-  gboolean matched_expected_remove;
-} WylDaemonRuntime;
-
-#ifdef WYL_HAS_AUDIT
-static void
-emit_wirelog_effective_member_audit (WylDaemonRuntime *runtime,
-    const gint64 row[3], WylDeltaKind kind)
-{
-  if (runtime == NULL || runtime->handle == NULL)
-    return;
-
-  g_autofree gchar *user =
-      wyl_handle_dup_engine_symbol (runtime->handle, row[0]);
-  g_autofree gchar *role =
-      wyl_handle_dup_engine_symbol (runtime->handle, row[1]);
-  g_autofree gchar *scope =
-      wyl_handle_dup_engine_symbol (runtime->handle, row[2]);
-  if (user == NULL || role == NULL || scope == NULL)
-    return;
-
-  g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
-  wyl_audit_event_set_subject_id (ev, user);
-  wyl_audit_event_set_action (ev, "effective_member_delta");
-  wyl_audit_event_set_resource_id (ev, role);
-  wyl_audit_event_set_deny_reason (ev,
-      kind == WYL_DELTA_INSERT ? "insert" : "remove");
-  wyl_audit_event_set_deny_origin (ev, scope);
-  wyl_audit_event_set_decision (ev, WYL_DECISION_ALLOW);
-  (void) wyl_audit_emit (runtime->handle, ev);
-}
-
-static wyrelog_error_t
-check_wirelog_delta_audit_rows (WylHandle *handle)
-{
-  duckdb_connection conn =
-      wyl_audit_conn_get_connection (wyl_handle_get_audit_conn (handle));
-  duckdb_result result;
-  if (duckdb_query (conn,
-          "SELECT COUNT(*) FROM audit_events "
-          "WHERE action = 'effective_member_delta' "
-          "AND subject_id = 'wyrelogd-check-user' "
-          "AND resource_id = 'wr.viewer' "
-          "AND deny_origin = 'wyrelogd-check-scope';", &result)
-      != DuckDBSuccess) {
-    duckdb_destroy_result (&result);
-    return WYRELOG_E_IO;
-  }
-
-  gint64 rows = duckdb_value_int64 (&result, 0, 0);
-  duckdb_destroy_result (&result);
-  return rows == 2 ? WYRELOG_E_OK : WYRELOG_E_POLICY;
-}
 #endif
 
 static gboolean
@@ -113,408 +41,52 @@ parse_options (gint *argc, gchar ***argv, WylDaemonOptions *opts,
   return g_option_context_parse (context, argc, argv, error);
 }
 
-static wyrelog_error_t
-check_wirelog_policy_ready (WylHandle *handle)
+static int
+run_checks (WylHandle *handle)
 {
-  gint64 row[1];
-  wyrelog_error_t rc =
-      wyl_handle_intern_engine_symbol (handle, "wr.audit.read", &row[0]);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-
-  gboolean found = FALSE;
-  rc = wyl_handle_engine_contains (handle, "guarded_perm", row, 1, &found);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  if (!found)
-    return WYRELOG_E_POLICY;
-  return WYRELOG_E_OK;
-}
-
-#ifdef WYL_HAS_DAEMON_HTTP
-static void
-healthz_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
-    GHashTable *query, gpointer user_data)
-{
-  (void) server;
-  (void) path;
-  (void) query;
-  (void) user_data;
-
-  const gchar *body = "ok\n";
-  soup_server_message_set_status (msg, 200, NULL);
-  soup_server_message_set_response (msg, "text/plain", SOUP_MEMORY_COPY, body,
-      strlen (body));
-}
-
-static void
-audit_events_handler (SoupServer *server, SoupServerMessage *msg,
-    const char *path, GHashTable *query, gpointer user_data)
-{
-  (void) server;
-  (void) path;
-
-#ifdef WYL_HAS_AUDIT
-  const gchar *filter = NULL;
-  if (query != NULL)
-    filter = g_hash_table_lookup (query, "filter");
-
-  WylHandle *handle = user_data;
-  g_autofree gchar *body = NULL;
-  wyrelog_error_t rc =
-      wyl_audit_conn_query_events_json (wyl_handle_get_audit_conn (handle),
-      filter, &body);
-  if (rc == WYRELOG_E_INVALID) {
-    const gchar *error_body = "{\"error\":\"invalid_filter\"}";
-    soup_server_message_set_status (msg, 400, NULL);
-    soup_server_message_set_response (msg, "application/json",
-        SOUP_MEMORY_COPY, error_body, strlen (error_body));
-    return;
-  }
+  wyrelog_error_t rc = wyl_daemon_check_delta_ready (handle);
   if (rc != WYRELOG_E_OK) {
-    const gchar *error_body = "{\"error\":\"audit_query_failed\"}";
-    soup_server_message_set_status (msg, 500, NULL);
-    soup_server_message_set_response (msg, "application/json",
-        SOUP_MEMORY_COPY, error_body, strlen (error_body));
-    return;
-  }
-#else
-  (void) query;
-  (void) user_data;
-  const gchar *body = "[]";
-#endif
-
-  soup_server_message_set_status (msg, 200, NULL);
-  soup_server_message_set_response (msg, "application/json",
-      SOUP_MEMORY_COPY, body, strlen (body));
-}
-
-static SoupServer *
-start_http_server (const WylDaemonOptions *opts, WylHandle *handle,
-    GError **error)
-{
-  g_return_val_if_fail (opts != NULL, NULL);
-  g_return_val_if_fail (WYL_IS_HANDLE (handle), NULL);
-
-  if (opts->listen_port < 0 || opts->listen_port > 65535) {
-    g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_BAD_VALUE,
-        "listen port must be between 0 and 65535");
-    return NULL;
+    g_printerr ("wyrelogd: delta readiness check failed: %s\n",
+        wyrelog_error_string (rc));
+    return 1;
   }
 
-  SoupServer *server = soup_server_new (NULL, NULL);
-  soup_server_add_handler (server, "/healthz", healthz_handler, NULL, NULL);
-  soup_server_add_handler (server, "/audit/events", audit_events_handler,
-      handle, NULL);
-  if (!soup_server_listen_local (server, (guint) opts->listen_port, 0, error)) {
-    g_object_unref (server);
-    return NULL;
+  rc = wyl_daemon_check_wirelog_policy_ready (handle);
+  if (rc != WYRELOG_E_OK) {
+    g_printerr ("wyrelogd: policy readiness check failed: %s\n",
+        wyrelog_error_string (rc));
+    return 1;
   }
 
-  return server;
-}
-#endif
-
-static wyrelog_error_t
-check_policy_store_ready (WylHandle *handle)
-{
-  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
-  const gchar *tables[] = {
-    "roles",
-    "permissions",
-    "role_permissions",
-    "role_inheritances",
-    "role_memberships",
-    "role_membership_events",
-    "direct_permissions",
-    "direct_permission_events",
-    "principal_events",
-    "principal_states",
-    "session_states",
-    "session_events",
-    "audit_events",
-    "policy_signatures",
-  };
-
-  for (gsize i = 0; i < G_N_ELEMENTS (tables); i++) {
-    gboolean found = FALSE;
-    wyrelog_error_t rc =
-        wyl_policy_store_table_exists (store, tables[i], &found);
-    if (rc != WYRELOG_E_OK)
-      return rc;
-    if (!found)
-      return WYRELOG_E_POLICY;
+  rc = wyl_daemon_check_policy_store_ready (handle);
+  if (rc != WYRELOG_E_OK) {
+    g_printerr ("wyrelogd: policy store readiness check failed: %s\n",
+        wyrelog_error_string (rc));
+    return 1;
   }
 
-  return WYRELOG_E_OK;
-}
-
-static wyrelog_error_t
-check_audit_sink_ready (WylHandle *handle)
-{
-#ifdef WYL_HAS_AUDIT
-  wyl_audit_conn_t *conn = wyl_handle_get_audit_conn (handle);
-  gboolean found = FALSE;
-
-  wyrelog_error_t rc =
-      wyl_audit_conn_table_exists (conn, "audit_events", &found);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  if (!found)
-    return WYRELOG_E_IO;
-
-  g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
-  wyl_audit_event_set_subject_id (ev, "wyrelogd");
-  wyl_audit_event_set_action (ev, "daemon_check");
-  wyl_audit_event_set_resource_id (ev, "audit_events");
-  wyl_audit_event_set_decision (ev, WYL_DECISION_ALLOW);
-  rc = wyl_audit_emit (handle, ev);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-#else
-  (void) handle;
-#endif
-  return WYRELOG_E_OK;
-}
-
-static wyrelog_error_t
-check_policy_snapshot_reload_ready (WylHandle *handle)
-{
-  g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
-  wyl_login_req_set_username (login, "wyrelogd-snapshot-user");
-  wyl_login_req_set_skip_mfa (login, TRUE);
-
-  g_autoptr (WylSession) session = NULL;
-  gboolean skip_mfa_was_allowed =
-      wyl_handle_get_login_skip_mfa_allowed (handle);
-  wyl_handle_set_login_skip_mfa_allowed (handle, TRUE);
-  wyrelog_error_t rc = wyl_session_login (handle, login, &session);
-  wyl_handle_set_login_skip_mfa_allowed (handle, skip_mfa_was_allowed);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-
-  g_autofree gchar *session_id = wyl_session_dup_id_string (session);
-  if (session_id == NULL)
-    return WYRELOG_E_INTERNAL;
-
-  g_autoptr (wyl_grant_req_t) grant = wyl_grant_req_new ();
-  wyl_grant_req_set_subject_id (grant, "wyrelogd-snapshot-user");
-  wyl_grant_req_set_action (grant, "wyrelogd.snapshot.read");
-  wyl_grant_req_set_resource_id (grant, session_id);
-  rc = wyl_perm_grant (handle, grant);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-
-  g_autoptr (wyl_decide_req_t) decide = wyl_decide_req_new ();
-  wyl_decide_req_set_subject_id (decide, "wyrelogd-snapshot-user");
-  wyl_decide_req_set_action (decide, "wyrelogd.snapshot.read");
-  wyl_decide_req_set_resource_id (decide, session_id);
-
-  g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
-  rc = wyl_decide (handle, decide, resp);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  return wyl_decide_resp_get_decision (resp) == WYL_DECISION_ALLOW ?
-      WYRELOG_E_OK : WYRELOG_E_POLICY;
-}
-
-static wyrelog_error_t
-insert_symbol_row (WylHandle *handle, const gchar *relation,
-    const gchar *const *symbols, gsize ncols)
-{
-  gint64 row[4];
-
-  if (ncols == 0 || ncols > G_N_ELEMENTS (row))
-    return WYRELOG_E_INVALID;
-
-  for (gsize i = 0; i < ncols; i++) {
-    wyrelog_error_t rc =
-        wyl_handle_intern_engine_symbol (handle, symbols[i], &row[i]);
-    if (rc != WYRELOG_E_OK)
-      return rc;
+  rc = wyl_daemon_check_policy_snapshot_reload_ready (handle);
+  if (rc != WYRELOG_E_OK) {
+    g_printerr ("wyrelogd: policy snapshot reload check failed: %s\n",
+        wyrelog_error_string (rc));
+    return 1;
   }
 
-  return wyl_handle_engine_insert (handle, relation, row, ncols);
-}
-
-static wyrelog_error_t
-check_role_permission_snapshot_reload_ready (WylHandle *handle)
-{
-  g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
-  wyl_login_req_set_username (login, "wyrelogd-role-user");
-  wyl_login_req_set_skip_mfa (login, TRUE);
-
-  g_autoptr (WylSession) session = NULL;
-  gboolean skip_mfa_was_allowed =
-      wyl_handle_get_login_skip_mfa_allowed (handle);
-  wyl_handle_set_login_skip_mfa_allowed (handle, TRUE);
-  wyrelog_error_t rc = wyl_session_login (handle, login, &session);
-  wyl_handle_set_login_skip_mfa_allowed (handle, skip_mfa_was_allowed);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-
-  g_autofree gchar *session_id = wyl_session_dup_id_string (session);
-  if (session_id == NULL)
-    return WYRELOG_E_INTERNAL;
-
-  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
-  rc = wyl_policy_store_upsert_role (store, "wr.snapshot-child",
-      "snapshot child");
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  rc = wyl_policy_store_upsert_role (store, "wr.snapshot-parent",
-      "snapshot parent");
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  rc = wyl_policy_store_upsert_permission (store, "wyrelogd.role.read",
-      "role read", "basic");
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  rc = wyl_policy_store_grant_role_permission (store, "wr.snapshot-parent",
-      "wyrelogd.role.read");
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  rc = wyl_policy_store_grant_role_inheritance (store, "wr.snapshot-child",
-      "wr.snapshot-parent");
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  rc = wyl_handle_reload_engine_pair (handle);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-
-  const gchar *member_row[] = {
-    "wyrelogd-role-user",
-    "wr.snapshot-child",
-    session_id,
-  };
-  rc = insert_symbol_row (handle, "member_of", member_row,
-      G_N_ELEMENTS (member_row));
-  if (rc != WYRELOG_E_OK)
-    return rc;
-
-  const gchar *perm_state_row[] = {
-    "wyrelogd-role-user",
-    "wyrelogd.role.read",
-    session_id,
-    "armed",
-  };
-  rc = insert_symbol_row (handle, "perm_state", perm_state_row,
-      G_N_ELEMENTS (perm_state_row));
-  if (rc != WYRELOG_E_OK)
-    return rc;
-
-  g_autoptr (wyl_decide_req_t) decide = wyl_decide_req_new ();
-  wyl_decide_req_set_subject_id (decide, "wyrelogd-role-user");
-  wyl_decide_req_set_action (decide, "wyrelogd.role.read");
-  wyl_decide_req_set_resource_id (decide, session_id);
-
-  g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
-  rc = wyl_decide (handle, decide, resp);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  return wyl_decide_resp_get_decision (resp) == WYL_DECISION_ALLOW ?
-      WYRELOG_E_OK : WYRELOG_E_POLICY;
-}
-
-static wyrelog_error_t
-emit_daemon_start_event (WylHandle *handle)
-{
-#ifdef WYL_HAS_AUDIT
-  g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
-  wyl_audit_event_set_subject_id (ev, "wyrelogd");
-  wyl_audit_event_set_action (ev, "daemon_start");
-  wyl_audit_event_set_resource_id (ev, "audit_events");
-  wyl_audit_event_set_decision (ev, WYL_DECISION_ALLOW);
-  return wyl_audit_emit (handle, ev);
-#else
-  (void) handle;
-  return WYRELOG_E_OK;
-#endif
-}
-
-static void
-daemon_delta_cb (const gchar *relation, const gint64 *row, guint ncols,
-    WylDeltaKind kind, gpointer user_data)
-{
-  WylDaemonRuntime *runtime = user_data;
-
-  if (runtime == NULL)
-    return;
-  if (kind == WYL_DELTA_INSERT) {
-    runtime->inserted++;
-  } else if (kind == WYL_DELTA_REMOVE) {
-    runtime->removed++;
+  rc = wyl_daemon_check_role_permission_snapshot_reload_ready (handle);
+  if (rc != WYRELOG_E_OK) {
+    g_printerr ("wyrelogd: role permission reload check failed: %s\n",
+        wyrelog_error_string (rc));
+    return 1;
   }
 
-  if (g_strcmp0 (relation, "effective_member") != 0)
-    return;
-  if ((kind != WYL_DELTA_INSERT && kind != WYL_DELTA_REMOVE) || ncols != 3)
-    return;
-
-#ifdef WYL_HAS_AUDIT
-  emit_wirelog_effective_member_audit (runtime, row, kind);
-#endif
-
-  if (!runtime->expect_effective_member)
-    return;
-  if (row[0] == runtime->expected_row[0]
-      && row[1] == runtime->expected_row[1]
-      && row[2] == runtime->expected_row[2]) {
-    if (kind == WYL_DELTA_INSERT)
-      runtime->matched_expected_insert = TRUE;
-    else if (kind == WYL_DELTA_REMOVE)
-      runtime->matched_expected_remove = TRUE;
+  rc = wyl_daemon_check_audit_sink_ready (handle);
+  if (rc != WYRELOG_E_OK) {
+    g_printerr ("wyrelogd: audit readiness check failed: %s\n",
+        wyrelog_error_string (rc));
+    return 1;
   }
-}
 
-static wyrelog_error_t
-start_wirelog_delta_callbacks (WylHandle *handle, WylDaemonRuntime *runtime)
-{
-  return wyl_handle_engine_set_delta_callback (handle, daemon_delta_cb,
-      runtime);
-}
-
-static wyrelog_error_t
-check_wirelog_delta_ready (WylHandle *handle)
-{
-  WylDaemonRuntime runtime = {
-    .handle = handle,
-    .expect_effective_member = TRUE,
-  };
-
-  wyrelog_error_t rc =
-      wyl_handle_intern_engine_symbol (handle, "wyrelogd-check-user",
-      &runtime.expected_row[0]);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  rc = wyl_handle_intern_engine_symbol (handle, "wr.viewer",
-      &runtime.expected_row[1]);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  rc = wyl_handle_intern_engine_symbol (handle, "wyrelogd-check-scope",
-      &runtime.expected_row[2]);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-
-  rc = start_wirelog_delta_callbacks (handle, &runtime);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  rc = wyl_handle_engine_insert (handle, "member_of", runtime.expected_row, 3);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  if (runtime.inserted == 0 || !runtime.matched_expected_insert)
-    return WYRELOG_E_POLICY;
-  rc = wyl_handle_engine_remove (handle, "member_of", runtime.expected_row, 3);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  if (runtime.removed == 0 || !runtime.matched_expected_remove)
-    return WYRELOG_E_POLICY;
-#ifdef WYL_HAS_AUDIT
-  rc = check_wirelog_delta_audit_rows (handle);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-#endif
-  return wyl_handle_engine_set_delta_callback (handle, NULL, NULL);
+  return 0;
 }
 
 #ifdef G_OS_UNIX
@@ -584,56 +156,20 @@ main (int argc, char **argv)
     return 1;
   }
 
-  if (opts.check_only) {
-    rc = check_wirelog_delta_ready (handle);
-    if (rc != WYRELOG_E_OK) {
-      g_printerr ("wyrelogd: delta readiness check failed: %s\n",
-          wyrelog_error_string (rc));
-      return 1;
-    }
-    rc = check_wirelog_policy_ready (handle);
-    if (rc != WYRELOG_E_OK) {
-      g_printerr ("wyrelogd: policy readiness check failed: %s\n",
-          wyrelog_error_string (rc));
-      return 1;
-    }
-    rc = check_policy_store_ready (handle);
-    if (rc != WYRELOG_E_OK) {
-      g_printerr ("wyrelogd: policy store readiness check failed: %s\n",
-          wyrelog_error_string (rc));
-      return 1;
-    }
-    rc = check_policy_snapshot_reload_ready (handle);
-    if (rc != WYRELOG_E_OK) {
-      g_printerr ("wyrelogd: policy snapshot reload check failed: %s\n",
-          wyrelog_error_string (rc));
-      return 1;
-    }
-    rc = check_role_permission_snapshot_reload_ready (handle);
-    if (rc != WYRELOG_E_OK) {
-      g_printerr ("wyrelogd: role permission reload check failed: %s\n",
-          wyrelog_error_string (rc));
-      return 1;
-    }
-    rc = check_audit_sink_ready (handle);
-    if (rc != WYRELOG_E_OK) {
-      g_printerr ("wyrelogd: audit readiness check failed: %s\n",
-          wyrelog_error_string (rc));
-      return 1;
-    }
-    return 0;
-  }
+  if (opts.check_only)
+    return run_checks (handle);
 
   WylDaemonRuntime runtime = {
     .handle = handle,
   };
-  rc = start_wirelog_delta_callbacks (handle, &runtime);
+  rc = wyl_daemon_start_delta_callbacks (handle, &runtime);
   if (rc != WYRELOG_E_OK) {
     g_printerr ("wyrelogd: delta callback setup failed: %s\n",
         wyrelog_error_string (rc));
     return 1;
   }
-  rc = emit_daemon_start_event (handle);
+
+  rc = wyl_daemon_emit_start_event (handle);
   if (rc != WYRELOG_E_OK) {
     g_printerr ("wyrelogd: audit start event failed: %s\n",
         wyrelog_error_string (rc));
@@ -642,7 +178,8 @@ main (int argc, char **argv)
 
   g_autoptr (GMainLoop) loop = g_main_loop_new (NULL, FALSE);
 #ifdef WYL_HAS_DAEMON_HTTP
-  g_autoptr (SoupServer) server = start_http_server (&opts, handle, &error);
+  g_autoptr (SoupServer) server =
+      wyl_daemon_start_http_server (&opts, handle, &error);
   if (server == NULL) {
     g_printerr ("wyrelogd: listen failed: %s\n", error->message);
     return 1;

--- a/wyrelog/meson.build
+++ b/wyrelog/meson.build
@@ -120,7 +120,12 @@ if get_option('enable_audit').allowed()
 endif
 
 wyrelogd_exe = executable('wyrelogd',
-  files('daemon/wyrelogd.c'),
+  files(
+    'daemon/checks.c',
+    'daemon/delta.c',
+    'daemon/http.c',
+    'daemon/wyrelogd.c',
+  ),
   include_directories : wyrelog_inc,
   dependencies : wyrelogd_deps,
   c_args : wyrelogd_c_args,


### PR DESCRIPTION
## Summary

- split wyrelogd into focused daemon check, delta, HTTP, and option modules
- audit principal_fired and session_fired insert/remove deltas from daemon
  callbacks
- tighten daemon readiness checks for exact insert/remove audit rows and
  callback cleanup

## Verification

- git diff --check
- meson test -C builddir --print-errorlogs wyrelogd-check
- meson test -C builddir-audit --print-errorlogs wyrelogd-check audit-emit
  client-audit-daemon
