### PR TITLE
policy: replay stored audit events

### DIFF
--- a/tests/test-audit-emit.c
+++ b/tests/test-audit-emit.c
@@ -414,6 +414,237 @@ check_emit_mirrors_policy_store_row (void)
 }
 
 static gint
+check_policy_store_audit_replay_loads_runtime_query (void)
+{
+  WylHandle *handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 171;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  static const gchar *replay_id = "01890c10-2e3f-7000-8000-000000000003";
+  if (wyl_policy_store_append_audit_event (store, replay_id, 789, NULL,
+          "audit.replay", "replay-resource", NULL, NULL, WYL_DECISION_ALLOW)
+      != WYRELOG_E_OK) {
+    g_object_unref (handle);
+    return 172;
+  }
+  if (wyl_handle_load_policy_store_audit_events (handle) != WYRELOG_E_OK) {
+    g_object_unref (handle);
+    return 173;
+  }
+  if (wyl_handle_load_policy_store_audit_events (handle) != WYRELOG_E_OK) {
+    g_object_unref (handle);
+    return 182;
+  }
+
+  duckdb_connection duck_conn =
+      wyl_audit_conn_get_connection (wyl_handle_get_audit_conn (handle));
+  duckdb_result count_result;
+  if (duckdb_query (duck_conn,
+          "SELECT COUNT(*) FROM audit_events "
+          "WHERE id = '01890c10-2e3f-7000-8000-000000000003';",
+          &count_result) != DuckDBSuccess) {
+    duckdb_destroy_result (&count_result);
+    g_object_unref (handle);
+    return 183;
+  }
+  if (duckdb_value_int64 (&count_result, 0, 0) != 1) {
+    duckdb_destroy_result (&count_result);
+    g_object_unref (handle);
+    return 184;
+  }
+  duckdb_destroy_result (&count_result);
+
+  g_autofree gchar *json = NULL;
+  if (wyl_audit_conn_query_events_json (wyl_handle_get_audit_conn (handle),
+          "action(\"audit.replay\")", &json) != WYRELOG_E_OK) {
+    g_object_unref (handle);
+    return 174;
+  }
+
+  gint rc = 0;
+  if (g_strstr_len (json, -1,
+          "\"id\":\"01890c10-2e3f-7000-8000-000000000003\"") == NULL)
+    rc = 175;
+  else if (g_strstr_len (json, -1, "\"created_at_us\":789") == NULL)
+    rc = 176;
+  else if (g_strstr_len (json, -1, "\"subject_id\":null") == NULL)
+    rc = 177;
+  else if (g_strstr_len (json, -1, "\"resource_id\":\"replay-resource\"")
+      == NULL)
+    rc = 178;
+  else if (g_strstr_len (json, -1, "\"deny_reason\":null") == NULL)
+    rc = 179;
+  else if (g_strstr_len (json, -1, "\"deny_origin\":null") == NULL)
+    rc = 180;
+  else if (g_strstr_len (json, -1, "\"decision\":1") == NULL)
+    rc = 181;
+
+  g_object_unref (handle);
+  return rc;
+}
+
+static gint
+check_audit_conn_insert_event_idempotence (void)
+{
+  WylHandle *handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 185;
+
+  wyl_audit_conn_t *conn = wyl_handle_get_audit_conn (handle);
+  static const gchar *id = "01890c10-2e3f-7000-8000-000000000004";
+  if (wyl_audit_conn_insert_event (conn, id, 890, "same-user",
+          "same.action", "same-resource", NULL, NULL, WYL_DECISION_ALLOW)
+      != WYRELOG_E_OK) {
+    g_object_unref (handle);
+    return 186;
+  }
+  if (wyl_audit_conn_insert_event (conn, id, 890, "same-user",
+          "same.action", "same-resource", NULL, NULL, WYL_DECISION_ALLOW)
+      != WYRELOG_E_OK) {
+    g_object_unref (handle);
+    return 187;
+  }
+  if (wyl_audit_conn_insert_event (conn, id, 890, "same-user",
+          "different.action", "same-resource", NULL, NULL,
+          WYL_DECISION_ALLOW) != WYRELOG_E_POLICY) {
+    g_object_unref (handle);
+    return 188;
+  }
+  if (wyl_audit_conn_insert_event (conn, "not-a-uuid", 890, "same-user",
+          "same.action", "same-resource", NULL, NULL, WYL_DECISION_ALLOW)
+      != WYRELOG_E_INVALID) {
+    g_object_unref (handle);
+    return 189;
+  }
+
+  duckdb_connection duck_conn = wyl_audit_conn_get_connection (conn);
+  duckdb_result result;
+  if (duckdb_query (duck_conn,
+          "SELECT COUNT(*) FROM audit_events "
+          "WHERE id = '01890c10-2e3f-7000-8000-000000000004';", &result)
+      != DuckDBSuccess) {
+    duckdb_destroy_result (&result);
+    g_object_unref (handle);
+    return 190;
+  }
+
+  gint rc = 0;
+  if (duckdb_value_int64 (&result, 0, 0) != 1)
+    rc = 191;
+
+  duckdb_destroy_result (&result);
+  g_object_unref (handle);
+  return rc;
+}
+
+static gint
+check_duplicate_emit_keeps_runtime_row (void)
+{
+  WylHandle *handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 192;
+
+  g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
+  wyl_audit_event_set_subject_id (ev, "duplicate-user");
+  wyl_audit_event_set_action (ev, "duplicate.action");
+  wyl_audit_event_set_resource_id (ev, "duplicate-resource");
+  wyl_audit_event_set_decision (ev, WYL_DECISION_ALLOW);
+  g_autofree gchar *id = wyl_audit_event_dup_id_string (ev);
+
+  if (wyl_audit_emit (handle, ev) != WYRELOG_E_OK) {
+    g_object_unref (handle);
+    return 193;
+  }
+  if (wyl_audit_emit (handle, ev) != WYRELOG_E_OK) {
+    g_object_unref (handle);
+    return 194;
+  }
+
+  duckdb_connection duck_conn =
+      wyl_audit_conn_get_connection (wyl_handle_get_audit_conn (handle));
+  duckdb_prepared_statement stmt = NULL;
+  duckdb_result result;
+  memset (&result, 0, sizeof (result));
+
+  static const gchar *sql = "SELECT COUNT(*) FROM audit_events WHERE id = ?;";
+  if (duckdb_prepare (duck_conn, sql, &stmt) != DuckDBSuccess) {
+    g_object_unref (handle);
+    return 195;
+  }
+  if (duckdb_bind_varchar (stmt, 1, id) != DuckDBSuccess) {
+    duckdb_destroy_prepare (&stmt);
+    g_object_unref (handle);
+    return 196;
+  }
+  duckdb_state step_rc = duckdb_execute_prepared (stmt, &result);
+  duckdb_destroy_prepare (&stmt);
+  if (step_rc != DuckDBSuccess) {
+    duckdb_destroy_result (&result);
+    g_object_unref (handle);
+    return 197;
+  }
+
+  gint rc = 0;
+  if (duckdb_value_int64 (&result, 0, 0) != 1)
+    rc = 198;
+
+  duckdb_destroy_result (&result);
+  g_object_unref (handle);
+  return rc;
+}
+
+static gint
+check_policy_store_audit_replay_rolls_back_corrupt_row (void)
+{
+  WylHandle *handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 199;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  static const gchar *valid_id = "01890c10-2e3f-7000-8000-000000000005";
+  if (wyl_policy_store_append_audit_event (store, valid_id, 901,
+          "valid-user", "valid.action", NULL, NULL, NULL, WYL_DECISION_ALLOW)
+      != WYRELOG_E_OK) {
+    g_object_unref (handle);
+    return 200;
+  }
+  if (sqlite3_exec (wyl_policy_store_get_db (store),
+          "INSERT INTO audit_events "
+          "(id, created_at_us, action, decision) "
+          "VALUES ('not-a-uuid', 902, 'bad.action', 1);",
+          NULL, NULL, NULL) != SQLITE_OK) {
+    g_object_unref (handle);
+    return 201;
+  }
+  if (wyl_handle_load_policy_store_audit_events (handle) != WYRELOG_E_POLICY) {
+    g_object_unref (handle);
+    return 202;
+  }
+
+  duckdb_connection duck_conn =
+      wyl_audit_conn_get_connection (wyl_handle_get_audit_conn (handle));
+  duckdb_result result;
+  memset (&result, 0, sizeof (result));
+  if (duckdb_query (duck_conn,
+          "SELECT COUNT(*) FROM audit_events "
+          "WHERE id = '01890c10-2e3f-7000-8000-000000000005';", &result)
+      != DuckDBSuccess) {
+    duckdb_destroy_result (&result);
+    g_object_unref (handle);
+    return 203;
+  }
+
+  gint rc = 0;
+  if (duckdb_value_int64 (&result, 0, 0) != 0)
+    rc = 204;
+
+  duckdb_destroy_result (&result);
+  g_object_unref (handle);
+  return rc;
+}
+
+static gint
 check_decide_persists_representative_deny_reason (void)
 {
   WylHandle *handle = NULL;
@@ -1226,6 +1457,14 @@ main (void)
   if ((rc = check_query_events_json_filters_rows ()) != 0)
     return rc;
   if ((rc = check_emit_mirrors_policy_store_row ()) != 0)
+    return rc;
+  if ((rc = check_policy_store_audit_replay_loads_runtime_query ()) != 0)
+    return rc;
+  if ((rc = check_audit_conn_insert_event_idempotence ()) != 0)
+    return rc;
+  if ((rc = check_duplicate_emit_keeps_runtime_row ()) != 0)
+    return rc;
+  if ((rc = check_policy_store_audit_replay_rolls_back_corrupt_row ()) != 0)
     return rc;
   if ((rc = check_decide_persists_representative_deny_reason ()) != 0)
     return rc;

--- a/tests/test-policy-store.c
+++ b/tests/test-policy-store.c
@@ -290,6 +290,19 @@ typedef struct
   guint matches;
 } RoleMembershipEventExpect;
 
+typedef struct
+{
+  const gchar *id;
+  gint64 created_at_us;
+  const gchar *subject_id;
+  const gchar *action;
+  const gchar *resource_id;
+  const gchar *deny_reason;
+  const gchar *deny_origin;
+  wyl_decision_t decision;
+  guint matches;
+} AuditEventExpect;
+
 static wyrelog_error_t
 role_permission_expect_cb (const gchar *role_id, const gchar *perm_id,
     gpointer user_data)
@@ -338,6 +351,26 @@ role_membership_event_expect_cb (const gchar *subject_id,
       && g_strcmp0 (role_id, expect->role_id) == 0
       && g_strcmp0 (scope, expect->scope) == 0
       && g_strcmp0 (operation, expect->operation) == 0)
+    expect->matches++;
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+audit_event_expect_cb (const gchar *id, gint64 created_at_us,
+    const gchar *subject_id, const gchar *action, const gchar *resource_id,
+    const gchar *deny_reason, const gchar *deny_origin,
+    wyl_decision_t decision, gpointer user_data)
+{
+  AuditEventExpect *expect = user_data;
+
+  if (g_strcmp0 (id, expect->id) == 0
+      && created_at_us == expect->created_at_us
+      && g_strcmp0 (subject_id, expect->subject_id) == 0
+      && g_strcmp0 (action, expect->action) == 0
+      && g_strcmp0 (resource_id, expect->resource_id) == 0
+      && g_strcmp0 (deny_reason, expect->deny_reason) == 0
+      && g_strcmp0 (deny_origin, expect->deny_origin) == 0
+      && decision == expect->decision)
     expect->matches++;
   return WYRELOG_E_OK;
 }
@@ -683,7 +716,8 @@ check_store_appends_audit_event (void)
     return 120;
   if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
     return 121;
-  if (wyl_policy_store_append_audit_event (store, "audit-store-id", 123,
+  if (wyl_policy_store_append_audit_event (store,
+          "01890c10-2e3f-7000-8000-000000000001", 123,
           "audit-user", "read", "doc/1", "not_armed", "perm_state",
           WYL_DECISION_DENY) != WYRELOG_E_OK)
     return 122;
@@ -695,8 +729,8 @@ check_store_appends_audit_event (void)
   if (sqlite3_prepare_v2 (wyl_policy_store_get_db (store), sql, -1, &stmt,
           NULL) != SQLITE_OK)
     return 123;
-  if (sqlite3_bind_text (stmt, 1, "audit-store-id", -1, SQLITE_TRANSIENT)
-      != SQLITE_OK) {
+  if (sqlite3_bind_text (stmt, 1, "01890c10-2e3f-7000-8000-000000000001",
+          -1, SQLITE_TRANSIENT) != SQLITE_OK) {
     sqlite3_finalize (stmt);
     return 124;
   }
@@ -725,6 +759,119 @@ check_store_appends_audit_event (void)
 
   sqlite3_finalize (stmt);
   return rc;
+}
+
+static gint
+check_store_iterates_audit_event (void)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 132;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 133;
+  if (wyl_policy_store_append_audit_event (store,
+          "01890c10-2e3f-7000-8000-000000000002", 456,
+          "audit-user", "write", "doc/2", "allowed", "test",
+          WYL_DECISION_ALLOW) != WYRELOG_E_OK)
+    return 134;
+
+  AuditEventExpect expect = {
+    .id = "01890c10-2e3f-7000-8000-000000000002",
+    .created_at_us = 456,
+    .subject_id = "audit-user",
+    .action = "write",
+    .resource_id = "doc/2",
+    .deny_reason = "allowed",
+    .deny_origin = "test",
+    .decision = WYL_DECISION_ALLOW,
+  };
+  if (wyl_policy_store_foreach_audit_event (store, audit_event_expect_cb,
+          &expect) != WYRELOG_E_OK)
+    return 135;
+  if (expect.matches != 1)
+    return 136;
+  return 0;
+}
+
+static gint
+check_store_append_audit_event_is_idempotent (void)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+  static const gchar *id = "01890c10-2e3f-7000-8000-000000000005";
+
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 144;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 145;
+  if (wyl_policy_store_append_audit_event (store, id, 777, NULL,
+          "same.action", NULL, NULL, NULL, WYL_DECISION_ALLOW)
+      != WYRELOG_E_OK)
+    return 146;
+  if (wyl_policy_store_append_audit_event (store, id, 777, NULL,
+          "same.action", NULL, NULL, NULL, WYL_DECISION_ALLOW)
+      != WYRELOG_E_OK)
+    return 147;
+  if (wyl_policy_store_append_audit_event (store, id, 777, NULL,
+          "different.action", NULL, NULL, NULL, WYL_DECISION_ALLOW)
+      != WYRELOG_E_POLICY)
+    return 148;
+
+  sqlite3_stmt *stmt = NULL;
+  static const gchar *sql = "SELECT COUNT(*) FROM audit_events WHERE id = ?;";
+  if (sqlite3_prepare_v2 (wyl_policy_store_get_db (store), sql, -1, &stmt,
+          NULL) != SQLITE_OK)
+    return 149;
+  if (sqlite3_bind_text (stmt, 1, id, -1, SQLITE_TRANSIENT) != SQLITE_OK) {
+    sqlite3_finalize (stmt);
+    return 150;
+  }
+
+  int step_rc = sqlite3_step (stmt);
+  gint rc = 0;
+  if (step_rc != SQLITE_ROW)
+    rc = 151;
+  else if (sqlite3_column_int64 (stmt, 0) != 1)
+    rc = 152;
+
+  sqlite3_finalize (stmt);
+  return rc;
+}
+
+static gint
+check_store_rejects_corrupt_audit_events (void)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 137;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 138;
+
+  if (sqlite3_exec (wyl_policy_store_get_db (store),
+          "INSERT INTO audit_events "
+          "(id, created_at_us, action, decision) "
+          "VALUES ('not-a-uuid', 1, 'bad.id', 1);",
+          NULL, NULL, NULL) != SQLITE_OK)
+    return 139;
+  if (wyl_policy_store_foreach_audit_event (store, audit_event_expect_cb,
+          NULL) != WYRELOG_E_POLICY)
+    return 140;
+  if (sqlite3_exec (wyl_policy_store_get_db (store),
+          "DELETE FROM audit_events;", NULL, NULL, NULL) != SQLITE_OK)
+    return 141;
+
+  if (sqlite3_exec (wyl_policy_store_get_db (store),
+          "INSERT INTO audit_events "
+          "(id, created_at_us, action, decision) "
+          "VALUES ('01890c10-2e3f-7000-8000-000000000004', -1, "
+          "'bad.timestamp', 1);", NULL, NULL, NULL) != SQLITE_OK)
+    return 142;
+  if (wyl_policy_store_foreach_audit_event (store, audit_event_expect_cb,
+          NULL) != WYRELOG_E_POLICY)
+    return 143;
+
+  return 0;
 }
 
 static gint
@@ -844,12 +991,16 @@ check_store_rejects_bad_role_permission (void)
   if (wyl_policy_store_append_audit_event (store, NULL, 0, NULL, NULL, NULL,
           NULL, NULL, WYL_DECISION_ALLOW) != WYRELOG_E_INVALID)
     return 94;
-  if (wyl_policy_store_append_audit_event (store, "audit-bad", -1, NULL,
-          NULL, NULL, NULL, NULL, WYL_DECISION_ALLOW) != WYRELOG_E_INVALID)
+  if (wyl_policy_store_append_audit_event (store,
+          "01890c10-2e3f-7000-8000-000000000003", -1, NULL, NULL, NULL,
+          NULL, NULL, WYL_DECISION_ALLOW) != WYRELOG_E_INVALID)
     return 95;
   if (wyl_policy_store_append_audit_event (store, "audit-bad", 0, NULL,
           NULL, NULL, NULL, NULL, (wyl_decision_t) 9) != WYRELOG_E_INVALID)
     return 96;
+  if (wyl_policy_store_foreach_audit_event (store, NULL, NULL)
+      != WYRELOG_E_INVALID)
+    return 105;
   return 0;
 }
 
@@ -885,6 +1036,12 @@ main (void)
   if ((rc = check_store_appends_session_event ()) != 0)
     return rc;
   if ((rc = check_store_appends_audit_event ()) != 0)
+    return rc;
+  if ((rc = check_store_iterates_audit_event ()) != 0)
+    return rc;
+  if ((rc = check_store_append_audit_event_is_idempotent ()) != 0)
+    return rc;
+  if ((rc = check_store_rejects_corrupt_audit_events ()) != 0)
     return rc;
   if ((rc = check_store_rejects_bad_direct_permission ()) != 0)
     return rc;

--- a/wyrelog/audit/conn-private.h
+++ b/wyrelog/audit/conn-private.h
@@ -4,6 +4,7 @@
 #include <glib.h>
 #include <duckdb.h>
 
+#include "wyrelog/decide.h"
 #include "wyrelog/error.h"
 
 G_BEGIN_DECLS;
@@ -92,6 +93,24 @@ wyrelog_error_t wyl_audit_conn_create_schema (wyl_audit_conn_t * conn);
  */
 wyrelog_error_t wyl_audit_conn_table_exists (wyl_audit_conn_t * conn,
     const gchar * table_name, gboolean * out_exists);
+
+/*
+ * Inserts a fully materialised audit row into the runtime DuckDB view.
+ * This is used by both freshly emitted events and policy-store replay;
+ * callers are responsible for deciding whether the source row should
+ * also be persisted elsewhere.
+ */
+wyrelog_error_t wyl_audit_conn_insert_event (wyl_audit_conn_t * conn,
+    const gchar * id, gint64 created_at_us, const gchar * subject_id,
+    const gchar * action, const gchar * resource_id,
+    const gchar * deny_reason, const gchar * deny_origin,
+    wyl_decision_t decision);
+
+wyrelog_error_t wyl_audit_conn_insert_event_full (wyl_audit_conn_t * conn,
+    const gchar * id, gint64 created_at_us, const gchar * subject_id,
+    const gchar * action, const gchar * resource_id,
+    const gchar * deny_reason, const gchar * deny_origin,
+    wyl_decision_t decision, gboolean * out_inserted);
 
 /*
  * Serialises audit_events rows to a compact JSON array ordered by newest

--- a/wyrelog/audit/conn.c
+++ b/wyrelog/audit/conn.c
@@ -4,6 +4,7 @@
 #include <string.h>
 
 #include "wyrelog/decide.h"
+#include "wyrelog/wyl-id-private.h"
 
 struct wyl_audit_conn_t
 {
@@ -62,6 +63,82 @@ wyl_audit_conn_get_connection (wyl_audit_conn_t *conn)
     return zero;
   }
   return conn->conn;
+}
+
+static wyrelog_error_t
+bind_nullable_varchar (duckdb_prepared_statement stmt, idx_t index,
+    const gchar *value)
+{
+  if (value == NULL)
+    return duckdb_bind_null (stmt, index) == DuckDBSuccess ?
+        WYRELOG_E_OK : WYRELOG_E_IO;
+  return duckdb_bind_varchar (stmt, index, value) == DuckDBSuccess ?
+      WYRELOG_E_OK : WYRELOG_E_IO;
+}
+
+static gboolean
+result_nullable_varchar_equal (duckdb_result *result, idx_t col, idx_t row,
+    const gchar *expected)
+{
+  if (duckdb_value_is_null (result, col, row))
+    return expected == NULL;
+
+  gchar *actual = duckdb_value_varchar (result, col, row);
+  gboolean equal = g_strcmp0 (actual, expected) == 0;
+  duckdb_free (actual);
+  return equal;
+}
+
+static wyrelog_error_t
+audit_event_matches_existing (wyl_audit_conn_t *conn, const gchar *id,
+    gint64 created_at_us, const gchar *subject_id, const gchar *action,
+    const gchar *resource_id, const gchar *deny_reason,
+    const gchar *deny_origin, wyl_decision_t decision, gboolean *out_exists)
+{
+  duckdb_prepared_statement stmt = NULL;
+  duckdb_result result;
+  memset (&result, 0, sizeof (result));
+
+  *out_exists = FALSE;
+  static const gchar *sql =
+      "SELECT created_at_us, subject_id, action, resource_id, "
+      "deny_reason, deny_origin, decision " "FROM audit_events WHERE id = ?;";
+  if (duckdb_prepare (conn->conn, sql, &stmt) != DuckDBSuccess)
+    return WYRELOG_E_IO;
+  if (duckdb_bind_varchar (stmt, 1, id) != DuckDBSuccess) {
+    duckdb_destroy_prepare (&stmt);
+    return WYRELOG_E_IO;
+  }
+
+  duckdb_state step_rc = duckdb_execute_prepared (stmt, &result);
+  duckdb_destroy_prepare (&stmt);
+  if (step_rc != DuckDBSuccess) {
+    duckdb_destroy_result (&result);
+    return WYRELOG_E_IO;
+  }
+
+  idx_t rows = duckdb_row_count (&result);
+  if (rows == 0) {
+    duckdb_destroy_result (&result);
+    return WYRELOG_E_OK;
+  }
+  if (rows != 1) {
+    duckdb_destroy_result (&result);
+    return WYRELOG_E_POLICY;
+  }
+
+  *out_exists = TRUE;
+  gboolean equal =
+      duckdb_value_int64 (&result, 0, 0) == created_at_us
+      && result_nullable_varchar_equal (&result, 1, 0, subject_id)
+      && result_nullable_varchar_equal (&result, 2, 0, action)
+      && result_nullable_varchar_equal (&result, 3, 0, resource_id)
+      && result_nullable_varchar_equal (&result, 4, 0, deny_reason)
+      && result_nullable_varchar_equal (&result, 5, 0, deny_origin)
+      && duckdb_value_int64 (&result, 6, 0) == decision;
+
+  duckdb_destroy_result (&result);
+  return equal ? WYRELOG_E_OK : WYRELOG_E_POLICY;
 }
 
 wyrelog_error_t
@@ -134,6 +211,80 @@ wyl_audit_conn_table_exists (wyl_audit_conn_t *conn, const gchar *table_name,
   *out_exists = duckdb_value_int64 (&result, 0, 0) > 0;
   duckdb_destroy_result (&result);
   return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
+wyl_audit_conn_insert_event_full (wyl_audit_conn_t *conn, const gchar *id,
+    gint64 created_at_us, const gchar *subject_id, const gchar *action,
+    const gchar *resource_id, const gchar *deny_reason,
+    const gchar *deny_origin, wyl_decision_t decision, gboolean *out_inserted)
+{
+  duckdb_prepared_statement stmt = NULL;
+  duckdb_result result;
+  duckdb_state step_rc;
+  wyl_id_t parsed_id;
+  gboolean exists = FALSE;
+
+  memset (&result, 0, sizeof (result));
+
+  if (conn == NULL || id == NULL || created_at_us < 0 || out_inserted == NULL)
+    return WYRELOG_E_INVALID;
+  *out_inserted = FALSE;
+  if (wyl_id_parse (id, &parsed_id) != WYRELOG_E_OK)
+    return WYRELOG_E_INVALID;
+  if (decision != WYL_DECISION_DENY && decision != WYL_DECISION_ALLOW)
+    return WYRELOG_E_INVALID;
+
+  wyrelog_error_t rc = audit_event_matches_existing (conn, id, created_at_us,
+      subject_id, action, resource_id, deny_reason, deny_origin, decision,
+      &exists);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if (exists)
+    return WYRELOG_E_OK;
+
+  static const gchar *sql =
+      "INSERT INTO audit_events "
+      "(id, created_at_us, subject_id, action, resource_id, "
+      "deny_reason, deny_origin, decision) " "VALUES (?, ?, ?, ?, ?, ?, ?, ?);";
+  if (duckdb_prepare (conn->conn, sql, &stmt) != DuckDBSuccess) {
+    duckdb_destroy_prepare (&stmt);
+    return WYRELOG_E_IO;
+  }
+
+  if (duckdb_bind_varchar (stmt, 1, id) != DuckDBSuccess
+      || duckdb_bind_int64 (stmt, 2, created_at_us) != DuckDBSuccess
+      || bind_nullable_varchar (stmt, 3, subject_id) != WYRELOG_E_OK
+      || bind_nullable_varchar (stmt, 4, action) != WYRELOG_E_OK
+      || bind_nullable_varchar (stmt, 5, resource_id) != WYRELOG_E_OK
+      || bind_nullable_varchar (stmt, 6, deny_reason) != WYRELOG_E_OK
+      || bind_nullable_varchar (stmt, 7, deny_origin) != WYRELOG_E_OK
+      || duckdb_bind_int16 (stmt, 8, (int16_t) decision) != DuckDBSuccess) {
+    duckdb_destroy_prepare (&stmt);
+    return WYRELOG_E_IO;
+  }
+
+  step_rc = duckdb_execute_prepared (stmt, &result);
+  duckdb_destroy_result (&result);
+  duckdb_destroy_prepare (&stmt);
+  if (step_rc != DuckDBSuccess)
+    return WYRELOG_E_IO;
+
+  *out_inserted = TRUE;
+  return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
+wyl_audit_conn_insert_event (wyl_audit_conn_t *conn, const gchar *id,
+    gint64 created_at_us, const gchar *subject_id, const gchar *action,
+    const gchar *resource_id, const gchar *deny_reason,
+    const gchar *deny_origin, wyl_decision_t decision)
+{
+  gboolean inserted = FALSE;
+
+  return wyl_audit_conn_insert_event_full (conn, id, created_at_us,
+      subject_id, action, resource_id, deny_reason, deny_origin, decision,
+      &inserted);
 }
 
 static void

--- a/wyrelog/audit/event.c
+++ b/wyrelog/audit/event.c
@@ -5,8 +5,6 @@
 #include "wyl-id-private.h"
 
 #ifdef WYL_HAS_AUDIT
-#include <duckdb.h>
-
 #include "audit/conn-private.h"
 #include "policy/store-private.h"
 #include "wyl-handle-private.h"
@@ -221,12 +219,8 @@ wyl_audit_emit (WylHandle *handle, const WylAuditEvent *event)
 {
 #ifdef WYL_HAS_AUDIT
   wyl_audit_conn_t *audit_conn;
-  duckdb_connection conn;
-  duckdb_prepared_statement stmt;
-  duckdb_result result;
-  duckdb_state rc;
   gchar id_buf[WYL_ID_STRING_BUF];
-  const gchar *value;
+  gboolean inserted = FALSE;
 
   if (handle == NULL || event == NULL)
     return WYRELOG_E_INVALID;
@@ -235,63 +229,15 @@ wyl_audit_emit (WylHandle *handle, const WylAuditEvent *event)
   if (audit_conn == NULL)
     return WYRELOG_E_INTERNAL;
 
-  conn = wyl_audit_conn_get_connection (audit_conn);
-
-  static const gchar *sql =
-      "INSERT INTO audit_events "
-      "(id, created_at_us, subject_id, action, resource_id, "
-      "deny_reason, deny_origin, decision) " "VALUES (?, ?, ?, ?, ?, ?, ?, ?);";
-
-  if (duckdb_prepare (conn, sql, &stmt) != DuckDBSuccess) {
-    duckdb_destroy_prepare (&stmt);
-    return WYRELOG_E_IO;
-  }
-
-  if (wyl_id_format (&event->id, id_buf, sizeof id_buf) != WYRELOG_E_OK) {
-    duckdb_destroy_prepare (&stmt);
+  if (wyl_id_format (&event->id, id_buf, sizeof id_buf) != WYRELOG_E_OK)
     return WYRELOG_E_INTERNAL;
-  }
-  duckdb_bind_varchar (stmt, 1, id_buf);
-  duckdb_bind_int64 (stmt, 2, event->created_at_us);
 
-  value = event->subject_id;
-  if (value != NULL)
-    duckdb_bind_varchar (stmt, 3, value);
-  else
-    duckdb_bind_null (stmt, 3);
-
-  value = event->action;
-  if (value != NULL)
-    duckdb_bind_varchar (stmt, 4, value);
-  else
-    duckdb_bind_null (stmt, 4);
-
-  value = event->resource_id;
-  if (value != NULL)
-    duckdb_bind_varchar (stmt, 5, value);
-  else
-    duckdb_bind_null (stmt, 5);
-
-  value = event->deny_reason;
-  if (value != NULL)
-    duckdb_bind_varchar (stmt, 6, value);
-  else
-    duckdb_bind_null (stmt, 6);
-
-  value = event->deny_origin;
-  if (value != NULL)
-    duckdb_bind_varchar (stmt, 7, value);
-  else
-    duckdb_bind_null (stmt, 7);
-
-  duckdb_bind_int16 (stmt, 8, (int16_t) event->decision);
-
-  rc = duckdb_execute_prepared (stmt, &result);
-  duckdb_destroy_result (&result);
-  duckdb_destroy_prepare (&stmt);
-
-  if (rc != DuckDBSuccess)
-    return WYRELOG_E_IO;
+  wyrelog_error_t rc = wyl_audit_conn_insert_event_full (audit_conn, id_buf,
+      event->created_at_us,
+      event->subject_id, event->action, event->resource_id,
+      event->deny_reason, event->deny_origin, event->decision, &inserted);
+  if (rc != WYRELOG_E_OK)
+    return rc;
 
   wyrelog_error_t store_rc =
       wyl_policy_store_append_audit_event (wyl_handle_get_policy_store (handle),
@@ -299,6 +245,10 @@ wyl_audit_emit (WylHandle *handle, const WylAuditEvent *event)
       event->subject_id, event->action, event->resource_id,
       event->deny_reason, event->deny_origin, event->decision);
   if (store_rc != WYRELOG_E_OK) {
+    if (!inserted)
+      return store_rc;
+
+    duckdb_connection conn = wyl_audit_conn_get_connection (audit_conn);
     duckdb_prepared_statement delete_stmt = NULL;
     duckdb_result delete_result = { 0 };
 

--- a/wyrelog/policy/store-private.h
+++ b/wyrelog/policy/store-private.h
@@ -35,6 +35,10 @@ typedef wyrelog_error_t (*wyl_policy_session_state_cb) (const gchar *
 typedef wyrelog_error_t (*wyl_policy_session_event_cb) (const gchar *
     session_id, const gchar * event, const gchar * from_state,
     const gchar * to_state, gpointer user_data);
+typedef wyrelog_error_t (*wyl_policy_audit_event_cb) (const gchar * id,
+    gint64 created_at_us, const gchar * subject_id, const gchar * action,
+    const gchar * resource_id, const gchar * deny_reason,
+    const gchar * deny_origin, wyl_decision_t decision, gpointer user_data);
 
 /*
  * Policy authority store lifecycle wrapper.
@@ -124,5 +128,7 @@ wyrelog_error_t wyl_policy_store_append_audit_event (wyl_policy_store_t *
     store, const gchar * id, gint64 created_at_us, const gchar * subject_id,
     const gchar * action, const gchar * resource_id, const gchar * deny_reason,
     const gchar * deny_origin, wyl_decision_t decision);
+wyrelog_error_t wyl_policy_store_foreach_audit_event (wyl_policy_store_t *
+    store, wyl_policy_audit_event_cb cb, gpointer user_data);
 
 G_END_DECLS;

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -1,6 +1,8 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #include "store-private.h"
 
+#include "wyrelog/wyl-id-private.h"
+
 struct wyl_policy_store_t
 {
   sqlite3 *db;
@@ -44,6 +46,15 @@ bind_nullable_text (sqlite3_stmt *stmt, int index, const gchar *value)
     return WYRELOG_E_OK;
   }
   return bind_text (stmt, index, value);
+}
+
+static gboolean
+column_nullable_text_equal (sqlite3_stmt *stmt, int col, const gchar *expected)
+{
+  if (sqlite3_column_type (stmt, col) == SQLITE_NULL)
+    return expected == NULL;
+  return g_strcmp0 ((const gchar *) sqlite3_column_text (stmt, col),
+      expected) == 0;
 }
 
 wyrelog_error_t
@@ -1115,18 +1126,50 @@ wyl_policy_store_append_audit_event (wyl_policy_store_t *store,
     const gchar *deny_origin, wyl_decision_t decision)
 {
   sqlite3_stmt *stmt = NULL;
+  wyl_id_t parsed_id;
 
   if (store == NULL || store->db == NULL || id == NULL || created_at_us < 0)
     return WYRELOG_E_INVALID;
+  if (wyl_id_parse (id, &parsed_id) != WYRELOG_E_OK)
+    return WYRELOG_E_INVALID;
   if (decision != WYL_DECISION_DENY && decision != WYL_DECISION_ALLOW)
     return WYRELOG_E_INVALID;
+
+  static const gchar *select_sql =
+      "SELECT created_at_us, subject_id, action, resource_id, "
+      "deny_reason, deny_origin, decision FROM audit_events WHERE id = ?;";
+  wyrelog_error_t rc = prepare_stmt (store->db, select_sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if ((rc = bind_text (stmt, 1, id)) != WYRELOG_E_OK) {
+    sqlite3_finalize (stmt);
+    return rc;
+  }
+
+  int select_rc = sqlite3_step (stmt);
+  if (select_rc == SQLITE_ROW) {
+    gboolean equal =
+        sqlite3_column_int64 (stmt, 0) == created_at_us
+        && column_nullable_text_equal (stmt, 1, subject_id)
+        && column_nullable_text_equal (stmt, 2, action)
+        && column_nullable_text_equal (stmt, 3, resource_id)
+        && column_nullable_text_equal (stmt, 4, deny_reason)
+        && column_nullable_text_equal (stmt, 5, deny_origin)
+        && sqlite3_column_int (stmt, 6) == (int) decision;
+    sqlite3_finalize (stmt);
+    return equal ? WYRELOG_E_OK : WYRELOG_E_POLICY;
+  }
+  sqlite3_finalize (stmt);
+  stmt = NULL;
+  if (select_rc != SQLITE_DONE)
+    return WYRELOG_E_IO;
 
   static const gchar *sql =
       "INSERT INTO audit_events "
       "  (id, created_at_us, subject_id, action, resource_id, "
       "   deny_reason, deny_origin, decision) "
       "VALUES (?, ?, ?, ?, ?, ?, ?, ?);";
-  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  rc = prepare_stmt (store->db, sql, &stmt);
   if (rc != WYRELOG_E_OK)
     return rc;
   if ((rc = bind_text (stmt, 1, id)) != WYRELOG_E_OK
@@ -1142,6 +1185,53 @@ wyl_policy_store_append_audit_event (wyl_policy_store_t *store,
   }
 
   int step_rc = sqlite3_step (stmt);
+  sqlite3_finalize (stmt);
+  return (step_rc == SQLITE_DONE) ? WYRELOG_E_OK : WYRELOG_E_IO;
+}
+
+wyrelog_error_t
+wyl_policy_store_foreach_audit_event (wyl_policy_store_t *store,
+    wyl_policy_audit_event_cb cb, gpointer user_data)
+{
+  sqlite3_stmt *stmt = NULL;
+
+  if (store == NULL || store->db == NULL || cb == NULL)
+    return WYRELOG_E_INVALID;
+
+  static const gchar *sql =
+      "SELECT id, created_at_us, subject_id, action, resource_id, "
+      "deny_reason, deny_origin, decision "
+      "FROM audit_events ORDER BY created_at_us ASC, id ASC;";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  int step_rc;
+  while ((step_rc = sqlite3_step (stmt)) == SQLITE_ROW) {
+    const gchar *id = (const gchar *) sqlite3_column_text (stmt, 0);
+    gint64 created_at_us = sqlite3_column_int64 (stmt, 1);
+    const gchar *subject_id = (const gchar *) sqlite3_column_text (stmt, 2);
+    const gchar *action = (const gchar *) sqlite3_column_text (stmt, 3);
+    const gchar *resource_id = (const gchar *) sqlite3_column_text (stmt, 4);
+    const gchar *deny_reason = (const gchar *) sqlite3_column_text (stmt, 5);
+    const gchar *deny_origin = (const gchar *) sqlite3_column_text (stmt, 6);
+    int decision = sqlite3_column_int (stmt, 7);
+    wyl_id_t parsed_id;
+
+    if (id == NULL || wyl_id_parse (id, &parsed_id) != WYRELOG_E_OK
+        || created_at_us < 0 || (decision != WYL_DECISION_DENY
+            && decision != WYL_DECISION_ALLOW)) {
+      sqlite3_finalize (stmt);
+      return WYRELOG_E_POLICY;
+    }
+    rc = cb (id, created_at_us, subject_id, action, resource_id, deny_reason,
+        deny_origin, (wyl_decision_t) decision, user_data);
+    if (rc != WYRELOG_E_OK) {
+      sqlite3_finalize (stmt);
+      return rc;
+    }
+  }
+
   sqlite3_finalize (stmt);
   return (step_rc == SQLITE_DONE) ? WYRELOG_E_OK : WYRELOG_E_IO;
 }

--- a/wyrelog/wyl-handle-private.h
+++ b/wyrelog/wyl-handle-private.h
@@ -22,6 +22,13 @@ G_BEGIN_DECLS;
  * non-audit builds (and neither does the underlying type).
  */
 wyl_audit_conn_t *wyl_handle_get_audit_conn (WylHandle * self);
+
+/*
+ * Replays persisted policy-store audit rows into the handle-owned runtime
+ * audit connection. This follows the audit connection lifecycle and does not
+ * append the replayed rows back into the policy store.
+ */
+wyrelog_error_t wyl_handle_load_policy_store_audit_events (WylHandle * self);
 #endif
 
 /*

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -1,6 +1,8 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #include "wyrelog/wyrelog.h"
 
+#include <string.h>
+
 #include "wyrelog/engine.h"
 #include "wyl-fsm-principal-private.h"
 #include "wyl-fsm-session-private.h"
@@ -227,6 +229,11 @@ wyl_init (const gchar *config_path, WylHandle **out_handle)
     g_object_unref (self);
     return rc;
   }
+  rc = wyl_handle_load_policy_store_audit_events (self);
+  if (rc != WYRELOG_E_OK) {
+    g_object_unref (self);
+    return rc;
+  }
 #endif
 
   *out_handle = self;
@@ -279,6 +286,57 @@ wyl_handle_get_audit_conn (WylHandle *self)
 {
   g_return_val_if_fail (WYL_IS_HANDLE (self), NULL);
   return self->audit_conn;
+}
+
+static wyrelog_error_t
+insert_policy_store_audit_event (const gchar *id, gint64 created_at_us,
+    const gchar *subject_id, const gchar *action, const gchar *resource_id,
+    const gchar *deny_reason, const gchar *deny_origin,
+    wyl_decision_t decision, gpointer user_data)
+{
+  WylHandle *self = user_data;
+
+  return wyl_audit_conn_insert_event (self->audit_conn, id, created_at_us,
+      subject_id, action, resource_id, deny_reason, deny_origin, decision);
+}
+
+wyrelog_error_t
+wyl_handle_load_policy_store_audit_events (WylHandle *self)
+{
+  if (self == NULL || !WYL_IS_HANDLE (self))
+    return WYRELOG_E_INVALID;
+  if (self->policy_store == NULL || self->audit_conn == NULL)
+    return WYRELOG_E_INVALID;
+
+  duckdb_connection conn = wyl_audit_conn_get_connection (self->audit_conn);
+  duckdb_result result;
+  memset (&result, 0, sizeof (result));
+
+  if (duckdb_query (conn, "BEGIN TRANSACTION;", &result) != DuckDBSuccess) {
+    duckdb_destroy_result (&result);
+    return WYRELOG_E_IO;
+  }
+  duckdb_destroy_result (&result);
+
+  wyrelog_error_t rc = wyl_policy_store_foreach_audit_event (self->policy_store,
+      insert_policy_store_audit_event, self);
+  if (rc != WYRELOG_E_OK) {
+    memset (&result, 0, sizeof (result));
+    duckdb_query (conn, "ROLLBACK;", &result);
+    duckdb_destroy_result (&result);
+    return rc;
+  }
+
+  memset (&result, 0, sizeof (result));
+  if (duckdb_query (conn, "COMMIT;", &result) != DuckDBSuccess) {
+    duckdb_destroy_result (&result);
+    memset (&result, 0, sizeof (result));
+    duckdb_query (conn, "ROLLBACK;", &result);
+    duckdb_destroy_result (&result);
+    return WYRELOG_E_IO;
+  }
+  duckdb_destroy_result (&result);
+  return WYRELOG_E_OK;
 }
 #endif
 


### PR DESCRIPTION
## Summary
- replay stored audit events into the runtime audit sink on init
- make matching audit inserts and policy appends idempotent
- reject malformed or conflicting persisted audit rows

## Tests
- git diff --check
- meson test -C builddir --print-errorlogs policy-store handle-engine-pair session-username
- meson test -C builddir-audit --print-errorlogs policy-store audit-emit handle-engine-pair session-username client-audit-daemon wyrelogd-check