### PR TITLE
Check LoBAC policy audit readiness

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -439,6 +439,20 @@ if get_option('enable_audit').allowed()
 
   test('audit-emit', test_audit_emit, env : audit_conn_test_env)
 
+  test_daemon_checks = executable('test-daemon-checks',
+    'test-daemon-checks.c',
+    '../wyrelog/daemon/checks.c',
+    '../wyrelog/daemon/delta.c',
+    c_args : [
+      '-DWYL_HAS_AUDIT',
+      '-DWYL_TEST_TEMPLATE_DIR="' + meson.project_source_root() / 'templates' / 'access' + '"',
+    ],
+    include_directories : [wyrelog_inc, include_directories('../wyrelog')],
+    dependencies : [wyrelog_dep, duckdb_dep],
+  )
+
+  test('daemon-checks', test_daemon_checks, env : audit_conn_test_env)
+
   test_daemon_delta = executable('test-daemon-delta',
     'test-daemon-delta.c',
     '../wyrelog/daemon/delta.c',

--- a/tests/test-daemon-checks.c
+++ b/tests/test-daemon-checks.c
@@ -4,6 +4,7 @@
 
 #include "wyrelog/wyrelog.h"
 #include "wyrelog/audit/conn-private.h"
+#include "wyrelog/engine.h"
 #include "wyrelog/wyl-handle-private.h"
 #include "daemon/checks.h"
 
@@ -24,6 +25,23 @@ count_duckdb_rows (duckdb_connection conn, const gchar *sql, gint64 *out_count)
   *out_count = duckdb_value_int64 (&result, 0, 0);
   duckdb_destroy_result (&result);
   return TRUE;
+}
+
+typedef struct
+{
+  gint64 action_id;
+  guint matches;
+} AuditActionProbe;
+
+static void
+count_audit_action_cb (const gchar *relation, const gint64 *row, guint ncols,
+    gpointer user_data)
+{
+  (void) relation;
+  AuditActionProbe *probe = user_data;
+
+  if (ncols == 2 && row[1] == probe->action_id)
+    probe->matches++;
 }
 
 static gint
@@ -93,11 +111,45 @@ check_login_skip_mfa_ready_allows_development_path (void)
   return 0;
 }
 
+static gint
+check_policy_audit_facts_ready_loads_read_engine (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  gint64 count = 0;
+
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 50;
+  if (wyl_daemon_check_policy_audit_facts_ready (handle) != WYRELOG_E_OK)
+    return 51;
+
+  duckdb_connection conn =
+      wyl_audit_conn_get_connection (wyl_handle_get_audit_conn (handle));
+  if (!count_duckdb_rows (conn,
+          "SELECT COUNT(*) FROM audit_events "
+          "WHERE action = 'policy_audit_reload_check';", &count))
+    return 52;
+  if (count != 0)
+    return 53;
+
+  AuditActionProbe probe = { 0 };
+  if (wyl_handle_intern_engine_symbol (handle, "policy_audit_reload_check",
+          &probe.action_id) != WYRELOG_E_OK)
+    return 54;
+  if (wyl_engine_snapshot (wyl_handle_get_read_engine (handle),
+          "audit_event_action", count_audit_action_cb, &probe) != WYRELOG_E_OK)
+    return 55;
+  if (probe.matches == 0)
+    return 56;
+  return 0;
+}
+
 int
 main (void)
 {
   gint rc;
 
+  if ((rc = check_policy_audit_facts_ready_loads_read_engine ()) != 0)
+    return rc;
   if ((rc = check_login_skip_mfa_ready_rejects_production_path ()) != 0)
     return rc;
   if ((rc = check_login_skip_mfa_ready_allows_development_path ()) != 0)

--- a/tests/test-daemon-checks.c
+++ b/tests/test-daemon-checks.c
@@ -1,0 +1,106 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <glib.h>
+#include <duckdb.h>
+
+#include "wyrelog/wyrelog.h"
+#include "wyrelog/audit/conn-private.h"
+#include "wyrelog/wyl-handle-private.h"
+#include "daemon/checks.h"
+
+#ifndef WYL_TEST_TEMPLATE_DIR
+#error "WYL_TEST_TEMPLATE_DIR must be defined by the build."
+#endif
+
+static gboolean
+count_duckdb_rows (duckdb_connection conn, const gchar *sql, gint64 *out_count)
+{
+  duckdb_result result = { 0 };
+
+  if (duckdb_query (conn, sql, &result) != DuckDBSuccess) {
+    duckdb_destroy_result (&result);
+    return FALSE;
+  }
+
+  *out_count = duckdb_value_int64 (&result, 0, 0);
+  duckdb_destroy_result (&result);
+  return TRUE;
+}
+
+static gint
+check_login_skip_mfa_ready_rejects_production_path (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  gint64 count = 0;
+
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 10;
+  if (wyl_daemon_check_login_skip_mfa_ready (handle) != WYRELOG_E_OK)
+    return 11;
+
+  duckdb_connection conn =
+      wyl_audit_conn_get_connection (wyl_handle_get_audit_conn (handle));
+  if (!count_duckdb_rows (conn,
+          "SELECT COUNT(*) FROM audit_events "
+          "WHERE action = 'login_skip_mfa' "
+          "AND subject_id = 'wyrelogd-skip-mfa-user' "
+          "AND deny_reason = 'skip_mfa_not_allowed' "
+          "AND decision = 0;", &count))
+    return 12;
+  if (count != 1)
+    return 13;
+
+  gint64 row[2];
+  gboolean found = FALSE;
+  if (wyl_handle_intern_engine_symbol (handle, "wyrelogd-skip-mfa-user",
+          &row[0]) != WYRELOG_E_OK)
+    return 14;
+  if (wyl_handle_intern_engine_symbol (handle, "authenticated", &row[1])
+      != WYRELOG_E_OK)
+    return 15;
+  if (wyl_handle_engine_contains (handle, "principal_state", row, 2, &found)
+      != WYRELOG_E_OK)
+    return 16;
+  if (found)
+    return 17;
+  return 0;
+}
+
+static gint
+check_login_skip_mfa_ready_allows_development_path (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  gint64 count = 0;
+
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 30;
+  if (wyl_policy_store_set_deployment_mode (wyl_handle_get_policy_store
+          (handle), "development") != WYRELOG_E_OK)
+    return 31;
+  if (wyl_daemon_check_login_skip_mfa_ready (handle) != WYRELOG_E_OK)
+    return 32;
+
+  duckdb_connection conn =
+      wyl_audit_conn_get_connection (wyl_handle_get_audit_conn (handle));
+  if (!count_duckdb_rows (conn,
+          "SELECT COUNT(*) FROM audit_events "
+          "WHERE action = 'principal_state' "
+          "AND subject_id = 'wyrelogd-skip-mfa-user' "
+          "AND deny_reason = 'login_skip_mfa' "
+          "AND resource_id = 'authenticated' " "AND decision = 1;", &count))
+    return 33;
+  if (count != 1)
+    return 34;
+  return 0;
+}
+
+int
+main (void)
+{
+  gint rc;
+
+  if ((rc = check_login_skip_mfa_ready_rejects_production_path ()) != 0)
+    return rc;
+  if ((rc = check_login_skip_mfa_ready_allows_development_path ()) != 0)
+    return rc;
+  return 0;
+}

--- a/wyrelog/daemon/checks.c
+++ b/wyrelog/daemon/checks.c
@@ -87,6 +87,26 @@ wyl_daemon_check_audit_sink_ready (WylHandle *handle)
   return WYRELOG_E_OK;
 }
 
+wyrelog_error_t
+wyl_daemon_check_login_skip_mfa_ready (WylHandle *handle)
+{
+  g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
+  g_autoptr (WylSession) session = NULL;
+
+  wyl_login_req_set_username (login, "wyrelogd-skip-mfa-user");
+  wyl_login_req_set_skip_mfa (login, TRUE);
+
+  gboolean allowed = wyl_handle_get_login_skip_mfa_allowed (handle);
+  wyrelog_error_t rc = wyl_session_login (handle, login, &session);
+  if (!allowed && rc == WYRELOG_E_POLICY)
+    return WYRELOG_E_OK;
+  if (allowed && rc == WYRELOG_E_OK && session != NULL)
+    return WYRELOG_E_OK;
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return WYRELOG_E_POLICY;
+}
+
 static wyrelog_error_t
 login_check_principal (WylHandle *handle, const gchar *username,
     WylSession **out_session)
@@ -292,6 +312,13 @@ wyl_daemon_run_checks (WylHandle *handle)
   rc = wyl_daemon_check_audit_sink_ready (handle);
   if (rc != WYRELOG_E_OK) {
     g_printerr ("wyrelogd: audit readiness check failed: %s\n",
+        wyrelog_error_string (rc));
+    return 1;
+  }
+
+  rc = wyl_daemon_check_login_skip_mfa_ready (handle);
+  if (rc != WYRELOG_E_OK) {
+    g_printerr ("wyrelogd: login skip-mfa readiness check failed: %s\n",
         wyrelog_error_string (rc));
     return 1;
   }

--- a/wyrelog/daemon/checks.c
+++ b/wyrelog/daemon/checks.c
@@ -59,6 +59,77 @@ wyl_daemon_check_policy_store_ready (WylHandle *handle)
   return WYRELOG_E_OK;
 }
 
+static wyrelog_error_t
+contains_symbol_row2 (WylHandle *handle, const gchar *relation,
+    const gchar *a, const gchar *b, gboolean *out_found)
+{
+  gint64 row[2];
+
+  wyrelog_error_t rc = wyl_handle_intern_engine_symbol (handle, a, &row[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, b, &row[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_engine_contains (handle, relation, row, 2, out_found);
+}
+
+wyrelog_error_t
+wyl_daemon_check_policy_audit_facts_ready (WylHandle *handle)
+{
+  g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
+
+  wyl_audit_event_set_subject_id (ev, "wyrelogd");
+  wyl_audit_event_set_action (ev, "policy_audit_reload_check");
+  wyl_audit_event_set_resource_id (ev, "audit_event");
+  wyl_audit_event_set_deny_reason (ev, "readiness");
+  wyl_audit_event_set_deny_origin (ev, "policy_store");
+  wyl_audit_event_set_decision (ev, WYL_DECISION_ALLOW);
+
+  g_autofree gchar *audit_id = wyl_audit_event_dup_id_string (ev);
+  if (audit_id == NULL)
+    return WYRELOG_E_INTERNAL;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  wyrelog_error_t rc = wyl_policy_store_append_audit_event (store, audit_id,
+      wyl_audit_event_get_created_at_us (ev),
+      wyl_audit_event_get_subject_id (ev), wyl_audit_event_get_action (ev),
+      wyl_audit_event_get_resource_id (ev),
+      wyl_audit_event_get_deny_reason (ev),
+      wyl_audit_event_get_deny_origin (ev),
+      wyl_audit_event_get_decision (ev));
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  rc = wyl_handle_reload_engine_pair (handle);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  gint64 event_row[3];
+  gboolean found = FALSE;
+  rc = wyl_handle_intern_engine_symbol (handle, audit_id, &event_row[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  event_row[1] = wyl_audit_event_get_created_at_us (ev);
+  rc = wyl_handle_intern_engine_symbol (handle, "allow", &event_row[2]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_engine_contains (handle, "audit_event", event_row, 3, &found);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if (!found)
+    return WYRELOG_E_POLICY;
+
+  rc = contains_symbol_row2 (handle, "audit_event_action", audit_id,
+      "policy_audit_reload_check", &found);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if (!found)
+    return WYRELOG_E_POLICY;
+
+  return WYRELOG_E_OK;
+}
+
 wyrelog_error_t
 wyl_daemon_check_audit_sink_ready (WylHandle *handle)
 {
@@ -291,6 +362,13 @@ wyl_daemon_run_checks (WylHandle *handle)
   rc = wyl_daemon_check_policy_store_ready (handle);
   if (rc != WYRELOG_E_OK) {
     g_printerr ("wyrelogd: policy store readiness check failed: %s\n",
+        wyrelog_error_string (rc));
+    return 1;
+  }
+
+  rc = wyl_daemon_check_policy_audit_facts_ready (handle);
+  if (rc != WYRELOG_E_OK) {
+    g_printerr ("wyrelogd: policy audit fact readiness check failed: %s\n",
         wyrelog_error_string (rc));
     return 1;
   }

--- a/wyrelog/daemon/checks.h
+++ b/wyrelog/daemon/checks.h
@@ -6,6 +6,7 @@
 wyrelog_error_t wyl_daemon_check_wirelog_policy_ready (WylHandle * handle);
 wyrelog_error_t wyl_daemon_check_policy_store_ready (WylHandle * handle);
 wyrelog_error_t wyl_daemon_check_audit_sink_ready (WylHandle * handle);
+wyrelog_error_t wyl_daemon_check_login_skip_mfa_ready (WylHandle * handle);
 wyrelog_error_t wyl_daemon_check_policy_snapshot_reload_ready (WylHandle *
     handle);
 wyrelog_error_t

--- a/wyrelog/daemon/checks.h
+++ b/wyrelog/daemon/checks.h
@@ -5,6 +5,7 @@
 
 wyrelog_error_t wyl_daemon_check_wirelog_policy_ready (WylHandle * handle);
 wyrelog_error_t wyl_daemon_check_policy_store_ready (WylHandle * handle);
+wyrelog_error_t wyl_daemon_check_policy_audit_facts_ready (WylHandle * handle);
 wyrelog_error_t wyl_daemon_check_audit_sink_ready (WylHandle * handle);
 wyrelog_error_t wyl_daemon_check_login_skip_mfa_ready (WylHandle * handle);
 wyrelog_error_t wyl_daemon_check_policy_snapshot_reload_ready (WylHandle *


### PR DESCRIPTION
## Summary
- Add daemon readiness coverage for login skip-MFA policy behavior.
- Add daemon readiness coverage for policy-store audit fact reloads.

## Tests
- meson test -C builddir-audit wyrelog:daemon-checks wyrelog:daemon-delta wyrelog:audit-emit wyrelog:handle-engine-pair wyrelog:wyrelogd-check --print-errorlogs
- meson test -C builddir wyrelog:wyrelogd-check wyrelog:handle-engine-pair --print-errorlogs
