### PR TITLE
Add HTTP login initiation

### DIFF
--- a/tests/test-client-smoke.c
+++ b/tests/test-client-smoke.c
@@ -17,6 +17,7 @@ typedef struct
   gchar *last_user;
   gchar *last_perm;
   gchar *last_session_token;
+  gchar *last_password;
   gchar *last_guard_timestamp;
   gchar *last_guard_loc_class;
   gchar *last_guard_risk;
@@ -60,18 +61,27 @@ test_http_server_handler (SoupServer *server, SoupServerMessage *msg,
   g_free (http->last_user);
   g_free (http->last_perm);
   g_free (http->last_session_token);
+  g_free (http->last_password);
   g_free (http->last_guard_timestamp);
   g_free (http->last_guard_loc_class);
   g_free (http->last_guard_risk);
   http->last_method = g_strdup (soup_server_message_get_method (msg));
   http->last_path = g_strdup (path);
-  http->last_user =
-      query != NULL ? g_strdup (g_hash_table_lookup (query, "user")) : NULL;
+  if (query != NULL) {
+    const gchar *user = g_hash_table_lookup (query, "user");
+    if (user == NULL)
+      user = g_hash_table_lookup (query, "username");
+    http->last_user = g_strdup (user);
+  } else {
+    http->last_user = NULL;
+  }
   http->last_perm =
       query != NULL ? g_strdup (g_hash_table_lookup (query, "perm")) : NULL;
   http->last_session_token =
       query != NULL ? g_strdup (g_hash_table_lookup (query,
           "session_token")) : NULL;
+  http->last_password =
+      query != NULL ? g_strdup (g_hash_table_lookup (query, "password")) : NULL;
   http->last_guard_timestamp =
       query != NULL ? g_strdup (g_hash_table_lookup (query,
           "guard_timestamp")) : NULL;
@@ -181,6 +191,33 @@ main (void)
   const gchar *body_data = g_bytes_get_data (body, &body_size);
   if (body_size != 2 || memcmp (body_data, "[]", 2) != 0)
     return 26;
+
+  if (wyl_client_login (NULL, "alice", NULL) != WYRELOG_E_INVALID)
+    return 38;
+  if (wyl_client_login (local_client, NULL, NULL) != WYRELOG_E_INVALID)
+    return 39;
+  if (wyl_client_login (local_client, "", NULL) != WYRELOG_E_INVALID)
+    return 40;
+  if (wyl_client_login (local_client, "alice", "secret") != WYRELOG_E_INVALID)
+    return 41;
+
+  http.body = "{\"session_token\":\"session-1\",\"username\":\"alice\","
+      "\"principal_state\":\"mfa_required\",\"session_state\":\"active\"}";
+  if (wyl_client_login (local_client, "alice", NULL) != WYRELOG_E_OK)
+    return 42;
+  if (g_strcmp0 (http.last_method, "POST") != 0)
+    return 43;
+  if (g_strcmp0 (http.last_path, "/auth/login") != 0)
+    return 44;
+  if (g_strcmp0 (http.last_user, "alice") != 0)
+    return 45;
+  if (http.last_password != NULL)
+    return 46;
+
+  http.body = "{\"session_token\":\"session-1\"}";
+  if (wyl_client_login (local_client, "alice", NULL) != WYRELOG_E_IO)
+    return 47;
+  http.body = "[]";
 
   gint decision = -1;
   if (wyl_client_decide (NULL, "alice", "read", "doc/42", &decision)
@@ -365,6 +402,7 @@ main (void)
   g_clear_pointer (&http.last_user, g_free);
   g_clear_pointer (&http.last_perm, g_free);
   g_clear_pointer (&http.last_session_token, g_free);
+  g_clear_pointer (&http.last_password, g_free);
   g_clear_pointer (&http.last_guard_timestamp, g_free);
   g_clear_pointer (&http.last_guard_loc_class, g_free);
   g_clear_pointer (&http.last_guard_risk, g_free);

--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -328,6 +328,104 @@ check_raw_decide_contract (const gchar *base_url)
   return 0;
 }
 
+static gint
+send_raw_login (SoupSession *session, const gchar *method,
+    const gchar *base_url, const gchar *query, guint *out_status,
+    gchar **out_body)
+{
+  g_autofree gchar *root = g_strdup (base_url);
+  while (root[0] != '\0' && g_str_has_suffix (root, "/"))
+    root[strlen (root) - 1] = '\0';
+
+  g_autofree gchar *uri = NULL;
+  if (query != NULL)
+    uri = g_strdup_printf ("%s/auth/login?%s", root, query);
+  else
+    uri = g_strdup_printf ("%s/auth/login", root);
+
+  g_autoptr (SoupMessage) msg = soup_message_new (method, uri);
+  if (msg == NULL)
+    return 1;
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GBytes) bytes = soup_session_send_and_read (session, msg, NULL,
+      &error);
+  if (bytes == NULL)
+    return 2;
+  gsize size = 0;
+  const gchar *data = g_bytes_get_data (bytes, &size);
+  *out_status = soup_message_get_status (msg);
+  *out_body = g_strndup (data, size);
+  return 0;
+}
+
+static gint
+check_raw_login_contract (const gchar *base_url)
+{
+  g_autoptr (SoupSession) session = soup_session_new ();
+  guint status = 0;
+  g_autofree gchar *body = NULL;
+
+  gint rc = send_raw_login (session, "GET", base_url,
+      "username=login-user", &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 405 || strstr (body, "\"method_not_allowed\"") == NULL)
+    return 470;
+  g_clear_pointer (&body, g_free);
+
+  rc = send_raw_login (session, "POST", base_url, NULL, &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 400 || strstr (body, "\"invalid_login_request\"") == NULL)
+    return 471;
+  g_clear_pointer (&body, g_free);
+
+  rc = send_raw_login (session, "POST", base_url, "username=", &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 400 || strstr (body, "\"invalid_login_request\"") == NULL)
+    return 472;
+  g_clear_pointer (&body, g_free);
+
+  rc = send_raw_login (session, "POST", base_url,
+      "username=login-user&skip_mfa=true", &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 400 || strstr (body, "\"invalid_login_request\"") == NULL)
+    return 473;
+  g_clear_pointer (&body, g_free);
+
+  rc = send_raw_login (session, "POST", base_url,
+      "username=login-user&skip_mfa=1", &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 400 || strstr (body, "\"invalid_login_request\"") == NULL)
+    return 474;
+  g_clear_pointer (&body, g_free);
+
+  rc = send_raw_login (session, "POST", base_url,
+      "username=login-user&password=secret", &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 400 || strstr (body, "\"invalid_login_request\"") == NULL)
+    return 478;
+  g_clear_pointer (&body, g_free);
+
+  rc = send_raw_login (session, "POST", base_url, "username=login-user",
+      &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 200 ||
+      strstr (body, "\"session_token\":\"") == NULL ||
+      strstr (body, "\"username\":\"login-user\"") == NULL ||
+      strstr (body, "\"principal_state\":\"mfa_required\"") == NULL ||
+      strstr (body, "\"session_state\":\"active\"") == NULL)
+    return 475;
+  g_clear_pointer (&body, g_free);
+
+  return 0;
+}
+
 #ifdef WYL_HAS_AUDIT
 static gint
 check_audit_event_present (WylClient *client, const gchar *filter,
@@ -398,7 +496,6 @@ main (void)
   gint raw_rc = check_raw_decide_contract (base_url);
   if (raw_rc != 0)
     return raw_rc;
-
   gint decision = -1;
   if (wyl_client_decide (client, "http-allow-user", "http.allow",
           "http-allow-scope", &decision) != WYRELOG_E_OK)
@@ -441,6 +538,10 @@ main (void)
   if (audit_rc != 0)
     return audit_rc;
 #endif
+
+  raw_rc = check_raw_login_contract (base_url);
+  if (raw_rc != 0)
+    return raw_rc;
 
   g_main_loop_quit (http.loop);
   g_thread_join (thread);

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -76,6 +76,22 @@ build_decide_json (const wyl_decide_resp_t *resp)
   return g_string_free (g_steal_pointer (&json), FALSE);
 }
 
+static gchar *
+build_login_json (const gchar *session_token, const gchar *username,
+    const gchar *principal_state)
+{
+  g_autoptr (GString) json = g_string_new ("{");
+
+  g_string_append (json, "\"session_token\":");
+  append_json_string (json, session_token);
+  g_string_append (json, ",\"username\":");
+  append_json_string (json, username);
+  g_string_append (json, ",\"principal_state\":");
+  append_json_string (json, principal_state);
+  g_string_append (json, ",\"session_state\":\"active\"}");
+  return g_string_free (g_steal_pointer (&json), FALSE);
+}
+
 static void
 set_json_error (SoupServerMessage *msg, guint status, const gchar *code)
 {
@@ -170,6 +186,71 @@ audit_events_handler (SoupServer *server, SoupServerMessage *msg,
 }
 
 static void
+login_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
+    GHashTable *query, gpointer user_data)
+{
+  (void) server;
+  (void) path;
+
+  if (g_strcmp0 (soup_server_message_get_method (msg), "POST") != 0) {
+    set_json_error (msg, 405, "method_not_allowed");
+    return;
+  }
+
+  const gchar *username = NULL;
+  const gchar *skip_mfa = NULL;
+  const gchar *password = NULL;
+  if (query != NULL) {
+    username = g_hash_table_lookup (query, "username");
+    skip_mfa = g_hash_table_lookup (query, "skip_mfa");
+    password = g_hash_table_lookup (query, "password");
+  }
+  if (username == NULL || username[0] == '\0') {
+    set_json_error (msg, 400, "invalid_login_request");
+    return;
+  }
+  if (password != NULL) {
+    set_json_error (msg, 400, "invalid_login_request");
+    return;
+  }
+  if (skip_mfa != NULL) {
+    set_json_error (msg, 400, "invalid_login_request");
+    return;
+  }
+
+  WylHandle *handle = user_data;
+  g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
+  wyl_login_req_set_username (login, username);
+
+  g_autoptr (WylSession) session = NULL;
+  wyrelog_error_t rc = wyl_session_login (handle, login, &session);
+  if (rc == WYRELOG_E_INVALID) {
+    set_json_error (msg, 400, "invalid_login_request");
+    return;
+  }
+  if (rc == WYRELOG_E_POLICY) {
+    set_json_error (msg, 403, "login_denied");
+    return;
+  }
+  if (rc != WYRELOG_E_OK || session == NULL) {
+    set_json_error (msg, 500, "login_failed");
+    return;
+  }
+
+  g_autofree gchar *session_token = wyl_session_dup_id_string (session);
+  if (session_token == NULL) {
+    set_json_error (msg, 500, "login_failed");
+    return;
+  }
+
+  g_autofree gchar *body =
+      build_login_json (session_token, username, "mfa_required");
+  soup_server_message_set_status (msg, 200, NULL);
+  soup_server_message_set_response (msg, "application/json",
+      SOUP_MEMORY_COPY, body, strlen (body));
+}
+
+static void
 decide_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
     GHashTable *query, gpointer user_data)
 {
@@ -257,6 +338,7 @@ wyl_daemon_start_http_server (const WylDaemonOptions *opts, WylHandle *handle,
 
   SoupServer *server = soup_server_new (NULL, NULL);
   soup_server_add_handler (server, "/healthz", healthz_handler, NULL, NULL);
+  soup_server_add_handler (server, "/auth/login", login_handler, handle, NULL);
   soup_server_add_handler (server, "/decide", decide_handler, handle, NULL);
   soup_server_add_handler (server, "/audit/events", audit_events_handler,
       handle, NULL);

--- a/wyrelog/wyl-client.c
+++ b/wyrelog/wyl-client.c
@@ -10,6 +10,8 @@ struct _WylClient
 
 G_DEFINE_FINAL_TYPE (WylClient, wyl_client, G_TYPE_OBJECT);
 
+static gboolean parse_login_response_json (const gchar * data, gsize size);
+
 static void
 wyl_client_finalize (GObject *object)
 {
@@ -103,10 +105,37 @@ wyrelog_error_t
 wyl_client_login (WylClient *client, const gchar *username,
     const gchar *password)
 {
-  (void) client;
-  (void) username;
-  (void) password;
-  return WYRELOG_E_INTERNAL;
+  if (client == NULL || !WYL_IS_CLIENT (client) || username == NULL ||
+      username[0] == '\0')
+    return WYRELOG_E_INVALID;
+  if (password != NULL && password[0] != '\0')
+    return WYRELOG_E_INVALID;
+
+  g_autofree gchar *base_url = wyl_client_dup_base_url (client);
+  if (base_url == NULL)
+    return WYRELOG_E_INVALID;
+  while (base_url[0] != '\0' && g_str_has_suffix (base_url, "/"))
+    base_url[strlen (base_url) - 1] = '\0';
+
+  g_autofree gchar *escaped_username =
+      g_uri_escape_string (username, NULL, TRUE);
+  g_autofree gchar *uri =
+      g_strdup_printf ("%s/auth/login?username=%s", base_url,
+      escaped_username);
+
+  g_autoptr (SoupMessage) message = soup_message_new ("POST", uri);
+  if (message == NULL)
+    return WYRELOG_E_INVALID;
+
+  g_autoptr (GBytes) body = NULL;
+  wyrelog_error_t rc = wyl_client_send_message (client, message, &body);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  gsize body_size = 0;
+  const gchar *body_data = g_bytes_get_data (body, &body_size);
+  return parse_login_response_json (body_data, body_size) ?
+      WYRELOG_E_OK : WYRELOG_E_IO;
 }
 
 wyrelog_error_t
@@ -306,6 +335,70 @@ parse_decide_response_json (const gchar *data, gsize size, gint *out_decision)
     return FALSE;
   *out_decision = decision;
   return TRUE;
+}
+
+static gboolean
+parse_login_response_json (const gchar *data, gsize size)
+{
+  if (data == NULL)
+    return FALSE;
+
+  JsonCursor cursor = { data, size, 0 };
+  if (!json_consume (&cursor, '{'))
+    return FALSE;
+
+  gboolean have_session_token = FALSE;
+  gboolean have_username = FALSE;
+  gboolean have_principal_state = FALSE;
+  gboolean have_session_state = FALSE;
+  json_skip_ws (&cursor);
+  if (cursor.pos < cursor.size && cursor.data[cursor.pos] == '}')
+    return FALSE;
+
+  while (TRUE) {
+    g_autofree gchar *key = NULL;
+    g_autofree gchar *value = NULL;
+    if (!json_parse_string (&cursor, &key) || !json_consume (&cursor, ':') ||
+        !json_parse_string (&cursor, &value))
+      return FALSE;
+
+    if (g_strcmp0 (key, "session_token") == 0) {
+      if (have_session_token || value[0] == '\0')
+        return FALSE;
+      have_session_token = TRUE;
+    } else if (g_strcmp0 (key, "username") == 0) {
+      if (have_username || value[0] == '\0')
+        return FALSE;
+      have_username = TRUE;
+    } else if (g_strcmp0 (key, "principal_state") == 0) {
+      if (have_principal_state ||
+          (g_strcmp0 (value, "mfa_required") != 0 &&
+              g_strcmp0 (value, "authenticated") != 0))
+        return FALSE;
+      have_principal_state = TRUE;
+    } else if (g_strcmp0 (key, "session_state") == 0) {
+      if (have_session_state || g_strcmp0 (value, "active") != 0)
+        return FALSE;
+      have_session_state = TRUE;
+    } else {
+      return FALSE;
+    }
+
+    json_skip_ws (&cursor);
+    if (cursor.pos < cursor.size && cursor.data[cursor.pos] == ',') {
+      cursor.pos++;
+      continue;
+    }
+    if (cursor.pos < cursor.size && cursor.data[cursor.pos] == '}') {
+      cursor.pos++;
+      break;
+    }
+    return FALSE;
+  }
+
+  json_skip_ws (&cursor);
+  return have_session_token && have_username && have_principal_state &&
+      have_session_state && cursor.pos == cursor.size;
 }
 
 static gboolean


### PR DESCRIPTION
## Summary
- Add a username-only HTTP login initiation endpoint.
- Wire the client login call to the strict session JSON response.
- Reject password and skip-mfa query params at the daemon boundary.

## Tests
- git diff --cached --check
- meson test -C builddir client-smoke daemon-http-decide --print-errorlogs
- meson test -C builddir-audit client-smoke daemon-http-decide --print-errorlogs
