### PR TITLE
Gate daemon startup on readiness

### DIFF
--- a/tests/check-wyrelogd-healthz.sh
+++ b/tests/check-wyrelogd-healthz.sh
@@ -19,6 +19,7 @@ trap cleanup EXIT INT TERM
 
 "$PYTHON" - "$PORT" "$EXPECT_AUDIT" <<'PY'
 import sys
+import json
 import time
 import urllib.request
 import urllib.error
@@ -38,6 +39,18 @@ def invalid_filter_is_rejected():
     except urllib.error.HTTPError as exc:
         return exc.code == 400
 
+def audit_events_match_startup_readiness(payload):
+    events = json.loads(payload)
+    if not expect_audit or events == []:
+        return events == []
+    return any(
+        event.get("subject_id") == "wyrelogd-skip-mfa-user"
+        and event.get("action") == "login_skip_mfa"
+        and event.get("deny_reason") == "skip_mfa_not_allowed"
+        and event.get("decision") == 0
+        for event in events
+    )
+
 for _ in range(50):
     try:
         health = urllib.request.urlopen(f"{base}/healthz", timeout=1).read()
@@ -45,7 +58,8 @@ for _ in range(50):
             f"{base}/audit/events?filter=decision%3Ddeny",
             timeout=1,
         ).read()
-        if health != b"ok\n" or events != b"[]":
+        if health != b"ok\n" or not audit_events_match_startup_readiness(
+                events):
             sys.exit(1)
         if expect_audit and not invalid_filter_is_rejected():
             sys.exit(1)

--- a/tests/check-wyrelogd-startup-readiness.sh
+++ b/tests/check-wyrelogd-startup-readiness.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+set -eu
+
+WYRELOGD=$1
+TEMPLATE_DIR=$2
+PYTHON=$3
+PORT=$((41000 + $$ % 20000))
+TMPDIR=$(mktemp -d)
+PID=
+
+cleanup() {
+  if [ -n "$PID" ]; then
+    kill "$PID" 2>/dev/null || true
+  fi
+  rm -rf "$TMPDIR"
+}
+trap cleanup EXIT INT TERM
+
+"$PYTHON" - "$TEMPLATE_DIR" "$TMPDIR/access" <<'PY'
+import pathlib
+import shutil
+import sys
+
+src = pathlib.Path(sys.argv[1])
+dst = pathlib.Path(sys.argv[2])
+shutil.copytree(src, dst)
+
+old = "guarded_perm(P) :- perm_arm_rule(P, G)."
+new = (
+    'guarded_perm(P) :- perm_arm_rule(P, G), '
+    'permission("__wyrelog_test_missing_permission").'
+)
+for rel in ("decision.dl", "lobac/decision.dl"):
+    path = dst / rel
+    text = path.read_text()
+    if old not in text:
+        raise SystemExit(f"{rel}: guarded permission rule not found")
+    path.write_text(text.replace(old, new))
+PY
+
+if "$WYRELOGD" --template-dir "$TMPDIR/access" --check; then
+  echo "readiness fixture unexpectedly passed --check" >&2
+  exit 1
+fi
+
+"$WYRELOGD" --template-dir "$TMPDIR/access" --listen-port "$PORT" &
+PID=$!
+
+if "$PYTHON" - "$PORT" <<'PY'
+import sys
+import time
+import urllib.request
+
+base = f"http://127.0.0.1:{sys.argv[1]}"
+for _ in range(50):
+    try:
+        urllib.request.urlopen(f"{base}/healthz", timeout=1).read()
+        sys.exit(0)
+    except Exception:
+        time.sleep(0.1)
+sys.exit(1)
+PY
+then
+  echo "daemon served healthz after readiness failure" >&2
+  exit 1
+fi
+
+set +e
+wait "$PID"
+rc=$?
+PID=
+set -e
+
+if [ "$rc" -eq 0 ]; then
+  echo "daemon exited successfully after readiness failure" >&2
+  exit 1
+fi

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -54,6 +54,15 @@ if host_machine.system() != 'windows'
       ],
       depends : wyrelogd_exe,
     )
+    test('wyrelogd-startup-readiness', sh,
+      args : [
+        meson.current_source_dir() / 'check-wyrelogd-startup-readiness.sh',
+        wyrelogd_exe.full_path(),
+        meson.project_source_root() / 'templates' / 'access',
+        python3.full_path(),
+      ],
+      depends : wyrelogd_exe,
+    )
   endif
 endif
 

--- a/wyrelog/daemon/runtime.c
+++ b/wyrelog/daemon/runtime.c
@@ -14,6 +14,21 @@ wyl_daemon_run_runtime (const WylDaemonOptions *opts)
 {
   g_autoptr (GError) error = NULL;
 
+  if (!opts->check_only) {
+    g_autoptr (WylHandle) readiness_handle = NULL;
+    wyrelog_error_t readiness_rc =
+        wyl_init (opts->template_dir, &readiness_handle);
+    if (readiness_rc != WYRELOG_E_OK) {
+      g_printerr ("wyrelogd: init failed: %s\n",
+          wyrelog_error_string (readiness_rc));
+      return 1;
+    }
+
+    int checks_rc = wyl_daemon_run_checks (readiness_handle);
+    if (checks_rc != 0)
+      return checks_rc;
+  }
+
   g_autoptr (WylHandle) handle = NULL;
   wyrelog_error_t rc = wyl_init (opts->template_dir, &handle);
   if (rc != WYRELOG_E_OK) {


### PR DESCRIPTION
## Summary

- Run daemon readiness checks before normal startup begins serving.

- Keep readiness fixture mutations out of the operational daemon handle.
- Add startup regression coverage for readiness failure before HTTP bind.


## Tests
- meson test -C builddir wyrelog:wyrelogd-check wyrelog:wyrelogd-startup-readiness wyrelog:wyrelogd-healthz --print-errorlogs
- meson test -C builddir-audit wyrelog:wyrelogd-check wyrelog:wyrelogd-startup-readiness wyrelog:wyrelogd-healthz wyrelog:daemon-checks --print-errorlogs
- git diff --check










