### PR TITLE
Route decide through daemon HTTP

### DIFF
--- a/tests/check-wyrelogd-healthz.sh
+++ b/tests/check-wyrelogd-healthz.sh
@@ -51,6 +51,58 @@ def audit_events_match_startup_readiness(payload):
         for event in events
     )
 
+def invalid_decide_is_rejected():
+    try:
+        urllib.request.urlopen(
+            f"{base}/decide?user=healthz-user&perm=wr.audit.read",
+            data=b"",
+            timeout=1,
+        ).read()
+        return False
+    except urllib.error.HTTPError as exc:
+        return exc.code == 400
+
+def decide_requires_post():
+    try:
+        urllib.request.urlopen(
+            f"{base}/decide?user=healthz-user"
+            "&perm=wr.audit.read&session_token=healthz-scope",
+            timeout=1,
+        ).read()
+        return False
+    except urllib.error.HTTPError as exc:
+        return exc.code == 405
+
+def decide_denies_unseeded_user():
+    payload = urllib.request.urlopen(
+        f"{base}/decide?user=healthz-user"
+        "&perm=wr.audit.read&session_token=healthz-scope",
+        data=b"",
+        timeout=1,
+    ).read()
+    body = json.loads(payload)
+    return (
+        body.get("decision") == 0
+        and "deny_reason" in body
+        and "deny_origin" in body
+    )
+
+def decide_audit_event_is_visible():
+    if not expect_audit:
+        return True
+    payload = urllib.request.urlopen(
+        f"{base}/audit/events?filter=action%28%22wr.audit.read%22%29",
+        timeout=1,
+    ).read()
+    events = json.loads(payload)
+    return any(
+        event.get("subject_id") == "healthz-user"
+        and event.get("action") == "wr.audit.read"
+        and event.get("resource_id") == "healthz-scope"
+        and event.get("decision") == 0
+        for event in events
+    )
+
 for _ in range(50):
     try:
         health = urllib.request.urlopen(f"{base}/healthz", timeout=1).read()
@@ -60,6 +112,14 @@ for _ in range(50):
         ).read()
         if health != b"ok\n" or not audit_events_match_startup_readiness(
                 events):
+            sys.exit(1)
+        if not invalid_decide_is_rejected():
+            sys.exit(1)
+        if not decide_requires_post():
+            sys.exit(1)
+        if not decide_denies_unseeded_user():
+            sys.exit(1)
+        if not decide_audit_event_is_visible():
             sys.exit(1)
         if expect_audit and not invalid_filter_is_rejected():
             sys.exit(1)

--- a/tests/test-client-smoke.c
+++ b/tests/test-client-smoke.c
@@ -12,6 +12,11 @@ typedef struct
   SoupServer *server;
   GMainLoop *loop;
   const gchar *body;
+  gchar *last_method;
+  gchar *last_path;
+  gchar *last_user;
+  gchar *last_perm;
+  gchar *last_session_token;
 } TestHttpServer;
 
 static const gchar *two_event_body =
@@ -45,9 +50,22 @@ test_http_server_handler (SoupServer *server, SoupServerMessage *msg,
     const char *path, GHashTable *query, gpointer user_data)
 {
   (void) server;
-  (void) path;
-  (void) query;
   TestHttpServer *http = user_data;
+
+  g_free (http->last_method);
+  g_free (http->last_path);
+  g_free (http->last_user);
+  g_free (http->last_perm);
+  g_free (http->last_session_token);
+  http->last_method = g_strdup (soup_server_message_get_method (msg));
+  http->last_path = g_strdup (path);
+  http->last_user =
+      query != NULL ? g_strdup (g_hash_table_lookup (query, "user")) : NULL;
+  http->last_perm =
+      query != NULL ? g_strdup (g_hash_table_lookup (query, "perm")) : NULL;
+  http->last_session_token =
+      query != NULL ? g_strdup (g_hash_table_lookup (query,
+          "session_token")) : NULL;
 
   const gchar *body = http->body != NULL ? http->body : "[]";
   soup_server_message_set_status (msg, 200, NULL);
@@ -149,6 +167,62 @@ main (void)
   if (body_size != 2 || memcmp (body_data, "[]", 2) != 0)
     return 26;
 
+  gint decision = -1;
+  if (wyl_client_decide (NULL, "alice", "read", "doc/42", &decision)
+      != WYRELOG_E_INVALID)
+    return 51;
+  if (wyl_client_decide (local_client, NULL, "read", "doc/42", &decision)
+      != WYRELOG_E_INVALID)
+    return 52;
+  if (wyl_client_decide (local_client, "alice", "read", "doc/42", NULL)
+      != WYRELOG_E_INVALID)
+    return 53;
+
+  http.body = "{\"decision\":1,\"deny_reason\":null,\"deny_origin\":null}";
+  if (wyl_client_decide (local_client, "alice", "wr.audit.read",
+          "doc/42", &decision) != WYRELOG_E_OK)
+    return 54;
+  if (decision != WYL_DECISION_ALLOW)
+    return 55;
+  if (g_strcmp0 (http.last_method, "POST") != 0)
+    return 56;
+  if (g_strcmp0 (http.last_path, "/decide") != 0)
+    return 57;
+  if (g_strcmp0 (http.last_user, "alice") != 0)
+    return 58;
+  if (g_strcmp0 (http.last_perm, "wr.audit.read") != 0)
+    return 59;
+  if (g_strcmp0 (http.last_session_token, "doc/42") != 0)
+    return 60;
+
+  http.body = "{\"decision\":0,\"deny_reason\":\"missing_grant\","
+      "\"deny_origin\":\"policy\"}";
+  if (wyl_client_decide (local_client, "bob", "write", "doc/43", &decision)
+      != WYRELOG_E_OK)
+    return 61;
+  if (decision != WYL_DECISION_DENY)
+    return 62;
+
+  http.body = "not-json";
+  if (wyl_client_decide (local_client, "bob", "write", "doc/43", &decision)
+      != WYRELOG_E_IO)
+    return 63;
+  if (decision != WYL_DECISION_DENY)
+    return 64;
+  http.body = "{\"decision\":1x,\"deny_reason\":null,\"deny_origin\":null}";
+  if (wyl_client_decide (local_client, "bob", "write", "doc/43", &decision)
+      != WYRELOG_E_IO)
+    return 65;
+  if (decision != WYL_DECISION_DENY)
+    return 66;
+  http.body = "{\"decision\":1}";
+  if (wyl_client_decide (local_client, "bob", "write", "doc/43", &decision)
+      != WYRELOG_E_IO)
+    return 67;
+  if (decision != WYL_DECISION_DENY)
+    return 68;
+  http.body = "[]";
+
   gboolean has_next = TRUE;
   if (wyl_audit_iter_next (local_iter, &has_next) != WYRELOG_E_OK)
     return 7;
@@ -222,6 +296,11 @@ main (void)
   g_thread_join (thread);
   soup_server_disconnect (http.server);
   g_clear_object (&http.server);
+  g_clear_pointer (&http.last_method, g_free);
+  g_clear_pointer (&http.last_path, g_free);
+  g_clear_pointer (&http.last_user, g_free);
+  g_clear_pointer (&http.last_perm, g_free);
+  g_clear_pointer (&http.last_session_token, g_free);
   g_clear_pointer (&http.loop, g_main_loop_unref);
 
   return 0;

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -4,7 +4,88 @@
 #ifdef WYL_HAS_DAEMON_HTTP
 #include <string.h>
 
+#include "wyrelog/wyrelog.h"
 #include "wyrelog/wyl-handle-private.h"
+
+static void
+append_json_string (GString *json, const gchar *value)
+{
+  g_string_append_c (json, '"');
+  for (const guchar * p = (const guchar *)value; *p != '\0'; p++) {
+    switch (*p) {
+      case '"':
+        g_string_append (json, "\\\"");
+        break;
+      case '\\':
+        g_string_append (json, "\\\\");
+        break;
+      case '\b':
+        g_string_append (json, "\\b");
+        break;
+      case '\f':
+        g_string_append (json, "\\f");
+        break;
+      case '\n':
+        g_string_append (json, "\\n");
+        break;
+      case '\r':
+        g_string_append (json, "\\r");
+        break;
+      case '\t':
+        g_string_append (json, "\\t");
+        break;
+      default:
+        if (*p < 0x20)
+          g_string_append_printf (json, "\\u%04x", *p);
+        else
+          g_string_append_c (json, (gchar) * p);
+        break;
+    }
+  }
+  g_string_append_c (json, '"');
+}
+
+static void
+append_json_nullable_string (GString *json, const gchar *name,
+    const gchar *value)
+{
+  g_string_append_c (json, '"');
+  g_string_append (json, name);
+  g_string_append (json, "\":");
+  if (value == NULL)
+    g_string_append (json, "null");
+  else
+    append_json_string (json, value);
+}
+
+static gchar *
+build_decide_json (const wyl_decide_resp_t *resp)
+{
+  g_autoptr (GString) json = g_string_new ("{");
+
+  g_string_append_printf (json, "\"decision\":%d",
+      (gint) wyl_decide_resp_get_decision (resp));
+  g_string_append_c (json, ',');
+  append_json_nullable_string (json, "deny_reason",
+      wyl_decide_resp_get_deny_reason (resp));
+  g_string_append_c (json, ',');
+  append_json_nullable_string (json, "deny_origin",
+      wyl_decide_resp_get_deny_origin (resp));
+  g_string_append_c (json, '}');
+  return g_string_free (g_steal_pointer (&json), FALSE);
+}
+
+static void
+set_json_error (SoupServerMessage *msg, guint status, const gchar *code)
+{
+  g_autoptr (GString) body = g_string_new ("{\"error\":");
+  append_json_string (body, code);
+  g_string_append_c (body, '}');
+
+  soup_server_message_set_status (msg, status, NULL);
+  soup_server_message_set_response (msg, "application/json",
+      SOUP_MEMORY_COPY, body->str, body->len);
+}
 
 static void
 healthz_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
@@ -63,6 +144,54 @@ audit_events_handler (SoupServer *server, SoupServerMessage *msg,
       SOUP_MEMORY_COPY, body, strlen (body));
 }
 
+static void
+decide_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
+    GHashTable *query, gpointer user_data)
+{
+  (void) server;
+  (void) path;
+
+  if (g_strcmp0 (soup_server_message_get_method (msg), "POST") != 0) {
+    set_json_error (msg, 405, "method_not_allowed");
+    return;
+  }
+
+  const gchar *user = NULL;
+  const gchar *perm = NULL;
+  const gchar *session_token = NULL;
+  if (query != NULL) {
+    user = g_hash_table_lookup (query, "user");
+    perm = g_hash_table_lookup (query, "perm");
+    session_token = g_hash_table_lookup (query, "session_token");
+  }
+  if (user == NULL || perm == NULL || session_token == NULL) {
+    set_json_error (msg, 400, "invalid_decide_request");
+    return;
+  }
+
+  WylHandle *handle = user_data;
+  g_autoptr (wyl_decide_req_t) req = wyl_decide_req_new ();
+  g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
+  wyl_decide_req_set_subject_id (req, user);
+  wyl_decide_req_set_action (req, perm);
+  wyl_decide_req_set_resource_id (req, session_token);
+
+  wyrelog_error_t rc = wyl_decide (handle, req, resp);
+  if (rc == WYRELOG_E_INVALID) {
+    set_json_error (msg, 400, "invalid_decide_request");
+    return;
+  }
+  if (rc != WYRELOG_E_OK) {
+    set_json_error (msg, 500, "decide_failed");
+    return;
+  }
+
+  g_autofree gchar *body = build_decide_json (resp);
+  soup_server_message_set_status (msg, 200, NULL);
+  soup_server_message_set_response (msg, "application/json",
+      SOUP_MEMORY_COPY, body, strlen (body));
+}
+
 SoupServer *
 wyl_daemon_start_http_server (const WylDaemonOptions *opts, WylHandle *handle,
     GError **error)
@@ -78,6 +207,7 @@ wyl_daemon_start_http_server (const WylDaemonOptions *opts, WylHandle *handle,
 
   SoupServer *server = soup_server_new (NULL, NULL);
   soup_server_add_handler (server, "/healthz", healthz_handler, NULL, NULL);
+  soup_server_add_handler (server, "/decide", decide_handler, handle, NULL);
   soup_server_add_handler (server, "/audit/events", audit_events_handler,
       handle, NULL);
   if (!soup_server_listen_local (server, (guint) opts->listen_port, 0, error)) {

--- a/wyrelog/wyl-client.c
+++ b/wyrelog/wyl-client.c
@@ -124,16 +124,231 @@ wyl_client_mfa_verify (WylClient *client, const gchar *otp)
   return WYRELOG_E_INTERNAL;
 }
 
+typedef struct
+{
+  const gchar *data;
+  gsize size;
+  gsize pos;
+} JsonCursor;
+
+static void
+json_skip_ws (JsonCursor *cursor)
+{
+  while (cursor->pos < cursor->size &&
+      g_ascii_isspace (cursor->data[cursor->pos]))
+    cursor->pos++;
+}
+
+static gboolean
+json_consume (JsonCursor *cursor, gchar ch)
+{
+  json_skip_ws (cursor);
+  if (cursor->pos >= cursor->size || cursor->data[cursor->pos] != ch)
+    return FALSE;
+  cursor->pos++;
+  return TRUE;
+}
+
+static gboolean
+json_hex_is_valid (gchar ch)
+{
+  return g_ascii_isxdigit (ch);
+}
+
+static gboolean
+json_parse_string (JsonCursor *cursor, gchar **out_string)
+{
+  if (out_string == NULL)
+    return FALSE;
+  *out_string = NULL;
+  if (!json_consume (cursor, '"'))
+    return FALSE;
+
+  g_autoptr (GString) value = g_string_new (NULL);
+  while (cursor->pos < cursor->size) {
+    guchar ch = (guchar) cursor->data[cursor->pos++];
+    if (ch == '"') {
+      *out_string = g_string_free (g_steal_pointer (&value), FALSE);
+      return TRUE;
+    }
+    if (ch < 0x20)
+      return FALSE;
+    if (ch != '\\') {
+      g_string_append_c (value, (gchar) ch);
+      continue;
+    }
+    if (cursor->pos >= cursor->size)
+      return FALSE;
+    ch = (guchar) cursor->data[cursor->pos++];
+    switch (ch) {
+      case '"':
+      case '\\':
+      case '/':
+        g_string_append_c (value, (gchar) ch);
+        break;
+      case 'b':
+        g_string_append_c (value, '\b');
+        break;
+      case 'f':
+        g_string_append_c (value, '\f');
+        break;
+      case 'n':
+        g_string_append_c (value, '\n');
+        break;
+      case 'r':
+        g_string_append_c (value, '\r');
+        break;
+      case 't':
+        g_string_append_c (value, '\t');
+        break;
+      case 'u':
+        if (cursor->pos + 4 > cursor->size)
+          return FALSE;
+        for (guint i = 0; i < 4; i++) {
+          if (!json_hex_is_valid (cursor->data[cursor->pos++]))
+            return FALSE;
+        }
+        g_string_append_c (value, '?');
+        break;
+      default:
+        return FALSE;
+    }
+  }
+  return FALSE;
+}
+
+static gboolean
+json_parse_nullable_string (JsonCursor *cursor)
+{
+  json_skip_ws (cursor);
+  if (cursor->pos + 4 <= cursor->size &&
+      memcmp (cursor->data + cursor->pos, "null", 4) == 0) {
+    cursor->pos += 4;
+    return TRUE;
+  }
+
+  g_autofree gchar *value = NULL;
+  return json_parse_string (cursor, &value);
+}
+
+static gboolean
+json_parse_decision (JsonCursor *cursor, gint *out_decision)
+{
+  if (out_decision == NULL)
+    return FALSE;
+  json_skip_ws (cursor);
+  if (cursor->pos >= cursor->size)
+    return FALSE;
+  gchar ch = cursor->data[cursor->pos++];
+  if (ch != '0' && ch != '1')
+    return FALSE;
+  if (cursor->pos < cursor->size && g_ascii_isdigit (cursor->data[cursor->pos]))
+    return FALSE;
+  *out_decision = ch == '1' ? WYL_DECISION_ALLOW : WYL_DECISION_DENY;
+  return TRUE;
+}
+
+static gboolean
+parse_decide_response_json (const gchar *data, gsize size, gint *out_decision)
+{
+  if (data == NULL || out_decision == NULL)
+    return FALSE;
+
+  JsonCursor cursor = { data, size, 0 };
+  if (!json_consume (&cursor, '{'))
+    return FALSE;
+
+  gboolean have_decision = FALSE;
+  gboolean have_deny_reason = FALSE;
+  gboolean have_deny_origin = FALSE;
+  gint decision = WYL_DECISION_DENY;
+  json_skip_ws (&cursor);
+  if (cursor.pos < cursor.size && cursor.data[cursor.pos] == '}')
+    return FALSE;
+
+  while (TRUE) {
+    g_autofree gchar *key = NULL;
+    if (!json_parse_string (&cursor, &key) || !json_consume (&cursor, ':'))
+      return FALSE;
+
+    if (g_strcmp0 (key, "decision") == 0) {
+      if (have_decision || !json_parse_decision (&cursor, &decision))
+        return FALSE;
+      have_decision = TRUE;
+    } else if (g_strcmp0 (key, "deny_reason") == 0 ||
+        g_strcmp0 (key, "deny_origin") == 0) {
+      gboolean *seen = g_strcmp0 (key, "deny_reason") == 0 ?
+          &have_deny_reason : &have_deny_origin;
+      if (*seen)
+        return FALSE;
+      if (!json_parse_nullable_string (&cursor))
+        return FALSE;
+      *seen = TRUE;
+    } else {
+      return FALSE;
+    }
+
+    json_skip_ws (&cursor);
+    if (cursor.pos < cursor.size && cursor.data[cursor.pos] == ',') {
+      cursor.pos++;
+      continue;
+    }
+    if (cursor.pos < cursor.size && cursor.data[cursor.pos] == '}') {
+      cursor.pos++;
+      break;
+    }
+    return FALSE;
+  }
+
+  json_skip_ws (&cursor);
+  if (!have_decision || !have_deny_reason || !have_deny_origin ||
+      cursor.pos != cursor.size)
+    return FALSE;
+  *out_decision = decision;
+  return TRUE;
+}
+
 wyrelog_error_t
 wyl_client_decide (WylClient *client, const gchar *user, const gchar *perm,
     const gchar *session_token, gint *out_decision)
 {
-  (void) client;
-  (void) user;
-  (void) perm;
-  (void) session_token;
-  (void) out_decision;
-  return WYRELOG_E_INTERNAL;
+  if (client == NULL || !WYL_IS_CLIENT (client) || user == NULL ||
+      perm == NULL || session_token == NULL || out_decision == NULL)
+    return WYRELOG_E_INVALID;
+  *out_decision = WYL_DECISION_DENY;
+
+  g_autofree gchar *base_url = wyl_client_dup_base_url (client);
+  if (base_url == NULL)
+    return WYRELOG_E_INVALID;
+  while (base_url[0] != '\0' && g_str_has_suffix (base_url, "/"))
+    base_url[strlen (base_url) - 1] = '\0';
+
+  g_autofree gchar *escaped_user = g_uri_escape_string (user, NULL, TRUE);
+  g_autofree gchar *escaped_perm = g_uri_escape_string (perm, NULL, TRUE);
+  g_autofree gchar *escaped_session_token =
+      g_uri_escape_string (session_token, NULL, TRUE);
+  g_autofree gchar *uri =
+      g_strdup_printf ("%s/decide?user=%s&perm=%s&session_token=%s", base_url,
+      escaped_user,
+      escaped_perm, escaped_session_token);
+
+  g_autoptr (SoupMessage) message = soup_message_new ("POST", uri);
+  if (message == NULL)
+    return WYRELOG_E_INVALID;
+
+  g_autoptr (GBytes) body = NULL;
+  wyrelog_error_t rc = wyl_client_send_message (client, message, &body);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  gsize body_size = 0;
+  const gchar *body_data = g_bytes_get_data (body, &body_size);
+  gint decision = WYL_DECISION_DENY;
+  if (!parse_decide_response_json (body_data, body_size, &decision))
+    return WYRELOG_E_IO;
+
+  *out_decision = decision;
+  return WYRELOG_E_OK;
 }
 
 wyrelog_error_t


### PR DESCRIPTION
## Summary

- Add daemon POST /decide for the existing client decide field mapping.
- Return decision, deny_reason, and deny_origin as JSON.
- Wire wyl_client_decide with fail-closed response parsing and tests.


## Tests
- meson test -C builddir wyrelog:client-smoke wyrelog:wyrelogd-healthz --print-errorlogs
- meson test -C builddir-audit wyrelog:client-smoke wyrelog:wyrelogd-healthz wyrelog:client-audit-daemon --print-errorlogs
- meson test -C builddir-noclient wyrelog:wyrelogd-check --print-errorlogs
- meson test -C builddir wyrelog:decide wyrelog:decide-req wyrelog:decide-resp --print-errorlogs
- git diff --check











