### PR TITLE
daemon: verify direct grant readiness

### DIFF
--- a/tests/test-daemon-checks.c
+++ b/tests/test-daemon-checks.c
@@ -143,12 +143,39 @@ check_policy_audit_facts_ready_loads_read_engine (void)
   return 0;
 }
 
+static gint
+check_direct_permission_grant_ready_allows_decide (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  gint64 count = 0;
+
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 70;
+  if (wyl_daemon_check_direct_permission_grant_ready (handle) != WYRELOG_E_OK)
+    return 71;
+
+  duckdb_connection conn =
+      wyl_audit_conn_get_connection (wyl_handle_get_audit_conn (handle));
+  if (!count_duckdb_rows (conn,
+          "SELECT COUNT(*) FROM audit_events "
+          "WHERE action = 'permission_grant' "
+          "AND subject_id = 'wyrelogd-direct-grant-user' "
+          "AND deny_origin = 'wyrelogd.direct_grant.read' "
+          "AND decision = 1;", &count))
+    return 72;
+  if (count != 1)
+    return 73;
+  return 0;
+}
+
 int
 main (void)
 {
   gint rc;
 
   if ((rc = check_policy_audit_facts_ready_loads_read_engine ()) != 0)
+    return rc;
+  if ((rc = check_direct_permission_grant_ready_allows_decide ()) != 0)
     return rc;
   if ((rc = check_login_skip_mfa_ready_rejects_production_path ()) != 0)
     return rc;

--- a/wyrelog/daemon/checks.c
+++ b/wyrelog/daemon/checks.c
@@ -260,6 +260,49 @@ wyl_daemon_check_policy_snapshot_reload_ready (WylHandle *handle)
       WYRELOG_E_OK : WYRELOG_E_POLICY;
 }
 
+wyrelog_error_t
+wyl_daemon_check_direct_permission_grant_ready (WylHandle *handle)
+{
+  g_autoptr (WylSession) session = NULL;
+  wyrelog_error_t rc =
+      login_check_principal (handle, "wyrelogd-direct-grant-user", &session);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  g_autofree gchar *session_id = wyl_session_dup_id_string (session);
+  if (session_id == NULL)
+    return WYRELOG_E_INTERNAL;
+
+  g_autoptr (wyl_grant_req_t) grant = wyl_grant_req_new ();
+  wyl_grant_req_set_subject_id (grant, "wyrelogd-direct-grant-user");
+  wyl_grant_req_set_action (grant, "wyrelogd.direct_grant.read");
+  wyl_grant_req_set_resource_id (grant, session_id);
+  rc = wyl_perm_grant (handle, grant);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  gboolean found = FALSE;
+  rc = wyl_policy_store_direct_permission_exists (wyl_handle_get_policy_store
+      (handle), "wyrelogd-direct-grant-user", "wyrelogd.direct_grant.read",
+      session_id, &found);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if (!found)
+    return WYRELOG_E_POLICY;
+
+  g_autoptr (wyl_decide_req_t) decide = wyl_decide_req_new ();
+  wyl_decide_req_set_subject_id (decide, "wyrelogd-direct-grant-user");
+  wyl_decide_req_set_action (decide, "wyrelogd.direct_grant.read");
+  wyl_decide_req_set_resource_id (decide, session_id);
+
+  g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
+  rc = wyl_decide (handle, decide, resp);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_decide_resp_get_decision (resp) == WYL_DECISION_ALLOW ?
+      WYRELOG_E_OK : WYRELOG_E_POLICY;
+}
+
 static wyrelog_error_t
 insert_symbol_row (WylHandle *handle, const gchar *relation,
     const gchar *const *symbols, gsize ncols)
@@ -401,6 +444,13 @@ wyl_daemon_run_checks (WylHandle *handle)
   rc = wyl_daemon_check_policy_snapshot_reload_ready (handle);
   if (rc != WYRELOG_E_OK) {
     g_printerr ("wyrelogd: policy snapshot reload check failed: %s\n",
+        wyrelog_error_string (rc));
+    return 1;
+  }
+
+  rc = wyl_daemon_check_direct_permission_grant_ready (handle);
+  if (rc != WYRELOG_E_OK) {
+    g_printerr ("wyrelogd: direct permission grant check failed: %s\n",
         wyrelog_error_string (rc));
     return 1;
   }

--- a/wyrelog/daemon/checks.h
+++ b/wyrelog/daemon/checks.h
@@ -11,6 +11,8 @@ wyrelog_error_t wyl_daemon_check_login_skip_mfa_ready (WylHandle * handle);
 wyrelog_error_t wyl_daemon_check_policy_snapshot_reload_ready (WylHandle *
     handle);
 wyrelog_error_t
+wyl_daemon_check_direct_permission_grant_ready (WylHandle * handle);
+wyrelog_error_t
 wyl_daemon_check_role_permission_snapshot_reload_ready (WylHandle * handle);
 wyrelog_error_t wyl_daemon_emit_start_event (WylHandle * handle);
 int wyl_daemon_run_checks (WylHandle * handle);


### PR DESCRIPTION
## Summary
- add an internal daemon readiness check for direct permission grants
- verify the durable Policy DB direct permission row before deciding
- cover the path in audit-enabled daemon checks

## Tests
- `tools/gst-indent wyrelog/daemon/checks.c tests/test-daemon-checks.c`
- `meson compile -C builddir`
- `meson test -C builddir wyrelog:perm wyrelog:daemon-http-decide`
- `meson test -C builddir wyrelog:perm wyrelog:daemon-http-decide wyrelog:session-username`
- `meson compile -C builddir-audit tests/test-daemon-checks`
- `meson test -C builddir-audit wyrelog:daemon-checks wyrelog:perm wyrelog:daemon-http-decide`
- `meson test -C builddir-audit wyrelog:daemon-checks wyrelog:perm wyrelog:daemon-http-decide wyrelog:audit-emit`
- `git diff --check`
