### PR TITLE
policy: add canonical decision template path

### DIFF
--- a/templates/access/lobac/decision.dl
+++ b/templates/access/lobac/decision.dl
@@ -1,11 +1,8 @@
-// decision.dl - Wyrelog Access Decision Rule Set v0
+// decision.dl - Wyrelog LoBAC Decision Rule Set v0
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2026 wyrelog authors. Also available under a separate
 // commercial license; see LICENSE.md at the project root.
-//
-// Legacy compatibility copy. The canonical decision template lives at
-// lobac/decision.dl.
 //
 // Conjunctive access decision plus a six-row deny-reason taxonomy.
 // The decision program produces a boolean projection (allow_bool/3)

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -183,6 +183,10 @@ test('fsm-permission-scope', test_fsm_permission_scope)
 
 access_decision_dl_path = join_paths(
   meson.project_source_root(),
+  'templates', 'access', 'lobac', 'decision.dl',
+)
+access_decision_legacy_dl_path = join_paths(
+  meson.project_source_root(),
   'templates', 'access', 'decision.dl',
 )
 
@@ -190,6 +194,7 @@ test_access_decision = executable('test-access-decision',
   'test-access-decision.c',
   c_args : [
     '-DWYL_TEST_ACCESS_DECISION_DL_PATH="' + access_decision_dl_path + '"',
+    '-DWYL_TEST_ACCESS_DECISION_LEGACY_DL_PATH="' + access_decision_legacy_dl_path + '"',
   ],
   dependencies : [wyrelog_dep],
 )

--- a/tests/test-access-decision.c
+++ b/tests/test-access-decision.c
@@ -10,10 +10,14 @@
 #error "WYL_TEST_ACCESS_DECISION_DL_PATH must be defined by the build."
 #endif
 
+#ifndef WYL_TEST_ACCESS_DECISION_LEGACY_DL_PATH
+#error "WYL_TEST_ACCESS_DECISION_LEGACY_DL_PATH must be defined by the build."
+#endif
+
 /* --- Stratification self-check ---------------------------------- */
 
 /*
- * Lifts the rule heads introduced by decision.dl into
+ * Lifts the rule heads introduced by lobac/decision.dl into
  * wyl_dl_rule_t form and asserts the program is stratified. Every
  * negation edge from these rules lands on either an EDB predicate
  * (frozen, disabled_role_for, policy_violation, principal_state,
@@ -195,7 +199,7 @@ check_origin_tags (void)
 /* --- .dl head-signature mirror oracle --------------------------- */
 
 /*
- * Confirms that decision.dl declares exactly one allow/3 head, one
+ * Confirms that lobac/decision.dl declares exactly one allow/3 head, one
  * allow_bool/3 head, and the six deny_reason/5 heads with literal
  * (code, origin) string pairs identical to the C catalogue. Body
  * compound terms are not parsed; the structural body equality is
@@ -304,6 +308,56 @@ check_head_mirror (void)
   return 0;
 }
 
+static void
+append_non_comment_lines (GString *out, const gchar *contents)
+{
+  g_auto (GStrv) lines = g_strsplit (contents, "\n", -1);
+
+  for (gsize i = 0; lines[i] != NULL; i++) {
+    g_autofree gchar *line = g_strdup (lines[i]);
+    gchar *trimmed = g_strstrip (line);
+
+    if (trimmed[0] == '\0' || g_str_has_prefix (trimmed, "//"))
+      continue;
+    g_string_append (out, trimmed);
+    g_string_append_c (out, '\n');
+  }
+}
+
+static gint
+check_legacy_template_matches_canonical (void)
+{
+  g_autofree gchar *canonical = NULL;
+  g_autofree gchar *legacy = NULL;
+  gsize canonical_len = 0;
+  gsize legacy_len = 0;
+  g_autoptr (GError) err = NULL;
+
+  if (!g_file_get_contents (WYL_TEST_ACCESS_DECISION_DL_PATH, &canonical,
+          &canonical_len, &err)) {
+    g_printerr ("cannot read %s: %s\n", WYL_TEST_ACCESS_DECISION_DL_PATH,
+        err ? err->message : "?");
+    return 170;
+  }
+
+  g_clear_error (&err);
+  if (!g_file_get_contents (WYL_TEST_ACCESS_DECISION_LEGACY_DL_PATH, &legacy,
+          &legacy_len, &err)) {
+    g_printerr ("cannot read %s: %s\n",
+        WYL_TEST_ACCESS_DECISION_LEGACY_DL_PATH, err ? err->message : "?");
+    return 171;
+  }
+
+  g_autoptr (GString) canonical_rules = g_string_new (NULL);
+  g_autoptr (GString) legacy_rules = g_string_new (NULL);
+  append_non_comment_lines (canonical_rules, canonical);
+  append_non_comment_lines (legacy_rules, legacy);
+
+  if (g_strcmp0 (canonical_rules->str, legacy_rules->str) != 0)
+    return 172;
+  return 0;
+}
+
 int
 main (void)
 {
@@ -317,6 +371,8 @@ main (void)
   if ((rc = check_origin_tags ()) != 0)
     return rc;
   if ((rc = check_head_mirror ()) != 0)
+    return rc;
+  if ((rc = check_legacy_template_matches_canonical ()) != 0)
     return rc;
   return 0;
 }

--- a/tests/test-engine.c
+++ b/tests/test-engine.c
@@ -48,7 +48,8 @@ make_tmpdir (void)
 
 /*
  * copy_real_templates_to: copies the 5 real template files from the
- * canonical template dir into dest_dir, creating fsm/ subdirectory.
+ * canonical template dir into dest_dir, creating fsm/ and lobac/
+ * subdirectories.
  * Returns FALSE on any error.
  */
 static gboolean
@@ -59,13 +60,18 @@ copy_real_templates_to (const gchar *dest_dir)
     "fsm/principal.dl",
     "fsm/session.dl",
     "fsm/permission_scope.dl",
-    "decision.dl",
+    "lobac/decision.dl",
   };
 
-  /* Create fsm/ subdir. */
+  /* Create nested subdirs used by the fixed template list. */
   g_autofree gchar *fsm_dir = g_build_filename (dest_dir, "fsm", NULL);
   if (g_mkdir (fsm_dir, 0755) != 0) {
     g_printerr ("copy_real_templates_to: mkdir %s failed\n", fsm_dir);
+    return FALSE;
+  }
+  g_autofree gchar *lobac_dir = g_build_filename (dest_dir, "lobac", NULL);
+  if (g_mkdir (lobac_dir, 0755) != 0) {
+    g_printerr ("copy_real_templates_to: mkdir %s failed\n", lobac_dir);
     return FALSE;
   }
 
@@ -144,16 +150,16 @@ test_engine_open_eager_build_surfaces_errors (void)
   if (tmpdir == NULL)
     return 10;
 
-  /* Create fsm/ subdir and copy 4 good files, then overwrite decision.dl
-   * with malformed content. */
+  /* Copy good files, then overwrite lobac/decision.dl with malformed
+   * content. */
   gboolean ok = copy_real_templates_to (tmpdir);
   if (!ok) {
     rmdir_recursive (tmpdir);
     return 11;
   }
 
-  /* Overwrite decision.dl with deliberately malformed content. */
-  if (!write_file_in_dir (tmpdir, "decision.dl",
+  /* Overwrite lobac/decision.dl with deliberately malformed content. */
+  if (!write_file_in_dir (tmpdir, "lobac/decision.dl",
           "this is not valid datalog ((((\n")) {
     rmdir_recursive (tmpdir);
     return 12;
@@ -180,26 +186,22 @@ test_engine_open_eager_build_surfaces_errors (void)
   return 0;
 }
 
-static gint
-test_engine_open_missing_decision_fail_closed (void)
+static gboolean
+copy_partial_templates_without_decision (const gchar *tmpdir)
 {
-  g_autofree gchar *tmpdir = make_tmpdir ();
-  if (tmpdir == NULL)
-    return 20;
-
-  /* Create fsm/ subdir and copy bootstrap + fsm files but omit decision.dl */
+  /* Copy bootstrap + fsm files but omit both decision template paths. */
   g_autofree gchar *fsm_dir = g_build_filename (tmpdir, "fsm", NULL);
-  if (g_mkdir (fsm_dir, 0755) != 0) {
-    rmdir_recursive (tmpdir);
-    return 21;
-  }
+  if (g_mkdir (fsm_dir, 0755) != 0)
+    return FALSE;
+  g_autofree gchar *lobac_dir = g_build_filename (tmpdir, "lobac", NULL);
+  if (g_mkdir (lobac_dir, 0755) != 0)
+    return FALSE;
 
   static const char *partial_files[] = {
     "bootstrap.dl",
     "fsm/principal.dl",
     "fsm/session.dl",
     "fsm/permission_scope.dl",
-    /* decision.dl intentionally omitted */
   };
 
   for (gsize i = 0; i < G_N_ELEMENTS (partial_files); i++) {
@@ -211,15 +213,26 @@ test_engine_open_missing_decision_fail_closed (void)
     g_autoptr (GError) err = NULL;
 
     if (!g_file_get_contents (src, &contents, &len, &err)) {
-      g_printerr ("test_engine_open_missing_decision_fail_closed: "
+      g_printerr ("copy_partial_templates_without_decision: "
           "cannot read %s: %s\n", src, err ? err->message : "?");
-      rmdir_recursive (tmpdir);
-      return 22;
+      return FALSE;
     }
-    if (!g_file_set_contents (dst, contents, (gssize) len, &err)) {
-      rmdir_recursive (tmpdir);
-      return 23;
-    }
+    if (!g_file_set_contents (dst, contents, (gssize) len, &err))
+      return FALSE;
+  }
+  return TRUE;
+}
+
+static gint
+test_engine_open_missing_decision_fail_closed (void)
+{
+  g_autofree gchar *tmpdir = make_tmpdir ();
+  if (tmpdir == NULL)
+    return 20;
+
+  if (!copy_partial_templates_without_decision (tmpdir)) {
+    rmdir_recursive (tmpdir);
+    return 21;
   }
 
   WylEngine *engine = NULL;
@@ -239,6 +252,107 @@ test_engine_open_missing_decision_fail_closed (void)
         "*out should be NULL on failure\n");
     g_object_unref (engine);
     return 25;
+  }
+  return 0;
+}
+
+static gint
+test_engine_open_legacy_decision_fallback (void)
+{
+  g_autofree gchar *tmpdir = make_tmpdir ();
+  if (tmpdir == NULL)
+    return 90;
+
+  if (!copy_partial_templates_without_decision (tmpdir)) {
+    rmdir_recursive (tmpdir);
+    return 91;
+  }
+
+  g_autofree gchar *src =
+      g_build_filename (WYL_TEST_TEMPLATE_DIR, "decision.dl", NULL);
+  g_autofree gchar *contents = NULL;
+  gsize len = 0;
+  g_autoptr (GError) err = NULL;
+  if (!g_file_get_contents (src, &contents, &len, &err)) {
+    g_printerr ("test_engine_open_legacy_decision_fallback: "
+        "cannot read %s: %s\n", src, err ? err->message : "?");
+    rmdir_recursive (tmpdir);
+    return 92;
+  }
+  g_autofree gchar *dst = g_build_filename (tmpdir, "decision.dl", NULL);
+  if (!g_file_set_contents (dst, contents, (gssize) len, &err)) {
+    rmdir_recursive (tmpdir);
+    return 93;
+  }
+
+  WylEngine *engine = NULL;
+  wyrelog_error_t rc = wyl_engine_open (tmpdir, 1, &engine);
+
+  rmdir_recursive (tmpdir);
+
+  if (rc != WYRELOG_E_OK || engine == NULL) {
+    g_printerr ("test_engine_open_legacy_decision_fallback: "
+        "expected open success, got %d\n", (int) rc);
+    if (engine != NULL)
+      g_object_unref (engine);
+    return 94;
+  }
+  wyl_engine_close (engine);
+  return 0;
+}
+
+static gint
+test_engine_open_canonical_read_error_beats_legacy (void)
+{
+  g_autofree gchar *tmpdir = make_tmpdir ();
+  if (tmpdir == NULL)
+    return 100;
+
+  if (!copy_partial_templates_without_decision (tmpdir)) {
+    rmdir_recursive (tmpdir);
+    return 101;
+  }
+
+  g_autofree gchar *legacy_src =
+      g_build_filename (WYL_TEST_TEMPLATE_DIR, "decision.dl", NULL);
+  g_autofree gchar *contents = NULL;
+  gsize len = 0;
+  g_autoptr (GError) err = NULL;
+  if (!g_file_get_contents (legacy_src, &contents, &len, &err)) {
+    rmdir_recursive (tmpdir);
+    return 102;
+  }
+  g_autofree gchar *legacy_dst = g_build_filename (tmpdir, "decision.dl",
+      NULL);
+  if (!g_file_set_contents (legacy_dst, contents, (gssize) len, &err)) {
+    rmdir_recursive (tmpdir);
+    return 103;
+  }
+
+  g_autofree gchar *canonical_dir =
+      g_build_filename (tmpdir, "lobac", "decision.dl", NULL);
+  if (g_mkdir (canonical_dir, 0755) != 0) {
+    rmdir_recursive (tmpdir);
+    return 104;
+  }
+
+  WylEngine *engine = NULL;
+  wyrelog_error_t rc = wyl_engine_open (tmpdir, 1, &engine);
+
+  rmdir_recursive (tmpdir);
+
+  if (rc != WYRELOG_E_IO) {
+    g_printerr ("test_engine_open_canonical_read_error_beats_legacy: "
+        "expected WYRELOG_E_IO, got %d\n", (int) rc);
+    if (engine != NULL)
+      g_object_unref (engine);
+    return 105;
+  }
+  if (engine != NULL) {
+    g_printerr ("test_engine_open_canonical_read_error_beats_legacy: "
+        "*out should be NULL on failure\n");
+    g_object_unref (engine);
+    return 106;
   }
   return 0;
 }
@@ -320,11 +434,16 @@ test_engine_concat_with_newline_helper (void)
   if (tmpdir == NULL)
     return 70;
 
-  /* Create fsm/ subdir. */
+  /* Create nested subdirs used by the fixed template list. */
   g_autofree gchar *fsm_dir = g_build_filename (tmpdir, "fsm", NULL);
   if (g_mkdir (fsm_dir, 0755) != 0) {
     rmdir_recursive (tmpdir);
     return 71;
+  }
+  g_autofree gchar *lobac_dir = g_build_filename (tmpdir, "lobac", NULL);
+  if (g_mkdir (lobac_dir, 0755) != 0) {
+    rmdir_recursive (tmpdir);
+    return 72;
   }
 
   /* Write a minimal but syntactically acceptable bootstrap.dl (no trailing
@@ -335,7 +454,7 @@ test_engine_concat_with_newline_helper (void)
 
   if (!write_file_in_dir (tmpdir, "bootstrap.dl", bootstrap_content)) {
     rmdir_recursive (tmpdir);
-    return 72;
+    return 73;
   }
 
   /* For the remaining 4 files, write minimal placeholder stubs. */
@@ -343,13 +462,13 @@ test_engine_concat_with_newline_helper (void)
     "fsm/principal.dl",
     "fsm/session.dl",
     "fsm/permission_scope.dl",
-    "decision.dl",
+    "lobac/decision.dl",
   };
   for (gsize i = 0; i < G_N_ELEMENTS (rest); i++) {
     g_autofree gchar *stub = g_strdup_printf ("%% stub for %s\n", rest[i]);
     if (!write_file_in_dir (tmpdir, rest[i], stub)) {
       rmdir_recursive (tmpdir);
-      return (gint) (73 + i);
+      return (gint) (74 + i);
     }
   }
 
@@ -391,11 +510,16 @@ test_engine_open_empty_templates (void)
   if (tmpdir == NULL)
     return 80;
 
-  /* Create fsm/ subdir. */
+  /* Create nested subdirs used by the fixed template list. */
   g_autofree gchar *fsm_dir = g_build_filename (tmpdir, "fsm", NULL);
   if (g_mkdir (fsm_dir, 0755) != 0) {
     rmdir_recursive (tmpdir);
     return 81;
+  }
+  g_autofree gchar *lobac_dir = g_build_filename (tmpdir, "lobac", NULL);
+  if (g_mkdir (lobac_dir, 0755) != 0) {
+    rmdir_recursive (tmpdir);
+    return 82;
   }
 
   /* Write all 5 template files as zero-byte files. */
@@ -404,7 +528,7 @@ test_engine_open_empty_templates (void)
     "fsm/principal.dl",
     "fsm/session.dl",
     "fsm/permission_scope.dl",
-    "decision.dl",
+    "lobac/decision.dl",
   };
   for (gsize i = 0; i < G_N_ELEMENTS (all_files); i++) {
     g_autofree gchar *path = g_build_filename (tmpdir, all_files[i], NULL);
@@ -454,6 +578,12 @@ main (void)
     return rc;
 
   if ((rc = test_engine_open_missing_decision_fail_closed ()) != 0)
+    return rc;
+
+  if ((rc = test_engine_open_legacy_decision_fallback ()) != 0)
+    return rc;
+
+  if ((rc = test_engine_open_canonical_read_error_beats_legacy ()) != 0)
     return rc;
 
   if ((rc = test_engine_open_null_template_dir_rejects ()) != 0)

--- a/wyrelog/access/decision-private.h
+++ b/wyrelog/access/decision-private.h
@@ -11,13 +11,13 @@ G_BEGIN_DECLS;
  * Access decision rule set support code.
  *
  * The Datalog source of truth lives at
- * <datadir>/wyrelog/access/decision.dl. This module exposes the
- * deny-reason taxonomy on the C side: the six v0 codes, their
- * matching origin tags, and a fixed priority that the engine uses
- * to pick a single representative reason for the H1 result struct
- * when multiple deny_reason rows fire for the same (user, perm,
- * scope) tuple. The full row set still goes to the audit log; the
- * priority only collapses the user-visible single-reason field.
+ * <datadir>/wyrelog/access/lobac/decision.dl, with a legacy copy at
+ * <datadir>/wyrelog/access/decision.dl for older template trees. This
+ * module exposes the deny-reason taxonomy on the C side: the six v0
+ * codes, their matching origin tags, and a fixed priority that the
+ * engine uses to pick a single representative reason for the H1 result
+ * struct when multiple deny_reason rows fire for the same (user, perm,
+ * scope) tuple.
  *
  * Code uniqueness contract: the v0 catalogue keys by code alone.
  * Every code maps to exactly one origin tag. A future row that
@@ -42,7 +42,7 @@ typedef enum wyl_deny_reason_code_t
 
 /*
  * Lexical names. The `name` is the string that appears as the
- * fourth argument of the deny_reason/5 fact in decision.dl; the
+ * fourth argument of the deny_reason/5 fact in lobac/decision.dl; the
  * `origin` is the fifth argument. NULL on out-of-range input;
  * callers must not free the returned strings.
  */

--- a/wyrelog/wyl-engine.c
+++ b/wyrelog/wyl-engine.c
@@ -19,10 +19,13 @@ static const char *const TEMPLATE_FILES[] = {
   "fsm/principal.dl",
   "fsm/session.dl",
   "fsm/permission_scope.dl",
-  "decision.dl",
+  "lobac/decision.dl",
 };
 
 G_STATIC_ASSERT (G_N_ELEMENTS (TEMPLATE_FILES) == WYL_ENGINE_TEMPLATE_COUNT);
+
+#define WYL_ENGINE_LOBAC_DECISION_TEMPLATE "lobac/decision.dl"
+#define WYL_ENGINE_LEGACY_DECISION_TEMPLATE "decision.dl"
 
 typedef struct
 {
@@ -133,13 +136,29 @@ wyl_engine_load_templates (const gchar *template_dir, gchar **dl_src_out,
   gsize total_content_bytes = 0;
 
   for (gsize i = 0; i < G_N_ELEMENTS (TEMPLATE_FILES); i++) {
+    const gchar *logical_path = TEMPLATE_FILES[i];
     g_autofree gchar *path =
-        g_build_filename (template_dir, TEMPLATE_FILES[i], NULL);
+        g_build_filename (template_dir, logical_path, NULL);
     g_autofree gchar *contents = NULL;
     gsize len = 0;
     g_autoptr (GError) err = NULL;
 
     if (!g_file_get_contents (path, &contents, &len, &err)) {
+      if (g_strcmp0 (logical_path, WYL_ENGINE_LOBAC_DECISION_TEMPLATE) == 0
+          && g_error_matches (err, G_FILE_ERROR, G_FILE_ERROR_NOENT)) {
+        g_clear_error (&err);
+        g_clear_pointer (&path, g_free);
+        path = g_build_filename (template_dir,
+            WYL_ENGINE_LEGACY_DECISION_TEMPLATE, NULL);
+        logical_path = WYL_ENGINE_LEGACY_DECISION_TEMPLATE;
+        if (g_file_get_contents (path, &contents, &len, &err)) {
+          WYL_LOG_INFO (WYL_LOG_SECTION_BOOT,
+              "loaded legacy decision template: %s", logical_path);
+        }
+      }
+    }
+
+    if (contents == NULL) {
       WYL_LOG_ERROR (WYL_LOG_SECTION_BOOT,
           "missing or unreadable template: %s", TEMPLATE_FILES[i]);
       return WYRELOG_E_IO;


### PR DESCRIPTION
## Summary
- Load access decision rules from templates/access/lobac/decision.dl.
- Keep templates/access/decision.dl as a legacy fallback when canonical is missing.
- Cover canonical loading, legacy fallback, read-error fail-closed behavior, and template parity.

## Tests
- git diff --check
- meson test -C builddir --print-errorlogs
- meson test -C builddir-audit --print-errorlogs
