### PR TITLE
daemon: retain HTTP login sessions

### DIFF
--- a/tests/test-client-smoke.c
+++ b/tests/test-client-smoke.c
@@ -213,10 +213,26 @@ main (void)
     return 45;
   if (http.last_password != NULL)
     return 46;
+  g_autofree gchar *client_session_token =
+      wyl_client_dup_session_token (local_client);
+  g_autofree gchar *client_username = wyl_client_dup_username (local_client);
+  g_autofree gchar *client_principal_state =
+      wyl_client_dup_principal_state (local_client);
+  g_autofree gchar *client_session_state =
+      wyl_client_dup_session_state (local_client);
+  if (g_strcmp0 (client_session_token, "session-1") != 0 ||
+      g_strcmp0 (client_username, "alice") != 0 ||
+      g_strcmp0 (client_principal_state, "mfa_required") != 0 ||
+      g_strcmp0 (client_session_state, "active") != 0)
+    return 138;
 
   http.body = "{\"session_token\":\"session-1\"}";
   if (wyl_client_login (local_client, "alice", NULL) != WYRELOG_E_IO)
     return 47;
+  g_clear_pointer (&client_session_token, g_free);
+  client_session_token = wyl_client_dup_session_token (local_client);
+  if (client_session_token != NULL)
+    return 139;
   http.body = "[]";
 
   gint decision = -1;

--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -358,8 +358,22 @@ send_raw_login (SoupSession *session, const gchar *method,
   return 0;
 }
 
+static gchar *
+extract_json_string (const gchar *body, const gchar *name)
+{
+  g_autofree gchar *prefix = g_strdup_printf ("\"%s\":\"", name);
+  const gchar *start = strstr (body, prefix);
+  if (start == NULL)
+    return NULL;
+  start += strlen (prefix);
+  const gchar *end = strchr (start, '"');
+  if (end == NULL)
+    return NULL;
+  return g_strndup (start, (gsize) (end - start));
+}
+
 static gint
-check_raw_login_contract (const gchar *base_url)
+check_raw_login_contract (SoupServer *server, const gchar *base_url)
 {
   g_autoptr (SoupSession) session = soup_session_new ();
   guint status = 0;
@@ -421,7 +435,22 @@ check_raw_login_contract (const gchar *base_url)
       strstr (body, "\"principal_state\":\"mfa_required\"") == NULL ||
       strstr (body, "\"session_state\":\"active\"") == NULL)
     return 475;
+  g_autofree gchar *session_token = extract_json_string (body, "session_token");
+  if (session_token == NULL)
+    return 476;
+  g_autoptr (WylSession) stored_session =
+      wyl_daemon_http_ref_session (server, session_token);
+  if (stored_session == NULL)
+    return 477;
+  g_autofree gchar *stored_username = wyl_session_dup_username (stored_session);
+  if (g_strcmp0 (stored_username, "login-user") != 0)
+    return 479;
   g_clear_pointer (&body, g_free);
+
+  g_autoptr (WylSession) unknown_session =
+      wyl_daemon_http_ref_session (server, "unknown-session");
+  if (unknown_session != NULL)
+    return 480;
 
   return 0;
 }
@@ -539,7 +568,7 @@ main (void)
     return audit_rc;
 #endif
 
-  raw_rc = check_raw_login_contract (base_url);
+  raw_rc = check_raw_login_contract (http.server, base_url);
   if (raw_rc != 0)
     return raw_rc;
 

--- a/wyrelog/client.h
+++ b/wyrelog/client.h
@@ -37,6 +37,10 @@ gchar *wyl_client_dup_base_url (const WylClient * client);
 /* Authentication */
 wyrelog_error_t wyl_client_login (WylClient * client,
     const gchar * username, const gchar * password);
+gchar *wyl_client_dup_session_token (const WylClient * client);
+gchar *wyl_client_dup_username (const WylClient * client);
+gchar *wyl_client_dup_principal_state (const WylClient * client);
+gchar *wyl_client_dup_session_state (const WylClient * client);
 wyrelog_error_t wyl_client_token_refresh (WylClient * client);
 wyrelog_error_t wyl_client_mfa_verify (WylClient * client, const gchar * otp);
 

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -8,6 +8,80 @@
 #include "wyrelog/wyrelog.h"
 #include "wyrelog/wyl-handle-private.h"
 
+typedef struct
+{
+  WylHandle *handle;
+  GHashTable *sessions_by_token;
+  GMutex lock;
+} WylDaemonHttpContext;
+
+static void
+wyl_daemon_http_context_free (gpointer data)
+{
+  WylDaemonHttpContext *ctx = data;
+
+  if (ctx == NULL)
+    return;
+
+  g_hash_table_unref (ctx->sessions_by_token);
+  g_mutex_clear (&ctx->lock);
+  g_free (ctx);
+}
+
+static WylDaemonHttpContext *
+wyl_daemon_http_context_new (WylHandle *handle)
+{
+  WylDaemonHttpContext *ctx = g_new0 (WylDaemonHttpContext, 1);
+
+  ctx->handle = handle;
+  ctx->sessions_by_token =
+      g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_object_unref);
+  g_mutex_init (&ctx->lock);
+  return ctx;
+}
+
+static gboolean
+wyl_daemon_http_context_store_session (WylDaemonHttpContext *ctx,
+    const gchar *session_token, WylSession *session)
+{
+  if (ctx == NULL || session_token == NULL || session_token[0] == '\0' ||
+      session == NULL || !WYL_IS_SESSION (session))
+    return FALSE;
+
+  g_mutex_lock (&ctx->lock);
+  g_hash_table_replace (ctx->sessions_by_token, g_strdup (session_token),
+      g_object_ref (session));
+  g_mutex_unlock (&ctx->lock);
+  return TRUE;
+}
+
+static WylDaemonHttpContext *
+wyl_daemon_http_get_context (SoupServer *server)
+{
+  if (server == NULL || !SOUP_IS_SERVER (server))
+    return NULL;
+  return g_object_get_data (G_OBJECT (server), "wyl-daemon-http-context");
+}
+
+WylSession *
+wyl_daemon_http_ref_session (SoupServer *server, const gchar *session_token)
+{
+  if (session_token == NULL || session_token[0] == '\0')
+    return NULL;
+
+  WylDaemonHttpContext *ctx = wyl_daemon_http_get_context (server);
+  if (ctx == NULL)
+    return NULL;
+
+  g_mutex_lock (&ctx->lock);
+  WylSession *session = g_hash_table_lookup (ctx->sessions_by_token,
+      session_token);
+  if (session != NULL)
+    g_object_ref (session);
+  g_mutex_unlock (&ctx->lock);
+  return session;
+}
+
 static void
 append_json_string (GString *json, const gchar *value)
 {
@@ -155,7 +229,8 @@ audit_events_handler (SoupServer *server, SoupServerMessage *msg,
   if (query != NULL)
     filter = g_hash_table_lookup (query, "filter");
 
-  WylHandle *handle = user_data;
+  WylDaemonHttpContext *ctx = user_data;
+  WylHandle *handle = ctx->handle;
   g_autofree gchar *body = NULL;
   wyrelog_error_t rc =
       wyl_audit_conn_query_events_json (wyl_handle_get_audit_conn (handle),
@@ -218,7 +293,8 @@ login_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
     return;
   }
 
-  WylHandle *handle = user_data;
+  WylDaemonHttpContext *ctx = user_data;
+  WylHandle *handle = ctx->handle;
   g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
   wyl_login_req_set_username (login, username);
 
@@ -239,6 +315,10 @@ login_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
 
   g_autofree gchar *session_token = wyl_session_dup_id_string (session);
   if (session_token == NULL) {
+    set_json_error (msg, 500, "login_failed");
+    return;
+  }
+  if (!wyl_daemon_http_context_store_session (ctx, session_token, session)) {
     set_json_error (msg, 500, "login_failed");
     return;
   }
@@ -289,7 +369,8 @@ decide_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
     return;
   }
 
-  WylHandle *handle = user_data;
+  WylDaemonHttpContext *ctx = user_data;
+  WylHandle *handle = ctx->handle;
   g_autoptr (wyl_decide_req_t) req = wyl_decide_req_new ();
   g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
   wyl_decide_req_set_subject_id (req, user);
@@ -337,11 +418,14 @@ wyl_daemon_start_http_server (const WylDaemonOptions *opts, WylHandle *handle,
   }
 
   SoupServer *server = soup_server_new (NULL, NULL);
+  WylDaemonHttpContext *ctx = wyl_daemon_http_context_new (handle);
+  g_object_set_data_full (G_OBJECT (server), "wyl-daemon-http-context", ctx,
+      wyl_daemon_http_context_free);
   soup_server_add_handler (server, "/healthz", healthz_handler, NULL, NULL);
-  soup_server_add_handler (server, "/auth/login", login_handler, handle, NULL);
-  soup_server_add_handler (server, "/decide", decide_handler, handle, NULL);
+  soup_server_add_handler (server, "/auth/login", login_handler, ctx, NULL);
+  soup_server_add_handler (server, "/decide", decide_handler, ctx, NULL);
   soup_server_add_handler (server, "/audit/events", audit_events_handler,
-      handle, NULL);
+      ctx, NULL);
   if (!soup_server_listen_local (server, (guint) opts->listen_port, 0, error)) {
     g_object_unref (server);
     return NULL;

--- a/wyrelog/daemon/http.h
+++ b/wyrelog/daemon/http.h
@@ -11,4 +11,6 @@
 
 SoupServer *wyl_daemon_start_http_server (const WylDaemonOptions * opts,
     WylHandle * handle, GError ** error);
+WylSession *wyl_daemon_http_ref_session (SoupServer * server,
+    const gchar * session_token);
 #endif

--- a/wyrelog/wyl-client.c
+++ b/wyrelog/wyl-client.c
@@ -5,12 +5,28 @@ struct _WylClient
 {
   GObject parent_instance;
   gchar *base_url;
+  gchar *session_token;
+  gchar *username;
+  gchar *principal_state;
+  gchar *session_state;
   SoupSession *session;
 };
 
 G_DEFINE_FINAL_TYPE (WylClient, wyl_client, G_TYPE_OBJECT);
 
-static gboolean parse_login_response_json (const gchar * data, gsize size);
+static gboolean parse_login_response_json (const gchar * data, gsize size,
+    gchar ** out_session_token,
+    gchar ** out_username,
+    gchar ** out_principal_state, gchar ** out_session_state);
+
+static void
+wyl_client_clear_login_state (WylClient *self)
+{
+  g_clear_pointer (&self->session_token, g_free);
+  g_clear_pointer (&self->username, g_free);
+  g_clear_pointer (&self->principal_state, g_free);
+  g_clear_pointer (&self->session_state, g_free);
+}
 
 static void
 wyl_client_finalize (GObject *object)
@@ -18,6 +34,7 @@ wyl_client_finalize (GObject *object)
   WylClient *self = WYL_CLIENT (object);
 
   g_free (self->base_url);
+  wyl_client_clear_login_state (self);
   g_clear_object (&self->session);
 
   G_OBJECT_CLASS (wyl_client_parent_class)->finalize (object);
@@ -67,6 +84,34 @@ wyl_client_dup_base_url (const WylClient *client)
 {
   g_return_val_if_fail (WYL_IS_CLIENT ((WylClient *) client), NULL);
   return g_strdup (client->base_url);
+}
+
+gchar *
+wyl_client_dup_session_token (const WylClient *client)
+{
+  g_return_val_if_fail (WYL_IS_CLIENT ((WylClient *) client), NULL);
+  return g_strdup (client->session_token);
+}
+
+gchar *
+wyl_client_dup_username (const WylClient *client)
+{
+  g_return_val_if_fail (WYL_IS_CLIENT ((WylClient *) client), NULL);
+  return g_strdup (client->username);
+}
+
+gchar *
+wyl_client_dup_principal_state (const WylClient *client)
+{
+  g_return_val_if_fail (WYL_IS_CLIENT ((WylClient *) client), NULL);
+  return g_strdup (client->principal_state);
+}
+
+gchar *
+wyl_client_dup_session_state (const WylClient *client)
+{
+  g_return_val_if_fail (WYL_IS_CLIENT ((WylClient *) client), NULL);
+  return g_strdup (client->session_state);
 }
 
 SoupSession *
@@ -129,13 +174,29 @@ wyl_client_login (WylClient *client, const gchar *username,
 
   g_autoptr (GBytes) body = NULL;
   wyrelog_error_t rc = wyl_client_send_message (client, message, &body);
-  if (rc != WYRELOG_E_OK)
+  if (rc != WYRELOG_E_OK) {
+    wyl_client_clear_login_state (client);
     return rc;
+  }
 
   gsize body_size = 0;
   const gchar *body_data = g_bytes_get_data (body, &body_size);
-  return parse_login_response_json (body_data, body_size) ?
-      WYRELOG_E_OK : WYRELOG_E_IO;
+  g_autofree gchar *session_token = NULL;
+  g_autofree gchar *parsed_username = NULL;
+  g_autofree gchar *principal_state = NULL;
+  g_autofree gchar *session_state = NULL;
+  if (!parse_login_response_json (body_data, body_size, &session_token,
+          &parsed_username, &principal_state, &session_state)) {
+    wyl_client_clear_login_state (client);
+    return WYRELOG_E_IO;
+  }
+
+  wyl_client_clear_login_state (client);
+  client->session_token = g_steal_pointer (&session_token);
+  client->username = g_steal_pointer (&parsed_username);
+  client->principal_state = g_steal_pointer (&principal_state);
+  client->session_state = g_steal_pointer (&session_state);
+  return WYRELOG_E_OK;
 }
 
 wyrelog_error_t
@@ -338,10 +399,17 @@ parse_decide_response_json (const gchar *data, gsize size, gint *out_decision)
 }
 
 static gboolean
-parse_login_response_json (const gchar *data, gsize size)
+parse_login_response_json (const gchar *data, gsize size,
+    gchar **out_session_token, gchar **out_username,
+    gchar **out_principal_state, gchar **out_session_state)
 {
-  if (data == NULL)
+  if (data == NULL || out_session_token == NULL || out_username == NULL ||
+      out_principal_state == NULL || out_session_state == NULL)
     return FALSE;
+  *out_session_token = NULL;
+  *out_username = NULL;
+  *out_principal_state = NULL;
+  *out_session_state = NULL;
 
   JsonCursor cursor = { data, size, 0 };
   if (!json_consume (&cursor, '{'))
@@ -366,20 +434,24 @@ parse_login_response_json (const gchar *data, gsize size)
       if (have_session_token || value[0] == '\0')
         return FALSE;
       have_session_token = TRUE;
+      *out_session_token = g_steal_pointer (&value);
     } else if (g_strcmp0 (key, "username") == 0) {
       if (have_username || value[0] == '\0')
         return FALSE;
       have_username = TRUE;
+      *out_username = g_steal_pointer (&value);
     } else if (g_strcmp0 (key, "principal_state") == 0) {
       if (have_principal_state ||
           (g_strcmp0 (value, "mfa_required") != 0 &&
               g_strcmp0 (value, "authenticated") != 0))
         return FALSE;
       have_principal_state = TRUE;
+      *out_principal_state = g_steal_pointer (&value);
     } else if (g_strcmp0 (key, "session_state") == 0) {
       if (have_session_state || g_strcmp0 (value, "active") != 0)
         return FALSE;
       have_session_state = TRUE;
+      *out_session_state = g_steal_pointer (&value);
     } else {
       return FALSE;
     }
@@ -397,8 +469,15 @@ parse_login_response_json (const gchar *data, gsize size)
   }
 
   json_skip_ws (&cursor);
-  return have_session_token && have_username && have_principal_state &&
-      have_session_state && cursor.pos == cursor.size;
+  if (!have_session_token || !have_username || !have_principal_state ||
+      !have_session_state || cursor.pos != cursor.size) {
+    g_clear_pointer (out_session_token, g_free);
+    g_clear_pointer (out_username, g_free);
+    g_clear_pointer (out_principal_state, g_free);
+    g_clear_pointer (out_session_state, g_free);
+    return FALSE;
+  }
+  return TRUE;
 }
 
 static gboolean


### PR DESCRIPTION
## Summary
- add an in-memory daemon HTTP session registry scoped to the server
- retain login-created sessions by returned session token for later auth flow use
- store strict login response state on the HTTP client with duplicate getters
- cover daemon registry lookup and client login state behavior

## Tests
- meson test -C builddir client-smoke daemon-http-decide --print-errorlogs
- meson test -C builddir-audit client-smoke daemon-http-decide --print-errorlogs
