### PR TITLE
Make live audit projection rollback atomic

### DIFF
--- a/tests/test-audit-emit.c
+++ b/tests/test-audit-emit.c
@@ -2070,6 +2070,65 @@ check_emit_reports_live_projection_failure (void)
 }
 
 static gint
+check_emit_rolls_back_partial_live_projection_failure (void)
+{
+  static const gchar *fault_relations[] = {
+    "audit_event_subject_input",
+    "audit_event_action_input",
+    "audit_event_resource_input",
+    "audit_event_deny_reason_input",
+    "audit_event_deny_origin_input",
+  };
+  static const gchar *projected_relations[] = {
+    "audit_event",
+    "audit_event_subject",
+    "audit_event_action",
+    "audit_event_resource",
+    "audit_event_deny_reason",
+    "audit_event_deny_origin",
+  };
+
+  for (gsize i = 0; i < G_N_ELEMENTS (fault_relations); i++) {
+    WylHandle *handle = NULL;
+    if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+      return (gint) (264 + i);
+
+    wyl_handle_set_engine_insert_fault_once (handle, fault_relations[i],
+        WYRELOG_E_INTERNAL);
+
+    g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
+    wyl_audit_event_set_subject_id (ev, "audit-live-partial-user");
+    wyl_audit_event_set_action (ev, "audit-live-partial-action");
+    wyl_audit_event_set_resource_id (ev, "audit-live-partial-resource");
+    wyl_audit_event_set_deny_reason (ev, "not_armed");
+    wyl_audit_event_set_deny_origin (ev, "perm_state");
+    wyl_audit_event_set_decision (ev, WYL_DECISION_DENY);
+    g_autofree gchar *id = wyl_audit_event_dup_id_string (ev);
+
+    if (wyl_audit_emit (handle, ev) != WYRELOG_E_INTERNAL) {
+      g_object_unref (handle);
+      return (gint) (270 + i);
+    }
+
+    for (gsize j = 0; j < G_N_ELEMENTS (projected_relations); j++) {
+      guint count = 0;
+      if (count_audit_attr_facts (handle, projected_relations[j], id, &count)
+          != WYRELOG_E_OK) {
+        g_object_unref (handle);
+        return (gint) (276 + i * 10 + j);
+      }
+      if (count != 0) {
+        g_object_unref (handle);
+        return (gint) (336 + i * 10 + j);
+      }
+    }
+
+    g_object_unref (handle);
+  }
+  return 0;
+}
+
+static gint
 check_denied_login_skip_mfa_projects_audit_fact (void)
 {
   WylHandle *handle = NULL;
@@ -2266,6 +2325,8 @@ main (void)
   if ((rc = check_emit_projects_sparse_wirelog_facts_immediately ()) != 0)
     return rc;
   if ((rc = check_emit_reports_live_projection_failure ()) != 0)
+    return rc;
+  if ((rc = check_emit_rolls_back_partial_live_projection_failure ()) != 0)
     return rc;
   if ((rc = check_decide_persists_representative_deny_reason ()) != 0)
     return rc;

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -927,18 +927,42 @@ decision_symbol (wyl_decision_t decision)
   }
 }
 
+typedef struct
+{
+  const gchar *relation;
+  gint64 row[2];
+  gboolean inserted;
+} WylAuditAttrFact;
+
+static void
+rollback_audit_fact_inputs (WylHandle *self, const gint64 audit_event[3],
+    gboolean audit_event_inserted, WylAuditAttrFact *attrs, gsize n_attrs)
+{
+  for (gsize i = n_attrs; i > 0; i--) {
+    WylAuditAttrFact *attr = &attrs[i - 1];
+    if (attr->inserted)
+      (void) wyl_handle_engine_remove (self, attr->relation, attr->row, 2);
+  }
+  if (audit_event_inserted)
+    (void) wyl_handle_engine_remove (self, "audit_event_input", audit_event, 3);
+}
+
 static wyrelog_error_t
-insert_audit_fact_symbol (WylHandle *self, const gchar *relation,
+insert_audit_attr_fact (WylHandle *self, WylAuditAttrFact *attr,
     gint64 audit_id, const gchar *value)
 {
   if (value == NULL)
     return WYRELOG_E_OK;
 
-  gint64 row[2] = { audit_id, 0 };
-  wyrelog_error_t rc = wyl_handle_intern_engine_symbol (self, value, &row[1]);
+  attr->row[0] = audit_id;
+  wyrelog_error_t rc =
+      wyl_handle_intern_engine_symbol (self, value, &attr->row[1]);
   if (rc != WYRELOG_E_OK)
     return rc;
-  return wyl_handle_engine_insert (self, relation, row, 2);
+  rc = wyl_handle_engine_insert (self, attr->relation, attr->row, 2);
+  if (rc == WYRELOG_E_OK)
+    attr->inserted = TRUE;
+  return rc;
 }
 
 static wyrelog_error_t
@@ -970,6 +994,15 @@ wyl_handle_insert_audit_fact (WylHandle *self, const gchar *id,
     return WYRELOG_E_POLICY;
 
   gint64 audit_event[3];
+  gboolean audit_event_inserted = FALSE;
+  WylAuditAttrFact attrs[] = {
+    {.relation = "audit_event_subject_input"},
+    {.relation = "audit_event_action_input"},
+    {.relation = "audit_event_resource_input"},
+    {.relation = "audit_event_deny_reason_input"},
+    {.relation = "audit_event_deny_origin_input"},
+  };
+
   wyrelog_error_t rc =
       wyl_handle_intern_engine_symbol (self, id, &audit_event[0]);
   if (rc != WYRELOG_E_OK)
@@ -981,25 +1014,25 @@ wyl_handle_insert_audit_fact (WylHandle *self, const gchar *id,
   rc = wyl_handle_engine_insert (self, "audit_event_input", audit_event, 3);
   if (rc != WYRELOG_E_OK)
     return rc;
+  audit_event_inserted = TRUE;
 
-  rc = insert_audit_fact_symbol (self, "audit_event_subject_input",
-      audit_event[0], subject_id);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  rc = insert_audit_fact_symbol (self, "audit_event_action_input",
-      audit_event[0], action);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  rc = insert_audit_fact_symbol (self, "audit_event_resource_input",
-      audit_event[0], resource_id);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  rc = insert_audit_fact_symbol (self, "audit_event_deny_reason_input",
-      audit_event[0], deny_reason);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  return insert_audit_fact_symbol (self, "audit_event_deny_origin_input",
-      audit_event[0], deny_origin);
+  const gchar *values[] = {
+    subject_id,
+    action,
+    resource_id,
+    deny_reason,
+    deny_origin,
+  };
+  for (gsize i = 0; i < G_N_ELEMENTS (attrs); i++) {
+    rc = insert_audit_attr_fact (self, &attrs[i], audit_event[0], values[i]);
+    if (rc != WYRELOG_E_OK) {
+      rollback_audit_fact_inputs (self, audit_event, audit_event_inserted,
+          attrs, G_N_ELEMENTS (attrs));
+      return rc;
+    }
+  }
+
+  return WYRELOG_E_OK;
 }
 
 wyrelog_error_t


### PR DESCRIPTION
## Summary
- roll back live audit input facts when a later projection insert fails
- cover each audit attribute projection fault so partial wirelog facts do not remain

## Tests
- meson test -C builddir --print-errorlogs
- meson test -C builddir-audit --print-errorlogs