### PR TITLE
Support guarded HTTP decide in client

### DIFF
--- a/tests/test-client-smoke.c
+++ b/tests/test-client-smoke.c
@@ -17,6 +17,9 @@ typedef struct
   gchar *last_user;
   gchar *last_perm;
   gchar *last_session_token;
+  gchar *last_guard_timestamp;
+  gchar *last_guard_loc_class;
+  gchar *last_guard_risk;
 } TestHttpServer;
 
 static const gchar *two_event_body =
@@ -57,6 +60,9 @@ test_http_server_handler (SoupServer *server, SoupServerMessage *msg,
   g_free (http->last_user);
   g_free (http->last_perm);
   g_free (http->last_session_token);
+  g_free (http->last_guard_timestamp);
+  g_free (http->last_guard_loc_class);
+  g_free (http->last_guard_risk);
   http->last_method = g_strdup (soup_server_message_get_method (msg));
   http->last_path = g_strdup (path);
   http->last_user =
@@ -66,6 +72,15 @@ test_http_server_handler (SoupServer *server, SoupServerMessage *msg,
   http->last_session_token =
       query != NULL ? g_strdup (g_hash_table_lookup (query,
           "session_token")) : NULL;
+  http->last_guard_timestamp =
+      query != NULL ? g_strdup (g_hash_table_lookup (query,
+          "guard_timestamp")) : NULL;
+  http->last_guard_loc_class =
+      query != NULL ? g_strdup (g_hash_table_lookup (query,
+          "guard_loc_class")) : NULL;
+  http->last_guard_risk =
+      query != NULL ? g_strdup (g_hash_table_lookup (query,
+          "guard_risk")) : NULL;
 
   const gchar *body = http->body != NULL ? http->body : "[]";
   soup_server_message_set_status (msg, 200, NULL);
@@ -194,33 +209,82 @@ main (void)
     return 59;
   if (g_strcmp0 (http.last_session_token, "doc/42") != 0)
     return 60;
+  if (http.last_guard_timestamp != NULL || http.last_guard_loc_class != NULL ||
+      http.last_guard_risk != NULL)
+    return 69;
+
+  if (wyl_client_decide_with_guard_context (NULL, "alice", "read", "doc/42",
+          123, "public", 69, &decision) != WYRELOG_E_INVALID)
+    return 70;
+  if (wyl_client_decide_with_guard_context (local_client, NULL, "read",
+          "doc/42", 123, "public", 69, &decision) != WYRELOG_E_INVALID)
+    return 71;
+  if (wyl_client_decide_with_guard_context (local_client, "alice", NULL,
+          "doc/42", 123, "public", 69, &decision) != WYRELOG_E_INVALID)
+    return 72;
+  if (wyl_client_decide_with_guard_context (local_client, "alice", "read",
+          NULL, 123, "public", 69, &decision) != WYRELOG_E_INVALID)
+    return 73;
+  if (wyl_client_decide_with_guard_context (local_client, "alice", "read",
+          "doc/42", 123, NULL, 69, &decision) != WYRELOG_E_INVALID)
+    return 74;
+  if (wyl_client_decide_with_guard_context (local_client, "alice", "read",
+          "doc/42", -1, "public", 69, &decision) != WYRELOG_E_INVALID)
+    return 75;
+  if (wyl_client_decide_with_guard_context (local_client, "alice", "read",
+          "doc/42", 123, "public", 101, &decision) != WYRELOG_E_INVALID)
+    return 76;
+  if (wyl_client_decide_with_guard_context (local_client, "alice", "read",
+          "doc/42", 123, "unknown", 69, &decision) != WYRELOG_E_INVALID)
+    return 77;
+  if (wyl_client_decide_with_guard_context (local_client, "alice", "read",
+          "doc/42", 123, "public", 69, NULL) != WYRELOG_E_INVALID)
+    return 78;
+
+  http.body = "{\"decision\":1,\"deny_reason\":null,\"deny_origin\":null}";
+  if (wyl_client_decide_with_guard_context (local_client, "alice",
+          "wr.audit.read", "doc/42", 123, "semi_trusted", 69,
+          &decision) != WYRELOG_E_OK)
+    return 79;
+  if (decision != WYL_DECISION_ALLOW)
+    return 80;
+  if (g_strcmp0 (http.last_method, "POST") != 0)
+    return 81;
+  if (g_strcmp0 (http.last_path, "/decide") != 0)
+    return 82;
+  if (g_strcmp0 (http.last_guard_timestamp, "123") != 0)
+    return 83;
+  if (g_strcmp0 (http.last_guard_loc_class, "semi_trusted") != 0)
+    return 84;
+  if (g_strcmp0 (http.last_guard_risk, "69") != 0)
+    return 85;
 
   http.body = "{\"decision\":0,\"deny_reason\":\"missing_grant\","
       "\"deny_origin\":\"policy\"}";
   if (wyl_client_decide (local_client, "bob", "write", "doc/43", &decision)
       != WYRELOG_E_OK)
-    return 61;
+    return 86;
   if (decision != WYL_DECISION_DENY)
-    return 62;
+    return 87;
 
   http.body = "not-json";
   if (wyl_client_decide (local_client, "bob", "write", "doc/43", &decision)
       != WYRELOG_E_IO)
-    return 63;
+    return 88;
   if (decision != WYL_DECISION_DENY)
-    return 64;
+    return 89;
   http.body = "{\"decision\":1x,\"deny_reason\":null,\"deny_origin\":null}";
   if (wyl_client_decide (local_client, "bob", "write", "doc/43", &decision)
       != WYRELOG_E_IO)
-    return 65;
+    return 90;
   if (decision != WYL_DECISION_DENY)
-    return 66;
+    return 91;
   http.body = "{\"decision\":1}";
   if (wyl_client_decide (local_client, "bob", "write", "doc/43", &decision)
       != WYRELOG_E_IO)
-    return 67;
+    return 92;
   if (decision != WYL_DECISION_DENY)
-    return 68;
+    return 93;
   http.body = "[]";
 
   gboolean has_next = TRUE;
@@ -301,6 +365,9 @@ main (void)
   g_clear_pointer (&http.last_user, g_free);
   g_clear_pointer (&http.last_perm, g_free);
   g_clear_pointer (&http.last_session_token, g_free);
+  g_clear_pointer (&http.last_guard_timestamp, g_free);
+  g_clear_pointer (&http.last_guard_loc_class, g_free);
+  g_clear_pointer (&http.last_guard_risk, g_free);
   g_clear_pointer (&http.loop, g_main_loop_unref);
 
   return 0;

--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -405,6 +405,18 @@ main (void)
     return 8;
   if (decision != WYL_DECISION_ALLOW)
     return 9;
+  if (wyl_client_decide_with_guard_context (client, "http-guard-user",
+          "wr.audit.read", "http-guard-scope", 123, "public", 69,
+          &decision) != WYRELOG_E_OK)
+    return 10;
+  if (decision != WYL_DECISION_ALLOW)
+    return 11;
+  if (wyl_client_decide_with_guard_context (client, "http-guard-user",
+          "wr.audit.read", "http-guard-scope", 123, "public", 70,
+          &decision) != WYRELOG_E_OK)
+    return 12;
+  if (decision != WYL_DECISION_DENY)
+    return 13;
 
 #ifdef WYL_HAS_AUDIT
   gint audit_rc = check_audit_event_present (client,

--- a/wyrelog/client.h
+++ b/wyrelog/client.h
@@ -44,6 +44,12 @@ wyrelog_error_t wyl_client_mfa_verify (WylClient * client, const gchar * otp);
 wyrelog_error_t wyl_client_decide (WylClient * client,
     const gchar * user,
     const gchar * perm, const gchar * session_token, gint * out_decision);
+wyrelog_error_t wyl_client_decide_with_guard_context (WylClient * client,
+    const gchar * user,
+    const gchar * perm,
+    const gchar * session_token,
+    gint64 guard_timestamp,
+    const gchar * guard_loc_class, gint64 guard_risk, gint * out_decision);
 
 /* Audit query (iterator) */
 wyrelog_error_t wyl_client_audit_query (WylClient * client,

--- a/wyrelog/wyl-client.c
+++ b/wyrelog/wyl-client.c
@@ -308,14 +308,29 @@ parse_decide_response_json (const gchar *data, gsize size, gint *out_decision)
   return TRUE;
 }
 
-wyrelog_error_t
-wyl_client_decide (WylClient *client, const gchar *user, const gchar *perm,
-    const gchar *session_token, gint *out_decision)
+static gboolean
+guard_loc_class_is_valid (const gchar *loc_class)
+{
+  return g_strcmp0 (loc_class, "trusted") == 0 ||
+      g_strcmp0 (loc_class, "semi_trusted") == 0 ||
+      g_strcmp0 (loc_class, "public") == 0 ||
+      g_strcmp0 (loc_class, "untrusted") == 0;
+}
+
+static wyrelog_error_t
+client_decide_request (WylClient *client, const gchar *user, const gchar *perm,
+    const gchar *session_token, gboolean has_guard_context,
+    gint64 guard_timestamp, const gchar *guard_loc_class, gint64 guard_risk,
+    gint *out_decision)
 {
   if (client == NULL || !WYL_IS_CLIENT (client) || user == NULL ||
       perm == NULL || session_token == NULL || out_decision == NULL)
     return WYRELOG_E_INVALID;
   *out_decision = WYL_DECISION_DENY;
+  if (has_guard_context &&
+      (guard_loc_class == NULL || guard_timestamp < 0 || guard_risk < 0 ||
+          guard_risk > 100 || !guard_loc_class_is_valid (guard_loc_class)))
+    return WYRELOG_E_INVALID;
 
   g_autofree gchar *base_url = wyl_client_dup_base_url (client);
   if (base_url == NULL)
@@ -327,10 +342,20 @@ wyl_client_decide (WylClient *client, const gchar *user, const gchar *perm,
   g_autofree gchar *escaped_perm = g_uri_escape_string (perm, NULL, TRUE);
   g_autofree gchar *escaped_session_token =
       g_uri_escape_string (session_token, NULL, TRUE);
-  g_autofree gchar *uri =
-      g_strdup_printf ("%s/decide?user=%s&perm=%s&session_token=%s", base_url,
-      escaped_user,
-      escaped_perm, escaped_session_token);
+  g_autofree gchar *escaped_guard_loc_class =
+      has_guard_context ? g_uri_escape_string (guard_loc_class, NULL,
+      TRUE) : NULL;
+  g_autofree gchar *uri = NULL;
+  if (has_guard_context) {
+    uri = g_strdup_printf ("%s/decide?user=%s&perm=%s&session_token=%s"
+        "&guard_timestamp=%" G_GINT64_FORMAT "&guard_loc_class=%s"
+        "&guard_risk=%" G_GINT64_FORMAT, base_url, escaped_user,
+        escaped_perm, escaped_session_token, guard_timestamp,
+        escaped_guard_loc_class, guard_risk);
+  } else {
+    uri = g_strdup_printf ("%s/decide?user=%s&perm=%s&session_token=%s",
+        base_url, escaped_user, escaped_perm, escaped_session_token);
+  }
 
   g_autoptr (SoupMessage) message = soup_message_new ("POST", uri);
   if (message == NULL)
@@ -349,6 +374,23 @@ wyl_client_decide (WylClient *client, const gchar *user, const gchar *perm,
 
   *out_decision = decision;
   return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
+wyl_client_decide (WylClient *client, const gchar *user, const gchar *perm,
+    const gchar *session_token, gint *out_decision)
+{
+  return client_decide_request (client, user, perm, session_token, FALSE, 0,
+      NULL, 0, out_decision);
+}
+
+wyrelog_error_t
+wyl_client_decide_with_guard_context (WylClient *client, const gchar *user,
+    const gchar *perm, const gchar *session_token, gint64 guard_timestamp,
+    const gchar *guard_loc_class, gint64 guard_risk, gint *out_decision)
+{
+  return client_decide_request (client, user, perm, session_token, TRUE,
+      guard_timestamp, guard_loc_class, guard_risk, out_decision);
 }
 
 wyrelog_error_t


### PR DESCRIPTION
## Summary
- Add an explicit client API for guarded remote decisions.
- Validate guard context locally before sending decide requests.
- Cover unguarded compatibility and guarded daemon decisions.

## Tests
- git diff --cached --check
- meson test -C builddir client-smoke daemon-http-decide --print-errorlogs
- meson test -C builddir-audit client-smoke daemon-http-decide --print-errorlogs
