### PR TITLE
Strengthen LoBAC session audit mutations

### DIFF
--- a/tests/test-audit-emit.c
+++ b/tests/test-audit-emit.c
@@ -1353,6 +1353,49 @@ check_denied_login_skip_mfa_emits_audit_row (void)
 }
 
 static gint
+check_denied_login_skip_mfa_reports_audit_failure (void)
+{
+  WylHandle *handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 225;
+
+  wyl_handle_set_engine_insert_fault_once (handle, "audit_event_input",
+      WYRELOG_E_INTERNAL);
+
+  g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
+  wyl_login_req_set_username (login, "audit-skip-mfa-fail-user");
+  wyl_login_req_set_skip_mfa (login, TRUE);
+  g_autoptr (WylSession) session = NULL;
+  if (wyl_session_login (handle, login, &session) != WYRELOG_E_INTERNAL) {
+    g_object_unref (handle);
+    return 226;
+  }
+  if (session != NULL) {
+    g_object_unref (handle);
+    return 227;
+  }
+
+  gboolean contains = FALSE;
+  gint64 authenticated[2];
+  if (intern_symbol (handle, "audit-skip-mfa-fail-user",
+          &authenticated[0]) != WYRELOG_E_OK
+      || intern_symbol (handle, "authenticated", &authenticated[1])
+      != WYRELOG_E_OK
+      || wyl_handle_engine_contains (handle, "principal_state", authenticated,
+          2, &contains) != WYRELOG_E_OK) {
+    g_object_unref (handle);
+    return 228;
+  }
+  if (contains) {
+    g_object_unref (handle);
+    return 229;
+  }
+
+  g_object_unref (handle);
+  return 0;
+}
+
+static gint
 check_permission_grant_emits_audit_row (void)
 {
   WylHandle *handle = NULL;
@@ -2009,6 +2052,8 @@ main (void)
   if ((rc = check_login_skip_mfa_emits_principal_state_audit_row ()) != 0)
     return rc;
   if ((rc = check_denied_login_skip_mfa_emits_audit_row ()) != 0)
+    return rc;
+  if ((rc = check_denied_login_skip_mfa_reports_audit_failure ()) != 0)
     return rc;
   if ((rc = check_denied_login_skip_mfa_projects_audit_fact ()) != 0)
     return rc;

--- a/tests/test-audit-emit.c
+++ b/tests/test-audit-emit.c
@@ -25,6 +25,24 @@ intern_symbol (WylHandle *handle, const gchar *symbol, gint64 *out_id)
   return wyl_handle_intern_engine_symbol (handle, symbol, out_id);
 }
 
+static gboolean
+policy_count_rows (wyl_policy_store_t *store, const gchar *sql,
+    gint64 *out_count)
+{
+  sqlite3_stmt *stmt = NULL;
+  if (sqlite3_prepare_v2 (wyl_policy_store_get_db (store), sql, -1, &stmt,
+          NULL) != SQLITE_OK)
+    return FALSE;
+
+  gboolean ok = FALSE;
+  if (sqlite3_step (stmt) == SQLITE_ROW) {
+    *out_count = sqlite3_column_int64 (stmt, 0);
+    ok = TRUE;
+  }
+  sqlite3_finalize (stmt);
+  return ok;
+}
+
 static wyrelog_error_t
 insert_symbol_row1 (WylHandle *handle, const gchar *relation,
     const gchar *value)
@@ -862,7 +880,7 @@ check_role_grant_rolls_back_on_store_audit_failure (void)
 {
   WylHandle *handle = NULL;
   if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
-    return 68;
+    return 246;
   if (seed_audit_role_permission (handle, "wr.audit-role-rollback",
           "wr.audit-role-rollback.read") != 0) {
     g_object_unref (handle);
@@ -951,6 +969,65 @@ check_permission_grant_survives_runtime_audit_failure (void)
   if (count != 1) {
     g_object_unref (handle);
     return 67;
+  }
+
+  g_object_unref (handle);
+  return 0;
+}
+
+static gint
+check_login_survives_runtime_audit_failure (void)
+{
+  WylHandle *handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 68;
+
+  duckdb_connection conn =
+      wyl_audit_conn_get_connection (wyl_handle_get_audit_conn (handle));
+  duckdb_result result;
+  if (duckdb_query (conn, "DROP TABLE audit_events;", &result)
+      != DuckDBSuccess) {
+    duckdb_destroy_result (&result);
+    g_object_unref (handle);
+    return 247;
+  }
+  duckdb_destroy_result (&result);
+
+  g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
+  wyl_login_req_set_username (login, "audit-login-runtime-user");
+  wyl_handle_set_login_skip_mfa_allowed (handle, TRUE);
+  wyl_login_req_set_skip_mfa (login, TRUE);
+  g_autoptr (WylSession) session = NULL;
+  if (wyl_session_login (handle, login, &session) != WYRELOG_E_OK) {
+    g_object_unref (handle);
+    return 248;
+  }
+  if (session == NULL) {
+    g_object_unref (handle);
+    return 249;
+  }
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  gint64 count = -1;
+  if (!policy_count_rows (store,
+          "SELECT COUNT(*) FROM audit_events "
+          "WHERE action = 'principal_state';", &count)) {
+    g_object_unref (handle);
+    return 250;
+  }
+  if (count != 1) {
+    g_object_unref (handle);
+    return 251;
+  }
+  if (!policy_count_rows (store,
+          "SELECT COUNT(*) FROM audit_events "
+          "WHERE action = 'session_state';", &count)) {
+    g_object_unref (handle);
+    return 252;
+  }
+  if (count != 1) {
+    g_object_unref (handle);
+    return 253;
   }
 
   g_object_unref (handle);
@@ -1389,6 +1466,165 @@ check_denied_login_skip_mfa_reports_audit_failure (void)
   if (contains) {
     g_object_unref (handle);
     return 229;
+  }
+
+  g_object_unref (handle);
+  return 0;
+}
+
+static gint
+check_allowed_login_skip_mfa_rolls_back_on_store_audit_failure (void)
+{
+  WylHandle *handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 230;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (sqlite3_exec (wyl_policy_store_get_db (store),
+          "CREATE TRIGGER fail_skip_mfa_principal_audit "
+          "BEFORE INSERT ON audit_events WHEN NEW.action = 'principal_state' "
+          "BEGIN SELECT RAISE(ABORT, 'fail audit'); END;",
+          NULL, NULL, NULL) != SQLITE_OK) {
+    g_object_unref (handle);
+    return 231;
+  }
+
+  g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
+  wyl_login_req_set_username (login, "audit-skip-mfa-store-fail-user");
+  wyl_login_req_set_skip_mfa (login, TRUE);
+  wyl_handle_set_login_skip_mfa_allowed (handle, TRUE);
+  g_autoptr (WylSession) session = NULL;
+  if (wyl_session_login (handle, login, &session) != WYRELOG_E_IO) {
+    g_object_unref (handle);
+    return 232;
+  }
+  if (session != NULL) {
+    g_object_unref (handle);
+    return 233;
+  }
+
+  gboolean contains = FALSE;
+  gint64 authenticated[2];
+  if (intern_symbol (handle, "audit-skip-mfa-store-fail-user",
+          &authenticated[0]) != WYRELOG_E_OK
+      || intern_symbol (handle, "authenticated", &authenticated[1])
+      != WYRELOG_E_OK
+      || wyl_handle_engine_contains (handle, "principal_state", authenticated,
+          2, &contains) != WYRELOG_E_OK) {
+    g_object_unref (handle);
+    return 234;
+  }
+  if (contains) {
+    g_object_unref (handle);
+    return 235;
+  }
+
+  gint64 count = -1;
+  if (!policy_count_rows (store, "SELECT COUNT(*) FROM principal_states;",
+          &count)) {
+    g_object_unref (handle);
+    return 254;
+  }
+  if (count != 0) {
+    g_object_unref (handle);
+    return 255;
+  }
+  if (!policy_count_rows (store, "SELECT COUNT(*) FROM principal_events;",
+          &count)) {
+    g_object_unref (handle);
+    return 256;
+  }
+  if (count != 0) {
+    g_object_unref (handle);
+    return 257;
+  }
+  if (!policy_count_rows (store, "SELECT COUNT(*) FROM audit_events;", &count)) {
+    g_object_unref (handle);
+    return 258;
+  }
+  if (count != 0) {
+    g_object_unref (handle);
+    return 259;
+  }
+
+  g_object_unref (handle);
+  return 0;
+}
+
+static gint
+check_login_session_state_rolls_back_on_store_audit_failure (void)
+{
+  WylHandle *handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 236;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (sqlite3_exec (wyl_policy_store_get_db (store),
+          "CREATE TRIGGER fail_session_state_audit "
+          "BEFORE INSERT ON audit_events WHEN NEW.action = 'session_state' "
+          "BEGIN SELECT RAISE(ABORT, 'fail audit'); END;",
+          NULL, NULL, NULL) != SQLITE_OK) {
+    g_object_unref (handle);
+    return 237;
+  }
+
+  g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
+  wyl_login_req_set_username (login, "audit-session-store-fail-user");
+  g_autoptr (WylSession) session = NULL;
+  if (wyl_session_login (handle, login, &session) != WYRELOG_E_IO) {
+    g_object_unref (handle);
+    return 238;
+  }
+  if (session != NULL) {
+    g_object_unref (handle);
+    return 239;
+  }
+
+  gint64 count = -1;
+  if (!policy_count_rows (store, "SELECT COUNT(*) FROM session_states;",
+          &count)) {
+    g_object_unref (handle);
+    return 240;
+  }
+  if (count != 0) {
+    g_object_unref (handle);
+    return 241;
+  }
+
+  if (!policy_count_rows (store, "SELECT COUNT(*) FROM principal_states;",
+          &count)) {
+    g_object_unref (handle);
+    return 242;
+  }
+  if (count != 0) {
+    g_object_unref (handle);
+    return 243;
+  }
+  if (!policy_count_rows (store, "SELECT COUNT(*) FROM session_events;",
+          &count)) {
+    g_object_unref (handle);
+    return 244;
+  }
+  if (count != 0) {
+    g_object_unref (handle);
+    return 245;
+  }
+  if (!policy_count_rows (store, "SELECT COUNT(*) FROM principal_events;",
+          &count)) {
+    g_object_unref (handle);
+    return 260;
+  }
+  if (count != 0) {
+    g_object_unref (handle);
+    return 261;
+  }
+  if (!policy_count_rows (store, "SELECT COUNT(*) FROM audit_events;", &count)) {
+    g_object_unref (handle);
+    return 262;
+  }
+  if (count != 0) {
+    g_object_unref (handle);
+    return 263;
   }
 
   g_object_unref (handle);
@@ -2041,6 +2277,8 @@ main (void)
     return rc;
   if ((rc = check_permission_grant_survives_runtime_audit_failure ()) != 0)
     return rc;
+  if ((rc = check_login_survives_runtime_audit_failure ()) != 0)
+    return rc;
   if ((rc = check_session_transition_emits_audit_row ()) != 0)
     return rc;
   if ((rc = check_login_session_state_emits_audit_row ()) != 0)
@@ -2054,6 +2292,12 @@ main (void)
   if ((rc = check_denied_login_skip_mfa_emits_audit_row ()) != 0)
     return rc;
   if ((rc = check_denied_login_skip_mfa_reports_audit_failure ()) != 0)
+    return rc;
+  if ((rc = check_allowed_login_skip_mfa_rolls_back_on_store_audit_failure ())
+      != 0)
+    return rc;
+  if ((rc = check_login_session_state_rolls_back_on_store_audit_failure ())
+      != 0)
     return rc;
   if ((rc = check_denied_login_skip_mfa_projects_audit_fact ()) != 0)
     return rc;

--- a/wyrelog/daemon/checks.c
+++ b/wyrelog/daemon/checks.c
@@ -86,19 +86,35 @@ wyl_daemon_check_audit_sink_ready (WylHandle *handle)
   return WYRELOG_E_OK;
 }
 
+static wyrelog_error_t
+login_check_principal (WylHandle *handle, const gchar *username,
+    WylSession **out_session)
+{
+  if (out_session == NULL)
+    return WYRELOG_E_INVALID;
+  *out_session = NULL;
+
+  g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
+  wyl_login_req_set_username (login, username);
+
+  g_autoptr (WylSession) session = NULL;
+  wyrelog_error_t rc = wyl_session_login (handle, login, &session);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_session_mfa_verify (handle, session);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  *out_session = g_steal_pointer (&session);
+  return WYRELOG_E_OK;
+}
+
 wyrelog_error_t
 wyl_daemon_check_policy_snapshot_reload_ready (WylHandle *handle)
 {
-  g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
-  wyl_login_req_set_username (login, "wyrelogd-snapshot-user");
-  wyl_login_req_set_skip_mfa (login, TRUE);
-
   g_autoptr (WylSession) session = NULL;
-  gboolean skip_mfa_was_allowed =
-      wyl_handle_get_login_skip_mfa_allowed (handle);
-  wyl_handle_set_login_skip_mfa_allowed (handle, TRUE);
-  wyrelog_error_t rc = wyl_session_login (handle, login, &session);
-  wyl_handle_set_login_skip_mfa_allowed (handle, skip_mfa_was_allowed);
+  wyrelog_error_t rc =
+      login_check_principal (handle, "wyrelogd-snapshot-user", &session);
   if (rc != WYRELOG_E_OK)
     return rc;
 
@@ -149,16 +165,9 @@ insert_symbol_row (WylHandle *handle, const gchar *relation,
 wyrelog_error_t
 wyl_daemon_check_role_permission_snapshot_reload_ready (WylHandle *handle)
 {
-  g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
-  wyl_login_req_set_username (login, "wyrelogd-role-user");
-  wyl_login_req_set_skip_mfa (login, TRUE);
-
   g_autoptr (WylSession) session = NULL;
-  gboolean skip_mfa_was_allowed =
-      wyl_handle_get_login_skip_mfa_allowed (handle);
-  wyl_handle_set_login_skip_mfa_allowed (handle, TRUE);
-  wyrelog_error_t rc = wyl_session_login (handle, login, &session);
-  wyl_handle_set_login_skip_mfa_allowed (handle, skip_mfa_was_allowed);
+  wyrelog_error_t rc =
+      login_check_principal (handle, "wyrelogd-role-user", &session);
   if (rc != WYRELOG_E_OK)
     return rc;
 

--- a/wyrelog/policy/store-private.h
+++ b/wyrelog/policy/store-private.h
@@ -55,6 +55,10 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC (wyl_policy_store_t, wyl_policy_store_close);
 
 sqlite3 *wyl_policy_store_get_db (wyl_policy_store_t * store);
 
+wyrelog_error_t wyl_policy_store_begin_mutation (wyl_policy_store_t * store);
+wyrelog_error_t wyl_policy_store_commit_mutation (wyl_policy_store_t * store);
+void wyl_policy_store_rollback_mutation (wyl_policy_store_t * store);
+
 wyrelog_error_t wyl_policy_store_create_schema (wyl_policy_store_t * store);
 wyrelog_error_t wyl_policy_store_table_exists (wyl_policy_store_t * store,
     const gchar * table_name, gboolean * out_exists);

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -57,24 +57,24 @@ column_nullable_text_equal (sqlite3_stmt *stmt, int col, const gchar *expected)
       expected) == 0;
 }
 
-static wyrelog_error_t
-begin_mutation_savepoint (wyl_policy_store_t *store)
+wyrelog_error_t
+wyl_policy_store_begin_mutation (wyl_policy_store_t *store)
 {
   if (store == NULL || store->db == NULL)
     return WYRELOG_E_INVALID;
   return exec_sql (store->db, "SAVEPOINT wyrelog_policy_mutation;");
 }
 
-static wyrelog_error_t
-commit_mutation_savepoint (wyl_policy_store_t *store)
+wyrelog_error_t
+wyl_policy_store_commit_mutation (wyl_policy_store_t *store)
 {
   if (store == NULL || store->db == NULL)
     return WYRELOG_E_INVALID;
   return exec_sql (store->db, "RELEASE SAVEPOINT wyrelog_policy_mutation;");
 }
 
-static void
-rollback_mutation_savepoint (wyl_policy_store_t *store)
+void
+wyl_policy_store_rollback_mutation (wyl_policy_store_t *store)
 {
   if (store == NULL || store->db == NULL)
     return;
@@ -430,7 +430,7 @@ wyrelog_error_t
       || perm_id == NULL || scope == NULL)
     return WYRELOG_E_INVALID;
 
-  wyrelog_error_t rc = begin_mutation_savepoint (store);
+  wyrelog_error_t rc = wyl_policy_store_begin_mutation (store);
   if (rc != WYRELOG_E_OK)
     return rc;
 
@@ -456,13 +456,13 @@ wyrelog_error_t
         audit_decision);
   }
   if (rc != WYRELOG_E_OK) {
-    rollback_mutation_savepoint (store);
+    wyl_policy_store_rollback_mutation (store);
     return rc;
   }
 
-  rc = commit_mutation_savepoint (store);
+  rc = wyl_policy_store_commit_mutation (store);
   if (rc != WYRELOG_E_OK) {
-    rollback_mutation_savepoint (store);
+    wyl_policy_store_rollback_mutation (store);
     return rc;
   }
   return WYRELOG_E_OK;
@@ -1111,7 +1111,7 @@ wyrelog_error_t
       || role_id == NULL || scope == NULL)
     return WYRELOG_E_INVALID;
 
-  wyrelog_error_t rc = begin_mutation_savepoint (store);
+  wyrelog_error_t rc = wyl_policy_store_begin_mutation (store);
   if (rc != WYRELOG_E_OK)
     return rc;
 
@@ -1131,13 +1131,13 @@ wyrelog_error_t
         audit_decision);
   }
   if (rc != WYRELOG_E_OK) {
-    rollback_mutation_savepoint (store);
+    wyl_policy_store_rollback_mutation (store);
     return rc;
   }
 
-  rc = commit_mutation_savepoint (store);
+  rc = wyl_policy_store_commit_mutation (store);
   if (rc != WYRELOG_E_OK) {
-    rollback_mutation_savepoint (store);
+    wyl_policy_store_rollback_mutation (store);
     return rc;
   }
   return WYRELOG_E_OK;

--- a/wyrelog/wyl-handle-private.h
+++ b/wyrelog/wyl-handle-private.h
@@ -275,5 +275,7 @@ wyrelog_error_t wyl_handle_engine_decide (WylHandle * self,
  */
 WylEngine *wyl_handle_get_read_engine (WylHandle * self);
 WylEngine *wyl_handle_get_delta_engine (WylHandle * self);
+wyrelog_error_t wyl_handle_replay_delta_insert (WylHandle * self,
+    const gchar * relation, const gint64 * row, gsize ncols);
 
 G_END_DECLS;

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -1088,3 +1088,22 @@ wyl_handle_get_delta_engine (WylHandle *self)
   g_return_val_if_fail (WYL_IS_HANDLE (self), NULL);
   return self->delta_engine;
 }
+
+wyrelog_error_t
+wyl_handle_replay_delta_insert (WylHandle *self, const gchar *relation,
+    const gint64 *row, gsize ncols)
+{
+  if (self == NULL || !WYL_IS_HANDLE (self))
+    return WYRELOG_E_INVALID;
+  if (relation == NULL || row == NULL || ncols == 0)
+    return WYRELOG_E_INVALID;
+  if (self->delta_engine == NULL)
+    return WYRELOG_E_INVALID;
+
+  if (self->delta_callback == NULL)
+    return WYRELOG_E_OK;
+
+  self->delta_callback (relation, row, (guint) ncols, WYL_DELTA_INSERT,
+      self->delta_callback_user_data);
+  return WYRELOG_E_OK;
+}

--- a/wyrelog/wyl-session.c
+++ b/wyrelog/wyl-session.c
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #include "wyrelog/wyrelog.h"
 
+#include "audit/event-private.h"
 #include "wyl-fsm-principal-private.h"
 #include "wyl-fsm-session-private.h"
 #include "wyl-handle-private.h"
@@ -54,68 +55,6 @@ wyl_session_init (WylSession *self)
 }
 
 static wyrelog_error_t
-insert_principal_state (WylHandle *handle, const gchar *username,
-    wyl_principal_state_t state)
-{
-  if (username == NULL || wyl_handle_get_read_engine (handle) == NULL)
-    return WYRELOG_E_OK;
-
-  const gchar *state_name = wyl_principal_state_name (state);
-  if (state_name == NULL)
-    return WYRELOG_E_INTERNAL;
-
-  gint64 row[2];
-  wyrelog_error_t rc =
-      wyl_handle_intern_engine_symbol (handle, username, &row[0]);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  rc = wyl_handle_intern_engine_symbol (handle, state_name, &row[1]);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  return wyl_handle_engine_insert (handle, "principal_state", row, 2);
-}
-
-static wyrelog_error_t
-remove_principal_state (WylHandle *handle, const gchar *username,
-    wyl_principal_state_t state)
-{
-  if (username == NULL || wyl_handle_get_read_engine (handle) == NULL)
-    return WYRELOG_E_OK;
-
-  const gchar *state_name = wyl_principal_state_name (state);
-  if (state_name == NULL)
-    return WYRELOG_E_INTERNAL;
-
-  gint64 row[2];
-  wyrelog_error_t rc =
-      wyl_handle_intern_engine_symbol (handle, username, &row[0]);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  rc = wyl_handle_intern_engine_symbol (handle, state_name, &row[1]);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  return wyl_handle_engine_remove (handle, "principal_state", row, 2);
-}
-
-static wyrelog_error_t
-store_principal_state (WylHandle *handle, const gchar *username,
-    wyl_principal_state_t state)
-{
-  if (username == NULL)
-    return WYRELOG_E_OK;
-
-  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
-  if (store == NULL)
-    return WYRELOG_E_OK;
-
-  const gchar *state_name = wyl_principal_state_name (state);
-  if (state_name == NULL)
-    return WYRELOG_E_INTERNAL;
-
-  return wyl_policy_store_set_principal_state (store, username, state_name);
-}
-
-static wyrelog_error_t
 reload_session_snapshot (WylHandle *handle)
 {
   if (wyl_handle_get_read_engine (handle) == NULL)
@@ -123,10 +62,81 @@ reload_session_snapshot (WylHandle *handle)
   return wyl_handle_reload_engine_pair (handle);
 }
 
+#ifdef WYL_HAS_AUDIT
+static WylAuditEvent *
+new_login_skip_mfa_denied_audit (const gchar *username)
+{
+  WylAuditEvent *ev = wyl_audit_event_new ();
+  wyl_audit_event_set_subject_id (ev, username);
+  wyl_audit_event_set_action (ev, "login_skip_mfa");
+  wyl_audit_event_set_resource_id (ev, "principal_state");
+  wyl_audit_event_set_deny_reason (ev, "skip_mfa_not_allowed");
+  wyl_audit_event_set_deny_origin (ev, "login_ingress");
+  wyl_audit_event_set_decision (ev, WYL_DECISION_DENY);
+  return ev;
+}
+
 static wyrelog_error_t
-store_principal_event (WylHandle *handle, const gchar *username,
+emit_login_skip_mfa_denied_audit (WylHandle *handle, const gchar *username)
+{
+  g_autoptr (WylAuditEvent) ev = new_login_skip_mfa_denied_audit (username);
+  return wyl_audit_emit (handle, ev);
+}
+
+static WylAuditEvent *
+new_principal_state_audit (const gchar *username,
+    const gchar *old_state, const gchar *new_state, const gchar *event)
+{
+  WylAuditEvent *ev = wyl_audit_event_new ();
+  wyl_audit_event_set_subject_id (ev, username);
+  wyl_audit_event_set_action (ev, "principal_state");
+  wyl_audit_event_set_resource_id (ev, new_state);
+  wyl_audit_event_set_deny_reason (ev, event);
+  wyl_audit_event_set_deny_origin (ev, old_state);
+  wyl_audit_event_set_decision (ev, WYL_DECISION_ALLOW);
+  return ev;
+}
+#endif
+
+static wyrelog_error_t
+insert_principal_event_fact (WylHandle *handle, gint64 event_id,
+    const gchar *username, wyl_principal_state_t old_state,
+    wyl_principal_event_t event, wyl_principal_state_t new_state)
+{
+  if (wyl_handle_get_read_engine (handle) == NULL)
+    return WYRELOG_E_OK;
+  if (event_id <= 0)
+    return WYRELOG_E_OK;
+
+  const gchar *old_state_name = wyl_principal_state_name (old_state);
+  const gchar *event_name = wyl_principal_event_name (event);
+  const gchar *new_state_name = wyl_principal_state_name (new_state);
+  if (old_state_name == NULL || event_name == NULL || new_state_name == NULL)
+    return WYRELOG_E_INTERNAL;
+
+  gint64 row[5];
+  row[0] = event_id;
+  wyrelog_error_t rc =
+      wyl_handle_intern_engine_symbol (handle, username, &row[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, old_state_name, &row[2]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, event_name, &row[3]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, new_state_name, &row[4]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_replay_delta_insert (handle, "principal_fired", row, 5);
+}
+
+static wyrelog_error_t
+apply_principal_state_mutation (WylHandle *handle, const gchar *username,
     wyl_principal_state_t old_state, wyl_principal_event_t event,
-    wyl_principal_state_t new_state)
+    wyl_principal_state_t new_state, const WylAuditEvent *audit_event,
+    gint64 *out_event_id)
 {
   if (username == NULL)
     return WYRELOG_E_OK;
@@ -142,80 +152,68 @@ store_principal_event (WylHandle *handle, const gchar *username,
     return WYRELOG_E_INTERNAL;
 
   wyl_principal_state_t validated = WYL_PRINCIPAL_STATE_LAST_;
-  wyrelog_error_t validate_rc =
-      wyl_fsm_principal_step (old_state, event, &validated);
-  if (validate_rc != WYRELOG_E_OK)
-    return validate_rc;
+  wyrelog_error_t rc = wyl_fsm_principal_step (old_state, event, &validated);
+  if (rc != WYRELOG_E_OK)
+    return rc;
   if (validated != new_state)
     return WYRELOG_E_POLICY;
 
+  g_autofree gchar *audit_id = NULL;
+  if (audit_event != NULL) {
+    audit_id = wyl_audit_event_dup_id_string (audit_event);
+    if (audit_id == NULL)
+      return WYRELOG_E_INTERNAL;
+  }
+
   gint64 event_id = -1;
-  wyrelog_error_t rc = wyl_policy_store_append_principal_event (store,
-      username, event_name, old_state_name, new_state_name, &event_id);
+  rc = wyl_policy_store_begin_mutation (store);
   if (rc != WYRELOG_E_OK)
     return rc;
 
-  if (wyl_handle_get_read_engine (handle) == NULL)
-    return WYRELOG_E_OK;
-
-  gint64 row[5];
-  row[0] = event_id;
-  rc = wyl_handle_intern_engine_symbol (handle, username, &row[1]);
-  if (rc != WYRELOG_E_OK)
+  rc = wyl_policy_store_set_principal_state (store, username, new_state_name);
+  if (rc == WYRELOG_E_OK) {
+    rc = wyl_policy_store_append_principal_event (store, username,
+        event_name, old_state_name, new_state_name, &event_id);
+  }
+  if (rc == WYRELOG_E_OK && audit_event != NULL) {
+    rc = wyl_policy_store_append_audit_event (store, audit_id,
+        wyl_audit_event_get_created_at_us (audit_event),
+        wyl_audit_event_get_subject_id (audit_event),
+        wyl_audit_event_get_action (audit_event),
+        wyl_audit_event_get_resource_id (audit_event),
+        wyl_audit_event_get_deny_reason (audit_event),
+        wyl_audit_event_get_deny_origin (audit_event),
+        wyl_audit_event_get_decision (audit_event));
+  }
+  if (rc == WYRELOG_E_OK)
+    rc = wyl_policy_store_commit_mutation (store);
+  if (rc != WYRELOG_E_OK) {
+    wyl_policy_store_rollback_mutation (store);
     return rc;
-  rc = wyl_handle_intern_engine_symbol (handle, event_name, &row[2]);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  rc = wyl_handle_intern_engine_symbol (handle, old_state_name, &row[3]);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  rc = wyl_handle_intern_engine_symbol (handle, new_state_name, &row[4]);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  return wyl_handle_engine_insert (handle, "principal_event", row, 5);
+  }
+  if (out_event_id != NULL)
+    *out_event_id = event_id;
+  return WYRELOG_E_OK;
 }
 
 static wyrelog_error_t
-set_principal_state (WylHandle *handle, const gchar *username,
-    wyl_principal_state_t state)
+finish_session_mutation (WylHandle *handle, const WylAuditEvent *audit_event)
 {
-  wyrelog_error_t rc = insert_principal_state (handle, username, state);
+  wyrelog_error_t rc = reload_session_snapshot (handle);
   if (rc != WYRELOG_E_OK)
     return rc;
-  rc = store_principal_state (handle, username, state);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  return reload_session_snapshot (handle);
-}
 
 #ifdef WYL_HAS_AUDIT
-static wyrelog_error_t
-emit_login_skip_mfa_denied_audit (WylHandle *handle, const gchar *username)
-{
-  g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
-  wyl_audit_event_set_subject_id (ev, username);
-  wyl_audit_event_set_action (ev, "login_skip_mfa");
-  wyl_audit_event_set_resource_id (ev, "principal_state");
-  wyl_audit_event_set_deny_reason (ev, "skip_mfa_not_allowed");
-  wyl_audit_event_set_deny_origin (ev, "login_ingress");
-  wyl_audit_event_set_decision (ev, WYL_DECISION_DENY);
-  return wyl_audit_emit (handle, ev);
-}
-
-static void
-emit_principal_state_audit (WylHandle *handle, const gchar *username,
-    const gchar *old_state, const gchar *new_state, const gchar *event)
-{
-  g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
-  wyl_audit_event_set_subject_id (ev, username);
-  wyl_audit_event_set_action (ev, "principal_state");
-  wyl_audit_event_set_resource_id (ev, new_state);
-  wyl_audit_event_set_deny_reason (ev, event);
-  wyl_audit_event_set_deny_origin (ev, old_state);
-  wyl_audit_event_set_decision (ev, WYL_DECISION_ALLOW);
-  (void) wyl_audit_emit (handle, ev);
-}
+  if (audit_event != NULL)
+    /* Policy-store audit is durable; the live audit sink is best effort. */
+    (void) wyl_audit_mirror_event (handle, audit_event);
+#else
+  (void) handle;
+  (void) audit_event;
 #endif
+
+  return rc;
+}
 
 static wyrelog_error_t
 transition_principal_state (WylHandle *handle, const gchar *username,
@@ -226,89 +224,79 @@ transition_principal_state (WylHandle *handle, const gchar *username,
   if (old_state_name == NULL || new_state_name == NULL)
     return WYRELOG_E_INTERNAL;
 
-  wyrelog_error_t rc = remove_principal_state (handle, username, old_state);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  rc = insert_principal_state (handle, username, new_state);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  rc = store_principal_state (handle, username, new_state);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  rc = reload_session_snapshot (handle);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  rc = store_principal_event (handle, username, old_state,
-      WYL_PRINCIPAL_EVENT_MFA_OK, new_state);
-  if (rc != WYRELOG_E_OK)
-    return rc;
 #ifdef WYL_HAS_AUDIT
-  emit_principal_state_audit (handle, username, old_state_name, new_state_name,
-      wyl_principal_event_name (WYL_PRINCIPAL_EVENT_MFA_OK));
+  g_autoptr (WylAuditEvent) ev = new_principal_state_audit (username,
+      old_state_name,
+      new_state_name, wyl_principal_event_name (WYL_PRINCIPAL_EVENT_MFA_OK));
+#else
+  WylAuditEvent *ev = NULL;
 #endif
-  return WYRELOG_E_OK;
+  gint64 event_id = -1;
+  wyrelog_error_t rc = apply_principal_state_mutation (handle, username,
+      old_state, WYL_PRINCIPAL_EVENT_MFA_OK, new_state, ev, &event_id);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = finish_session_mutation (handle, ev);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return insert_principal_event_fact (handle, event_id, username, old_state,
+      WYL_PRINCIPAL_EVENT_MFA_OK, new_state);
 }
 
-static wyrelog_error_t
-insert_session_state (WylHandle *handle, const gchar *session_id,
-    const gchar *state)
+#ifdef WYL_HAS_AUDIT
+static WylAuditEvent *
+new_session_state_audit (const gchar *session_id,
+    const gchar *old_state, const gchar *new_state)
 {
-  if (session_id == NULL || wyl_handle_get_read_engine (handle) == NULL)
-    return WYRELOG_E_OK;
-  if (state == NULL)
-    return WYRELOG_E_INVALID;
+  WylAuditEvent *ev = wyl_audit_event_new ();
+  wyl_audit_event_set_subject_id (ev, session_id);
+  wyl_audit_event_set_action (ev, "session_state");
+  wyl_audit_event_set_resource_id (ev, new_state);
+  wyl_audit_event_set_deny_origin (ev, old_state);
+  wyl_audit_event_set_decision (ev, WYL_DECISION_ALLOW);
+  return ev;
+}
+#endif
 
-  gint64 row[2];
+static wyrelog_error_t
+insert_session_event_fact (WylHandle *handle, gint64 event_id,
+    const gchar *session_id, wyl_session_state_t old_state,
+    wyl_session_event_t event, wyl_session_state_t new_state)
+{
+  if (wyl_handle_get_read_engine (handle) == NULL)
+    return WYRELOG_E_OK;
+  if (event_id <= 0)
+    return WYRELOG_E_OK;
+
+  const gchar *old_state_name = wyl_session_state_name (old_state);
+  const gchar *event_name = wyl_session_event_name (event);
+  const gchar *new_state_name = wyl_session_state_name (new_state);
+  if (old_state_name == NULL || event_name == NULL || new_state_name == NULL)
+    return WYRELOG_E_INTERNAL;
+
+  gint64 row[5];
+  row[0] = event_id;
   wyrelog_error_t rc =
-      wyl_handle_intern_engine_symbol (handle, session_id, &row[0]);
+      wyl_handle_intern_engine_symbol (handle, session_id, &row[1]);
   if (rc != WYRELOG_E_OK)
     return rc;
-  rc = wyl_handle_intern_engine_symbol (handle, state, &row[1]);
+  rc = wyl_handle_intern_engine_symbol (handle, old_state_name, &row[2]);
   if (rc != WYRELOG_E_OK)
     return rc;
-  return wyl_handle_engine_insert (handle, "session_state", row, 2);
+  rc = wyl_handle_intern_engine_symbol (handle, event_name, &row[3]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, new_state_name, &row[4]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_replay_delta_insert (handle, "session_fired", row, 5);
 }
 
 static wyrelog_error_t
-remove_session_state (WylHandle *handle, const gchar *session_id,
-    const gchar *state)
-{
-  if (session_id == NULL || wyl_handle_get_read_engine (handle) == NULL)
-    return WYRELOG_E_OK;
-  if (state == NULL)
-    return WYRELOG_E_INVALID;
-
-  gint64 row[2];
-  wyrelog_error_t rc =
-      wyl_handle_intern_engine_symbol (handle, session_id, &row[0]);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  rc = wyl_handle_intern_engine_symbol (handle, state, &row[1]);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  return wyl_handle_engine_remove (handle, "session_state", row, 2);
-}
-
-static wyrelog_error_t
-store_session_state (WylHandle *handle, const gchar *session_id,
-    const gchar *state)
-{
-  if (session_id == NULL)
-    return WYRELOG_E_OK;
-  if (state == NULL)
-    return WYRELOG_E_INVALID;
-
-  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
-  if (store == NULL)
-    return WYRELOG_E_OK;
-
-  return wyl_policy_store_set_session_state (store, session_id, state);
-}
-
-static wyrelog_error_t
-store_session_event (WylHandle *handle, const gchar *session_id,
+apply_session_state_mutation (WylHandle *handle, const gchar *session_id,
     wyl_session_state_t old_state, wyl_session_event_t event,
-    wyl_session_state_t new_state)
+    wyl_session_state_t new_state, const WylAuditEvent *audit_event,
+    gint64 *out_event_id)
 {
   if (session_id == NULL)
     return WYRELOG_E_OK;
@@ -324,65 +312,163 @@ store_session_event (WylHandle *handle, const gchar *session_id,
     return WYRELOG_E_INTERNAL;
 
   wyl_session_state_t validated = WYL_SESSION_STATE_LAST_;
-  wyrelog_error_t validate_rc =
-      wyl_fsm_session_step (old_state, event, &validated);
-  if (validate_rc != WYRELOG_E_OK)
-    return validate_rc;
+  wyrelog_error_t rc = wyl_fsm_session_step (old_state, event, &validated);
+  if (rc != WYRELOG_E_OK)
+    return rc;
   if (validated != new_state)
     return WYRELOG_E_POLICY;
 
+  g_autofree gchar *audit_id = NULL;
+  if (audit_event != NULL) {
+    audit_id = wyl_audit_event_dup_id_string (audit_event);
+    if (audit_id == NULL)
+      return WYRELOG_E_INTERNAL;
+  }
+
   gint64 event_id = -1;
-  wyrelog_error_t rc = wyl_policy_store_append_session_event (store,
-      session_id, event_name, old_state_name, new_state_name, &event_id);
+  rc = wyl_policy_store_begin_mutation (store);
   if (rc != WYRELOG_E_OK)
     return rc;
 
-  if (wyl_handle_get_read_engine (handle) == NULL)
-    return WYRELOG_E_OK;
-
-  gint64 row[5];
-  row[0] = event_id;
-  rc = wyl_handle_intern_engine_symbol (handle, session_id, &row[1]);
-  if (rc != WYRELOG_E_OK)
+  rc = wyl_policy_store_set_session_state (store, session_id, new_state_name);
+  if (rc == WYRELOG_E_OK) {
+    rc = wyl_policy_store_append_session_event (store, session_id,
+        event_name, old_state_name, new_state_name, &event_id);
+  }
+  if (rc == WYRELOG_E_OK && audit_event != NULL) {
+    rc = wyl_policy_store_append_audit_event (store, audit_id,
+        wyl_audit_event_get_created_at_us (audit_event),
+        wyl_audit_event_get_subject_id (audit_event),
+        wyl_audit_event_get_action (audit_event),
+        wyl_audit_event_get_resource_id (audit_event),
+        wyl_audit_event_get_deny_reason (audit_event),
+        wyl_audit_event_get_deny_origin (audit_event),
+        wyl_audit_event_get_decision (audit_event));
+  }
+  if (rc == WYRELOG_E_OK)
+    rc = wyl_policy_store_commit_mutation (store);
+  if (rc != WYRELOG_E_OK) {
+    wyl_policy_store_rollback_mutation (store);
     return rc;
-  rc = wyl_handle_intern_engine_symbol (handle, event_name, &row[2]);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  rc = wyl_handle_intern_engine_symbol (handle, old_state_name, &row[3]);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  rc = wyl_handle_intern_engine_symbol (handle, new_state_name, &row[4]);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  return wyl_handle_engine_insert (handle, "session_event", row, 5);
+  }
+  if (out_event_id != NULL)
+    *out_event_id = event_id;
+  return WYRELOG_E_OK;
 }
-
-#ifdef WYL_HAS_AUDIT
-static void
-emit_session_state_audit (WylHandle *handle, const gchar *session_id,
-    const gchar *old_state, const gchar *new_state)
-{
-  g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
-  wyl_audit_event_set_subject_id (ev, session_id);
-  wyl_audit_event_set_action (ev, "session_state");
-  wyl_audit_event_set_resource_id (ev, new_state);
-  wyl_audit_event_set_deny_origin (ev, old_state);
-  wyl_audit_event_set_decision (ev, WYL_DECISION_ALLOW);
-  (void) wyl_audit_emit (handle, ev);
-}
-#endif
 
 static wyrelog_error_t
-set_session_state (WylHandle *handle, WylSession *session, const gchar *state)
+apply_login_state_mutation (WylHandle *handle, const gchar *username,
+    wyl_principal_event_t principal_event,
+    wyl_principal_state_t principal_new_state, const gchar *session_id,
+    wyl_session_state_t session_old_state, wyl_session_event_t session_event,
+    wyl_session_state_t session_new_state,
+    const WylAuditEvent *principal_audit_event,
+    const WylAuditEvent *session_audit_event, gint64 *out_principal_event_id,
+    gint64 *out_session_event_id)
 {
-  g_autofree gchar *session_id = wyl_session_dup_id_string (session);
-  wyrelog_error_t rc = insert_session_state (handle, session_id, state);
+  if (username == NULL || session_id == NULL)
+    return WYRELOG_E_INVALID;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (store == NULL)
+    return WYRELOG_E_OK;
+
+  wyl_principal_state_t validated_principal = WYL_PRINCIPAL_STATE_LAST_;
+  wyrelog_error_t rc =
+      wyl_fsm_principal_step (WYL_PRINCIPAL_STATE_UNVERIFIED, principal_event,
+      &validated_principal);
   if (rc != WYRELOG_E_OK)
     return rc;
-  rc = store_session_state (handle, session_id, state);
+  if (validated_principal != principal_new_state)
+    return WYRELOG_E_POLICY;
+
+  wyl_session_state_t validated_session = WYL_SESSION_STATE_LAST_;
+  rc = wyl_fsm_session_step (session_old_state, session_event,
+      &validated_session);
   if (rc != WYRELOG_E_OK)
     return rc;
-  return reload_session_snapshot (handle);
+  if (validated_session != session_new_state)
+    return WYRELOG_E_POLICY;
+
+  const gchar *principal_event_name =
+      wyl_principal_event_name (principal_event);
+  const gchar *principal_from_state =
+      wyl_principal_state_name (WYL_PRINCIPAL_STATE_UNVERIFIED);
+  const gchar *principal_to_state =
+      wyl_principal_state_name (principal_new_state);
+  const gchar *session_event_name = wyl_session_event_name (session_event);
+  const gchar *session_from_state = wyl_session_state_name (session_old_state);
+  const gchar *session_to_state = wyl_session_state_name (session_new_state);
+  if (principal_event_name == NULL || principal_from_state == NULL
+      || principal_to_state == NULL || session_event_name == NULL
+      || session_from_state == NULL || session_to_state == NULL)
+    return WYRELOG_E_INTERNAL;
+
+  g_autofree gchar *principal_audit_id = NULL;
+  if (principal_audit_event != NULL) {
+    principal_audit_id = wyl_audit_event_dup_id_string (principal_audit_event);
+    if (principal_audit_id == NULL)
+      return WYRELOG_E_INTERNAL;
+  }
+  g_autofree gchar *session_audit_id = NULL;
+  if (session_audit_event != NULL) {
+    session_audit_id = wyl_audit_event_dup_id_string (session_audit_event);
+    if (session_audit_id == NULL)
+      return WYRELOG_E_INTERNAL;
+  }
+
+  gint64 principal_event_id = -1;
+  gint64 session_event_id = -1;
+  rc = wyl_policy_store_begin_mutation (store);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  rc = wyl_policy_store_set_principal_state (store, username,
+      principal_to_state);
+  if (rc == WYRELOG_E_OK) {
+    rc = wyl_policy_store_append_principal_event (store, username,
+        principal_event_name, principal_from_state, principal_to_state,
+        &principal_event_id);
+  }
+  if (rc == WYRELOG_E_OK && principal_audit_event != NULL) {
+    rc = wyl_policy_store_append_audit_event (store, principal_audit_id,
+        wyl_audit_event_get_created_at_us (principal_audit_event),
+        wyl_audit_event_get_subject_id (principal_audit_event),
+        wyl_audit_event_get_action (principal_audit_event),
+        wyl_audit_event_get_resource_id (principal_audit_event),
+        wyl_audit_event_get_deny_reason (principal_audit_event),
+        wyl_audit_event_get_deny_origin (principal_audit_event),
+        wyl_audit_event_get_decision (principal_audit_event));
+  }
+  if (rc == WYRELOG_E_OK)
+    rc = wyl_policy_store_set_session_state (store, session_id,
+        session_to_state);
+  if (rc == WYRELOG_E_OK) {
+    rc = wyl_policy_store_append_session_event (store, session_id,
+        session_event_name, session_from_state, session_to_state,
+        &session_event_id);
+  }
+  if (rc == WYRELOG_E_OK && session_audit_event != NULL) {
+    rc = wyl_policy_store_append_audit_event (store, session_audit_id,
+        wyl_audit_event_get_created_at_us (session_audit_event),
+        wyl_audit_event_get_subject_id (session_audit_event),
+        wyl_audit_event_get_action (session_audit_event),
+        wyl_audit_event_get_resource_id (session_audit_event),
+        wyl_audit_event_get_deny_reason (session_audit_event),
+        wyl_audit_event_get_deny_origin (session_audit_event),
+        wyl_audit_event_get_decision (session_audit_event));
+  }
+  if (rc == WYRELOG_E_OK)
+    rc = wyl_policy_store_commit_mutation (store);
+  if (rc != WYRELOG_E_OK) {
+    wyl_policy_store_rollback_mutation (store);
+    return rc;
+  }
+  if (out_principal_event_id != NULL)
+    *out_principal_event_id = principal_event_id;
+  if (out_session_event_id != NULL)
+    *out_session_event_id = session_event_id;
+  return WYRELOG_E_OK;
 }
 
 static wyrelog_error_t
@@ -396,25 +482,24 @@ transition_session_state (WylHandle *handle, WylSession *session,
   if (old_state_name == NULL || new_state_name == NULL)
     return WYRELOG_E_INTERNAL;
 
-  wyrelog_error_t rc =
-      remove_session_state (handle, session_id, old_state_name);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  rc = insert_session_state (handle, session_id, new_state_name);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  rc = store_session_state (handle, session_id, new_state_name);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  rc = store_session_event (handle, session_id, old_state, event, new_state);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  rc = reload_session_snapshot (handle);
-  if (rc != WYRELOG_E_OK)
-    return rc;
 #ifdef WYL_HAS_AUDIT
-  emit_session_state_audit (handle, session_id, old_state_name, new_state_name);
+  g_autoptr (WylAuditEvent) ev = new_session_state_audit (session_id,
+      old_state_name, new_state_name);
+#else
+  WylAuditEvent *ev = NULL;
 #endif
+  gint64 event_id = -1;
+  wyrelog_error_t rc = apply_session_state_mutation (handle, session_id,
+      old_state, event, new_state, ev, &event_id);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = finish_session_mutation (handle, ev);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = insert_session_event_fact (handle, event_id, session_id, old_state,
+      event, new_state);
+  if (rc != WYRELOG_E_OK)
+    return rc;
   session->state = new_state;
   return WYRELOG_E_OK;
 }
@@ -447,6 +532,7 @@ wyl_session_login (WylHandle *handle, const wyl_login_req_t *req,
     session->username = g_strdup (username);
   }
 
+  g_autofree gchar *session_id = wyl_session_dup_id_string (session);
   if (username != NULL) {
     wyl_principal_state_t state = WYL_PRINCIPAL_STATE_LAST_;
     wyl_principal_event_t event = WYL_PRINCIPAL_EVENT_LOGIN_OK;
@@ -461,40 +547,81 @@ wyl_session_login (WylHandle *handle, const wyl_login_req_t *req,
       g_object_unref (session);
       return (rc == WYRELOG_E_OK) ? WYRELOG_E_INTERNAL : rc;
     }
-    rc = set_principal_state (handle, username, state);
+#ifdef WYL_HAS_AUDIT
+    g_autoptr (WylAuditEvent) principal_ev =
+        new_principal_state_audit (username,
+        wyl_principal_state_name (WYL_PRINCIPAL_STATE_UNVERIFIED),
+        wyl_principal_state_name (state), wyl_principal_event_name (event));
+    g_autoptr (WylAuditEvent) session_ev =
+        new_session_state_audit (session_id,
+        wyl_session_state_name (session->state), "active");
+#else
+    WylAuditEvent *principal_ev = NULL;
+    WylAuditEvent *session_ev = NULL;
+#endif
+    gint64 principal_event_id = -1;
+    gint64 session_event_id = -1;
+    rc = apply_login_state_mutation (handle, username, event, state,
+        session_id, WYL_SESSION_STATE_IDLE, WYL_SESSION_EVENT_REQUEST,
+        WYL_SESSION_STATE_ACTIVE, principal_ev, session_ev,
+        &principal_event_id, &session_event_id);
     if (rc != WYRELOG_E_OK) {
       g_object_unref (session);
       return rc;
     }
-    rc = store_principal_event (handle, username,
+    rc = reload_session_snapshot (handle);
+    if (rc != WYRELOG_E_OK) {
+      g_object_unref (session);
+      return rc;
+    }
+#ifdef WYL_HAS_AUDIT
+    /* Policy-store audit is durable; the live audit sink is best effort. */
+    (void) wyl_audit_mirror_event (handle, principal_ev);
+    (void) wyl_audit_mirror_event (handle, session_ev);
+#endif
+    rc = insert_principal_event_fact (handle, principal_event_id, username,
         WYL_PRINCIPAL_STATE_UNVERIFIED, event, state);
     if (rc != WYRELOG_E_OK) {
       g_object_unref (session);
       return rc;
     }
-#ifdef WYL_HAS_AUDIT
-    emit_principal_state_audit (handle, username,
-        wyl_principal_state_name (WYL_PRINCIPAL_STATE_UNVERIFIED),
-        wyl_principal_state_name (state), wyl_principal_event_name (event));
-#endif
-  }
-
-  wyrelog_error_t rc = set_session_state (handle, session, "active");
-  if (rc != WYRELOG_E_OK) {
-    g_object_unref (session);
-    return rc;
-  }
-  g_autofree gchar *session_id = wyl_session_dup_id_string (session);
-  rc = store_session_event (handle, session_id, WYL_SESSION_STATE_IDLE,
-      WYL_SESSION_EVENT_REQUEST, WYL_SESSION_STATE_ACTIVE);
-  if (rc != WYRELOG_E_OK) {
-    g_object_unref (session);
-    return rc;
+    rc = insert_session_event_fact (handle, session_event_id, session_id,
+        WYL_SESSION_STATE_IDLE, WYL_SESSION_EVENT_REQUEST,
+        WYL_SESSION_STATE_ACTIVE);
+    if (rc != WYRELOG_E_OK) {
+      g_object_unref (session);
+      return rc;
+    }
+    session->state = WYL_SESSION_STATE_ACTIVE;
+    *out_session = session;
+    return WYRELOG_E_OK;
   }
 #ifdef WYL_HAS_AUDIT
-  emit_session_state_audit (handle, session_id,
+  g_autoptr (WylAuditEvent) ev = new_session_state_audit (session_id,
       wyl_session_state_name (session->state), "active");
+#else
+  WylAuditEvent *ev = NULL;
 #endif
+  gint64 event_id = -1;
+  wyrelog_error_t rc = apply_session_state_mutation (handle, session_id,
+      WYL_SESSION_STATE_IDLE, WYL_SESSION_EVENT_REQUEST,
+      WYL_SESSION_STATE_ACTIVE, ev, &event_id);
+  if (rc != WYRELOG_E_OK) {
+    g_object_unref (session);
+    return rc;
+  }
+  rc = finish_session_mutation (handle, ev);
+  if (rc != WYRELOG_E_OK) {
+    g_object_unref (session);
+    return rc;
+  }
+  rc = insert_session_event_fact (handle, event_id, session_id,
+      WYL_SESSION_STATE_IDLE, WYL_SESSION_EVENT_REQUEST,
+      WYL_SESSION_STATE_ACTIVE);
+  if (rc != WYRELOG_E_OK) {
+    g_object_unref (session);
+    return rc;
+  }
   session->state = WYL_SESSION_STATE_ACTIVE;
 
   *out_session = session;

--- a/wyrelog/wyl-session.c
+++ b/wyrelog/wyl-session.c
@@ -189,7 +189,7 @@ set_principal_state (WylHandle *handle, const gchar *username,
 }
 
 #ifdef WYL_HAS_AUDIT
-static void
+static wyrelog_error_t
 emit_login_skip_mfa_denied_audit (WylHandle *handle, const gchar *username)
 {
   g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
@@ -199,7 +199,7 @@ emit_login_skip_mfa_denied_audit (WylHandle *handle, const gchar *username)
   wyl_audit_event_set_deny_reason (ev, "skip_mfa_not_allowed");
   wyl_audit_event_set_deny_origin (ev, "login_ingress");
   wyl_audit_event_set_decision (ev, WYL_DECISION_DENY);
-  (void) wyl_audit_emit (handle, ev);
+  return wyl_audit_emit (handle, ev);
 }
 
 static void
@@ -432,7 +432,10 @@ wyl_session_login (WylHandle *handle, const wyl_login_req_t *req,
   if (req != NULL && wyl_login_req_get_skip_mfa (req) &&
       !wyl_handle_get_login_skip_mfa_allowed (handle)) {
 #ifdef WYL_HAS_AUDIT
-    emit_login_skip_mfa_denied_audit (handle, wyl_login_req_get_username (req));
+    wyrelog_error_t audit_rc = emit_login_skip_mfa_denied_audit (handle,
+        wyl_login_req_get_username (req));
+    if (audit_rc != WYRELOG_E_OK)
+      return audit_rc;
 #endif
     return WYRELOG_E_POLICY;
   }


### PR DESCRIPTION
## Summary
- avoid changing skip-MFA readiness behavior during daemon startup checks
- return audit persistence errors for denied skip-MFA login attempts
- group login state, transition event, and audit rows before reloading policy projections

## Tests
- meson test -C builddir --print-errorlogs
- meson test -C builddir-audit --print-errorlogs