### PR TITLE
policy-store: harden LoBAC audit mutation integrity

### DIFF
--- a/tests/test-audit-emit.c
+++ b/tests/test-audit-emit.c
@@ -1657,6 +1657,206 @@ check_emit_rejects_null_args (void)
 }
 
 static gint
+check_emit_projects_wirelog_facts_immediately (void)
+{
+  WylHandle *handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 193;
+
+  g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
+  wyl_audit_event_set_subject_id (ev, "audit-live-user");
+  wyl_audit_event_set_action (ev, "audit-live-action");
+  wyl_audit_event_set_resource_id (ev, "audit-live-resource");
+  wyl_audit_event_set_deny_reason (ev, "not_armed");
+  wyl_audit_event_set_deny_origin (ev, "perm_state");
+  wyl_audit_event_set_decision (ev, WYL_DECISION_DENY);
+  g_autofree gchar *id = wyl_audit_event_dup_id_string (ev);
+  gint64 created_at_us = wyl_audit_event_get_created_at_us (ev);
+
+  if (wyl_audit_emit (handle, ev) != WYRELOG_E_OK) {
+    g_object_unref (handle);
+    return 194;
+  }
+
+  gboolean contains = FALSE;
+  if (contains_audit_event_fact (handle, id, created_at_us, "deny", &contains)
+      != WYRELOG_E_OK || !contains) {
+    g_object_unref (handle);
+    return 195;
+  }
+  if (contains_audit_event_attr_fact (handle, "audit_event_subject", id,
+          "audit-live-user", &contains) != WYRELOG_E_OK || !contains) {
+    g_object_unref (handle);
+    return 196;
+  }
+  if (contains_audit_event_attr_fact (handle, "audit_event_action", id,
+          "audit-live-action", &contains) != WYRELOG_E_OK || !contains) {
+    g_object_unref (handle);
+    return 197;
+  }
+  if (contains_audit_event_attr_fact (handle, "audit_event_resource", id,
+          "audit-live-resource", &contains) != WYRELOG_E_OK || !contains) {
+    g_object_unref (handle);
+    return 198;
+  }
+  if (contains_audit_event_attr_fact (handle, "audit_event_deny_reason", id,
+          "not_armed", &contains) != WYRELOG_E_OK || !contains) {
+    g_object_unref (handle);
+    return 199;
+  }
+  if (contains_audit_event_attr_fact (handle, "audit_event_deny_origin", id,
+          "perm_state", &contains) != WYRELOG_E_OK || !contains) {
+    g_object_unref (handle);
+    return 200;
+  }
+
+  g_object_unref (handle);
+  return 0;
+}
+
+static gint
+check_emit_projects_sparse_wirelog_facts_immediately (void)
+{
+  WylHandle *handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 201;
+
+  g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
+  wyl_audit_event_set_action (ev, "audit-live-sparse-action");
+  wyl_audit_event_set_decision (ev, WYL_DECISION_ALLOW);
+  g_autofree gchar *id = wyl_audit_event_dup_id_string (ev);
+  gint64 created_at_us = wyl_audit_event_get_created_at_us (ev);
+
+  if (wyl_audit_emit (handle, ev) != WYRELOG_E_OK) {
+    g_object_unref (handle);
+    return 202;
+  }
+
+  gboolean contains = FALSE;
+  if (contains_audit_event_fact (handle, id, created_at_us, "allow", &contains)
+      != WYRELOG_E_OK || !contains) {
+    g_object_unref (handle);
+    return 203;
+  }
+  if (contains_audit_event_attr_fact (handle, "audit_event_action", id,
+          "audit-live-sparse-action", &contains) != WYRELOG_E_OK || !contains) {
+    g_object_unref (handle);
+    return 204;
+  }
+
+  static const gchar *relations[] = {
+    "audit_event_subject",
+    "audit_event_resource",
+    "audit_event_deny_reason",
+    "audit_event_deny_origin",
+  };
+  for (gsize i = 0; i < G_N_ELEMENTS (relations); i++) {
+    guint count = 0;
+    if (count_audit_attr_facts (handle, relations[i], id, &count)
+        != WYRELOG_E_OK) {
+      g_object_unref (handle);
+      return (gint) (205 + i);
+    }
+    if (count != 0) {
+      g_object_unref (handle);
+      return (gint) (210 + i);
+    }
+  }
+
+  g_object_unref (handle);
+  return 0;
+}
+
+static gint
+check_emit_reports_live_projection_failure (void)
+{
+  WylHandle *handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 215;
+
+  wyl_handle_set_engine_insert_fault_once (handle, "audit_event_input",
+      WYRELOG_E_INTERNAL);
+
+  g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
+  wyl_audit_event_set_subject_id (ev, "audit-live-fail-user");
+  wyl_audit_event_set_action (ev, "audit-live-fail-action");
+  wyl_audit_event_set_decision (ev, WYL_DECISION_DENY);
+  if (wyl_audit_emit (handle, ev) != WYRELOG_E_INTERNAL) {
+    g_object_unref (handle);
+    return 216;
+  }
+
+  g_object_unref (handle);
+  return 0;
+}
+
+static gint
+check_denied_login_skip_mfa_projects_audit_fact (void)
+{
+  WylHandle *handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 217;
+
+  g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
+  wyl_login_req_set_username (login, "audit-live-skip-mfa-denied-user");
+  wyl_login_req_set_skip_mfa (login, TRUE);
+  g_autoptr (WylSession) session = NULL;
+  if (wyl_session_login (handle, login, &session) != WYRELOG_E_POLICY) {
+    g_object_unref (handle);
+    return 218;
+  }
+  if (session != NULL) {
+    g_object_unref (handle);
+    return 219;
+  }
+
+  gboolean contains = FALSE;
+  gint64 authenticated[2];
+  if (intern_symbol (handle, "audit-live-skip-mfa-denied-user",
+          &authenticated[0]) != WYRELOG_E_OK
+      || intern_symbol (handle, "authenticated", &authenticated[1])
+      != WYRELOG_E_OK
+      || wyl_handle_engine_contains (handle, "principal_state", authenticated,
+          2, &contains) != WYRELOG_E_OK) {
+    g_object_unref (handle);
+    return 220;
+  }
+  if (contains) {
+    g_object_unref (handle);
+    return 221;
+  }
+
+  duckdb_connection conn =
+      wyl_audit_conn_get_connection (wyl_handle_get_audit_conn (handle));
+  duckdb_result result;
+  if (duckdb_query (conn,
+          "SELECT id FROM audit_events WHERE action = 'login_skip_mfa';",
+          &result) != DuckDBSuccess) {
+    duckdb_destroy_result (&result);
+    g_object_unref (handle);
+    return 222;
+  }
+  if (duckdb_row_count (&result) != 1) {
+    duckdb_destroy_result (&result);
+    g_object_unref (handle);
+    return 223;
+  }
+  const gchar *audit_id = duckdb_value_varchar (&result, 0, 0);
+  if (contains_audit_event_attr_fact (handle, "audit_event_action",
+          audit_id, "login_skip_mfa", &contains) != WYRELOG_E_OK || !contains) {
+    duckdb_free ((void *) audit_id);
+    duckdb_destroy_result (&result);
+    g_object_unref (handle);
+    return 224;
+  }
+
+  duckdb_free ((void *) audit_id);
+  duckdb_destroy_result (&result);
+  g_object_unref (handle);
+  return 0;
+}
+
+static gint
 check_policy_store_audit_rows_load_wirelog_facts (void)
 {
   WylHandle *handle = NULL;
@@ -1782,6 +1982,12 @@ main (void)
     return rc;
   if ((rc = check_policy_store_audit_replay_rolls_back_corrupt_row ()) != 0)
     return rc;
+  if ((rc = check_emit_projects_wirelog_facts_immediately ()) != 0)
+    return rc;
+  if ((rc = check_emit_projects_sparse_wirelog_facts_immediately ()) != 0)
+    return rc;
+  if ((rc = check_emit_reports_live_projection_failure ()) != 0)
+    return rc;
   if ((rc = check_decide_persists_representative_deny_reason ()) != 0)
     return rc;
   if ((rc = check_decide_fail_closes_on_audit_append_failure ()) != 0)
@@ -1803,6 +2009,8 @@ main (void)
   if ((rc = check_login_skip_mfa_emits_principal_state_audit_row ()) != 0)
     return rc;
   if ((rc = check_denied_login_skip_mfa_emits_audit_row ()) != 0)
+    return rc;
+  if ((rc = check_denied_login_skip_mfa_projects_audit_fact ()) != 0)
     return rc;
   if ((rc = check_permission_grant_emits_audit_row ()) != 0)
     return rc;

--- a/tests/test-audit-emit.c
+++ b/tests/test-audit-emit.c
@@ -87,6 +87,9 @@ insert_symbol_row4 (WylHandle *handle, const gchar *relation, const gchar *a,
   return wyl_handle_engine_insert (handle, relation, row, 4);
 }
 
+static gint seed_audit_role_permission (WylHandle * handle,
+    const gchar * role_id, const gchar * perm_id);
+
 static wyrelog_error_t
 contains_audit_event_fact (WylHandle *handle, const gchar *id,
     gint64 created_at_us, const gchar *decision, gboolean *out_contains)
@@ -806,6 +809,148 @@ check_decide_fail_closes_on_audit_append_failure (void)
   if (g_strcmp0 (wyl_decide_resp_get_deny_origin (resp), "audit_events") != 0) {
     g_object_unref (handle);
     return 56;
+  }
+
+  g_object_unref (handle);
+  return 0;
+}
+
+static gint
+check_permission_grant_rolls_back_on_store_audit_failure (void)
+{
+  WylHandle *handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 57;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (sqlite3_exec (wyl_policy_store_get_db (store),
+          "CREATE TRIGGER fail_permission_grant_audit "
+          "BEFORE INSERT ON audit_events "
+          "BEGIN SELECT RAISE(ABORT, 'fail audit'); END;",
+          NULL, NULL, NULL) != SQLITE_OK) {
+    g_object_unref (handle);
+    return 58;
+  }
+
+  g_autoptr (wyl_grant_req_t) req = wyl_grant_req_new ();
+  wyl_grant_req_set_subject_id (req, "audit-grant-rollback-user");
+  wyl_grant_req_set_action (req, "wr.audit-grant-rollback");
+  wyl_grant_req_set_resource_id (req, "audit-grant-rollback-scope");
+  if (wyl_perm_grant (handle, req) != WYRELOG_E_IO) {
+    g_object_unref (handle);
+    return 59;
+  }
+
+  gboolean exists = TRUE;
+  if (wyl_policy_store_direct_permission_exists (store,
+          "audit-grant-rollback-user", "wr.audit-grant-rollback",
+          "audit-grant-rollback-scope", &exists) != WYRELOG_E_OK) {
+    g_object_unref (handle);
+    return 60;
+  }
+  if (exists) {
+    g_object_unref (handle);
+    return 61;
+  }
+
+  g_object_unref (handle);
+  return 0;
+}
+
+static gint
+check_role_grant_rolls_back_on_store_audit_failure (void)
+{
+  WylHandle *handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 68;
+  if (seed_audit_role_permission (handle, "wr.audit-role-rollback",
+          "wr.audit-role-rollback.read") != 0) {
+    g_object_unref (handle);
+    return 69;
+  }
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (sqlite3_exec (wyl_policy_store_get_db (store),
+          "CREATE TRIGGER fail_role_grant_audit "
+          "BEFORE INSERT ON audit_events "
+          "BEGIN SELECT RAISE(ABORT, 'fail audit'); END;",
+          NULL, NULL, NULL) != SQLITE_OK) {
+    g_object_unref (handle);
+    return 70;
+  }
+
+  g_autoptr (wyl_role_grant_req_t) req = wyl_role_grant_req_new ();
+  wyl_role_grant_req_set_subject_id (req, "audit-role-rollback-user");
+  wyl_role_grant_req_set_role_id (req, "wr.audit-role-rollback");
+  wyl_role_grant_req_set_scope (req, "audit-role-rollback-scope");
+  if (wyl_role_grant (handle, req) != WYRELOG_E_IO) {
+    g_object_unref (handle);
+    return 71;
+  }
+
+  gboolean exists = TRUE;
+  if (wyl_policy_store_role_membership_exists (store,
+          "audit-role-rollback-user", "wr.audit-role-rollback",
+          "audit-role-rollback-scope", &exists) != WYRELOG_E_OK) {
+    g_object_unref (handle);
+    return 72;
+  }
+  if (exists) {
+    g_object_unref (handle);
+    return 73;
+  }
+
+  g_object_unref (handle);
+  return 0;
+}
+
+static gint
+check_permission_grant_survives_runtime_audit_failure (void)
+{
+  WylHandle *handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 62;
+
+  duckdb_connection conn =
+      wyl_audit_conn_get_connection (wyl_handle_get_audit_conn (handle));
+  duckdb_result result;
+  if (duckdb_query (conn, "DROP TABLE audit_events;", &result)
+      != DuckDBSuccess) {
+    duckdb_destroy_result (&result);
+    g_object_unref (handle);
+    return 63;
+  }
+  duckdb_destroy_result (&result);
+
+  g_autoptr (wyl_grant_req_t) req = wyl_grant_req_new ();
+  wyl_grant_req_set_subject_id (req, "audit-grant-runtime-user");
+  wyl_grant_req_set_action (req, "wr.audit-grant-runtime");
+  wyl_grant_req_set_resource_id (req, "audit-grant-runtime-scope");
+  if (wyl_perm_grant (handle, req) != WYRELOG_E_OK) {
+    g_object_unref (handle);
+    return 64;
+  }
+
+  sqlite3_stmt *stmt = NULL;
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (sqlite3_prepare_v2 (wyl_policy_store_get_db (store),
+          "SELECT COUNT(*) FROM audit_events WHERE action = ?;", -1, &stmt,
+          NULL) != SQLITE_OK) {
+    g_object_unref (handle);
+    return 65;
+  }
+  if (sqlite3_bind_text (stmt, 1, "permission_grant", -1,
+          SQLITE_TRANSIENT) != SQLITE_OK) {
+    sqlite3_finalize (stmt);
+    g_object_unref (handle);
+    return 66;
+  }
+  int step_rc = sqlite3_step (stmt);
+  gint64 count = step_rc == SQLITE_ROW ? sqlite3_column_int64 (stmt, 0) : -1;
+  sqlite3_finalize (stmt);
+  if (count != 1) {
+    g_object_unref (handle);
+    return 67;
   }
 
   g_object_unref (handle);
@@ -1640,6 +1785,12 @@ main (void)
   if ((rc = check_decide_persists_representative_deny_reason ()) != 0)
     return rc;
   if ((rc = check_decide_fail_closes_on_audit_append_failure ()) != 0)
+    return rc;
+  if ((rc = check_permission_grant_rolls_back_on_store_audit_failure ()) != 0)
+    return rc;
+  if ((rc = check_role_grant_rolls_back_on_store_audit_failure ()) != 0)
+    return rc;
+  if ((rc = check_permission_grant_survives_runtime_audit_failure ()) != 0)
     return rc;
   if ((rc = check_session_transition_emits_audit_row ()) != 0)
     return rc;

--- a/tests/test-policy-store.c
+++ b/tests/test-policy-store.c
@@ -577,6 +577,90 @@ check_store_grants_direct_permission (void)
 }
 
 static gint
+check_role_membership_mutation_rolls_back_on_event_failure (void)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 197;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 198;
+  if (wyl_policy_store_upsert_role (store, "wr.rollback-role",
+          "rollback role") != WYRELOG_E_OK)
+    return 199;
+  if (sqlite3_exec (wyl_policy_store_get_db (store),
+          "CREATE TRIGGER fail_role_membership_event "
+          "BEFORE INSERT ON role_membership_events "
+          "BEGIN SELECT RAISE(ABORT, 'fail event'); END;",
+          NULL, NULL, NULL) != SQLITE_OK)
+    return 200;
+
+  if (wyl_policy_store_apply_role_membership_mutation (store,
+          "rollback-role-user", "wr.rollback-role", "rollback-role-scope",
+          TRUE) != WYRELOG_E_IO)
+    return 201;
+
+  gboolean exists = TRUE;
+  if (wyl_policy_store_role_membership_exists (store, "rollback-role-user",
+          "wr.rollback-role", "rollback-role-scope", &exists)
+      != WYRELOG_E_OK)
+    return 202;
+  if (exists)
+    return 203;
+
+  RoleMembershipEventExpect expect = {
+    .subject_id = "rollback-role-user",
+    .role_id = "wr.rollback-role",
+    .scope = "rollback-role-scope",
+    .operation = "grant",
+  };
+  if (wyl_policy_store_foreach_role_membership_event (store,
+          role_membership_event_expect_cb, &expect) != WYRELOG_E_OK)
+    return 204;
+  if (expect.matches != 0)
+    return 205;
+  return 0;
+}
+
+static gint
+check_role_membership_revoke_rolls_back_on_event_failure (void)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 206;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 207;
+  if (wyl_policy_store_upsert_role (store, "wr.rollback-role-revoke",
+          "rollback role revoke") != WYRELOG_E_OK)
+    return 208;
+  if (wyl_policy_store_grant_role_membership (store,
+          "rollback-role-revoke-user", "wr.rollback-role-revoke",
+          "rollback-role-revoke-scope") != WYRELOG_E_OK)
+    return 209;
+  if (sqlite3_exec (wyl_policy_store_get_db (store),
+          "CREATE TRIGGER fail_role_membership_revoke_event "
+          "BEFORE INSERT ON role_membership_events "
+          "BEGIN SELECT RAISE(ABORT, 'fail event'); END;",
+          NULL, NULL, NULL) != SQLITE_OK)
+    return 210;
+
+  if (wyl_policy_store_apply_role_membership_mutation (store,
+          "rollback-role-revoke-user", "wr.rollback-role-revoke",
+          "rollback-role-revoke-scope", FALSE) != WYRELOG_E_IO)
+    return 211;
+
+  gboolean exists = FALSE;
+  if (wyl_policy_store_role_membership_exists (store,
+          "rollback-role-revoke-user", "wr.rollback-role-revoke",
+          "rollback-role-revoke-scope", &exists) != WYRELOG_E_OK)
+    return 212;
+  if (!exists)
+    return 213;
+  return 0;
+}
+
+static gint
 check_store_appends_direct_permission_event (void)
 {
   g_autoptr (wyl_policy_store_t) store = NULL;
@@ -600,6 +684,106 @@ check_store_appends_direct_permission_event (void)
     return 95;
   if (expect.matches != 1)
     return 96;
+  return 0;
+}
+
+static gint
+check_direct_permission_mutation_rolls_back_on_event_failure (void)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 180;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 181;
+  if (sqlite3_exec (wyl_policy_store_get_db (store),
+          "CREATE TRIGGER fail_direct_permission_event "
+          "BEFORE INSERT ON direct_permission_events "
+          "BEGIN SELECT RAISE(ABORT, 'fail event'); END;",
+          NULL, NULL, NULL) != SQLITE_OK)
+    return 182;
+
+  if (wyl_policy_store_apply_direct_permission_mutation (store,
+          "rollback-user", "wr.rollback-direct", "rollback-scope", TRUE)
+      != WYRELOG_E_IO)
+    return 183;
+
+  gboolean exists = TRUE;
+  if (wyl_policy_store_direct_permission_exists (store, "rollback-user",
+          "wr.rollback-direct", "rollback-scope", &exists) != WYRELOG_E_OK)
+    return 184;
+  if (exists)
+    return 185;
+
+  DirectPermissionExpect expect = {
+    .subject_id = "rollback-user",
+    .perm_id = "wr.rollback-direct",
+    .scope = "rollback-scope",
+    .operation = "grant",
+  };
+  if (wyl_policy_store_foreach_direct_permission_event (store,
+          direct_permission_event_expect_cb, &expect) != WYRELOG_E_OK)
+    return 186;
+  if (expect.matches != 0)
+    return 187;
+
+  gboolean permission_exists = FALSE;
+  if (wyl_policy_store_table_exists (store, "permissions", &permission_exists)
+      != WYRELOG_E_OK || !permission_exists)
+    return 188;
+  sqlite3_stmt *stmt = NULL;
+  if (sqlite3_prepare_v2 (wyl_policy_store_get_db (store),
+          "SELECT 1 FROM permissions WHERE perm_id = ?;", -1, &stmt,
+          NULL) != SQLITE_OK)
+    return 214;
+  if (sqlite3_bind_text (stmt, 1, "wr.rollback-direct", -1,
+          SQLITE_TRANSIENT) != SQLITE_OK) {
+    sqlite3_finalize (stmt);
+    return 215;
+  }
+  int step_rc = sqlite3_step (stmt);
+  sqlite3_finalize (stmt);
+  if (step_rc == SQLITE_ROW)
+    return 216;
+  if (step_rc != SQLITE_DONE)
+    return 217;
+  return 0;
+}
+
+static gint
+check_direct_permission_revoke_rolls_back_on_event_failure (void)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 189;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 190;
+  if (wyl_policy_store_upsert_permission (store, "wr.rollback-revoke",
+          "rollback revoke", "basic") != WYRELOG_E_OK)
+    return 191;
+  if (wyl_policy_store_grant_direct_permission (store, "rollback-revoke-user",
+          "wr.rollback-revoke", "rollback-revoke-scope") != WYRELOG_E_OK)
+    return 192;
+  if (sqlite3_exec (wyl_policy_store_get_db (store),
+          "CREATE TRIGGER fail_direct_permission_revoke_event "
+          "BEFORE INSERT ON direct_permission_events "
+          "BEGIN SELECT RAISE(ABORT, 'fail event'); END;",
+          NULL, NULL, NULL) != SQLITE_OK)
+    return 193;
+
+  if (wyl_policy_store_apply_direct_permission_mutation (store,
+          "rollback-revoke-user", "wr.rollback-revoke",
+          "rollback-revoke-scope", FALSE) != WYRELOG_E_IO)
+    return 194;
+
+  gboolean exists = FALSE;
+  if (wyl_policy_store_direct_permission_exists (store,
+          "rollback-revoke-user", "wr.rollback-revoke",
+          "rollback-revoke-scope", &exists) != WYRELOG_E_OK)
+    return 195;
+  if (!exists)
+    return 196;
   return 0;
 }
 
@@ -1097,7 +1281,19 @@ main (void)
     return rc;
   if ((rc = check_store_grants_direct_permission ()) != 0)
     return rc;
+  if ((rc = check_role_membership_mutation_rolls_back_on_event_failure ())
+      != 0)
+    return rc;
+  if ((rc = check_role_membership_revoke_rolls_back_on_event_failure ())
+      != 0)
+    return rc;
   if ((rc = check_store_appends_direct_permission_event ()) != 0)
+    return rc;
+  if ((rc = check_direct_permission_mutation_rolls_back_on_event_failure ())
+      != 0)
+    return rc;
+  if ((rc = check_direct_permission_revoke_rolls_back_on_event_failure ())
+      != 0)
     return rc;
   if ((rc = check_store_sets_principal_state ()) != 0)
     return rc;

--- a/wyrelog/audit/event-private.h
+++ b/wyrelog/audit/event-private.h
@@ -19,4 +19,7 @@ wyrelog_error_t wyl_audit_event_new_from_fields (const gchar * id,
     const gchar * deny_origin,
     wyl_decision_t decision, WylAuditEvent ** out_event);
 
+wyrelog_error_t wyl_audit_mirror_event (WylHandle * handle,
+    const WylAuditEvent * event);
+
 G_END_DECLS;

--- a/wyrelog/audit/event.c
+++ b/wyrelog/audit/event.c
@@ -215,12 +215,11 @@ wyl_audit_event_get_decision (const WylAuditEvent *self)
 }
 
 wyrelog_error_t
-wyl_audit_emit (WylHandle *handle, const WylAuditEvent *event)
+wyl_audit_mirror_event (WylHandle *handle, const WylAuditEvent *event)
 {
 #ifdef WYL_HAS_AUDIT
   wyl_audit_conn_t *audit_conn;
   gchar id_buf[WYL_ID_STRING_BUF];
-  gboolean inserted = FALSE;
 
   if (handle == NULL || event == NULL)
     return WYRELOG_E_INVALID;
@@ -232,10 +231,37 @@ wyl_audit_emit (WylHandle *handle, const WylAuditEvent *event)
   if (wyl_id_format (&event->id, id_buf, sizeof id_buf) != WYRELOG_E_OK)
     return WYRELOG_E_INTERNAL;
 
+  return wyl_audit_conn_insert_event (audit_conn, id_buf, event->created_at_us,
+      event->subject_id, event->action, event->resource_id, event->deny_reason,
+      event->deny_origin, event->decision);
+#else
+  (void) handle;
+  (void) event;
+  return WYRELOG_E_INTERNAL;
+#endif
+}
+
+wyrelog_error_t
+wyl_audit_emit (WylHandle *handle, const WylAuditEvent *event)
+{
+#ifdef WYL_HAS_AUDIT
+  gchar id_buf[WYL_ID_STRING_BUF];
+  gboolean inserted = FALSE;
+
+  if (handle == NULL || event == NULL)
+    return WYRELOG_E_INVALID;
+
+  if (wyl_id_format (&event->id, id_buf, sizeof id_buf) != WYRELOG_E_OK)
+    return WYRELOG_E_INTERNAL;
+
+  wyl_audit_conn_t *audit_conn = wyl_handle_get_audit_conn (handle);
+  if (audit_conn == NULL)
+    return WYRELOG_E_INTERNAL;
+
   wyrelog_error_t rc = wyl_audit_conn_insert_event_full (audit_conn, id_buf,
-      event->created_at_us,
-      event->subject_id, event->action, event->resource_id,
-      event->deny_reason, event->deny_origin, event->decision, &inserted);
+      event->created_at_us, event->subject_id, event->action,
+      event->resource_id, event->deny_reason, event->deny_origin,
+      event->decision, &inserted);
   if (rc != WYRELOG_E_OK)
     return rc;
 

--- a/wyrelog/audit/event.c
+++ b/wyrelog/audit/event.c
@@ -288,6 +288,12 @@ wyl_audit_emit (WylHandle *handle, const WylAuditEvent *event)
     return store_rc;
   }
 
+  rc = wyl_handle_insert_audit_fact (handle, id_buf, event->created_at_us,
+      event->subject_id, event->action, event->resource_id,
+      event->deny_reason, event->deny_origin, event->decision);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
   return WYRELOG_E_OK;
 #else
   (void) handle;

--- a/wyrelog/policy/store-private.h
+++ b/wyrelog/policy/store-private.h
@@ -76,6 +76,10 @@ wyrelog_error_t wyl_policy_store_grant_role_membership (wyl_policy_store_t *
 wyrelog_error_t wyl_policy_store_revoke_role_membership (wyl_policy_store_t *
     store, const gchar * subject_id, const gchar * role_id,
     const gchar * scope);
+wyrelog_error_t
+wyl_policy_store_apply_role_membership_mutation (wyl_policy_store_t * store,
+    const gchar * subject_id, const gchar * role_id, const gchar * scope,
+    gboolean insert);
 wyrelog_error_t wyl_policy_store_role_membership_exists (wyl_policy_store_t *
     store, const gchar * subject_id, const gchar * role_id,
     const gchar * scope, gboolean * out_exists);
@@ -94,6 +98,10 @@ wyrelog_error_t wyl_policy_store_grant_direct_permission (wyl_policy_store_t *
 wyrelog_error_t wyl_policy_store_revoke_direct_permission (wyl_policy_store_t *
     store, const gchar * subject_id, const gchar * perm_id,
     const gchar * scope);
+wyrelog_error_t
+wyl_policy_store_apply_direct_permission_mutation (wyl_policy_store_t * store,
+    const gchar * subject_id, const gchar * perm_id, const gchar * scope,
+    gboolean insert);
 wyrelog_error_t wyl_policy_store_direct_permission_exists (wyl_policy_store_t *
     store, const gchar * subject_id, const gchar * perm_id, const gchar * scope,
     gboolean * out_exists);

--- a/wyrelog/policy/store-private.h
+++ b/wyrelog/policy/store-private.h
@@ -80,6 +80,14 @@ wyrelog_error_t
 wyl_policy_store_apply_role_membership_mutation (wyl_policy_store_t * store,
     const gchar * subject_id, const gchar * role_id, const gchar * scope,
     gboolean insert);
+wyrelog_error_t
+    wyl_policy_store_apply_role_membership_mutation_with_audit
+    (wyl_policy_store_t * store, const gchar * subject_id,
+    const gchar * role_id, const gchar * scope, gboolean insert,
+    const gchar * audit_id, gint64 audit_created_at_us,
+    const gchar * audit_subject_id, const gchar * audit_action,
+    const gchar * audit_resource_id, const gchar * audit_deny_reason,
+    const gchar * audit_deny_origin, wyl_decision_t audit_decision);
 wyrelog_error_t wyl_policy_store_role_membership_exists (wyl_policy_store_t *
     store, const gchar * subject_id, const gchar * role_id,
     const gchar * scope, gboolean * out_exists);
@@ -102,6 +110,14 @@ wyrelog_error_t
 wyl_policy_store_apply_direct_permission_mutation (wyl_policy_store_t * store,
     const gchar * subject_id, const gchar * perm_id, const gchar * scope,
     gboolean insert);
+wyrelog_error_t
+    wyl_policy_store_apply_direct_permission_mutation_with_audit
+    (wyl_policy_store_t * store, const gchar * subject_id,
+    const gchar * perm_id, const gchar * scope, gboolean insert,
+    const gchar * audit_id, gint64 audit_created_at_us,
+    const gchar * audit_subject_id, const gchar * audit_action,
+    const gchar * audit_resource_id, const gchar * audit_deny_reason,
+    const gchar * audit_deny_origin, wyl_decision_t audit_decision);
 wyrelog_error_t wyl_policy_store_direct_permission_exists (wyl_policy_store_t *
     store, const gchar * subject_id, const gchar * perm_id, const gchar * scope,
     gboolean * out_exists);

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -418,9 +418,13 @@ wyl_policy_store_revoke_direct_permission (wyl_policy_store_t *store,
 }
 
 wyrelog_error_t
-wyl_policy_store_apply_direct_permission_mutation (wyl_policy_store_t *store,
-    const gchar *subject_id, const gchar *perm_id, const gchar *scope,
-    gboolean insert)
+    wyl_policy_store_apply_direct_permission_mutation_with_audit
+    (wyl_policy_store_t * store, const gchar * subject_id,
+    const gchar * perm_id, const gchar * scope, gboolean insert,
+    const gchar * audit_id, gint64 audit_created_at_us,
+    const gchar * audit_subject_id, const gchar * audit_action,
+    const gchar * audit_resource_id, const gchar * audit_deny_reason,
+    const gchar * audit_deny_origin, wyl_decision_t audit_decision)
 {
   if (store == NULL || store->db == NULL || subject_id == NULL
       || perm_id == NULL || scope == NULL)
@@ -445,6 +449,12 @@ wyl_policy_store_apply_direct_permission_mutation (wyl_policy_store_t *store,
     rc = wyl_policy_store_append_direct_permission_event (store, subject_id,
         perm_id, scope, insert ? "grant" : "revoke");
   }
+  if (rc == WYRELOG_E_OK && audit_id != NULL) {
+    rc = wyl_policy_store_append_audit_event (store, audit_id,
+        audit_created_at_us, audit_subject_id, audit_action,
+        audit_resource_id, audit_deny_reason, audit_deny_origin,
+        audit_decision);
+  }
   if (rc != WYRELOG_E_OK) {
     rollback_mutation_savepoint (store);
     return rc;
@@ -456,6 +466,16 @@ wyl_policy_store_apply_direct_permission_mutation (wyl_policy_store_t *store,
     return rc;
   }
   return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
+wyl_policy_store_apply_direct_permission_mutation (wyl_policy_store_t *store,
+    const gchar *subject_id, const gchar *perm_id, const gchar *scope,
+    gboolean insert)
+{
+  return wyl_policy_store_apply_direct_permission_mutation_with_audit (store,
+      subject_id, perm_id, scope, insert, NULL, 0, NULL, NULL, NULL, NULL, NULL,
+      WYL_DECISION_DENY);
 }
 
 wyrelog_error_t
@@ -1079,9 +1099,13 @@ wyl_policy_store_revoke_role_membership (wyl_policy_store_t *store,
 }
 
 wyrelog_error_t
-wyl_policy_store_apply_role_membership_mutation (wyl_policy_store_t *store,
-    const gchar *subject_id, const gchar *role_id, const gchar *scope,
-    gboolean insert)
+    wyl_policy_store_apply_role_membership_mutation_with_audit
+    (wyl_policy_store_t * store, const gchar * subject_id,
+    const gchar * role_id, const gchar * scope, gboolean insert,
+    const gchar * audit_id, gint64 audit_created_at_us,
+    const gchar * audit_subject_id, const gchar * audit_action,
+    const gchar * audit_resource_id, const gchar * audit_deny_reason,
+    const gchar * audit_deny_origin, wyl_decision_t audit_decision)
 {
   if (store == NULL || store->db == NULL || subject_id == NULL
       || role_id == NULL || scope == NULL)
@@ -1100,6 +1124,12 @@ wyl_policy_store_apply_role_membership_mutation (wyl_policy_store_t *store,
     rc = wyl_policy_store_append_role_membership_event (store, subject_id,
         role_id, scope, insert ? "grant" : "revoke");
   }
+  if (rc == WYRELOG_E_OK && audit_id != NULL) {
+    rc = wyl_policy_store_append_audit_event (store, audit_id,
+        audit_created_at_us, audit_subject_id, audit_action,
+        audit_resource_id, audit_deny_reason, audit_deny_origin,
+        audit_decision);
+  }
   if (rc != WYRELOG_E_OK) {
     rollback_mutation_savepoint (store);
     return rc;
@@ -1111,6 +1141,16 @@ wyl_policy_store_apply_role_membership_mutation (wyl_policy_store_t *store,
     return rc;
   }
   return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
+wyl_policy_store_apply_role_membership_mutation (wyl_policy_store_t *store,
+    const gchar *subject_id, const gchar *role_id, const gchar *scope,
+    gboolean insert)
+{
+  return wyl_policy_store_apply_role_membership_mutation_with_audit (store,
+      subject_id, role_id, scope, insert, NULL, 0, NULL, NULL, NULL, NULL, NULL,
+      WYL_DECISION_DENY);
 }
 
 wyrelog_error_t

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -57,6 +57,31 @@ column_nullable_text_equal (sqlite3_stmt *stmt, int col, const gchar *expected)
       expected) == 0;
 }
 
+static wyrelog_error_t
+begin_mutation_savepoint (wyl_policy_store_t *store)
+{
+  if (store == NULL || store->db == NULL)
+    return WYRELOG_E_INVALID;
+  return exec_sql (store->db, "SAVEPOINT wyrelog_policy_mutation;");
+}
+
+static wyrelog_error_t
+commit_mutation_savepoint (wyl_policy_store_t *store)
+{
+  if (store == NULL || store->db == NULL)
+    return WYRELOG_E_INVALID;
+  return exec_sql (store->db, "RELEASE SAVEPOINT wyrelog_policy_mutation;");
+}
+
+static void
+rollback_mutation_savepoint (wyl_policy_store_t *store)
+{
+  if (store == NULL || store->db == NULL)
+    return;
+  (void) exec_sql (store->db, "ROLLBACK TO SAVEPOINT wyrelog_policy_mutation;");
+  (void) exec_sql (store->db, "RELEASE SAVEPOINT wyrelog_policy_mutation;");
+}
+
 wyrelog_error_t
 wyl_policy_store_open (const gchar *path, wyl_policy_store_t **out_store)
 {
@@ -390,6 +415,47 @@ wyl_policy_store_revoke_direct_permission (wyl_policy_store_t *store,
   int step_rc = sqlite3_step (stmt);
   sqlite3_finalize (stmt);
   return (step_rc == SQLITE_DONE) ? WYRELOG_E_OK : WYRELOG_E_IO;
+}
+
+wyrelog_error_t
+wyl_policy_store_apply_direct_permission_mutation (wyl_policy_store_t *store,
+    const gchar *subject_id, const gchar *perm_id, const gchar *scope,
+    gboolean insert)
+{
+  if (store == NULL || store->db == NULL || subject_id == NULL
+      || perm_id == NULL || scope == NULL)
+    return WYRELOG_E_INVALID;
+
+  wyrelog_error_t rc = begin_mutation_savepoint (store);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  if (insert)
+    rc = wyl_policy_store_upsert_permission (store, perm_id, perm_id, "basic");
+  else
+    rc = WYRELOG_E_OK;
+  if (rc == WYRELOG_E_OK) {
+    rc = insert
+        ? wyl_policy_store_grant_direct_permission (store, subject_id, perm_id,
+        scope)
+        : wyl_policy_store_revoke_direct_permission (store, subject_id,
+        perm_id, scope);
+  }
+  if (rc == WYRELOG_E_OK) {
+    rc = wyl_policy_store_append_direct_permission_event (store, subject_id,
+        perm_id, scope, insert ? "grant" : "revoke");
+  }
+  if (rc != WYRELOG_E_OK) {
+    rollback_mutation_savepoint (store);
+    return rc;
+  }
+
+  rc = commit_mutation_savepoint (store);
+  if (rc != WYRELOG_E_OK) {
+    rollback_mutation_savepoint (store);
+    return rc;
+  }
+  return WYRELOG_E_OK;
 }
 
 wyrelog_error_t
@@ -1010,6 +1076,41 @@ wyl_policy_store_revoke_role_membership (wyl_policy_store_t *store,
   int step_rc = sqlite3_step (stmt);
   sqlite3_finalize (stmt);
   return (step_rc == SQLITE_DONE) ? WYRELOG_E_OK : WYRELOG_E_IO;
+}
+
+wyrelog_error_t
+wyl_policy_store_apply_role_membership_mutation (wyl_policy_store_t *store,
+    const gchar *subject_id, const gchar *role_id, const gchar *scope,
+    gboolean insert)
+{
+  if (store == NULL || store->db == NULL || subject_id == NULL
+      || role_id == NULL || scope == NULL)
+    return WYRELOG_E_INVALID;
+
+  wyrelog_error_t rc = begin_mutation_savepoint (store);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  rc = insert
+      ? wyl_policy_store_grant_role_membership (store, subject_id, role_id,
+      scope)
+      : wyl_policy_store_revoke_role_membership (store, subject_id, role_id,
+      scope);
+  if (rc == WYRELOG_E_OK) {
+    rc = wyl_policy_store_append_role_membership_event (store, subject_id,
+        role_id, scope, insert ? "grant" : "revoke");
+  }
+  if (rc != WYRELOG_E_OK) {
+    rollback_mutation_savepoint (store);
+    return rc;
+  }
+
+  rc = commit_mutation_savepoint (store);
+  if (rc != WYRELOG_E_OK) {
+    rollback_mutation_savepoint (store);
+    return rc;
+  }
+  return WYRELOG_E_OK;
 }
 
 wyrelog_error_t

--- a/wyrelog/wyl-handle-private.h
+++ b/wyrelog/wyl-handle-private.h
@@ -83,7 +83,27 @@ typedef struct
 {
   gchar *relation;
   wyrelog_error_t rc;
-} WylHandleEngineRemoveFaultOnce;
+} WylHandleEngineFaultOnce;
+
+typedef WylHandleEngineFaultOnce WylHandleEngineInsertFaultOnce;
+typedef WylHandleEngineFaultOnce WylHandleEngineRemoveFaultOnce;
+
+static inline void
+wyl_handle_engine_fault_once_free (gpointer data)
+{
+  WylHandleEngineFaultOnce *fault = data;
+
+  if (fault == NULL)
+    return;
+  g_free (fault->relation);
+  g_free (fault);
+}
+
+static inline GQuark
+wyl_handle_engine_insert_fault_once_quark (void)
+{
+  return g_quark_from_static_string ("wyrelog-handle-engine-insert-fault-once");
+}
 
 static inline GQuark
 wyl_handle_engine_remove_fault_once_quark (void)
@@ -94,12 +114,31 @@ wyl_handle_engine_remove_fault_once_quark (void)
 static inline void
 wyl_handle_engine_remove_fault_once_free (gpointer data)
 {
-  WylHandleEngineRemoveFaultOnce *fault = data;
+  wyl_handle_engine_fault_once_free (data);
+}
 
-  if (fault == NULL)
-    return;
-  g_free (fault->relation);
-  g_free (fault);
+/*
+ * Test-only fault hook for private insert-path coverage. The next
+ * wyl_handle_engine_insert() call for @relation fails with @rc before the row
+ * reaches the engine. The hook clears after one match.
+ * @rc must be a non-OK error.
+ */
+static inline void
+wyl_handle_set_engine_insert_fault_once (WylHandle *self,
+    const gchar *relation, wyrelog_error_t rc)
+{
+  WylHandleEngineInsertFaultOnce *fault;
+
+  g_return_if_fail (WYL_IS_HANDLE (self));
+  g_return_if_fail (relation != NULL);
+  g_return_if_fail (rc != WYRELOG_E_OK);
+
+  fault = g_new0 (WylHandleEngineInsertFaultOnce, 1);
+  fault->relation = g_strdup (relation);
+  fault->rc = rc;
+  g_object_set_qdata_full (G_OBJECT (self),
+      wyl_handle_engine_insert_fault_once_quark (), fault,
+      wyl_handle_engine_fault_once_free);
 }
 
 /*
@@ -201,6 +240,17 @@ wyrelog_error_t wyl_handle_load_policy_store_session_events (WylHandle * self);
  * symbols. Rejected unless both the store and engine pair are available.
  */
 wyrelog_error_t wyl_handle_load_policy_store_audit_facts (WylHandle * self);
+
+/*
+ * Projects one durable audit row into the currently attached read engine as
+ * private audit_event* facts. A handle without an open engine pair accepts the
+ * row as already durable and performs no live projection.
+ */
+wyrelog_error_t wyl_handle_insert_audit_fact (WylHandle * self,
+    const gchar * id, gint64 created_at_us, const gchar * subject_id,
+    const gchar * action, const gchar * resource_id,
+    const gchar * deny_reason, const gchar * deny_origin,
+    wyl_decision_t decision);
 
 /*
  * Probes the read engine for an exact EDB/IDB row match. Rejected unless the

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -558,6 +558,16 @@ wyl_handle_engine_insert (WylHandle *self, const gchar *relation,
   if (self->read_engine == NULL || self->delta_engine == NULL)
     return WYRELOG_E_INVALID;
 
+  WylHandleEngineInsertFaultOnce *fault = g_object_get_qdata (G_OBJECT (self),
+      wyl_handle_engine_insert_fault_once_quark ());
+  if (fault != NULL && g_strcmp0 (fault->relation, relation) == 0) {
+    wyrelog_error_t fault_rc = fault->rc;
+    g_object_steal_qdata (G_OBJECT (self),
+        wyl_handle_engine_insert_fault_once_quark ());
+    wyl_handle_engine_fault_once_free (fault);
+    return fault_rc;
+  }
+
   wyrelog_error_t rc =
       wyl_engine_insert (self->read_engine, relation, row, ncols);
   if (rc != WYRELOG_E_OK)
@@ -938,6 +948,23 @@ insert_policy_store_audit_fact (const gchar *id, gint64 created_at_us,
     wyl_decision_t decision, gpointer user_data)
 {
   WylHandle *self = user_data;
+  return wyl_handle_insert_audit_fact (self, id, created_at_us, subject_id,
+      action, resource_id, deny_reason, deny_origin, decision);
+}
+
+wyrelog_error_t
+wyl_handle_insert_audit_fact (WylHandle *self, const gchar *id,
+    gint64 created_at_us, const gchar *subject_id, const gchar *action,
+    const gchar *resource_id, const gchar *deny_reason,
+    const gchar *deny_origin, wyl_decision_t decision)
+{
+  if (self == NULL || !WYL_IS_HANDLE (self))
+    return WYRELOG_E_INVALID;
+  if (id == NULL || created_at_us < 0)
+    return WYRELOG_E_INVALID;
+  if (self->read_engine == NULL || self->delta_engine == NULL)
+    return WYRELOG_E_OK;
+
   const gchar *decision_name = decision_symbol (decision);
   if (decision_name == NULL)
     return WYRELOG_E_POLICY;

--- a/wyrelog/wyl-perm.c
+++ b/wyrelog/wyl-perm.c
@@ -341,25 +341,8 @@ update_direct_permission_store (WylHandle *handle, const gchar *subject_id,
   if (store == NULL)
     return WYRELOG_E_INVALID;
 
-  if (insert) {
-    wyrelog_error_t rc =
-        wyl_policy_store_upsert_permission (store, action, action, "basic");
-    if (rc != WYRELOG_E_OK)
-      return rc;
-    rc = wyl_policy_store_grant_direct_permission (store, subject_id,
-        action, resource_id);
-    if (rc != WYRELOG_E_OK)
-      return rc;
-    return wyl_policy_store_append_direct_permission_event (store, subject_id,
-        action, resource_id, "grant");
-  }
-
-  wyrelog_error_t rc = wyl_policy_store_revoke_direct_permission (store,
-      subject_id, action, resource_id);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  return wyl_policy_store_append_direct_permission_event (store, subject_id,
-      action, resource_id, "revoke");
+  return wyl_policy_store_apply_direct_permission_mutation (store, subject_id,
+      action, resource_id, insert);
 }
 
 static wyrelog_error_t
@@ -370,15 +353,8 @@ update_role_membership_store (WylHandle *handle, const gchar *subject_id,
   if (store == NULL)
     return WYRELOG_E_INVALID;
 
-  wyrelog_error_t rc = insert
-      ? wyl_policy_store_grant_role_membership (store, subject_id, role_id,
-      scope)
-      : wyl_policy_store_revoke_role_membership (store, subject_id, role_id,
-      scope);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  return wyl_policy_store_append_role_membership_event (store, subject_id,
-      role_id, scope, insert ? "grant" : "revoke");
+  return wyl_policy_store_apply_role_membership_mutation (store, subject_id,
+      role_id, scope, insert);
 }
 
 static wyrelog_error_t

--- a/wyrelog/wyl-perm.c
+++ b/wyrelog/wyl-perm.c
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #include "wyrelog/wyrelog.h"
 
+#include "audit/event-private.h"
 #include "wyl-handle-private.h"
 #include "wyl-permission-scope-private.h"
 
@@ -335,26 +336,60 @@ wyl_role_revoke_req_get_scope (const wyl_role_revoke_req_t *req)
 
 static wyrelog_error_t
 update_direct_permission_store (WylHandle *handle, const gchar *subject_id,
-    const gchar *action, const gchar *resource_id, gboolean insert)
+    const gchar *action, const gchar *resource_id, gboolean insert,
+    const WylAuditEvent *audit_event)
 {
   wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
   if (store == NULL)
     return WYRELOG_E_INVALID;
 
-  return wyl_policy_store_apply_direct_permission_mutation (store, subject_id,
-      action, resource_id, insert);
+  if (audit_event == NULL) {
+    return wyl_policy_store_apply_direct_permission_mutation (store,
+        subject_id, action, resource_id, insert);
+  }
+
+  g_autofree gchar *audit_id = wyl_audit_event_dup_id_string (audit_event);
+  if (audit_id == NULL)
+    return WYRELOG_E_INTERNAL;
+
+  return wyl_policy_store_apply_direct_permission_mutation_with_audit (store,
+      subject_id, action, resource_id, insert, audit_id,
+      wyl_audit_event_get_created_at_us (audit_event),
+      wyl_audit_event_get_subject_id (audit_event),
+      wyl_audit_event_get_action (audit_event),
+      wyl_audit_event_get_resource_id (audit_event),
+      wyl_audit_event_get_deny_reason (audit_event),
+      wyl_audit_event_get_deny_origin (audit_event),
+      wyl_audit_event_get_decision (audit_event));
 }
 
 static wyrelog_error_t
 update_role_membership_store (WylHandle *handle, const gchar *subject_id,
-    const gchar *role_id, const gchar *scope, gboolean insert)
+    const gchar *role_id, const gchar *scope, gboolean insert,
+    const WylAuditEvent *audit_event)
 {
   wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
   if (store == NULL)
     return WYRELOG_E_INVALID;
 
-  return wyl_policy_store_apply_role_membership_mutation (store, subject_id,
-      role_id, scope, insert);
+  if (audit_event == NULL) {
+    return wyl_policy_store_apply_role_membership_mutation (store, subject_id,
+        role_id, scope, insert);
+  }
+
+  g_autofree gchar *audit_id = wyl_audit_event_dup_id_string (audit_event);
+  if (audit_id == NULL)
+    return WYRELOG_E_INTERNAL;
+
+  return wyl_policy_store_apply_role_membership_mutation_with_audit (store,
+      subject_id, role_id, scope, insert, audit_id,
+      wyl_audit_event_get_created_at_us (audit_event),
+      wyl_audit_event_get_subject_id (audit_event),
+      wyl_audit_event_get_action (audit_event),
+      wyl_audit_event_get_resource_id (audit_event),
+      wyl_audit_event_get_deny_reason (audit_event),
+      wyl_audit_event_get_deny_origin (audit_event),
+      wyl_audit_event_get_decision (audit_event));
 }
 
 static wyrelog_error_t
@@ -363,6 +398,21 @@ reload_policy_snapshot (WylHandle *handle)
   if (wyl_handle_get_read_engine (handle) == NULL)
     return WYRELOG_E_OK;
   return wyl_handle_reload_engine_pair (handle);
+}
+
+static wyrelog_error_t
+finish_policy_mutation (WylHandle *handle, const WylAuditEvent *audit_event)
+{
+  wyrelog_error_t rc = reload_policy_snapshot (handle);
+
+#ifdef WYL_HAS_AUDIT
+  if (audit_event != NULL)
+    (void) wyl_audit_mirror_event (handle, audit_event);
+#else
+  (void) audit_event;
+#endif
+
+  return rc;
 }
 
 wyrelog_error_t
@@ -378,30 +428,26 @@ wyl_perm_grant (WylHandle *handle, const wyl_grant_req_t *req)
       && wyl_perm_arm_rule_lookup (wyl_grant_req_get_action (req)) != NULL)
     return WYRELOG_E_POLICY;
 
-  wyrelog_error_t rc = update_direct_permission_store (handle,
-      wyl_grant_req_get_subject_id (req), wyl_grant_req_get_action (req),
-      wyl_grant_req_get_resource_id (req), TRUE);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  rc = reload_policy_snapshot (handle);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-
 #ifdef WYL_HAS_AUDIT
-  /* Record the accepted admin operation in the audit log. The
-   * action column carries operation semantics while deny_origin
-   * retains the granted permission name for readers that need the
-   * full target triple. */
+  /* Record the accepted admin operation in the durable audit store as
+   * part of the policy mutation savepoint. The action column carries
+   * operation semantics while deny_origin retains the permission name. */
   g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
   wyl_audit_event_set_subject_id (ev, wyl_grant_req_get_subject_id (req));
   wyl_audit_event_set_action (ev, "permission_grant");
   wyl_audit_event_set_resource_id (ev, wyl_grant_req_get_resource_id (req));
   wyl_audit_event_set_deny_origin (ev, wyl_grant_req_get_action (req));
   wyl_audit_event_set_decision (ev, WYL_DECISION_ALLOW);
-  (void) wyl_audit_emit (handle, ev);
+#else
+  WylAuditEvent *ev = NULL;
 #endif
 
-  return WYRELOG_E_OK;
+  wyrelog_error_t rc = update_direct_permission_store (handle,
+      wyl_grant_req_get_subject_id (req), wyl_grant_req_get_action (req),
+      wyl_grant_req_get_resource_id (req), TRUE, ev);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return finish_policy_mutation (handle, ev);
 }
 
 wyrelog_error_t
@@ -414,28 +460,23 @@ wyl_perm_revoke (WylHandle *handle, const wyl_revoke_req_t *req)
       || wyl_revoke_req_get_resource_id (req) == NULL)
     return WYRELOG_E_INVALID;
 
-  wyrelog_error_t rc = update_direct_permission_store (handle,
-      wyl_revoke_req_get_subject_id (req), wyl_revoke_req_get_action (req),
-      wyl_revoke_req_get_resource_id (req), FALSE);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  rc = reload_policy_snapshot (handle);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-
 #ifdef WYL_HAS_AUDIT
-  /* Mirror revoke in audit alongside grant (see wyl_perm_grant for
-   * rationale). */
   g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
   wyl_audit_event_set_subject_id (ev, wyl_revoke_req_get_subject_id (req));
   wyl_audit_event_set_action (ev, "permission_revoke");
   wyl_audit_event_set_resource_id (ev, wyl_revoke_req_get_resource_id (req));
   wyl_audit_event_set_deny_origin (ev, wyl_revoke_req_get_action (req));
   wyl_audit_event_set_decision (ev, WYL_DECISION_ALLOW);
-  (void) wyl_audit_emit (handle, ev);
+#else
+  WylAuditEvent *ev = NULL;
 #endif
 
-  return WYRELOG_E_OK;
+  wyrelog_error_t rc = update_direct_permission_store (handle,
+      wyl_revoke_req_get_subject_id (req), wyl_revoke_req_get_action (req),
+      wyl_revoke_req_get_resource_id (req), FALSE, ev);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return finish_policy_mutation (handle, ev);
 }
 
 wyrelog_error_t
@@ -448,16 +489,6 @@ wyl_role_grant (WylHandle *handle, const wyl_role_grant_req_t *req)
       || wyl_role_grant_req_get_scope (req) == NULL)
     return WYRELOG_E_INVALID;
 
-  wyrelog_error_t rc = update_role_membership_store (handle,
-      wyl_role_grant_req_get_subject_id (req),
-      wyl_role_grant_req_get_role_id (req), wyl_role_grant_req_get_scope (req),
-      TRUE);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  rc = reload_policy_snapshot (handle);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-
 #ifdef WYL_HAS_AUDIT
   g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
   wyl_audit_event_set_subject_id (ev, wyl_role_grant_req_get_subject_id (req));
@@ -465,10 +496,17 @@ wyl_role_grant (WylHandle *handle, const wyl_role_grant_req_t *req)
   wyl_audit_event_set_resource_id (ev, wyl_role_grant_req_get_scope (req));
   wyl_audit_event_set_deny_origin (ev, wyl_role_grant_req_get_role_id (req));
   wyl_audit_event_set_decision (ev, WYL_DECISION_ALLOW);
-  (void) wyl_audit_emit (handle, ev);
+#else
+  WylAuditEvent *ev = NULL;
 #endif
 
-  return WYRELOG_E_OK;
+  wyrelog_error_t rc = update_role_membership_store (handle,
+      wyl_role_grant_req_get_subject_id (req),
+      wyl_role_grant_req_get_role_id (req), wyl_role_grant_req_get_scope (req),
+      TRUE, ev);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return finish_policy_mutation (handle, ev);
 }
 
 wyrelog_error_t
@@ -481,16 +519,6 @@ wyl_role_revoke (WylHandle *handle, const wyl_role_revoke_req_t *req)
       || wyl_role_revoke_req_get_scope (req) == NULL)
     return WYRELOG_E_INVALID;
 
-  wyrelog_error_t rc = update_role_membership_store (handle,
-      wyl_role_revoke_req_get_subject_id (req),
-      wyl_role_revoke_req_get_role_id (req),
-      wyl_role_revoke_req_get_scope (req), FALSE);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  rc = reload_policy_snapshot (handle);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-
 #ifdef WYL_HAS_AUDIT
   g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
   wyl_audit_event_set_subject_id (ev, wyl_role_revoke_req_get_subject_id (req));
@@ -498,8 +526,15 @@ wyl_role_revoke (WylHandle *handle, const wyl_role_revoke_req_t *req)
   wyl_audit_event_set_resource_id (ev, wyl_role_revoke_req_get_scope (req));
   wyl_audit_event_set_deny_origin (ev, wyl_role_revoke_req_get_role_id (req));
   wyl_audit_event_set_decision (ev, WYL_DECISION_ALLOW);
-  (void) wyl_audit_emit (handle, ev);
+#else
+  WylAuditEvent *ev = NULL;
 #endif
 
-  return WYRELOG_E_OK;
+  wyrelog_error_t rc = update_role_membership_store (handle,
+      wyl_role_revoke_req_get_subject_id (req),
+      wyl_role_revoke_req_get_role_id (req),
+      wyl_role_revoke_req_get_scope (req), FALSE, ev);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return finish_policy_mutation (handle, ev);
 }


### PR DESCRIPTION
## Summary

- group permission and role mutation state rows with their mutation event rows
- persist accepted mutation audit rows in the same policy-store savepoint
- project emitted audit rows into active wirelog audit facts immediately

## Tests

- git diff --check
- meson test -C builddir --print-errorlogs
- meson test -C builddir-audit --print-errorlogs
