### PR TITLE
daemon: catch sigterm during readiness phase

### DIFF
--- a/wyrelog/daemon/runtime.c
+++ b/wyrelog/daemon/runtime.c
@@ -15,16 +15,26 @@ wyl_daemon_run_runtime (const WylDaemonOptions *opts)
   g_autoptr (GError) error = NULL;
 
   if (!opts->check_only) {
+    /* Install early signal handlers so SIGINT/SIGTERM arriving during
+     * the readiness phase (before the GMainLoop and its glib-based
+     * handlers exist) sets a flag we can observe instead of letting
+     * the default disposition terminate the process. */
+    wyl_daemon_install_early_signal_handlers ();
+
     g_autoptr (WylHandle) readiness_handle = NULL;
     wyrelog_error_t readiness_rc =
         wyl_init (opts->template_dir, &readiness_handle);
     if (readiness_rc != WYRELOG_E_OK) {
+      if (wyl_daemon_early_signal_received ())
+        return 0;
       g_printerr ("wyrelogd: init failed: %s\n",
           wyrelog_error_string (readiness_rc));
       return 1;
     }
 
     int checks_rc = wyl_daemon_run_checks (readiness_handle);
+    if (wyl_daemon_early_signal_received ())
+      return 0;
     if (checks_rc != 0)
       return checks_rc;
   }
@@ -69,6 +79,12 @@ wyl_daemon_run_runtime (const WylDaemonOptions *opts)
   guint sigint_id = 0;
   guint sigterm_id = 0;
   wyl_daemon_install_signal_handlers (loop, &sigint_id, &sigterm_id);
+  /* If SIGTERM/SIGINT arrived during readiness or post-readiness setup,
+   * the early handler captured it but the GMainLoop's signal source did
+   * not. Quit the loop preemptively so we exit cleanly without serving
+   * a single request. */
+  if (wyl_daemon_early_signal_received ())
+    g_main_loop_quit (loop);
   g_main_loop_run (loop);
 #ifdef WYL_HAS_DAEMON_HTTP
   soup_server_disconnect (server);

--- a/wyrelog/daemon/signals.c
+++ b/wyrelog/daemon/signals.c
@@ -1,13 +1,46 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+/* SA_RESTART and struct sigaction require POSIX-2001 visibility, which
+ * is not exposed under strict c_std=c17 unless we ask for it. */
+#define _POSIX_C_SOURCE 200809L
+
 #include "daemon/signals.h"
 
 #include <signal.h>
+#include <string.h>
 
 #ifdef G_OS_UNIX
 #include <glib-unix.h>
 #endif
 
 #ifdef G_OS_UNIX
+static volatile sig_atomic_t early_signal_received_flag = 0;
+
+static void
+early_signal_handler (int signum)
+{
+  (void) signum;
+  early_signal_received_flag = 1;
+}
+
+void
+wyl_daemon_install_early_signal_handlers (void)
+{
+  struct sigaction sa;
+
+  memset (&sa, 0, sizeof (sa));
+  sa.sa_handler = early_signal_handler;
+  sigemptyset (&sa.sa_mask);
+  sa.sa_flags = SA_RESTART;
+  sigaction (SIGINT, &sa, NULL);
+  sigaction (SIGTERM, &sa, NULL);
+}
+
+gboolean
+wyl_daemon_early_signal_received (void)
+{
+  return early_signal_received_flag != 0;
+}
+
 static gboolean
 quit_loop_from_signal (gpointer user_data)
 {
@@ -34,6 +67,17 @@ wyl_daemon_remove_signal_handler (guint *source_id)
   }
 }
 #else
+void
+wyl_daemon_install_early_signal_handlers (void)
+{
+}
+
+gboolean
+wyl_daemon_early_signal_received (void)
+{
+  return FALSE;
+}
+
 void
 wyl_daemon_install_signal_handlers (GMainLoop *loop, guint *sigint_id,
     guint *sigterm_id)

--- a/wyrelog/daemon/signals.h
+++ b/wyrelog/daemon/signals.h
@@ -3,6 +3,9 @@
 
 #include <glib.h>
 
+void wyl_daemon_install_early_signal_handlers (void);
+gboolean wyl_daemon_early_signal_received (void);
+
 void wyl_daemon_install_signal_handlers (GMainLoop * loop, guint * sigint_id,
     guint * sigterm_id);
 void wyl_daemon_remove_signal_handler (guint * source_id);


### PR DESCRIPTION
## Summary

- Install a POSIX sigaction-based SIGINT/SIGTERM handler before the readiness gate runs, so signals arriving prior to `g_main_loop_run` set a flag instead of triggering the default disposition.
- After `wyl_daemon_run_checks` and again immediately before `g_main_loop_run`, observe the flag and return zero / quit the loop preemptively. glib's `g_unix_signal_add` later overrides the sigaction once the operational mainloop is ready.

## Why

109e224 ("daemon: gate startup on readiness checks") moved the readiness probe in front of every other startup step, including signal handler installation. Under ASAN+UBSAN on the GitHub `ubuntu-latest` runner the readiness phase consistently exceeds the one-second sleep used by the `wyrelogd-sigterm` meson test, so the test's `kill -TERM` lands while the daemon has no signal handler installed. The default disposition terminates the process with exit 143 and the test fails. With the early handler in place the readiness step finishes (SA_RESTART keeps DuckDB and engine calls non-interruptible), the flag check returns 0, and the daemon exits cleanly without serving a request.

## Test plan

- [x] `meson test -C builddir wyrelogd-sigterm wyrelogd-check wyrelogd-healthz wyrelogd-startup-readiness` (all OK)
- [x] Manual: `wyrelogd ... & pid=$!; sleep 0.05; kill -TERM $pid; wait $pid` (exit 0, previously default-killed)
- [x] Full `meson test -C builddir` suite green except for an unrelated pre-existing slowness in `session-username` that passes with `--timeout-multiplier 4`