### PR TITLE
daemon: count audit rows without sum aggregate

### DIFF
--- a/wyrelog/daemon/delta.c
+++ b/wyrelog/daemon/delta.c
@@ -69,18 +69,18 @@ check_wirelog_delta_audit_rows (WylHandle *handle)
   duckdb_result result;
   if (duckdb_query (conn,
           "SELECT "
-          "SUM(CASE WHEN action = 'effective_member_delta' "
+          "COUNT(*) FILTER (WHERE action = 'effective_member_delta' "
           "AND subject_id = 'wyrelogd-check-user' "
           "AND resource_id = 'wr.viewer' "
           "AND deny_origin = 'wyrelogd-check-scope' "
           "AND deny_reason = 'insert' "
-          "AND decision = 1 THEN 1 ELSE 0 END), "
-          "SUM(CASE WHEN action = 'effective_member_delta' "
+          "AND decision = 1), "
+          "COUNT(*) FILTER (WHERE action = 'effective_member_delta' "
           "AND subject_id = 'wyrelogd-check-user' "
           "AND resource_id = 'wr.viewer' "
           "AND deny_origin = 'wyrelogd-check-scope' "
           "AND deny_reason = 'remove' "
-          "AND decision = 1 THEN 1 ELSE 0 END) " "FROM audit_events;", &result)
+          "AND decision = 1) " "FROM audit_events;", &result)
       != DuckDBSuccess) {
     duckdb_destroy_result (&result);
     return WYRELOG_E_IO;
@@ -100,30 +100,30 @@ check_wirelog_fsm_audit_rows (WylHandle *handle)
   duckdb_result result;
   if (duckdb_query (conn,
           "SELECT "
-          "SUM(CASE WHEN action = 'principal_fired_delta_insert' "
+          "COUNT(*) FILTER (WHERE action = 'principal_fired_delta_insert' "
           "AND subject_id = 'wyrelogd-principal-user' "
           "AND resource_id = 'mfa_required' "
           "AND deny_reason = 'login_ok' "
           "AND deny_origin = 'unverified' "
-          "AND decision = 1 THEN 1 ELSE 0 END), "
-          "SUM(CASE WHEN action = 'session_fired_delta_insert' "
+          "AND decision = 1), "
+          "COUNT(*) FILTER (WHERE action = 'session_fired_delta_insert' "
           "AND subject_id = 'wyrelogd-session' "
           "AND resource_id = 'elevated' "
           "AND deny_reason = 'elevate_grant' "
           "AND deny_origin = 'active' "
-          "AND decision = 1 THEN 1 ELSE 0 END), "
-          "SUM(CASE WHEN action = 'principal_fired_delta_remove' "
+          "AND decision = 1), "
+          "COUNT(*) FILTER (WHERE action = 'principal_fired_delta_remove' "
           "AND subject_id = 'wyrelogd-principal-user' "
           "AND resource_id = 'mfa_required' "
           "AND deny_reason = 'login_ok' "
           "AND deny_origin = 'unverified' "
-          "AND decision = 1 THEN 1 ELSE 0 END), "
-          "SUM(CASE WHEN action = 'session_fired_delta_remove' "
+          "AND decision = 1), "
+          "COUNT(*) FILTER (WHERE action = 'session_fired_delta_remove' "
           "AND subject_id = 'wyrelogd-session' "
           "AND resource_id = 'elevated' "
           "AND deny_reason = 'elevate_grant' "
           "AND deny_origin = 'active' "
-          "AND decision = 1 THEN 1 ELSE 0 END) " "FROM audit_events;", &result)
+          "AND decision = 1) " "FROM audit_events;", &result)
       != DuckDBSuccess) {
     duckdb_destroy_result (&result);
     return WYRELOG_E_IO;


### PR DESCRIPTION
## Summary
- Main branch CI has been failing on every push since `fa6bd04` because `wyrelog:wyrelogd-check` exits with `delta readiness check failed: i/o error`.
- Root cause: DuckDB 1.5 moved the `sum` scalar function out of the default catalog into the `core_functions` extension. The bare amalgamation we link against does not load that extension, so the readiness query (`SUM(CASE WHEN ... THEN 1 ELSE 0 END)`) failed with `Catalog Error: Scalar Function with name "sum" is not in the catalog`, and `check_wirelog_delta_audit_rows` returned `WYRELOG_E_IO`.
- Fix: rewrite the two readiness aggregations in `wyrelog/daemon/delta.c` as `COUNT(*) FILTER (WHERE ...)`, which is built into DuckDB's SQL parser and is semantically equivalent for the binary match counts the readiness check needs.

## Test plan
- [x] `meson test -C builddir wyrelog:wyrelogd-check` passes (was failing before)
- [x] `audit-emit`, `audit-conn`, `wyrelogd-sigterm`, `wyrelogd-healthz`, `client-audit-daemon` still pass under ASan/UBSan with `-Denable_audit=enabled`
- [ ] CI green on `ubuntu-latest`, `macos-latest`, and `windows`