### PR TITLE
Harden audit emit rollback

### DIFF
--- a/tests/test-audit-emit.c
+++ b/tests/test-audit-emit.c
@@ -43,6 +43,58 @@ policy_count_rows (wyl_policy_store_t *store, const gchar *sql,
   return ok;
 }
 
+static gboolean
+policy_count_audit_rows (WylHandle *handle, const gchar *id, gint64 *out_count)
+{
+  sqlite3_stmt *stmt = NULL;
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+
+  if (sqlite3_prepare_v2 (wyl_policy_store_get_db (store),
+          "SELECT COUNT(*) FROM audit_events WHERE id = ?;", -1, &stmt, NULL)
+      != SQLITE_OK)
+    return FALSE;
+  if (sqlite3_bind_text (stmt, 1, id, -1, SQLITE_TRANSIENT) != SQLITE_OK) {
+    sqlite3_finalize (stmt);
+    return FALSE;
+  }
+
+  gboolean ok = FALSE;
+  if (sqlite3_step (stmt) == SQLITE_ROW) {
+    *out_count = sqlite3_column_int64 (stmt, 0);
+    ok = TRUE;
+  }
+  sqlite3_finalize (stmt);
+  return ok;
+}
+
+static gboolean
+runtime_count_audit_rows (WylHandle *handle, const gchar *id, gint64 *out_count)
+{
+  duckdb_connection conn =
+      wyl_audit_conn_get_connection (wyl_handle_get_audit_conn (handle));
+  duckdb_prepared_statement stmt = NULL;
+  duckdb_result result = { 0 };
+
+  if (duckdb_prepare (conn,
+          "SELECT COUNT(*) FROM audit_events WHERE id = ?;", &stmt)
+      != DuckDBSuccess)
+    return FALSE;
+  if (duckdb_bind_varchar (stmt, 1, id) != DuckDBSuccess) {
+    duckdb_destroy_prepare (&stmt);
+    return FALSE;
+  }
+
+  gboolean ok = FALSE;
+  if (duckdb_execute_prepared (stmt, &result) == DuckDBSuccess
+      && duckdb_row_count (&result) == 1) {
+    *out_count = duckdb_value_int64 (&result, 0, 0);
+    ok = TRUE;
+  }
+  duckdb_destroy_result (&result);
+  duckdb_destroy_prepare (&stmt);
+  return ok;
+}
+
 static wyrelog_error_t
 insert_symbol_row1 (WylHandle *handle, const gchar *relation,
     const gchar *value)
@@ -2060,9 +2112,66 @@ check_emit_reports_live_projection_failure (void)
   wyl_audit_event_set_subject_id (ev, "audit-live-fail-user");
   wyl_audit_event_set_action (ev, "audit-live-fail-action");
   wyl_audit_event_set_decision (ev, WYL_DECISION_DENY);
+  g_autofree gchar *id = wyl_audit_event_dup_id_string (ev);
   if (wyl_audit_emit (handle, ev) != WYRELOG_E_INTERNAL) {
     g_object_unref (handle);
     return 216;
+  }
+  gint64 count = -1;
+  if (!runtime_count_audit_rows (handle, id, &count) || count != 0) {
+    g_object_unref (handle);
+    return 225;
+  }
+  if (!policy_count_audit_rows (handle, id, &count) || count != 0) {
+    g_object_unref (handle);
+    return 226;
+  }
+
+  g_object_unref (handle);
+  return 0;
+}
+
+static gint
+check_failed_duplicate_emit_keeps_durable_rows (void)
+{
+  WylHandle *handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 227;
+
+  g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
+  wyl_audit_event_set_subject_id (ev, "audit-live-duplicate-user");
+  wyl_audit_event_set_action (ev, "audit-live-duplicate-action");
+  wyl_audit_event_set_resource_id (ev, "audit-live-duplicate-resource");
+  wyl_audit_event_set_decision (ev, WYL_DECISION_ALLOW);
+  g_autofree gchar *id = wyl_audit_event_dup_id_string (ev);
+  gint64 created_at_us = wyl_audit_event_get_created_at_us (ev);
+
+  if (wyl_audit_emit (handle, ev) != WYRELOG_E_OK) {
+    g_object_unref (handle);
+    return 228;
+  }
+
+  wyl_handle_set_engine_insert_fault_once (handle, "audit_event_input",
+      WYRELOG_E_INTERNAL);
+  if (wyl_audit_emit (handle, ev) != WYRELOG_E_INTERNAL) {
+    g_object_unref (handle);
+    return 229;
+  }
+
+  gint64 count = -1;
+  if (!runtime_count_audit_rows (handle, id, &count) || count != 1) {
+    g_object_unref (handle);
+    return 230;
+  }
+  if (!policy_count_audit_rows (handle, id, &count) || count != 1) {
+    g_object_unref (handle);
+    return 231;
+  }
+  gboolean contains = FALSE;
+  if (contains_audit_event_fact (handle, id, created_at_us, "allow",
+          &contains) != WYRELOG_E_OK || !contains) {
+    g_object_unref (handle);
+    return 232;
   }
 
   g_object_unref (handle);
@@ -2108,6 +2217,15 @@ check_emit_rolls_back_partial_live_projection_failure (void)
     if (wyl_audit_emit (handle, ev) != WYRELOG_E_INTERNAL) {
       g_object_unref (handle);
       return (gint) (270 + i);
+    }
+    gint64 count = -1;
+    if (!runtime_count_audit_rows (handle, id, &count) || count != 0) {
+      g_object_unref (handle);
+      return (gint) (390 + i);
+    }
+    if (!policy_count_audit_rows (handle, id, &count) || count != 0) {
+      g_object_unref (handle);
+      return (gint) (400 + i);
     }
 
     for (gsize j = 0; j < G_N_ELEMENTS (projected_relations); j++) {
@@ -2325,6 +2443,8 @@ main (void)
   if ((rc = check_emit_projects_sparse_wirelog_facts_immediately ()) != 0)
     return rc;
   if ((rc = check_emit_reports_live_projection_failure ()) != 0)
+    return rc;
+  if ((rc = check_failed_duplicate_emit_keeps_durable_rows ()) != 0)
     return rc;
   if ((rc = check_emit_rolls_back_partial_live_projection_failure ()) != 0)
     return rc;

--- a/wyrelog/audit/conn-private.h
+++ b/wyrelog/audit/conn-private.h
@@ -112,6 +112,9 @@ wyrelog_error_t wyl_audit_conn_insert_event_full (wyl_audit_conn_t * conn,
     const gchar * deny_reason, const gchar * deny_origin,
     wyl_decision_t decision, gboolean * out_inserted);
 
+wyrelog_error_t wyl_audit_conn_delete_event (wyl_audit_conn_t * conn,
+    const gchar * id);
+
 /*
  * Serialises audit_events rows to a compact JSON array ordered by newest
  * first. @filter may be NULL/empty or one exact-match term. Both

--- a/wyrelog/audit/conn.c
+++ b/wyrelog/audit/conn.c
@@ -287,6 +287,32 @@ wyl_audit_conn_insert_event (wyl_audit_conn_t *conn, const gchar *id,
       &inserted);
 }
 
+wyrelog_error_t
+wyl_audit_conn_delete_event (wyl_audit_conn_t *conn, const gchar *id)
+{
+  duckdb_prepared_statement stmt = NULL;
+  duckdb_result result = { 0 };
+  wyl_id_t parsed_id;
+
+  if (conn == NULL || id == NULL)
+    return WYRELOG_E_INVALID;
+  if (wyl_id_parse (id, &parsed_id) != WYRELOG_E_OK)
+    return WYRELOG_E_INVALID;
+
+  static const gchar *sql = "DELETE FROM audit_events WHERE id = ?;";
+  if (duckdb_prepare (conn->conn, sql, &stmt) != DuckDBSuccess)
+    return WYRELOG_E_IO;
+  if (duckdb_bind_varchar (stmt, 1, id) != DuckDBSuccess) {
+    duckdb_destroy_prepare (&stmt);
+    return WYRELOG_E_IO;
+  }
+
+  duckdb_state step_rc = duckdb_execute_prepared (stmt, &result);
+  duckdb_destroy_result (&result);
+  duckdb_destroy_prepare (&stmt);
+  return step_rc == DuckDBSuccess ? WYRELOG_E_OK : WYRELOG_E_IO;
+}
+
 static void
 append_json_string (GString *json, const gchar *value)
 {

--- a/wyrelog/audit/event.c
+++ b/wyrelog/audit/event.c
@@ -247,6 +247,7 @@ wyl_audit_emit (WylHandle *handle, const WylAuditEvent *event)
 #ifdef WYL_HAS_AUDIT
   gchar id_buf[WYL_ID_STRING_BUF];
   gboolean inserted = FALSE;
+  gboolean store_inserted = FALSE;
 
   if (handle == NULL || event == NULL)
     return WYRELOG_E_INVALID;
@@ -266,33 +267,40 @@ wyl_audit_emit (WylHandle *handle, const WylAuditEvent *event)
     return rc;
 
   wyrelog_error_t store_rc =
-      wyl_policy_store_append_audit_event (wyl_handle_get_policy_store (handle),
-      id_buf, event->created_at_us,
+      wyl_policy_store_append_audit_event_full (wyl_handle_get_policy_store
+      (handle), id_buf, event->created_at_us,
       event->subject_id, event->action, event->resource_id,
-      event->deny_reason, event->deny_origin, event->decision);
+      event->deny_reason, event->deny_origin, event->decision,
+      &store_inserted);
   if (store_rc != WYRELOG_E_OK) {
-    if (!inserted)
-      return store_rc;
-
-    duckdb_connection conn = wyl_audit_conn_get_connection (audit_conn);
-    duckdb_prepared_statement delete_stmt = NULL;
-    duckdb_result delete_result = { 0 };
-
-    static const gchar *delete_sql = "DELETE FROM audit_events WHERE id = ?;";
-    if (duckdb_prepare (conn, delete_sql, &delete_stmt) == DuckDBSuccess) {
-      duckdb_bind_varchar (delete_stmt, 1, id_buf);
-      duckdb_execute_prepared (delete_stmt, &delete_result);
-      duckdb_destroy_result (&delete_result);
+    if (inserted) {
+      wyrelog_error_t cleanup_rc =
+          wyl_audit_conn_delete_event (audit_conn, id_buf);
+      if (cleanup_rc != WYRELOG_E_OK)
+        return cleanup_rc;
     }
-    duckdb_destroy_prepare (&delete_stmt);
     return store_rc;
   }
 
   rc = wyl_handle_insert_audit_fact (handle, id_buf, event->created_at_us,
       event->subject_id, event->action, event->resource_id,
       event->deny_reason, event->deny_origin, event->decision);
-  if (rc != WYRELOG_E_OK)
+  if (rc != WYRELOG_E_OK) {
+    if (store_inserted) {
+      wyrelog_error_t cleanup_rc =
+          wyl_policy_store_delete_audit_event (wyl_handle_get_policy_store
+          (handle), id_buf);
+      if (cleanup_rc != WYRELOG_E_OK)
+        return cleanup_rc;
+    }
+    if (inserted) {
+      wyrelog_error_t cleanup_rc =
+          wyl_audit_conn_delete_event (audit_conn, id_buf);
+      if (cleanup_rc != WYRELOG_E_OK)
+        return cleanup_rc;
+    }
     return rc;
+  }
 
   return WYRELOG_E_OK;
 #else

--- a/wyrelog/policy/store-private.h
+++ b/wyrelog/policy/store-private.h
@@ -160,6 +160,13 @@ wyrelog_error_t wyl_policy_store_append_audit_event (wyl_policy_store_t *
     store, const gchar * id, gint64 created_at_us, const gchar * subject_id,
     const gchar * action, const gchar * resource_id, const gchar * deny_reason,
     const gchar * deny_origin, wyl_decision_t decision);
+wyrelog_error_t wyl_policy_store_append_audit_event_full (wyl_policy_store_t *
+    store, const gchar * id, gint64 created_at_us, const gchar * subject_id,
+    const gchar * action, const gchar * resource_id,
+    const gchar * deny_reason, const gchar * deny_origin,
+    wyl_decision_t decision, gboolean * out_inserted);
+wyrelog_error_t wyl_policy_store_delete_audit_event (wyl_policy_store_t *
+    store, const gchar * id);
 wyrelog_error_t wyl_policy_store_foreach_audit_event (wyl_policy_store_t *
     store, wyl_policy_audit_event_cb cb, gpointer user_data);
 

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -1367,16 +1367,18 @@ wyl_policy_store_foreach_role_membership_event (wyl_policy_store_t *store,
 }
 
 wyrelog_error_t
-wyl_policy_store_append_audit_event (wyl_policy_store_t *store,
+wyl_policy_store_append_audit_event_full (wyl_policy_store_t *store,
     const gchar *id, gint64 created_at_us, const gchar *subject_id,
     const gchar *action, const gchar *resource_id, const gchar *deny_reason,
-    const gchar *deny_origin, wyl_decision_t decision)
+    const gchar *deny_origin, wyl_decision_t decision, gboolean *out_inserted)
 {
   sqlite3_stmt *stmt = NULL;
   wyl_id_t parsed_id;
 
-  if (store == NULL || store->db == NULL || id == NULL || created_at_us < 0)
+  if (store == NULL || store->db == NULL || id == NULL || created_at_us < 0
+      || out_inserted == NULL)
     return WYRELOG_E_INVALID;
+  *out_inserted = FALSE;
   if (wyl_id_parse (id, &parsed_id) != WYRELOG_E_OK)
     return WYRELOG_E_INVALID;
   if (decision != WYL_DECISION_DENY && decision != WYL_DECISION_ALLOW)
@@ -1429,6 +1431,47 @@ wyl_policy_store_append_audit_event (wyl_policy_store_t *store,
       || sqlite3_bind_int (stmt, 8, (int) decision) != SQLITE_OK) {
     sqlite3_finalize (stmt);
     return WYRELOG_E_IO;
+  }
+
+  int step_rc = sqlite3_step (stmt);
+  sqlite3_finalize (stmt);
+  if (step_rc != SQLITE_DONE)
+    return WYRELOG_E_IO;
+  *out_inserted = TRUE;
+  return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
+wyl_policy_store_append_audit_event (wyl_policy_store_t *store,
+    const gchar *id, gint64 created_at_us, const gchar *subject_id,
+    const gchar *action, const gchar *resource_id, const gchar *deny_reason,
+    const gchar *deny_origin, wyl_decision_t decision)
+{
+  gboolean inserted = FALSE;
+
+  return wyl_policy_store_append_audit_event_full (store, id, created_at_us,
+      subject_id, action, resource_id, deny_reason, deny_origin, decision,
+      &inserted);
+}
+
+wyrelog_error_t
+wyl_policy_store_delete_audit_event (wyl_policy_store_t *store, const gchar *id)
+{
+  sqlite3_stmt *stmt = NULL;
+  wyl_id_t parsed_id;
+
+  if (store == NULL || store->db == NULL || id == NULL)
+    return WYRELOG_E_INVALID;
+  if (wyl_id_parse (id, &parsed_id) != WYRELOG_E_OK)
+    return WYRELOG_E_INVALID;
+
+  static const gchar *sql = "DELETE FROM audit_events WHERE id = ?;";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if ((rc = bind_text (stmt, 1, id)) != WYRELOG_E_OK) {
+    sqlite3_finalize (stmt);
+    return rc;
   }
 
   int step_rc = sqlite3_step (stmt);


### PR DESCRIPTION
## Summary

- Track runtime and policy-store audit row ownership during emit.
- Roll back rows created by the current emit if live audit fact projection fails.
- Preserve existing durable rows during idempotent retry failures.

## Tests

- `git diff --check`
- `meson test -C builddir-audit wyrelog:audit-emit wyrelog:audit-conn wyrelog:decide wyrelog:handle-engine-pair wyrelog:wyrelogd-check --print-errorlogs`
- `meson test -C builddir wyrelog:handle-engine-pair wyrelog:decide wyrelog:wyrelogd-check --print-errorlogs`
