### PR TITLE
Count daemon delta audit failures

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -428,4 +428,17 @@ if get_option('enable_audit').allowed()
   )
 
   test('audit-emit', test_audit_emit, env : audit_conn_test_env)
+
+  test_daemon_delta = executable('test-daemon-delta',
+    'test-daemon-delta.c',
+    '../wyrelog/daemon/delta.c',
+    c_args : [
+      '-DWYL_HAS_AUDIT',
+      '-DWYL_TEST_TEMPLATE_DIR="' + meson.project_source_root() / 'templates' / 'access' + '"',
+    ],
+    include_directories : [wyrelog_inc, include_directories('../wyrelog')],
+    dependencies : [wyrelog_dep, duckdb_dep],
+  )
+
+  test('daemon-delta', test_daemon_delta, env : audit_conn_test_env)
 endif

--- a/tests/test-daemon-delta.c
+++ b/tests/test-daemon-delta.c
@@ -1,0 +1,100 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <glib.h>
+#include <duckdb.h>
+
+#include "wyrelog/wyrelog.h"
+#include "wyrelog/audit/conn-private.h"
+#include "wyrelog/wyl-handle-private.h"
+#include "daemon/delta.h"
+
+#ifndef WYL_TEST_TEMPLATE_DIR
+#error "WYL_TEST_TEMPLATE_DIR must be defined by the build."
+#endif
+
+static wyrelog_error_t
+intern3 (WylHandle *handle, const gchar *a, const gchar *b, const gchar *c,
+    gint64 row[3])
+{
+  wyrelog_error_t rc = wyl_handle_intern_engine_symbol (handle, a, &row[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, b, &row[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_intern_engine_symbol (handle, c, &row[2]);
+}
+
+static wyrelog_error_t
+drop_audit_events_table (WylHandle *handle)
+{
+  duckdb_connection conn =
+      wyl_audit_conn_get_connection (wyl_handle_get_audit_conn (handle));
+  duckdb_result result = { 0 };
+
+  if (duckdb_query (conn, "DROP TABLE audit_events;", &result)
+      != DuckDBSuccess) {
+    duckdb_destroy_result (&result);
+    return WYRELOG_E_IO;
+  }
+  duckdb_destroy_result (&result);
+  return WYRELOG_E_OK;
+}
+
+static gint
+check_delta_callback_counts_audit_failure (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  gint64 row[3];
+  WylDaemonRuntime runtime = { 0 };
+
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 10;
+  runtime.handle = handle;
+  if (wyl_daemon_start_delta_callbacks (handle, &runtime) != WYRELOG_E_OK)
+    return 11;
+  if (drop_audit_events_table (handle) != WYRELOG_E_OK)
+    return 12;
+  if (intern3 (handle, "daemon-delta-audit-user", "wr.viewer",
+          "daemon-delta-audit-scope", row) != WYRELOG_E_OK)
+    return 13;
+
+  if (wyl_handle_engine_insert (handle, "member_of", row, 3) != WYRELOG_E_OK)
+    return 14;
+  if (runtime.inserted != 1)
+    return 15;
+  if (runtime.audit_errors != 1)
+    return 16;
+  if (runtime.last_audit_error == WYRELOG_E_OK)
+    return 17;
+
+  if (wyl_handle_engine_set_delta_callback (handle, NULL, NULL)
+      != WYRELOG_E_OK)
+    return 18;
+  return 0;
+}
+
+static gint
+check_delta_readiness_fails_on_audit_failure (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 30;
+  if (drop_audit_events_table (handle) != WYRELOG_E_OK)
+    return 31;
+  if (wyl_daemon_check_delta_ready (handle) != WYRELOG_E_IO)
+    return 32;
+  return 0;
+}
+
+int
+main (void)
+{
+  gint rc;
+
+  if ((rc = check_delta_callback_counts_audit_failure ()) != 0)
+    return rc;
+  if ((rc = check_delta_readiness_fails_on_audit_failure ()) != 0)
+    return rc;
+  return 0;
+}

--- a/wyrelog/daemon/delta.c
+++ b/wyrelog/daemon/delta.c
@@ -5,6 +5,16 @@
 
 #ifdef WYL_HAS_AUDIT
 static void
+record_daemon_audit_result (WylDaemonRuntime *runtime, wyrelog_error_t rc)
+{
+  if (runtime == NULL || rc == WYRELOG_E_OK)
+    return;
+
+  runtime->audit_errors++;
+  runtime->last_audit_error = rc;
+}
+
+static void
 emit_wirelog_effective_member_audit (WylDaemonRuntime *runtime,
     const gint64 row[3], WylDeltaKind kind)
 {
@@ -28,7 +38,7 @@ emit_wirelog_effective_member_audit (WylDaemonRuntime *runtime,
       kind == WYL_DELTA_INSERT ? "insert" : "remove");
   wyl_audit_event_set_deny_origin (ev, scope);
   wyl_audit_event_set_decision (ev, WYL_DECISION_ALLOW);
-  (void) wyl_audit_emit (runtime->handle, ev);
+  record_daemon_audit_result (runtime, wyl_audit_emit (runtime->handle, ev));
 }
 
 static void
@@ -58,7 +68,7 @@ emit_wirelog_fsm_fired_audit (WylDaemonRuntime *runtime, const gchar *relation,
   wyl_audit_event_set_deny_reason (ev, event);
   wyl_audit_event_set_deny_origin (ev, from_state);
   wyl_audit_event_set_decision (ev, WYL_DECISION_ALLOW);
-  (void) wyl_audit_emit (runtime->handle, ev);
+  record_daemon_audit_result (runtime, wyl_audit_emit (runtime->handle, ev));
 }
 
 static wyrelog_error_t
@@ -343,6 +353,11 @@ wyl_daemon_check_delta_ready (WylHandle *handle)
     goto cleanup;
   }
 #ifdef WYL_HAS_AUDIT
+  if (runtime.audit_errors > 0) {
+    rc = runtime.last_audit_error != WYRELOG_E_OK ?
+        runtime.last_audit_error : WYRELOG_E_IO;
+    goto cleanup;
+  }
   rc = check_wirelog_delta_audit_rows (handle);
   if (rc != WYRELOG_E_OK)
     goto cleanup;

--- a/wyrelog/daemon/delta.h
+++ b/wyrelog/daemon/delta.h
@@ -8,6 +8,8 @@ typedef struct
   WylHandle *handle;
   guint64 inserted;
   guint64 removed;
+  guint64 audit_errors;
+  wyrelog_error_t last_audit_error;
   gboolean expect_effective_member;
   gint64 expected_row[3];
   gboolean matched_expected_insert;


### PR DESCRIPTION
Summary

- Count daemon delta audit emit failures without failing callbacks.
- Fail delta readiness when synthetic audit side effects fail.
- Add focused audit-build daemon delta coverage.


Tests
- meson test -C builddir-audit wyrelog:daemon-delta wyrelog:audit-emit wyrelog:wyrelogd-check --print-errorlogs
- meson test -C builddir wyrelog:wyrelogd-check --print-errorlogs








