### PR TITLE
policy: preserve fsm event occurrence ids

### DIFF
--- a/templates/access/fsm/principal.dl
+++ b/templates/access/fsm/principal.dl
@@ -23,9 +23,9 @@
 // side without the other will fail the build.
 
 .decl principal_transition(from: symbol, event: symbol, to: symbol)
-.decl principal_event(user: symbol, ev: symbol, from: symbol, to: symbol)
+.decl principal_event(event_id: int64, user: symbol, ev: symbol, from: symbol, to: symbol)
 .decl principal_step(from: symbol, event: symbol, to: symbol)
-.decl principal_fired(user: symbol, from: symbol, ev: symbol, to: symbol)
+.decl principal_fired(event_id: int64, user: symbol, from: symbol, ev: symbol, to: symbol)
 
 principal_transition("unverified",    "login_ok",       "mfa_required").
 principal_transition("unverified",    "login_skip_mfa", "authenticated").
@@ -38,6 +38,6 @@ principal_transition("locked",        "unlock",         "unverified").
 
 principal_step(From, Ev, To) :- principal_transition(From, Ev, To).
 
-principal_fired(U, From, Ev, To) :-
-    principal_event(U, Ev, From, To),
+principal_fired(EventId, U, From, Ev, To) :-
+    principal_event(EventId, U, Ev, From, To),
     principal_transition(From, Ev, To).

--- a/templates/access/fsm/session.dl
+++ b/templates/access/fsm/session.dl
@@ -28,8 +28,8 @@
 // `session_transition(` token may appear inside comments.
 
 .decl session_transition(from: symbol, event: symbol, to: symbol)
-.decl session_event(session: symbol, event: symbol, from: symbol, to: symbol)
-.decl session_fired(session: symbol, from: symbol, event: symbol, to: symbol)
+.decl session_event(event_id: int64, session: symbol, event: symbol, from: symbol, to: symbol)
+.decl session_fired(event_id: int64, session: symbol, from: symbol, event: symbol, to: symbol)
 .decl session_step(from: symbol, event: symbol, to: symbol)
 
 session_transition("idle",     "request",       "active").
@@ -47,6 +47,6 @@ session_transition("expiring", "expiry",        "closed").
 session_transition("expiring", "logout",        "closed").
 
 session_step(From, Ev, To) :- session_transition(From, Ev, To).
-session_fired(S, From, Ev, To) :-
-    session_event(S, Ev, From, To),
+session_fired(EventId, S, From, Ev, To) :-
+    session_event(EventId, S, Ev, From, To),
     session_transition(From, Ev, To).

--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -25,6 +25,16 @@ typedef struct
 typedef struct
 {
   const gchar *expected_relation;
+  const gint64 *first_row;
+  const gint64 *second_row;
+  guint ncols;
+  guint first_seen;
+  guint second_seen;
+} RelationPairSnapshotExpect;
+
+typedef struct
+{
+  const gchar *expected_relation;
   const gint64 *expected_row;
   WylDeltaKind expected_kind;
   guint matching;
@@ -88,6 +98,31 @@ relation_snapshot_expect_cb (const gchar *relation, const gint64 *row,
       return;
   }
   expect->seen++;
+}
+
+static void
+relation_pair_snapshot_expect_cb (const gchar *relation, const gint64 *row,
+    guint ncols, gpointer user_data)
+{
+  RelationPairSnapshotExpect *expect = user_data;
+
+  if (g_strcmp0 (relation, expect->expected_relation) != 0)
+    return;
+  if (ncols != expect->ncols)
+    return;
+
+  gboolean matches_first = TRUE;
+  gboolean matches_second = TRUE;
+  for (guint i = 0; i < ncols; i++) {
+    if (row[i] != expect->first_row[i])
+      matches_first = FALSE;
+    if (row[i] != expect->second_row[i])
+      matches_second = FALSE;
+  }
+  if (matches_first)
+    expect->first_seen++;
+  if (matches_second)
+    expect->second_seen++;
 }
 
 static void
@@ -166,6 +201,23 @@ intern4 (WylHandle *handle, const gchar *a, const gchar *b, const gchar *c,
   if (rc != WYRELOG_E_OK)
     return rc;
   return wyl_handle_intern_engine_symbol (handle, d, &row[3]);
+}
+
+static wyrelog_error_t
+intern_event5 (WylHandle *handle, gint64 event_id, const gchar *a,
+    const gchar *b, const gchar *c, const gchar *d, gint64 row[5])
+{
+  row[0] = event_id;
+  wyrelog_error_t rc = wyl_handle_intern_engine_symbol (handle, a, &row[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, b, &row[2]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, c, &row[3]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_intern_engine_symbol (handle, d, &row[4]);
 }
 
 static wyrelog_error_t
@@ -635,12 +687,12 @@ static gint
 check_principal_event_fanout_derives_delta (void)
 {
   g_autoptr (WylHandle) handle = NULL;
-  gint64 event_row[4];
-  gint64 fired_row[4];
+  gint64 event_row[5];
+  gint64 fired_row[5];
   DeltaRowExpect expect = {
     "principal_fired",
     fired_row,
-    4,
+    5,
     WYL_DELTA_INSERT,
     0,
   };
@@ -650,36 +702,40 @@ check_principal_event_fanout_derives_delta (void)
   if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
       != WYRELOG_E_OK)
     return 107;
-  if (intern4 (handle, "delta-principal-user", "login_ok", "unverified",
-          "mfa_required", event_row) != WYRELOG_E_OK)
+  if (intern_event5 (handle, 101, "delta-principal-user", "login_ok",
+          "unverified", "mfa_required", event_row) != WYRELOG_E_OK)
     return 108;
-  if (intern4 (handle, "delta-principal-user", "unverified", "login_ok",
-          "mfa_required", fired_row) != WYRELOG_E_OK)
+  if (intern_event5 (handle, 101, "delta-principal-user", "unverified",
+          "login_ok", "mfa_required", fired_row) != WYRELOG_E_OK)
     return 109;
   if (wyl_handle_engine_set_delta_callback (handle, delta_row_expect_cb,
           &expect) != WYRELOG_E_OK)
     return 117;
-  if (wyl_handle_engine_insert (handle, "principal_event", event_row, 4)
+  if (wyl_handle_engine_insert (handle, "principal_event", event_row, 5)
       != WYRELOG_E_OK)
     return 118;
   if (expect.matching != 1)
     return 119;
-  if (wyl_handle_engine_insert (handle, "principal_event", event_row, 4)
-      != WYRELOG_E_OK)
+  if (intern_event5 (handle, 102, "delta-principal-user", "login_ok",
+          "unverified", "mfa_required", event_row) != WYRELOG_E_OK)
     return 150;
-  return expect.matching == 1 ? 0 : 151;
+  fired_row[0] = 102;
+  if (wyl_handle_engine_insert (handle, "principal_event", event_row, 5)
+      != WYRELOG_E_OK)
+    return 151;
+  return expect.matching == 2 ? 0 : 152;
 }
 
 static gint
 check_session_event_fanout_derives_delta (void)
 {
   g_autoptr (WylHandle) handle = NULL;
-  gint64 event_row[4];
-  gint64 fired_row[4];
+  gint64 event_row[5];
+  gint64 fired_row[5];
   DeltaRowExpect expect = {
     "session_fired",
     fired_row,
-    4,
+    5,
     WYL_DELTA_INSERT,
     0,
   };
@@ -689,31 +745,40 @@ check_session_event_fanout_derives_delta (void)
   if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
       != WYRELOG_E_OK)
     return 126;
-  if (intern4 (handle, "delta-session", "elevate_grant", "active",
+  if (intern_event5 (handle, 201, "delta-session", "elevate_grant", "active",
           "elevated", event_row) != WYRELOG_E_OK)
     return 127;
-  if (intern4 (handle, "delta-session", "active", "elevate_grant",
+  if (intern_event5 (handle, 201, "delta-session", "active", "elevate_grant",
           "elevated", fired_row) != WYRELOG_E_OK)
     return 128;
   if (wyl_handle_engine_set_delta_callback (handle, delta_row_expect_cb,
           &expect) != WYRELOG_E_OK)
     return 129;
-  if (wyl_handle_engine_insert (handle, "session_event", event_row, 4)
+  if (wyl_handle_engine_insert (handle, "session_event", event_row, 5)
       != WYRELOG_E_OK)
     return 135;
-  return expect.matching == 1 ? 0 : 136;
+  if (expect.matching != 1)
+    return 136;
+  if (intern_event5 (handle, 202, "delta-session", "elevate_grant", "active",
+          "elevated", event_row) != WYRELOG_E_OK)
+    return 153;
+  fired_row[0] = 202;
+  if (wyl_handle_engine_insert (handle, "session_event", event_row, 5)
+      != WYRELOG_E_OK)
+    return 154;
+  return expect.matching == 2 ? 0 : 155;
 }
 
 static gint
 check_delta_callback_survives_reload (void)
 {
   g_autoptr (WylHandle) handle = NULL;
-  gint64 live_event_row[4];
-  gint64 fired_row[4];
+  gint64 live_event_row[5];
+  gint64 fired_row[5];
   DeltaRowExpect expect = {
     "session_fired",
     fired_row,
-    4,
+    5,
     WYL_DELTA_INSERT,
     0,
   };
@@ -725,13 +790,13 @@ check_delta_callback_survives_reload (void)
     return 138;
   wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
   if (wyl_policy_store_append_session_event (store, "delta-replay-session",
-          "elevate_grant", "active", "elevated") != WYRELOG_E_OK)
+          "elevate_grant", "active", "elevated", NULL) != WYRELOG_E_OK)
     return 139;
-  if (intern4 (handle, "delta-reload-session", "idle_timeout", "active",
-          "idle", live_event_row) != WYRELOG_E_OK)
+  if (intern_event5 (handle, 301, "delta-reload-session", "idle_timeout",
+          "active", "idle", live_event_row) != WYRELOG_E_OK)
     return 146;
-  if (intern4 (handle, "delta-reload-session", "active", "idle_timeout",
-          "idle", fired_row) != WYRELOG_E_OK)
+  if (intern_event5 (handle, 301, "delta-reload-session", "active",
+          "idle_timeout", "idle", fired_row) != WYRELOG_E_OK)
     return 146;
   if (wyl_handle_engine_set_delta_callback (handle, delta_row_expect_cb,
           &expect) != WYRELOG_E_OK)
@@ -740,7 +805,7 @@ check_delta_callback_survives_reload (void)
     return 148;
   if (expect.matching != 0)
     return 152;
-  if (wyl_handle_engine_insert (handle, "session_event", live_event_row, 4)
+  if (wyl_handle_engine_insert (handle, "session_event", live_event_row, 5)
       != WYRELOG_E_OK)
     return 149;
   return expect.matching == 1 ? 0 : 156;
@@ -1400,21 +1465,23 @@ check_policy_store_principal_events_autoload_on_open (void)
     return 390;
 
   wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  gint64 event_id = -1;
   if (wyl_policy_store_append_principal_event (store, "event-load-user",
-          "login_ok", "unverified", "mfa_required") != WYRELOG_E_OK)
+          "login_ok", "unverified", "mfa_required", &event_id)
+      != WYRELOG_E_OK)
     return 391;
   if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
       != WYRELOG_E_OK)
     return 392;
 
-  gint64 fired_row[4];
-  if (intern4 (handle, "event-load-user", "unverified", "login_ok",
-          "mfa_required", fired_row) != WYRELOG_E_OK)
+  gint64 fired_row[5];
+  if (intern_event5 (handle, event_id, "event-load-user", "unverified",
+          "login_ok", "mfa_required", fired_row) != WYRELOG_E_OK)
     return 393;
   RelationSnapshotExpect fired_expect = {
     .expected_relation = "principal_fired",
     .expected_row = fired_row,
-    .ncols = 4,
+    .ncols = 5,
   };
   if (wyl_engine_snapshot (wyl_handle_get_read_engine (handle),
           "principal_fired", relation_snapshot_expect_cb, &fired_expect)
@@ -1435,11 +1502,61 @@ check_policy_store_principal_events_reject_invalid_edges (void)
 
   wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
   if (wyl_policy_store_append_principal_event (store, "event-invalid-user",
-          "mfa_ok", "unverified", "authenticated") != WYRELOG_E_OK)
+          "mfa_ok", "unverified", "authenticated", NULL) != WYRELOG_E_OK)
     return 401;
   if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
       != WYRELOG_E_POLICY)
     return 402;
+  return 0;
+}
+
+static gint
+check_policy_store_principal_event_duplicates_autoload_on_open (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 446;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  gint64 first_event_id = -1;
+  gint64 second_event_id = -1;
+  if (wyl_policy_store_append_principal_event (store, "event-dup-user",
+          "login_ok", "unverified", "mfa_required", &first_event_id)
+      != WYRELOG_E_OK)
+    return 447;
+  if (wyl_policy_store_append_principal_event (store, "event-dup-user",
+          "login_ok", "unverified", "mfa_required", &second_event_id)
+      != WYRELOG_E_OK)
+    return 448;
+  if (second_event_id <= first_event_id)
+    return 449;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 450;
+
+  gint64 first_fired[5];
+  if (intern_event5 (handle, first_event_id, "event-dup-user", "unverified",
+          "login_ok", "mfa_required", first_fired) != WYRELOG_E_OK)
+    return 451;
+  gint64 second_fired[5];
+  if (intern_event5 (handle, second_event_id, "event-dup-user", "unverified",
+          "login_ok", "mfa_required", second_fired) != WYRELOG_E_OK)
+    return 452;
+  RelationPairSnapshotExpect fired_expect = {
+    .expected_relation = "principal_fired",
+    .first_row = first_fired,
+    .second_row = second_fired,
+    .ncols = 5,
+  };
+  if (wyl_engine_snapshot (wyl_handle_get_read_engine (handle),
+          "principal_fired", relation_pair_snapshot_expect_cb, &fired_expect)
+      != WYRELOG_E_OK)
+    return 453;
+  if (fired_expect.first_seen != 1)
+    return 454;
+  if (fired_expect.second_seen != 1)
+    return 455;
   return 0;
 }
 
@@ -1529,21 +1646,22 @@ check_policy_store_session_events_autoload_on_open (void)
     return 420;
 
   wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  gint64 event_id = -1;
   if (wyl_policy_store_append_session_event (store, "session-event-load",
-          "elevate_grant", "active", "elevated") != WYRELOG_E_OK)
+          "elevate_grant", "active", "elevated", &event_id) != WYRELOG_E_OK)
     return 421;
   if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
       != WYRELOG_E_OK)
     return 422;
 
-  gint64 fired_row[4];
-  if (intern4 (handle, "session-event-load", "active", "elevate_grant",
-          "elevated", fired_row) != WYRELOG_E_OK)
+  gint64 fired_row[5];
+  if (intern_event5 (handle, event_id, "session-event-load", "active",
+          "elevate_grant", "elevated", fired_row) != WYRELOG_E_OK)
     return 423;
   RelationSnapshotExpect fired_expect = {
     .expected_relation = "session_fired",
     .expected_row = fired_row,
-    .ncols = 4,
+    .ncols = 5,
   };
   if (wyl_engine_snapshot (wyl_handle_get_read_engine (handle),
           "session_fired", relation_snapshot_expect_cb, &fired_expect)
@@ -1564,11 +1682,61 @@ check_policy_store_session_events_reject_invalid_edges (void)
 
   wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
   if (wyl_policy_store_append_session_event (store, "session-event-invalid",
-          "request", "expiring", "active") != WYRELOG_E_OK)
+          "request", "expiring", "active", NULL) != WYRELOG_E_OK)
     return 431;
   if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
       != WYRELOG_E_POLICY)
     return 432;
+  return 0;
+}
+
+static gint
+check_policy_store_session_event_duplicates_autoload_on_open (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 457;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  gint64 first_event_id = -1;
+  gint64 second_event_id = -1;
+  if (wyl_policy_store_append_session_event (store, "session-event-dup",
+          "elevate_grant", "active", "elevated", &first_event_id)
+      != WYRELOG_E_OK)
+    return 458;
+  if (wyl_policy_store_append_session_event (store, "session-event-dup",
+          "elevate_grant", "active", "elevated", &second_event_id)
+      != WYRELOG_E_OK)
+    return 459;
+  if (second_event_id <= first_event_id)
+    return 460;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 461;
+
+  gint64 first_fired[5];
+  if (intern_event5 (handle, first_event_id, "session-event-dup", "active",
+          "elevate_grant", "elevated", first_fired) != WYRELOG_E_OK)
+    return 462;
+  gint64 second_fired[5];
+  if (intern_event5 (handle, second_event_id, "session-event-dup", "active",
+          "elevate_grant", "elevated", second_fired) != WYRELOG_E_OK)
+    return 463;
+  RelationPairSnapshotExpect fired_expect = {
+    .expected_relation = "session_fired",
+    .first_row = first_fired,
+    .second_row = second_fired,
+    .ncols = 5,
+  };
+  if (wyl_engine_snapshot (wyl_handle_get_read_engine (handle),
+          "session_fired", relation_pair_snapshot_expect_cb, &fired_expect)
+      != WYRELOG_E_OK)
+    return 464;
+  if (fired_expect.first_seen != 1)
+    return 465;
+  if (fired_expect.second_seen != 1)
+    return 466;
   return 0;
 }
 
@@ -1587,7 +1755,7 @@ check_policy_store_session_events_reload_failure_preserves_pair (void)
 
   wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
   if (wyl_policy_store_append_session_event (store, "session-event-invalid",
-          "request", "expiring", "active") != WYRELOG_E_OK)
+          "request", "expiring", "active", NULL) != WYRELOG_E_OK)
     return 435;
   if (wyl_handle_reload_engine_pair (handle) != WYRELOG_E_POLICY)
     return 436;
@@ -1698,6 +1866,9 @@ main (void)
     return rc;
   if ((rc = check_policy_store_principal_events_autoload_on_open ()) != 0)
     return rc;
+  if ((rc = check_policy_store_principal_event_duplicates_autoload_on_open ())
+      != 0)
+    return rc;
   if ((rc = check_policy_store_principal_events_reject_invalid_edges ()) != 0)
     return rc;
   if ((rc = check_policy_store_principal_events_require_engine_pair ()) != 0)
@@ -1707,6 +1878,9 @@ main (void)
   if ((rc = check_policy_store_session_states_require_engine_pair ()) != 0)
     return rc;
   if ((rc = check_policy_store_session_events_autoload_on_open ()) != 0)
+    return rc;
+  if ((rc = check_policy_store_session_event_duplicates_autoload_on_open ())
+      != 0)
     return rc;
   if ((rc = check_policy_store_session_events_reject_invalid_edges ()) != 0)
     return rc;

--- a/tests/test-policy-store.c
+++ b/tests/test-policy-store.c
@@ -184,6 +184,7 @@ typedef struct
 
 typedef struct
 {
+  gint64 event_id;
   const gchar *subject_id;
   const gchar *event;
   const gchar *from_state;
@@ -204,12 +205,14 @@ principal_state_expect_cb (const gchar *subject_id, const gchar *state,
 }
 
 static wyrelog_error_t
-principal_event_expect_cb (const gchar *subject_id, const gchar *event,
-    const gchar *from_state, const gchar *to_state, gpointer user_data)
+principal_event_expect_cb (gint64 event_id, const gchar *subject_id,
+    const gchar *event, const gchar *from_state, const gchar *to_state,
+    gpointer user_data)
 {
   PrincipalEventExpect *expect = user_data;
 
-  if (g_strcmp0 (subject_id, expect->subject_id) == 0
+  if ((expect->event_id <= 0 || event_id == expect->event_id)
+      && g_strcmp0 (subject_id, expect->subject_id) == 0
       && g_strcmp0 (event, expect->event) == 0
       && g_strcmp0 (from_state, expect->from_state) == 0
       && g_strcmp0 (to_state, expect->to_state) == 0)
@@ -226,6 +229,7 @@ typedef struct
 
 typedef struct
 {
+  gint64 event_id;
   const gchar *session_id;
   const gchar *event;
   const gchar *from_state;
@@ -246,12 +250,14 @@ session_state_expect_cb (const gchar *session_id, const gchar *state,
 }
 
 static wyrelog_error_t
-session_event_expect_cb (const gchar *session_id, const gchar *event,
-    const gchar *from_state, const gchar *to_state, gpointer user_data)
+session_event_expect_cb (gint64 event_id, const gchar *session_id,
+    const gchar *event, const gchar *from_state, const gchar *to_state,
+    gpointer user_data)
 {
   SessionEventExpect *expect = user_data;
 
-  if (g_strcmp0 (session_id, expect->session_id) == 0
+  if ((expect->event_id <= 0 || event_id == expect->event_id)
+      && g_strcmp0 (session_id, expect->session_id) == 0
       && g_strcmp0 (event, expect->event) == 0
       && g_strcmp0 (from_state, expect->from_state) == 0
       && g_strcmp0 (to_state, expect->to_state) == 0)
@@ -662,11 +668,14 @@ check_store_appends_principal_event (void)
     return 92;
   if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
     return 93;
+  gint64 event_id = -1;
   if (wyl_policy_store_append_principal_event (store, "principal-user",
-          "login_skip_mfa", "unverified", "authenticated") != WYRELOG_E_OK)
+          "login_skip_mfa", "unverified", "authenticated", &event_id)
+      != WYRELOG_E_OK)
     return 94;
 
   PrincipalEventExpect expect = {
+    .event_id = event_id,
     .subject_id = "principal-user",
     .event = "login_skip_mfa",
     .from_state = "unverified",
@@ -689,11 +698,13 @@ check_store_appends_session_event (void)
     return 97;
   if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
     return 98;
+  gint64 event_id = -1;
   if (wyl_policy_store_append_session_event (store, "session/1",
-          "elevate_grant", "active", "elevated") != WYRELOG_E_OK)
+          "elevate_grant", "active", "elevated", &event_id) != WYRELOG_E_OK)
     return 99;
 
   SessionEventExpect expect = {
+    .event_id = event_id,
     .session_id = "session/1",
     .event = "elevate_grant",
     .from_state = "active",
@@ -704,6 +715,67 @@ check_store_appends_session_event (void)
     return 100;
   if (expect.matches != 1)
     return 101;
+  return 0;
+}
+
+static gint
+check_store_distinguishes_duplicate_events (void)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 102;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 103;
+  gint64 principal_first = -1;
+  gint64 principal_second = -1;
+  if (wyl_policy_store_append_principal_event (store, "principal-dup",
+          "login_ok", "unverified", "mfa_required", &principal_first)
+      != WYRELOG_E_OK)
+    return 104;
+  if (wyl_policy_store_append_principal_event (store, "principal-dup",
+          "login_ok", "unverified", "mfa_required", &principal_second)
+      != WYRELOG_E_OK)
+    return 105;
+  if (principal_first <= 0 || principal_second <= principal_first)
+    return 106;
+
+  PrincipalEventExpect principal_expect = {
+    .subject_id = "principal-dup",
+    .event = "login_ok",
+    .from_state = "unverified",
+    .to_state = "mfa_required",
+  };
+  if (wyl_policy_store_foreach_principal_event (store,
+          principal_event_expect_cb, &principal_expect) != WYRELOG_E_OK)
+    return 107;
+  if (principal_expect.matches != 2)
+    return 108;
+
+  gint64 session_first = -1;
+  gint64 session_second = -1;
+  if (wyl_policy_store_append_session_event (store, "session-dup",
+          "elevate_grant", "active", "elevated", &session_first)
+      != WYRELOG_E_OK)
+    return 109;
+  if (wyl_policy_store_append_session_event (store, "session-dup",
+          "elevate_grant", "active", "elevated", &session_second)
+      != WYRELOG_E_OK)
+    return 110;
+  if (session_first <= 0 || session_second <= session_first)
+    return 111;
+
+  SessionEventExpect session_expect = {
+    .session_id = "session-dup",
+    .event = "elevate_grant",
+    .from_state = "active",
+    .to_state = "elevated",
+  };
+  if (wyl_policy_store_foreach_session_event (store, session_event_expect_cb,
+          &session_expect) != WYRELOG_E_OK)
+    return 112;
+  if (session_expect.matches != 2)
+    return 113;
   return 0;
 }
 
@@ -971,7 +1043,7 @@ check_store_rejects_bad_role_permission (void)
       != WYRELOG_E_INVALID)
     return 57;
   if (wyl_policy_store_append_principal_event (store, NULL, "login_ok",
-          "unverified", "mfa_required") != WYRELOG_E_INVALID)
+          "unverified", "mfa_required", NULL) != WYRELOG_E_INVALID)
     return 92;
   if (wyl_policy_store_foreach_principal_event (store, NULL, NULL)
       != WYRELOG_E_INVALID)
@@ -983,7 +1055,7 @@ check_store_rejects_bad_role_permission (void)
       != WYRELOG_E_INVALID)
     return 59;
   if (wyl_policy_store_append_session_event (store, NULL, "request", "idle",
-          "active") != WYRELOG_E_INVALID)
+          "active", NULL) != WYRELOG_E_INVALID)
     return 60;
   if (wyl_policy_store_foreach_session_event (store, NULL, NULL)
       != WYRELOG_E_INVALID)
@@ -1034,6 +1106,8 @@ main (void)
   if ((rc = check_store_appends_principal_event ()) != 0)
     return rc;
   if ((rc = check_store_appends_session_event ()) != 0)
+    return rc;
+  if ((rc = check_store_distinguishes_duplicate_events ()) != 0)
     return rc;
   if ((rc = check_store_appends_audit_event ()) != 0)
     return rc;

--- a/tests/test-session-username.c
+++ b/tests/test-session-username.c
@@ -59,6 +59,7 @@ typedef struct
 
 typedef struct
 {
+  gint64 event_id;
   const gchar *session_id;
   const gchar *event;
   const gchar *from_state;
@@ -79,16 +80,21 @@ session_state_expect_cb (const gchar *session_id, const gchar *state,
 }
 
 static wyrelog_error_t
-session_event_expect_cb (const gchar *session_id, const gchar *event,
-    const gchar *from_state, const gchar *to_state, gpointer user_data)
+session_event_expect_cb (gint64 event_id, const gchar *session_id,
+    const gchar *event, const gchar *from_state, const gchar *to_state,
+    gpointer user_data)
 {
   SessionEventExpect *expect = user_data;
 
-  if (g_strcmp0 (session_id, expect->session_id) == 0
+  if ((expect->event_id <= 0 || event_id == expect->event_id)
+      && g_strcmp0 (session_id, expect->session_id) == 0
       && g_strcmp0 (event, expect->event) == 0
       && g_strcmp0 (from_state, expect->from_state) == 0
-      && g_strcmp0 (to_state, expect->to_state) == 0)
+      && g_strcmp0 (to_state, expect->to_state) == 0) {
+    if (expect->event_id <= 0)
+      expect->event_id = event_id;
     expect->matches++;
+  }
   return WYRELOG_E_OK;
 }
 
@@ -101,6 +107,7 @@ typedef struct
 
 typedef struct
 {
+  gint64 event_id;
   const gchar *subject_id;
   const gchar *event;
   const gchar *from_state;
@@ -137,16 +144,21 @@ principal_state_expect_cb (const gchar *subject_id, const gchar *state,
 }
 
 static wyrelog_error_t
-principal_event_expect_cb (const gchar *subject_id, const gchar *event,
-    const gchar *from_state, const gchar *to_state, gpointer user_data)
+principal_event_expect_cb (gint64 event_id, const gchar *subject_id,
+    const gchar *event, const gchar *from_state, const gchar *to_state,
+    gpointer user_data)
 {
   PrincipalEventExpect *expect = user_data;
 
-  if (g_strcmp0 (subject_id, expect->subject_id) == 0
+  if ((expect->event_id <= 0 || event_id == expect->event_id)
+      && g_strcmp0 (subject_id, expect->subject_id) == 0
       && g_strcmp0 (event, expect->event) == 0
       && g_strcmp0 (from_state, expect->from_state) == 0
-      && g_strcmp0 (to_state, expect->to_state) == 0)
+      && g_strcmp0 (to_state, expect->to_state) == 0) {
+    if (expect->event_id <= 0)
+      expect->event_id = event_id;
     expect->matches++;
+  }
   return WYRELOG_E_OK;
 }
 
@@ -156,10 +168,11 @@ principal_event_fact_expect_cb (const gchar *relation, const gint64 *row,
 {
   PrincipalEventFactExpect *expect = user_data;
 
-  if (g_strcmp0 (relation, expect->relation) != 0 || ncols != 4)
+  if (g_strcmp0 (relation, expect->relation) != 0 || ncols != 5)
     return;
   if (row[0] == expect->row[0] && row[1] == expect->row[1]
-      && row[2] == expect->row[2] && row[3] == expect->row[3])
+      && row[2] == expect->row[2] && row[3] == expect->row[3]
+      && row[4] == expect->row[4])
     expect->matches++;
 }
 
@@ -187,50 +200,52 @@ delta_relation_count_cb (const gchar *relation, const gint64 *row,
 
   (void) row;
 
-  if (g_strcmp0 (relation, "session_fired") == 0 && ncols == 4
+  if (g_strcmp0 (relation, "session_fired") == 0 && ncols == 5
       && kind == WYL_DELTA_INSERT)
     (*matches)++;
 }
 
 static wyrelog_error_t
-intern_principal_fired_row (WylHandle *handle, const gchar *subject_id,
-    const gchar *from_state, const gchar *event, const gchar *to_state,
-    gint64 row[4])
+intern_principal_fired_row (WylHandle *handle, gint64 event_id,
+    const gchar *subject_id, const gchar *from_state, const gchar *event,
+    const gchar *to_state, gint64 row[5])
 {
+  row[0] = event_id;
   wyrelog_error_t rc =
-      wyl_handle_intern_engine_symbol (handle, subject_id, &row[0]);
+      wyl_handle_intern_engine_symbol (handle, subject_id, &row[1]);
   if (rc != WYRELOG_E_OK)
     return rc;
-  rc = wyl_handle_intern_engine_symbol (handle, from_state, &row[1]);
+  rc = wyl_handle_intern_engine_symbol (handle, from_state, &row[2]);
   if (rc != WYRELOG_E_OK)
     return rc;
-  rc = wyl_handle_intern_engine_symbol (handle, event, &row[2]);
+  rc = wyl_handle_intern_engine_symbol (handle, event, &row[3]);
   if (rc != WYRELOG_E_OK)
     return rc;
-  return wyl_handle_intern_engine_symbol (handle, to_state, &row[3]);
+  return wyl_handle_intern_engine_symbol (handle, to_state, &row[4]);
 }
 
 static wyrelog_error_t
-intern_session_fired_row (WylHandle *handle, const gchar *session_id,
-    const gchar *from_state, const gchar *event, const gchar *to_state,
-    gint64 row[4])
+intern_session_fired_row (WylHandle *handle, gint64 event_id,
+    const gchar *session_id, const gchar *from_state, const gchar *event,
+    const gchar *to_state, gint64 row[5])
 {
+  row[0] = event_id;
   wyrelog_error_t rc =
-      wyl_handle_intern_engine_symbol (handle, session_id, &row[0]);
+      wyl_handle_intern_engine_symbol (handle, session_id, &row[1]);
   if (rc != WYRELOG_E_OK)
     return rc;
-  rc = wyl_handle_intern_engine_symbol (handle, from_state, &row[1]);
+  rc = wyl_handle_intern_engine_symbol (handle, from_state, &row[2]);
   if (rc != WYRELOG_E_OK)
     return rc;
-  rc = wyl_handle_intern_engine_symbol (handle, event, &row[2]);
+  rc = wyl_handle_intern_engine_symbol (handle, event, &row[3]);
   if (rc != WYRELOG_E_OK)
     return rc;
-  return wyl_handle_intern_engine_symbol (handle, to_state, &row[3]);
+  return wyl_handle_intern_engine_symbol (handle, to_state, &row[4]);
 }
 
 static wyrelog_error_t
 count_principal_event_fact (WylHandle *handle, const gchar *relation,
-    const gint64 row[4], guint *out_matches)
+    const gint64 row[5], guint *out_matches)
 {
   PrincipalEventFactExpect expect = { relation, row, 0 };
 
@@ -259,9 +274,9 @@ expect_session_transition (WylHandle *handle, const gchar *session_id,
   if (event_expect.matches != 1)
     return base_code + 1;
 
-  gint64 row[4];
-  if (intern_session_fired_row (handle, session_id, from_state, event,
-          to_state, row) != WYRELOG_E_OK)
+  gint64 row[5];
+  if (intern_session_fired_row (handle, event_expect.event_id, session_id,
+          from_state, event, to_state, row) != WYRELOG_E_OK)
     return base_code + 2;
   guint matches = 0;
   if (count_principal_event_fact (handle, "session_fired", row, &matches)
@@ -272,8 +287,8 @@ expect_session_transition (WylHandle *handle, const gchar *session_id,
 
   if (wyl_handle_reload_engine_pair (handle) != WYRELOG_E_OK)
     return base_code + 5;
-  if (intern_session_fired_row (handle, session_id, from_state, event,
-          to_state, row) != WYRELOG_E_OK)
+  if (intern_session_fired_row (handle, event_expect.event_id, session_id,
+          from_state, event, to_state, row) != WYRELOG_E_OK)
     return base_code + 6;
   matches = 0;
   if (count_principal_event_fact (handle, "session_fired", row, &matches)
@@ -476,14 +491,14 @@ check_mfa_delta_callback_survives_state_reload (void)
   if (wyl_session_login (handle, login, &session) != WYRELOG_E_OK)
     return 92;
 
-  gint64 row[4];
-  if (intern_principal_fired_row (handle, "mfa-delta-user", "mfa_required",
-          "mfa_ok", "authenticated", row) != WYRELOG_E_OK)
+  gint64 row[5];
+  if (intern_principal_fired_row (handle, 2, "mfa-delta-user",
+          "mfa_required", "mfa_ok", "authenticated", row) != WYRELOG_E_OK)
     return 93;
   DeltaFactExpect expect = {
     .relation = "principal_fired",
     .row = row,
-    .ncols = 4,
+    .ncols = 5,
     .kind = WYL_DELTA_INSERT,
   };
   if (wyl_handle_engine_set_delta_callback (handle, delta_fact_expect_cb,
@@ -621,14 +636,14 @@ check_login_delta_callback_survives_state_reload (void)
   if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
     return 141;
 
-  gint64 row[4];
-  if (intern_principal_fired_row (handle, "login-delta-user", "unverified",
-          "login_ok", "mfa_required", row) != WYRELOG_E_OK)
+  gint64 row[5];
+  if (intern_principal_fired_row (handle, 1, "login-delta-user",
+          "unverified", "login_ok", "mfa_required", row) != WYRELOG_E_OK)
     return 142;
   DeltaFactExpect principal_expect = {
     .relation = "principal_fired",
     .row = row,
-    .ncols = 4,
+    .ncols = 5,
     .kind = WYL_DELTA_INSERT,
   };
   if (wyl_handle_engine_set_delta_callback (handle, delta_fact_expect_cb,
@@ -790,8 +805,8 @@ check_login_skip_mfa_inserts_wirelog_principal_fired (void)
   if (wyl_session_login (handle, login, &session) != WYRELOG_E_OK)
     return 163;
 
-  gint64 row[4];
-  if (intern_principal_fired_row (handle, "skip-mfa-fired-user",
+  gint64 row[5];
+  if (intern_principal_fired_row (handle, 1, "skip-mfa-fired-user",
           "unverified", "login_skip_mfa", "authenticated", row)
       != WYRELOG_E_OK)
     return 164;
@@ -804,7 +819,7 @@ check_login_skip_mfa_inserts_wirelog_principal_fired (void)
 
   if (wyl_handle_reload_engine_pair (handle) != WYRELOG_E_OK)
     return 167;
-  if (intern_principal_fired_row (handle, "skip-mfa-fired-user",
+  if (intern_principal_fired_row (handle, 1, "skip-mfa-fired-user",
           "unverified", "login_skip_mfa", "authenticated", row)
       != WYRELOG_E_OK)
     return 168;

--- a/wyrelog/daemon/delta.c
+++ b/wyrelog/daemon/delta.c
@@ -33,19 +33,19 @@ emit_wirelog_effective_member_audit (WylDaemonRuntime *runtime,
 
 static void
 emit_wirelog_fsm_fired_audit (WylDaemonRuntime *runtime, const gchar *relation,
-    const gint64 row[4], WylDeltaKind kind)
+    const gint64 row[5], WylDeltaKind kind)
 {
   if (runtime == NULL || runtime->handle == NULL)
     return;
 
   g_autofree gchar *entity =
-      wyl_handle_dup_engine_symbol (runtime->handle, row[0]);
-  g_autofree gchar *from_state =
       wyl_handle_dup_engine_symbol (runtime->handle, row[1]);
-  g_autofree gchar *event =
+  g_autofree gchar *from_state =
       wyl_handle_dup_engine_symbol (runtime->handle, row[2]);
-  g_autofree gchar *to_state =
+  g_autofree gchar *event =
       wyl_handle_dup_engine_symbol (runtime->handle, row[3]);
+  g_autofree gchar *to_state =
+      wyl_handle_dup_engine_symbol (runtime->handle, row[4]);
   if (entity == NULL || from_state == NULL || event == NULL || to_state == NULL)
     return;
 
@@ -178,7 +178,7 @@ daemon_delta_cb (const gchar *relation, const gint64 *row, guint ncols,
 fsm_relations:
   if ((g_strcmp0 (relation, "principal_fired") != 0
           && g_strcmp0 (relation, "session_fired") != 0)
-      || (kind != WYL_DELTA_INSERT && kind != WYL_DELTA_REMOVE) || ncols != 4)
+      || (kind != WYL_DELTA_INSERT && kind != WYL_DELTA_REMOVE) || ncols != 5)
     return;
 
 #ifdef WYL_HAS_AUDIT
@@ -190,7 +190,8 @@ fsm_relations:
       && row[0] == runtime->expected_principal_fired[0]
       && row[1] == runtime->expected_principal_fired[1]
       && row[2] == runtime->expected_principal_fired[2]
-      && row[3] == runtime->expected_principal_fired[3]) {
+      && row[3] == runtime->expected_principal_fired[3]
+      && row[4] == runtime->expected_principal_fired[4]) {
     if (kind == WYL_DELTA_INSERT)
       runtime->matched_principal_fired_insert = TRUE;
     else if (kind == WYL_DELTA_REMOVE)
@@ -201,7 +202,8 @@ fsm_relations:
       && row[0] == runtime->expected_session_fired[0]
       && row[1] == runtime->expected_session_fired[1]
       && row[2] == runtime->expected_session_fired[2]
-      && row[3] == runtime->expected_session_fired[3]) {
+      && row[3] == runtime->expected_session_fired[3]
+      && row[4] == runtime->expected_session_fired[4]) {
     if (kind == WYL_DELTA_INSERT)
       runtime->matched_session_fired_insert = TRUE;
     else if (kind == WYL_DELTA_REMOVE)
@@ -239,36 +241,38 @@ wyl_daemon_check_delta_ready (WylHandle *handle)
       &runtime.expected_row[2]);
   if (rc != WYRELOG_E_OK)
     return rc;
+  runtime.expected_principal_fired[0] = 1;
   rc = wyl_handle_intern_engine_symbol (handle, "wyrelogd-principal-user",
-      &runtime.expected_principal_fired[0]);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  rc = wyl_handle_intern_engine_symbol (handle, "unverified",
       &runtime.expected_principal_fired[1]);
   if (rc != WYRELOG_E_OK)
     return rc;
-  rc = wyl_handle_intern_engine_symbol (handle, "login_ok",
+  rc = wyl_handle_intern_engine_symbol (handle, "unverified",
       &runtime.expected_principal_fired[2]);
   if (rc != WYRELOG_E_OK)
     return rc;
-  rc = wyl_handle_intern_engine_symbol (handle, "mfa_required",
+  rc = wyl_handle_intern_engine_symbol (handle, "login_ok",
       &runtime.expected_principal_fired[3]);
   if (rc != WYRELOG_E_OK)
     return rc;
-  rc = wyl_handle_intern_engine_symbol (handle, "wyrelogd-session",
-      &runtime.expected_session_fired[0]);
+  rc = wyl_handle_intern_engine_symbol (handle, "mfa_required",
+      &runtime.expected_principal_fired[4]);
   if (rc != WYRELOG_E_OK)
     return rc;
-  rc = wyl_handle_intern_engine_symbol (handle, "active",
+  runtime.expected_session_fired[0] = 2;
+  rc = wyl_handle_intern_engine_symbol (handle, "wyrelogd-session",
       &runtime.expected_session_fired[1]);
   if (rc != WYRELOG_E_OK)
     return rc;
-  rc = wyl_handle_intern_engine_symbol (handle, "elevate_grant",
+  rc = wyl_handle_intern_engine_symbol (handle, "active",
       &runtime.expected_session_fired[2]);
   if (rc != WYRELOG_E_OK)
     return rc;
-  rc = wyl_handle_intern_engine_symbol (handle, "elevated",
+  rc = wyl_handle_intern_engine_symbol (handle, "elevate_grant",
       &runtime.expected_session_fired[3]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, "elevated",
+      &runtime.expected_session_fired[4]);
   if (rc != WYRELOG_E_OK)
     return rc;
 
@@ -276,17 +280,19 @@ wyl_daemon_check_delta_ready (WylHandle *handle)
   if (rc != WYRELOG_E_OK)
     return rc;
 
-  gint64 principal_event[4] = {
+  gint64 principal_event[5] = {
     runtime.expected_principal_fired[0],
-    runtime.expected_principal_fired[2],
     runtime.expected_principal_fired[1],
     runtime.expected_principal_fired[3],
+    runtime.expected_principal_fired[2],
+    runtime.expected_principal_fired[4],
   };
-  gint64 session_event[4] = {
+  gint64 session_event[5] = {
     runtime.expected_session_fired[0],
-    runtime.expected_session_fired[2],
     runtime.expected_session_fired[1],
     runtime.expected_session_fired[3],
+    runtime.expected_session_fired[2],
+    runtime.expected_session_fired[4],
   };
 
   rc = wyl_handle_engine_insert (handle, "member_of", runtime.expected_row, 3);
@@ -297,7 +303,7 @@ wyl_daemon_check_delta_ready (WylHandle *handle)
     goto cleanup;
   }
 
-  rc = wyl_handle_engine_insert (handle, "principal_event", principal_event, 4);
+  rc = wyl_handle_engine_insert (handle, "principal_event", principal_event, 5);
   if (rc != WYRELOG_E_OK)
     goto cleanup;
   if (!runtime.matched_principal_fired_insert) {
@@ -305,7 +311,7 @@ wyl_daemon_check_delta_ready (WylHandle *handle)
     goto cleanup;
   }
 
-  rc = wyl_handle_engine_insert (handle, "session_event", session_event, 4);
+  rc = wyl_handle_engine_insert (handle, "session_event", session_event, 5);
   if (rc != WYRELOG_E_OK)
     goto cleanup;
   if (!runtime.matched_session_fired_insert) {
@@ -313,7 +319,7 @@ wyl_daemon_check_delta_ready (WylHandle *handle)
     goto cleanup;
   }
 
-  rc = wyl_handle_engine_remove (handle, "principal_event", principal_event, 4);
+  rc = wyl_handle_engine_remove (handle, "principal_event", principal_event, 5);
   if (rc != WYRELOG_E_OK)
     goto cleanup;
   if (!runtime.matched_principal_fired_remove) {
@@ -321,7 +327,7 @@ wyl_daemon_check_delta_ready (WylHandle *handle)
     goto cleanup;
   }
 
-  rc = wyl_handle_engine_remove (handle, "session_event", session_event, 4);
+  rc = wyl_handle_engine_remove (handle, "session_event", session_event, 5);
   if (rc != WYRELOG_E_OK)
     goto cleanup;
   if (!runtime.matched_session_fired_remove) {

--- a/wyrelog/daemon/delta.h
+++ b/wyrelog/daemon/delta.h
@@ -14,8 +14,8 @@ typedef struct
   gboolean matched_expected_remove;
   gboolean expect_principal_fired;
   gboolean expect_session_fired;
-  gint64 expected_principal_fired[4];
-  gint64 expected_session_fired[4];
+  gint64 expected_principal_fired[5];
+  gint64 expected_session_fired[5];
   gboolean matched_principal_fired_insert;
   gboolean matched_session_fired_insert;
   gboolean matched_principal_fired_remove;

--- a/wyrelog/policy/store-private.h
+++ b/wyrelog/policy/store-private.h
@@ -27,14 +27,14 @@ typedef wyrelog_error_t (*wyl_policy_direct_permission_event_cb) (const gchar *
     const gchar * operation, gpointer user_data);
 typedef wyrelog_error_t (*wyl_policy_principal_state_cb) (const gchar *
     subject_id, const gchar * state, gpointer user_data);
-typedef wyrelog_error_t (*wyl_policy_principal_event_cb) (const gchar *
-    subject_id, const gchar * event, const gchar * from_state,
-    const gchar * to_state, gpointer user_data);
+typedef wyrelog_error_t (*wyl_policy_principal_event_cb) (gint64 event_id,
+    const gchar * subject_id, const gchar * event,
+    const gchar * from_state, const gchar * to_state, gpointer user_data);
 typedef wyrelog_error_t (*wyl_policy_session_state_cb) (const gchar *
     session_id, const gchar * state, gpointer user_data);
-typedef wyrelog_error_t (*wyl_policy_session_event_cb) (const gchar *
-    session_id, const gchar * event, const gchar * from_state,
-    const gchar * to_state, gpointer user_data);
+typedef wyrelog_error_t (*wyl_policy_session_event_cb) (gint64 event_id,
+    const gchar * session_id, const gchar * event,
+    const gchar * from_state, const gchar * to_state, gpointer user_data);
 typedef wyrelog_error_t (*wyl_policy_audit_event_cb) (const gchar * id,
     gint64 created_at_us, const gchar * subject_id, const gchar * action,
     const gchar * resource_id, const gchar * deny_reason,
@@ -112,7 +112,7 @@ wyrelog_error_t wyl_policy_store_foreach_principal_state (wyl_policy_store_t *
     store, wyl_policy_principal_state_cb cb, gpointer user_data);
 wyrelog_error_t wyl_policy_store_append_principal_event (wyl_policy_store_t *
     store, const gchar * subject_id, const gchar * event,
-    const gchar * from_state, const gchar * to_state);
+    const gchar * from_state, const gchar * to_state, gint64 * out_event_id);
 wyrelog_error_t wyl_policy_store_foreach_principal_event (wyl_policy_store_t *
     store, wyl_policy_principal_event_cb cb, gpointer user_data);
 wyrelog_error_t wyl_policy_store_set_session_state (wyl_policy_store_t * store,
@@ -121,7 +121,7 @@ wyrelog_error_t wyl_policy_store_foreach_session_state (wyl_policy_store_t *
     store, wyl_policy_session_state_cb cb, gpointer user_data);
 wyrelog_error_t wyl_policy_store_append_session_event (wyl_policy_store_t *
     store, const gchar * session_id, const gchar * event,
-    const gchar * from_state, const gchar * to_state);
+    const gchar * from_state, const gchar * to_state, gint64 * out_event_id);
 wyrelog_error_t wyl_policy_store_foreach_session_event (wyl_policy_store_t *
     store, wyl_policy_session_event_cb cb, gpointer user_data);
 wyrelog_error_t wyl_policy_store_append_audit_event (wyl_policy_store_t *

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -586,7 +586,7 @@ wyl_policy_store_foreach_principal_state (wyl_policy_store_t *store,
 wyrelog_error_t
 wyl_policy_store_append_principal_event (wyl_policy_store_t *store,
     const gchar *subject_id, const gchar *event, const gchar *from_state,
-    const gchar *to_state)
+    const gchar *to_state, gint64 *out_event_id)
 {
   sqlite3_stmt *stmt = NULL;
 
@@ -611,7 +611,15 @@ wyl_policy_store_append_principal_event (wyl_policy_store_t *store,
 
   int step_rc = sqlite3_step (stmt);
   sqlite3_finalize (stmt);
-  return (step_rc == SQLITE_DONE) ? WYRELOG_E_OK : WYRELOG_E_IO;
+  if (step_rc != SQLITE_DONE)
+    return WYRELOG_E_IO;
+  if (out_event_id != NULL) {
+    sqlite3_int64 event_id = sqlite3_last_insert_rowid (store->db);
+    if (event_id <= 0)
+      return WYRELOG_E_IO;
+    *out_event_id = event_id;
+  }
+  return WYRELOG_E_OK;
 }
 
 wyrelog_error_t
@@ -624,7 +632,7 @@ wyl_policy_store_foreach_principal_event (wyl_policy_store_t *store,
     return WYRELOG_E_INVALID;
 
   static const gchar *sql =
-      "SELECT subject_id, event, from_state, to_state "
+      "SELECT event_id, subject_id, event, from_state, to_state "
       "FROM principal_events ORDER BY event_id;";
   wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
   if (rc != WYRELOG_E_OK)
@@ -632,11 +640,16 @@ wyl_policy_store_foreach_principal_event (wyl_policy_store_t *store,
 
   int step_rc;
   while ((step_rc = sqlite3_step (stmt)) == SQLITE_ROW) {
-    const gchar *subject_id = (const gchar *) sqlite3_column_text (stmt, 0);
-    const gchar *event = (const gchar *) sqlite3_column_text (stmt, 1);
-    const gchar *from_state = (const gchar *) sqlite3_column_text (stmt, 2);
-    const gchar *to_state = (const gchar *) sqlite3_column_text (stmt, 3);
-    rc = cb (subject_id, event, from_state, to_state, user_data);
+    gint64 event_id = sqlite3_column_int64 (stmt, 0);
+    const gchar *subject_id = (const gchar *) sqlite3_column_text (stmt, 1);
+    const gchar *event = (const gchar *) sqlite3_column_text (stmt, 2);
+    const gchar *from_state = (const gchar *) sqlite3_column_text (stmt, 3);
+    const gchar *to_state = (const gchar *) sqlite3_column_text (stmt, 4);
+    if (event_id <= 0) {
+      sqlite3_finalize (stmt);
+      return WYRELOG_E_POLICY;
+    }
+    rc = cb (event_id, subject_id, event, from_state, to_state, user_data);
     if (rc != WYRELOG_E_OK) {
       sqlite3_finalize (stmt);
       return rc;
@@ -708,7 +721,7 @@ wyl_policy_store_foreach_session_state (wyl_policy_store_t *store,
 wyrelog_error_t
 wyl_policy_store_append_session_event (wyl_policy_store_t *store,
     const gchar *session_id, const gchar *event, const gchar *from_state,
-    const gchar *to_state)
+    const gchar *to_state, gint64 *out_event_id)
 {
   sqlite3_stmt *stmt = NULL;
 
@@ -733,7 +746,15 @@ wyl_policy_store_append_session_event (wyl_policy_store_t *store,
 
   int step_rc = sqlite3_step (stmt);
   sqlite3_finalize (stmt);
-  return (step_rc == SQLITE_DONE) ? WYRELOG_E_OK : WYRELOG_E_IO;
+  if (step_rc != SQLITE_DONE)
+    return WYRELOG_E_IO;
+  if (out_event_id != NULL) {
+    sqlite3_int64 event_id = sqlite3_last_insert_rowid (store->db);
+    if (event_id <= 0)
+      return WYRELOG_E_IO;
+    *out_event_id = event_id;
+  }
+  return WYRELOG_E_OK;
 }
 
 wyrelog_error_t
@@ -746,7 +767,7 @@ wyl_policy_store_foreach_session_event (wyl_policy_store_t *store,
     return WYRELOG_E_INVALID;
 
   static const gchar *sql =
-      "SELECT session_id, event, from_state, to_state "
+      "SELECT event_id, session_id, event, from_state, to_state "
       "FROM session_events ORDER BY event_id;";
   wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
   if (rc != WYRELOG_E_OK)
@@ -754,11 +775,16 @@ wyl_policy_store_foreach_session_event (wyl_policy_store_t *store,
 
   int step_rc;
   while ((step_rc = sqlite3_step (stmt)) == SQLITE_ROW) {
-    const gchar *session_id = (const gchar *) sqlite3_column_text (stmt, 0);
-    const gchar *event = (const gchar *) sqlite3_column_text (stmt, 1);
-    const gchar *from_state = (const gchar *) sqlite3_column_text (stmt, 2);
-    const gchar *to_state = (const gchar *) sqlite3_column_text (stmt, 3);
-    rc = cb (session_id, event, from_state, to_state, user_data);
+    gint64 event_id = sqlite3_column_int64 (stmt, 0);
+    const gchar *session_id = (const gchar *) sqlite3_column_text (stmt, 1);
+    const gchar *event = (const gchar *) sqlite3_column_text (stmt, 2);
+    const gchar *from_state = (const gchar *) sqlite3_column_text (stmt, 3);
+    const gchar *to_state = (const gchar *) sqlite3_column_text (stmt, 4);
+    if (event_id <= 0) {
+      sqlite3_finalize (stmt);
+      return WYRELOG_E_POLICY;
+    }
+    rc = cb (event_id, session_id, event, from_state, to_state, user_data);
     if (rc != WYRELOG_E_OK) {
       sqlite3_finalize (stmt);
       return rc;

--- a/wyrelog/wyl-handle-private.h
+++ b/wyrelog/wyl-handle-private.h
@@ -174,7 +174,7 @@ wyrelog_error_t wyl_handle_load_policy_store_principal_states (WylHandle *
 
 /*
  * Loads principal_event rows from the handle-owned policy authority store into
- * the attached read/delta engine pair as principal_event/4 facts. Rejected
+ * the attached read/delta engine pair as principal_event/5 facts. Rejected
  * unless both the store and engine pair are available.
  */
 wyrelog_error_t wyl_handle_load_policy_store_principal_events (WylHandle *
@@ -189,7 +189,7 @@ wyrelog_error_t wyl_handle_load_policy_store_session_states (WylHandle * self);
 
 /*
  * Loads session_event rows from the handle-owned policy authority store into
- * the attached read/delta engine pair as session_event/4 facts. Rejected
+ * the attached read/delta engine pair as session_event/5 facts. Rejected
  * unless both the store and engine pair are available.
  */
 wyrelog_error_t wyl_handle_load_policy_store_session_events (WylHandle * self);

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -772,12 +772,12 @@ wyl_handle_load_policy_store_principal_states (WylHandle *self)
 }
 
 static wyrelog_error_t
-insert_policy_store_principal_event (const gchar *subject_id,
+insert_policy_store_principal_event (gint64 event_id, const gchar *subject_id,
     const gchar *event, const gchar *from_state, const gchar *to_state,
     gpointer user_data)
 {
   WylHandle *self = user_data;
-  gint64 row[4];
+  gint64 row[5];
   wyl_principal_state_t from = wyl_principal_state_from_name (from_state);
   wyl_principal_event_t ev = wyl_principal_event_from_name (event);
   wyl_principal_state_t to = wyl_principal_state_from_name (to_state);
@@ -792,19 +792,20 @@ insert_policy_store_principal_event (const gchar *subject_id,
   if (validated != to)
     return WYRELOG_E_POLICY;
 
-  rc = wyl_handle_intern_engine_symbol (self, subject_id, &row[0]);
+  row[0] = event_id;
+  rc = wyl_handle_intern_engine_symbol (self, subject_id, &row[1]);
   if (rc != WYRELOG_E_OK)
     return rc;
-  rc = wyl_handle_intern_engine_symbol (self, event, &row[1]);
+  rc = wyl_handle_intern_engine_symbol (self, event, &row[2]);
   if (rc != WYRELOG_E_OK)
     return rc;
-  rc = wyl_handle_intern_engine_symbol (self, from_state, &row[2]);
+  rc = wyl_handle_intern_engine_symbol (self, from_state, &row[3]);
   if (rc != WYRELOG_E_OK)
     return rc;
-  rc = wyl_handle_intern_engine_symbol (self, to_state, &row[3]);
+  rc = wyl_handle_intern_engine_symbol (self, to_state, &row[4]);
   if (rc != WYRELOG_E_OK)
     return rc;
-  return wyl_handle_engine_insert (self, "principal_event", row, 4);
+  return wyl_handle_engine_insert (self, "principal_event", row, 5);
 }
 
 wyrelog_error_t
@@ -851,12 +852,12 @@ wyl_handle_load_policy_store_session_states (WylHandle *self)
 }
 
 static wyrelog_error_t
-insert_policy_store_session_event (const gchar *session_id,
+insert_policy_store_session_event (gint64 event_id, const gchar *session_id,
     const gchar *event, const gchar *from_state, const gchar *to_state,
     gpointer user_data)
 {
   WylHandle *self = user_data;
-  gint64 row[4];
+  gint64 row[5];
   wyl_session_state_t from = wyl_session_state_from_name (from_state);
   wyl_session_event_t ev = wyl_session_event_from_name (event);
   wyl_session_state_t to = wyl_session_state_from_name (to_state);
@@ -871,19 +872,20 @@ insert_policy_store_session_event (const gchar *session_id,
   if (validated != to)
     return WYRELOG_E_POLICY;
 
-  rc = wyl_handle_intern_engine_symbol (self, session_id, &row[0]);
+  row[0] = event_id;
+  rc = wyl_handle_intern_engine_symbol (self, session_id, &row[1]);
   if (rc != WYRELOG_E_OK)
     return rc;
-  rc = wyl_handle_intern_engine_symbol (self, event, &row[1]);
+  rc = wyl_handle_intern_engine_symbol (self, event, &row[2]);
   if (rc != WYRELOG_E_OK)
     return rc;
-  rc = wyl_handle_intern_engine_symbol (self, from_state, &row[2]);
+  rc = wyl_handle_intern_engine_symbol (self, from_state, &row[3]);
   if (rc != WYRELOG_E_OK)
     return rc;
-  rc = wyl_handle_intern_engine_symbol (self, to_state, &row[3]);
+  rc = wyl_handle_intern_engine_symbol (self, to_state, &row[4]);
   if (rc != WYRELOG_E_OK)
     return rc;
-  return wyl_handle_engine_insert (self, "session_event", row, 4);
+  return wyl_handle_engine_insert (self, "session_event", row, 5);
 }
 
 wyrelog_error_t

--- a/wyrelog/wyl-session.c
+++ b/wyrelog/wyl-session.c
@@ -149,28 +149,30 @@ store_principal_event (WylHandle *handle, const gchar *username,
   if (validated != new_state)
     return WYRELOG_E_POLICY;
 
+  gint64 event_id = -1;
   wyrelog_error_t rc = wyl_policy_store_append_principal_event (store,
-      username, event_name, old_state_name, new_state_name);
+      username, event_name, old_state_name, new_state_name, &event_id);
   if (rc != WYRELOG_E_OK)
     return rc;
 
   if (wyl_handle_get_read_engine (handle) == NULL)
     return WYRELOG_E_OK;
 
-  gint64 row[4];
-  rc = wyl_handle_intern_engine_symbol (handle, username, &row[0]);
+  gint64 row[5];
+  row[0] = event_id;
+  rc = wyl_handle_intern_engine_symbol (handle, username, &row[1]);
   if (rc != WYRELOG_E_OK)
     return rc;
-  rc = wyl_handle_intern_engine_symbol (handle, event_name, &row[1]);
+  rc = wyl_handle_intern_engine_symbol (handle, event_name, &row[2]);
   if (rc != WYRELOG_E_OK)
     return rc;
-  rc = wyl_handle_intern_engine_symbol (handle, old_state_name, &row[2]);
+  rc = wyl_handle_intern_engine_symbol (handle, old_state_name, &row[3]);
   if (rc != WYRELOG_E_OK)
     return rc;
-  rc = wyl_handle_intern_engine_symbol (handle, new_state_name, &row[3]);
+  rc = wyl_handle_intern_engine_symbol (handle, new_state_name, &row[4]);
   if (rc != WYRELOG_E_OK)
     return rc;
-  return wyl_handle_engine_insert (handle, "principal_event", row, 4);
+  return wyl_handle_engine_insert (handle, "principal_event", row, 5);
 }
 
 static wyrelog_error_t
@@ -329,28 +331,30 @@ store_session_event (WylHandle *handle, const gchar *session_id,
   if (validated != new_state)
     return WYRELOG_E_POLICY;
 
+  gint64 event_id = -1;
   wyrelog_error_t rc = wyl_policy_store_append_session_event (store,
-      session_id, event_name, old_state_name, new_state_name);
+      session_id, event_name, old_state_name, new_state_name, &event_id);
   if (rc != WYRELOG_E_OK)
     return rc;
 
   if (wyl_handle_get_read_engine (handle) == NULL)
     return WYRELOG_E_OK;
 
-  gint64 row[4];
-  rc = wyl_handle_intern_engine_symbol (handle, session_id, &row[0]);
+  gint64 row[5];
+  row[0] = event_id;
+  rc = wyl_handle_intern_engine_symbol (handle, session_id, &row[1]);
   if (rc != WYRELOG_E_OK)
     return rc;
-  rc = wyl_handle_intern_engine_symbol (handle, event_name, &row[1]);
+  rc = wyl_handle_intern_engine_symbol (handle, event_name, &row[2]);
   if (rc != WYRELOG_E_OK)
     return rc;
-  rc = wyl_handle_intern_engine_symbol (handle, old_state_name, &row[2]);
+  rc = wyl_handle_intern_engine_symbol (handle, old_state_name, &row[3]);
   if (rc != WYRELOG_E_OK)
     return rc;
-  rc = wyl_handle_intern_engine_symbol (handle, new_state_name, &row[3]);
+  rc = wyl_handle_intern_engine_symbol (handle, new_state_name, &row[4]);
   if (rc != WYRELOG_E_OK)
     return rc;
-  return wyl_handle_engine_insert (handle, "session_event", row, 4);
+  return wyl_handle_engine_insert (handle, "session_event", row, 5);
 }
 
 #ifdef WYL_HAS_AUDIT


### PR DESCRIPTION
## Summary
- carry policy-store FSM event ids into Wirelog event and fired facts
- replay stored principal/session occurrences with durable event ids
- update daemon delta handling for occurrence-aware fired rows
- add duplicate occurrence coverage for direct, store, and autoload paths

## Tests
- git diff --check
- meson test -C builddir --print-errorlogs
- meson test -C builddir-audit --print-errorlogs
