### PR TITLE
Add deployment mode skip-MFA guard

### DIFF
--- a/templates/access/sqlite-schema.sql
+++ b/templates/access/sqlite-schema.sql
@@ -7,6 +7,20 @@ PRAGMA journal_mode = WAL;
 PRAGMA foreign_keys = ON;
 
 -- ---------------------------------------------------------------------------
+-- Table: wyrelog_config
+-- Runtime policy settings owned by the policy authority.
+-- deployment_mode defaults to production when absent.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS wyrelog_config (
+    config_key   TEXT    PRIMARY KEY,
+    config_value TEXT    NOT NULL CHECK (
+        config_key != 'deployment_mode'
+        OR config_value IN ('production', 'development', 'demo')
+    ),
+    updated_at   INTEGER NOT NULL
+);
+
+-- ---------------------------------------------------------------------------
 -- Table: roles
 -- Defines named roles assignable to users/services.
 -- ---------------------------------------------------------------------------

--- a/tests/test-policy-store.c
+++ b/tests/test-policy-store.c
@@ -20,6 +20,7 @@ check_store_creates_authority_schema (void)
     return 11;
 
   const gchar *tables[] = {
+    "wyrelog_config",
     "roles",
     "permissions",
     "role_permissions",
@@ -68,6 +69,7 @@ check_template_schema_creates_state_tables (void)
   }
 
   const gchar *tables[] = {
+    "wyrelog_config",
     "roles",
     "permissions",
     "role_permissions",
@@ -113,6 +115,79 @@ check_store_rejects_invalid_args (void)
   if (wyl_policy_store_table_exists (store, "roles", NULL)
       != WYRELOG_E_INVALID)
     return 34;
+  if (wyl_policy_store_set_deployment_mode (NULL, "production")
+      != WYRELOG_E_INVALID)
+    return 35;
+  if (wyl_policy_store_set_deployment_mode (store, NULL) != WYRELOG_E_INVALID)
+    return 36;
+  if (wyl_policy_store_get_deployment_mode (NULL, NULL) != WYRELOG_E_INVALID)
+    return 37;
+  if (wyl_policy_store_get_deployment_mode (store, NULL)
+      != WYRELOG_E_INVALID)
+    return 38;
+  return 0;
+}
+
+static gint
+check_store_gets_default_deployment_mode (void)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+  g_autofree gchar *mode = NULL;
+
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 40;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 41;
+  if (wyl_policy_store_get_deployment_mode (store, &mode) != WYRELOG_E_OK)
+    return 42;
+  if (g_strcmp0 (mode, "production") != 0)
+    return 43;
+  return 0;
+}
+
+static gint
+check_store_sets_deployment_mode (void)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+  g_autofree gchar *mode = NULL;
+
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 44;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 45;
+  if (wyl_policy_store_set_deployment_mode (store, "development")
+      != WYRELOG_E_OK)
+    return 46;
+  if (wyl_policy_store_get_deployment_mode (store, &mode) != WYRELOG_E_OK)
+    return 47;
+  if (g_strcmp0 (mode, "development") != 0)
+    return 48;
+
+  g_clear_pointer (&mode, g_free);
+  if (wyl_policy_store_set_deployment_mode (store, "demo") != WYRELOG_E_OK)
+    return 49;
+  if (wyl_policy_store_get_deployment_mode (store, &mode) != WYRELOG_E_OK)
+    return 50;
+  if (g_strcmp0 (mode, "demo") != 0)
+    return 51;
+  const gchar *bad_modes[] = { "test", "", " demo", "DEMO" };
+  for (gsize i = 0; i < G_N_ELEMENTS (bad_modes); i++) {
+    if (wyl_policy_store_set_deployment_mode (store, bad_modes[i])
+        != WYRELOG_E_POLICY)
+      return 52;
+  }
+  if (sqlite3_exec (wyl_policy_store_get_db (store),
+          "UPDATE wyrelog_config SET config_value = 'test' "
+          "WHERE config_key = 'deployment_mode';", NULL, NULL, NULL)
+      == SQLITE_OK)
+    return 53;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 54;
+  g_clear_pointer (&mode, g_free);
+  if (wyl_policy_store_get_deployment_mode (store, &mode) != WYRELOG_E_OK)
+    return 55;
+  if (g_strcmp0 (mode, "demo") != 0)
+    return 56;
   return 0;
 }
 
@@ -1270,6 +1345,10 @@ main (void)
   if ((rc = check_template_schema_creates_state_tables ()) != 0)
     return rc;
   if ((rc = check_store_rejects_invalid_args ()) != 0)
+    return rc;
+  if ((rc = check_store_gets_default_deployment_mode ()) != 0)
+    return rc;
+  if ((rc = check_store_sets_deployment_mode ()) != 0)
     return rc;
   if ((rc = check_handle_owns_policy_store ()) != 0)
     return rc;

--- a/tests/test-session-username.c
+++ b/tests/test-session-username.c
@@ -790,6 +790,66 @@ check_login_skip_mfa_authenticates_principal (void)
   return 0;
 }
 
+static wyrelog_error_t
+login_skip_mfa_user (WylHandle *handle, const gchar *username,
+    WylSession **out_session)
+{
+  g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
+  wyl_login_req_set_username (login, username);
+  wyl_login_req_set_skip_mfa (login, TRUE);
+  return wyl_session_login (handle, login, out_session);
+}
+
+static gint
+check_login_skip_mfa_uses_deployment_mode (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 160;
+
+  if (wyl_policy_store_set_deployment_mode (wyl_handle_get_policy_store
+          (handle), "development") != WYRELOG_E_OK)
+    return 161;
+  if (!wyl_handle_get_login_skip_mfa_allowed (handle))
+    return 162;
+
+  g_autoptr (WylSession) development_session = NULL;
+  if (login_skip_mfa_user (handle, "skip-mfa-development-user",
+          &development_session) != WYRELOG_E_OK)
+    return 163;
+  if (development_session == NULL)
+    return 164;
+
+  if (wyl_policy_store_set_deployment_mode (wyl_handle_get_policy_store
+          (handle), "demo") != WYRELOG_E_OK)
+    return 165;
+
+  g_autoptr (WylSession) demo_session = NULL;
+  if (login_skip_mfa_user (handle, "skip-mfa-demo-user", &demo_session)
+      != WYRELOG_E_OK)
+    return 166;
+  if (demo_session == NULL)
+    return 167;
+
+  wyl_handle_set_login_skip_mfa_allowed (handle, FALSE);
+  if (!wyl_handle_get_login_skip_mfa_allowed (handle))
+    return 168;
+
+  if (wyl_policy_store_set_deployment_mode (wyl_handle_get_policy_store
+          (handle), "production") != WYRELOG_E_OK)
+    return 169;
+  if (wyl_handle_get_login_skip_mfa_allowed (handle))
+    return 170;
+
+  g_autoptr (WylSession) production_session = NULL;
+  if (login_skip_mfa_user (handle, "skip-mfa-production-user",
+          &production_session) != WYRELOG_E_POLICY)
+    return 171;
+  if (production_session != NULL)
+    return 172;
+  return 0;
+}
+
 static gint
 check_login_skip_mfa_inserts_wirelog_principal_fired (void)
 {
@@ -1492,6 +1552,8 @@ main (void)
   if ((rc = check_login_skip_mfa_rejected_by_default ()) != 0)
     return rc;
   if ((rc = check_login_skip_mfa_authenticates_principal ()) != 0)
+    return rc;
+  if ((rc = check_login_skip_mfa_uses_deployment_mode ()) != 0)
     return rc;
   if ((rc = check_login_skip_mfa_inserts_wirelog_principal_fired ()) != 0)
     return rc;

--- a/wyrelog/daemon/checks.c
+++ b/wyrelog/daemon/checks.c
@@ -29,6 +29,7 @@ wyl_daemon_check_policy_store_ready (WylHandle *handle)
 {
   wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
   const gchar *tables[] = {
+    "wyrelog_config",
     "roles",
     "permissions",
     "role_permissions",

--- a/wyrelog/policy/store-private.h
+++ b/wyrelog/policy/store-private.h
@@ -62,6 +62,10 @@ void wyl_policy_store_rollback_mutation (wyl_policy_store_t * store);
 wyrelog_error_t wyl_policy_store_create_schema (wyl_policy_store_t * store);
 wyrelog_error_t wyl_policy_store_table_exists (wyl_policy_store_t * store,
     const gchar * table_name, gboolean * out_exists);
+wyrelog_error_t wyl_policy_store_set_deployment_mode (wyl_policy_store_t *
+    store, const gchar * mode);
+wyrelog_error_t wyl_policy_store_get_deployment_mode (wyl_policy_store_t *
+    store, gchar ** out_mode);
 wyrelog_error_t wyl_policy_store_upsert_role (wyl_policy_store_t * store,
     const gchar * role_id, const gchar * role_name);
 wyrelog_error_t wyl_policy_store_upsert_permission (wyl_policy_store_t * store,

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -57,6 +57,13 @@ column_nullable_text_equal (sqlite3_stmt *stmt, int col, const gchar *expected)
       expected) == 0;
 }
 
+static gboolean
+deployment_mode_is_valid (const gchar *mode)
+{
+  return g_strcmp0 (mode, "production") == 0
+      || g_strcmp0 (mode, "development") == 0 || g_strcmp0 (mode, "demo") == 0;
+}
+
 wyrelog_error_t
 wyl_policy_store_begin_mutation (wyl_policy_store_t *store)
 {
@@ -135,6 +142,13 @@ wyrelog_error_t
 wyl_policy_store_create_schema (wyl_policy_store_t *store)
 {
   static const gchar *ddl =
+      "CREATE TABLE IF NOT EXISTS wyrelog_config ("
+      "  config_key TEXT PRIMARY KEY,"
+      "  config_value TEXT NOT NULL CHECK ("
+      "    config_key != 'deployment_mode' OR "
+      "    config_value IN ('production', 'development', 'demo')),"
+      "  updated_at INTEGER NOT NULL"
+      ");"
       "CREATE TABLE IF NOT EXISTS roles ("
       "  role_id TEXT PRIMARY KEY,"
       "  role_name TEXT UNIQUE NOT NULL,"
@@ -293,6 +307,72 @@ wyl_policy_store_create_schema (wyl_policy_store_t *store)
   if (store == NULL || store->db == NULL)
     return WYRELOG_E_INVALID;
   return exec_sql (store->db, ddl);
+}
+
+wyrelog_error_t
+wyl_policy_store_set_deployment_mode (wyl_policy_store_t *store,
+    const gchar *mode)
+{
+  sqlite3_stmt *stmt = NULL;
+
+  if (store == NULL || store->db == NULL || mode == NULL)
+    return WYRELOG_E_INVALID;
+  if (!deployment_mode_is_valid (mode))
+    return WYRELOG_E_POLICY;
+
+  static const gchar *sql =
+      "INSERT INTO wyrelog_config (config_key, config_value, updated_at) "
+      "VALUES ('deployment_mode', ?, unixepoch()) "
+      "ON CONFLICT(config_key) DO UPDATE SET "
+      "  config_value = excluded.config_value,"
+      "  updated_at = excluded.updated_at;";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if ((rc = bind_text (stmt, 1, mode)) != WYRELOG_E_OK) {
+    sqlite3_finalize (stmt);
+    return rc;
+  }
+
+  int step_rc = sqlite3_step (stmt);
+  sqlite3_finalize (stmt);
+  return (step_rc == SQLITE_DONE) ? WYRELOG_E_OK : WYRELOG_E_IO;
+}
+
+wyrelog_error_t
+wyl_policy_store_get_deployment_mode (wyl_policy_store_t *store,
+    gchar **out_mode)
+{
+  sqlite3_stmt *stmt = NULL;
+
+  if (store == NULL || store->db == NULL || out_mode == NULL)
+    return WYRELOG_E_INVALID;
+
+  *out_mode = NULL;
+  static const gchar *sql =
+      "SELECT config_value FROM wyrelog_config "
+      "WHERE config_key = 'deployment_mode';";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  int step_rc = sqlite3_step (stmt);
+  if (step_rc == SQLITE_ROW) {
+    const gchar *mode = (const gchar *) sqlite3_column_text (stmt, 0);
+    if (!deployment_mode_is_valid (mode)) {
+      sqlite3_finalize (stmt);
+      return WYRELOG_E_POLICY;
+    }
+    *out_mode = g_strdup (mode);
+  } else if (step_rc == SQLITE_DONE) {
+    *out_mode = g_strdup ("production");
+  } else {
+    sqlite3_finalize (stmt);
+    return WYRELOG_E_IO;
+  }
+
+  sqlite3_finalize (stmt);
+  return WYRELOG_E_OK;
 }
 
 wyrelog_error_t

--- a/wyrelog/session.h
+++ b/wyrelog/session.h
@@ -55,8 +55,9 @@ const gchar *wyl_login_req_get_username (const wyl_login_req_t * req);
  * Marks the request as already satisfying the MFA requirement. When TRUE,
  * wyl_session_login may drive the principal FSM through the login_skip_mfa
  * event and record the principal as authenticated. The host-side ingress
- * policy must explicitly allow this path for the WylHandle; otherwise login
- * fails with WYRELOG_E_POLICY. The default for a fresh request is FALSE.
+ * policy must allow this path through an explicit WylHandle override or a
+ * non-production Policy DB deployment mode; otherwise login fails with
+ * WYRELOG_E_POLICY. The default for a fresh request is FALSE.
  */
 void wyl_login_req_set_skip_mfa (wyl_login_req_t * req, gboolean skip_mfa);
 gboolean wyl_login_req_get_skip_mfa (const wyl_login_req_t * req);

--- a/wyrelog/wyl-handle-private.h
+++ b/wyrelog/wyl-handle-private.h
@@ -38,9 +38,10 @@ wyrelog_error_t wyl_handle_load_policy_store_audit_events (WylHandle * self);
 wyl_policy_store_t *wyl_handle_get_policy_store (WylHandle * self);
 
 /*
- * Host-side ingress guard for login requests that carry skip_mfa. The default
- * is FALSE; callers that model a trusted non-production path must opt in
- * explicitly before passing such requests to wyl_session_login.
+ * Host-side ingress guard for login requests that carry skip_mfa. Explicitly
+ * setting this flag to TRUE allows skip-MFA independently of deployment mode.
+ * When it is FALSE, the Policy DB deployment mode still allows skip-MFA for
+ * non-production modes and rejects it for production or unreadable config.
  */
 void wyl_handle_set_login_skip_mfa_allowed (WylHandle * self, gboolean allowed);
 gboolean wyl_handle_get_login_skip_mfa_allowed (WylHandle * self);

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -358,7 +358,14 @@ gboolean
 wyl_handle_get_login_skip_mfa_allowed (WylHandle *self)
 {
   g_return_val_if_fail (WYL_IS_HANDLE (self), FALSE);
-  return self->login_skip_mfa_allowed;
+  if (self->login_skip_mfa_allowed)
+    return TRUE;
+
+  g_autofree gchar *deployment_mode = NULL;
+  if (wyl_policy_store_get_deployment_mode (self->policy_store,
+          &deployment_mode) != WYRELOG_E_OK)
+    return FALSE;
+  return g_strcmp0 (deployment_mode, "production") != 0;
 }
 
 static GHashTable *


### PR DESCRIPTION
## Summary

- add a Policy DB-backed deployment mode config with production default
- enforce deployment mode values in both SQLite schemas
- gate skip-MFA on explicit override or non-production deployment mode


## Tests
- meson test -C builddir --print-errorlogs
- meson test -C builddir-audit --print-errorlogs
