### PR TITLE
policy: project audit rows into wirelog facts

### DIFF
--- a/templates/access/decision.dl
+++ b/templates/access/decision.dl
@@ -22,6 +22,20 @@
 //   frozen(scope)
 //   disabled_role_for(user, perm)
 //   policy_violation(kind, user, perm, witness)
+//   audit_event_input(id, created_at_us, decision)
+//   audit_event_subject_input(id, subject)
+//   audit_event_action_input(id, action)
+//   audit_event_resource_input(id, resource)
+//   audit_event_deny_reason_input(id, reason)
+//   audit_event_deny_origin_input(id, origin)
+//
+// Audit fact projections (host-observable):
+//   audit_event(id, created_at_us, decision)
+//   audit_event_subject(id, subject)
+//   audit_event_action(id, action)
+//   audit_event_resource(id, resource)
+//   audit_event_deny_reason(id, reason)
+//   audit_event_deny_origin(id, origin)
 //
 // `has_permission/3` and `armed/3` are IDB rules defined elsewhere
 // (bootstrap.dl and permission_scope.dl respectively); both are
@@ -39,6 +53,18 @@
 .decl disabled_role_for(user: symbol, perm: symbol)
 .decl policy_violation(kind: symbol, user: symbol, perm: symbol,
     witness: symbol)
+.decl audit_event_input(id: symbol, created_at_us: int64, decision: symbol)
+.decl audit_event_subject_input(id: symbol, subject: symbol)
+.decl audit_event_action_input(id: symbol, action: symbol)
+.decl audit_event_resource_input(id: symbol, resource: symbol)
+.decl audit_event_deny_reason_input(id: symbol, reason: symbol)
+.decl audit_event_deny_origin_input(id: symbol, origin: symbol)
+.decl audit_event(id: symbol, created_at_us: int64, decision: symbol)
+.decl audit_event_subject(id: symbol, subject: symbol)
+.decl audit_event_action(id: symbol, action: symbol)
+.decl audit_event_resource(id: symbol, resource: symbol)
+.decl audit_event_deny_reason(id: symbol, reason: symbol)
+.decl audit_event_deny_origin(id: symbol, origin: symbol)
 
 .decl allow(user: symbol, perm: symbol, scope: symbol)
 .decl allow_guard_base(user: symbol, perm: symbol, scope: symbol)
@@ -46,6 +72,26 @@
 .decl allow_bool(user: symbol, perm: symbol, scope: symbol)
 .decl deny_reason(user: symbol, perm: symbol, scope: symbol,
     code: symbol, origin: symbol)
+
+// --- audit fact projection -----------------------------------------
+
+audit_event(ID, CreatedAtUs, Decision) :-
+    audit_event_input(ID, CreatedAtUs, Decision).
+
+audit_event_subject(ID, Subject) :-
+    audit_event_subject_input(ID, Subject).
+
+audit_event_action(ID, Action) :-
+    audit_event_action_input(ID, Action).
+
+audit_event_resource(ID, Resource) :-
+    audit_event_resource_input(ID, Resource).
+
+audit_event_deny_reason(ID, Reason) :-
+    audit_event_deny_reason_input(ID, Reason).
+
+audit_event_deny_origin(ID, Origin) :-
+    audit_event_deny_origin_input(ID, Origin).
 
 // --- allow / allow_bool ----------------------------------------------
 

--- a/templates/access/lobac/decision.dl
+++ b/templates/access/lobac/decision.dl
@@ -19,6 +19,20 @@
 //   frozen(scope)
 //   disabled_role_for(user, perm)
 //   policy_violation(kind, user, perm, witness)
+//   audit_event_input(id, created_at_us, decision)
+//   audit_event_subject_input(id, subject)
+//   audit_event_action_input(id, action)
+//   audit_event_resource_input(id, resource)
+//   audit_event_deny_reason_input(id, reason)
+//   audit_event_deny_origin_input(id, origin)
+//
+// Audit fact projections (host-observable):
+//   audit_event(id, created_at_us, decision)
+//   audit_event_subject(id, subject)
+//   audit_event_action(id, action)
+//   audit_event_resource(id, resource)
+//   audit_event_deny_reason(id, reason)
+//   audit_event_deny_origin(id, origin)
 //
 // `has_permission/3` and `armed/3` are IDB rules defined elsewhere
 // (bootstrap.dl and permission_scope.dl respectively); both are
@@ -36,6 +50,18 @@
 .decl disabled_role_for(user: symbol, perm: symbol)
 .decl policy_violation(kind: symbol, user: symbol, perm: symbol,
     witness: symbol)
+.decl audit_event_input(id: symbol, created_at_us: int64, decision: symbol)
+.decl audit_event_subject_input(id: symbol, subject: symbol)
+.decl audit_event_action_input(id: symbol, action: symbol)
+.decl audit_event_resource_input(id: symbol, resource: symbol)
+.decl audit_event_deny_reason_input(id: symbol, reason: symbol)
+.decl audit_event_deny_origin_input(id: symbol, origin: symbol)
+.decl audit_event(id: symbol, created_at_us: int64, decision: symbol)
+.decl audit_event_subject(id: symbol, subject: symbol)
+.decl audit_event_action(id: symbol, action: symbol)
+.decl audit_event_resource(id: symbol, resource: symbol)
+.decl audit_event_deny_reason(id: symbol, reason: symbol)
+.decl audit_event_deny_origin(id: symbol, origin: symbol)
 
 .decl allow(user: symbol, perm: symbol, scope: symbol)
 .decl allow_guard_base(user: symbol, perm: symbol, scope: symbol)
@@ -43,6 +69,26 @@
 .decl allow_bool(user: symbol, perm: symbol, scope: symbol)
 .decl deny_reason(user: symbol, perm: symbol, scope: symbol,
     code: symbol, origin: symbol)
+
+// --- audit fact projection -----------------------------------------
+
+audit_event(ID, CreatedAtUs, Decision) :-
+    audit_event_input(ID, CreatedAtUs, Decision).
+
+audit_event_subject(ID, Subject) :-
+    audit_event_subject_input(ID, Subject).
+
+audit_event_action(ID, Action) :-
+    audit_event_action_input(ID, Action).
+
+audit_event_resource(ID, Resource) :-
+    audit_event_resource_input(ID, Resource).
+
+audit_event_deny_reason(ID, Reason) :-
+    audit_event_deny_reason_input(ID, Reason).
+
+audit_event_deny_origin(ID, Origin) :-
+    audit_event_deny_origin_input(ID, Origin).
 
 // --- allow / allow_bool ----------------------------------------------
 

--- a/tests/test-access-decision.c
+++ b/tests/test-access-decision.c
@@ -308,6 +308,36 @@ check_head_mirror (void)
   return 0;
 }
 
+static gint
+check_audit_fact_declarations (void)
+{
+  static const gchar *decls[] = {
+    ".decl audit_event(id: symbol, created_at_us: int64, decision: symbol)",
+    ".decl audit_event_subject(id: symbol, subject: symbol)",
+    ".decl audit_event_action(id: symbol, action: symbol)",
+    ".decl audit_event_resource(id: symbol, resource: symbol)",
+    ".decl audit_event_deny_reason(id: symbol, reason: symbol)",
+    ".decl audit_event_deny_origin(id: symbol, origin: symbol)",
+    "audit_event(ID, CreatedAtUs, Decision) :-",
+  };
+  g_autofree gchar *contents = NULL;
+  gsize len = 0;
+  g_autoptr (GError) err = NULL;
+
+  if (!g_file_get_contents (WYL_TEST_ACCESS_DECISION_DL_PATH, &contents,
+          &len, &err)) {
+    g_printerr ("cannot read %s: %s\n", WYL_TEST_ACCESS_DECISION_DL_PATH,
+        err ? err->message : "?");
+    return 163;
+  }
+
+  for (gsize i = 0; i < G_N_ELEMENTS (decls); i++) {
+    if (g_strstr_len (contents, (gssize) len, decls[i]) == NULL)
+      return (gint) (164 + i);
+  }
+  return 0;
+}
+
 static void
 append_non_comment_lines (GString *out, const gchar *contents)
 {
@@ -371,6 +401,8 @@ main (void)
   if ((rc = check_origin_tags ()) != 0)
     return rc;
   if ((rc = check_head_mirror ()) != 0)
+    return rc;
+  if ((rc = check_audit_fact_declarations ()) != 0)
     return rc;
   if ((rc = check_legacy_template_matches_canonical ()) != 0)
     return rc;

--- a/tests/test-audit-emit.c
+++ b/tests/test-audit-emit.c
@@ -88,6 +88,71 @@ insert_symbol_row4 (WylHandle *handle, const gchar *relation, const gchar *a,
 }
 
 static wyrelog_error_t
+contains_audit_event_fact (WylHandle *handle, const gchar *id,
+    gint64 created_at_us, const gchar *decision, gboolean *out_contains)
+{
+  gint64 row[3];
+  wyrelog_error_t rc = intern_symbol (handle, id, &row[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  row[1] = created_at_us;
+  rc = intern_symbol (handle, decision, &row[2]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_engine_contains (handle, "audit_event", row, 3,
+      out_contains);
+}
+
+static wyrelog_error_t
+contains_audit_event_attr_fact (WylHandle *handle, const gchar *relation,
+    const gchar *id, const gchar *value, gboolean *out_contains)
+{
+  gint64 row[2];
+  wyrelog_error_t rc = intern_symbol (handle, id, &row[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = intern_symbol (handle, value, &row[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_engine_contains (handle, relation, row, 2, out_contains);
+}
+
+typedef struct
+{
+  gint64 audit_id;
+  guint matches;
+} AuditFactCount;
+
+static void
+count_audit_fact_cb (const gchar *relation, const gint64 *row, guint ncols,
+    gpointer user_data)
+{
+  (void) relation;
+  AuditFactCount *count = user_data;
+
+  if (ncols >= 1 && row[0] == count->audit_id)
+    count->matches++;
+}
+
+static wyrelog_error_t
+count_audit_attr_facts (WylHandle *handle, const gchar *relation,
+    const gchar *id, guint *out_count)
+{
+  gint64 audit_id = 0;
+  wyrelog_error_t rc = intern_symbol (handle, id, &audit_id);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  AuditFactCount count = { audit_id, 0 };
+  rc = wyl_engine_snapshot (wyl_handle_get_read_engine (handle), relation,
+      count_audit_fact_cb, &count);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  *out_count = count.matches;
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
 insert_not_armed_decide_fixture (WylHandle *handle)
 {
   wyrelog_error_t rc = insert_symbol_row2 (handle, "role_permission",
@@ -1446,6 +1511,112 @@ check_emit_rejects_null_args (void)
   return 0;
 }
 
+static gint
+check_policy_store_audit_rows_load_wirelog_facts (void)
+{
+  WylHandle *handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 161;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  static const gchar *full_id = "01890c10-2e3f-7000-8000-000000000010";
+  if (wyl_policy_store_append_audit_event (store, full_id, 1001,
+          "audit-fact-user", "audit-fact-action", "audit-fact-resource",
+          "not_armed", "perm_state", WYL_DECISION_DENY) != WYRELOG_E_OK) {
+    g_object_unref (handle);
+    return 162;
+  }
+  if (wyl_handle_reload_engine_pair (handle) != WYRELOG_E_OK) {
+    g_object_unref (handle);
+    return 163;
+  }
+
+  gboolean contains = FALSE;
+  wyrelog_error_t fact_rc =
+      contains_audit_event_fact (handle, full_id, 1001, "deny", &contains);
+  if (fact_rc != WYRELOG_E_OK) {
+    g_object_unref (handle);
+    return 192;
+  }
+  if (!contains) {
+    g_object_unref (handle);
+    return 164;
+  }
+  if (contains_audit_event_attr_fact (handle, "audit_event_subject", full_id,
+          "audit-fact-user", &contains) != WYRELOG_E_OK || !contains) {
+    g_object_unref (handle);
+    return 165;
+  }
+  if (contains_audit_event_attr_fact (handle, "audit_event_action", full_id,
+          "audit-fact-action", &contains) != WYRELOG_E_OK || !contains) {
+    g_object_unref (handle);
+    return 166;
+  }
+  if (contains_audit_event_attr_fact (handle, "audit_event_resource", full_id,
+          "audit-fact-resource", &contains) != WYRELOG_E_OK || !contains) {
+    g_object_unref (handle);
+    return 167;
+  }
+  if (contains_audit_event_attr_fact (handle, "audit_event_deny_reason",
+          full_id, "not_armed", &contains) != WYRELOG_E_OK || !contains) {
+    g_object_unref (handle);
+    return 168;
+  }
+  if (contains_audit_event_attr_fact (handle, "audit_event_deny_origin",
+          full_id, "perm_state", &contains) != WYRELOG_E_OK || !contains) {
+    g_object_unref (handle);
+    return 169;
+  }
+
+  static const gchar *sparse_id = "01890c10-2e3f-7000-8000-000000000011";
+  if (wyl_policy_store_append_audit_event (store, sparse_id, 1002, NULL,
+          "audit-sparse-action", NULL, NULL, NULL, WYL_DECISION_ALLOW)
+      != WYRELOG_E_OK) {
+    g_object_unref (handle);
+    return 170;
+  }
+  if (wyl_handle_reload_engine_pair (handle) != WYRELOG_E_OK) {
+    g_object_unref (handle);
+    return 171;
+  }
+  if (contains_audit_event_fact (handle, sparse_id, 1002, "allow", &contains)
+      != WYRELOG_E_OK || !contains) {
+    g_object_unref (handle);
+    return 172;
+  }
+  if (contains_audit_event_attr_fact (handle, "audit_event_action", sparse_id,
+          "audit-sparse-action", &contains) != WYRELOG_E_OK || !contains) {
+    g_object_unref (handle);
+    return 173;
+  }
+
+  static const struct
+  {
+    const gchar *relation;
+    guint expected;
+  } optional_counts[] = {
+    {"audit_event_subject", 0},
+    {"audit_event_resource", 0},
+    {"audit_event_deny_reason", 0},
+    {"audit_event_deny_origin", 0},
+  };
+  for (gsize i = 0; i < G_N_ELEMENTS (optional_counts); i++) {
+    guint count = 0;
+    if (count_audit_attr_facts (handle, optional_counts[i].relation,
+            sparse_id, &count) != WYRELOG_E_OK) {
+      g_object_unref (handle);
+      return (gint) (174 + i);
+    }
+    if (count != optional_counts[i].expected) {
+      g_object_unref (handle);
+      return (gint) (180 + i);
+    }
+  }
+
+  g_object_unref (handle);
+  return 0;
+}
+
 int
 main (void)
 {
@@ -1489,6 +1660,8 @@ main (void)
   if ((rc = check_role_grant_emits_audit_row ()) != 0)
     return rc;
   if ((rc = check_role_revoke_emits_audit_row ()) != 0)
+    return rc;
+  if ((rc = check_policy_store_audit_rows_load_wirelog_facts ()) != 0)
     return rc;
   if ((rc = check_emit_rejects_null_args ()) != 0)
     return rc;

--- a/wyrelog/wyl-handle-private.h
+++ b/wyrelog/wyl-handle-private.h
@@ -195,6 +195,14 @@ wyrelog_error_t wyl_handle_load_policy_store_session_states (WylHandle * self);
 wyrelog_error_t wyl_handle_load_policy_store_session_events (WylHandle * self);
 
 /*
+ * Loads persisted audit rows from the handle-owned policy authority store into
+ * the read engine as private audit_event* facts. Optional audit fields are
+ * projected through split predicates so NULL values do not need sentinel
+ * symbols. Rejected unless both the store and engine pair are available.
+ */
+wyrelog_error_t wyl_handle_load_policy_store_audit_facts (WylHandle * self);
+
+/*
  * Probes the read engine for an exact EDB/IDB row match. Rejected unless the
  * engine pair is already open.
  */

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -400,7 +400,10 @@ load_current_engine_pair (WylHandle *self)
   rc = wyl_handle_load_policy_store_session_states (self);
   if (rc != WYRELOG_E_OK)
     return rc;
-  return wyl_handle_load_policy_store_session_events (self);
+  rc = wyl_handle_load_policy_store_session_events (self);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_load_policy_store_audit_facts (self);
 }
 
 static wyrelog_error_t
@@ -899,6 +902,90 @@ wyl_handle_load_policy_store_session_events (WylHandle *self)
 
   return wyl_policy_store_foreach_session_event (self->policy_store,
       insert_policy_store_session_event, self);
+}
+
+static const gchar *
+decision_symbol (wyl_decision_t decision)
+{
+  switch (decision) {
+    case WYL_DECISION_DENY:
+      return "deny";
+    case WYL_DECISION_ALLOW:
+      return "allow";
+    default:
+      return NULL;
+  }
+}
+
+static wyrelog_error_t
+insert_audit_fact_symbol (WylHandle *self, const gchar *relation,
+    gint64 audit_id, const gchar *value)
+{
+  if (value == NULL)
+    return WYRELOG_E_OK;
+
+  gint64 row[2] = { audit_id, 0 };
+  wyrelog_error_t rc = wyl_handle_intern_engine_symbol (self, value, &row[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_engine_insert (self, relation, row, 2);
+}
+
+static wyrelog_error_t
+insert_policy_store_audit_fact (const gchar *id, gint64 created_at_us,
+    const gchar *subject_id, const gchar *action, const gchar *resource_id,
+    const gchar *deny_reason, const gchar *deny_origin,
+    wyl_decision_t decision, gpointer user_data)
+{
+  WylHandle *self = user_data;
+  const gchar *decision_name = decision_symbol (decision);
+  if (decision_name == NULL)
+    return WYRELOG_E_POLICY;
+
+  gint64 audit_event[3];
+  wyrelog_error_t rc =
+      wyl_handle_intern_engine_symbol (self, id, &audit_event[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  audit_event[1] = created_at_us;
+  rc = wyl_handle_intern_engine_symbol (self, decision_name, &audit_event[2]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_engine_insert (self, "audit_event_input", audit_event, 3);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  rc = insert_audit_fact_symbol (self, "audit_event_subject_input",
+      audit_event[0], subject_id);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = insert_audit_fact_symbol (self, "audit_event_action_input",
+      audit_event[0], action);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = insert_audit_fact_symbol (self, "audit_event_resource_input",
+      audit_event[0], resource_id);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = insert_audit_fact_symbol (self, "audit_event_deny_reason_input",
+      audit_event[0], deny_reason);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return insert_audit_fact_symbol (self, "audit_event_deny_origin_input",
+      audit_event[0], deny_origin);
+}
+
+wyrelog_error_t
+wyl_handle_load_policy_store_audit_facts (WylHandle *self)
+{
+  if (self == NULL || !WYL_IS_HANDLE (self))
+    return WYRELOG_E_INVALID;
+  if (self->policy_store == NULL || self->read_engine == NULL
+      || self->delta_engine == NULL)
+    return WYRELOG_E_INVALID;
+
+  return wyl_policy_store_foreach_audit_event (self->policy_store,
+      insert_policy_store_audit_fact, self);
 }
 
 typedef struct


### PR DESCRIPTION
## Summary
- add LoBAC audit input facts and observable audit_event projections
- replay persisted policy-store audit rows when engine pairs load or reload
- cover full and sparse audit rows in the audit replay test

## Tests
- git diff --check
- meson test -C builddir --print-errorlogs
- meson test -C builddir-audit --print-errorlogs
