### PR TITLE
access: keep guarded direct grants unarmed

### DIFF
--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -1476,6 +1476,56 @@ check_policy_store_direct_permissions_autoload_on_open (void)
 }
 
 static gint
+check_policy_store_guarded_direct_permissions_do_not_auto_arm (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 365;
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (wyl_policy_store_upsert_permission (store, "wr.audit.read",
+          "audit read", "sensitive") != WYRELOG_E_OK)
+    return 366;
+  if (wyl_policy_store_grant_direct_permission (store, "guarded-load-user",
+          "wr.audit.read", "guarded-load-scope") != WYRELOG_E_OK)
+    return 367;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 368;
+
+  if (insert2_symbol (handle, "principal_state", "guarded-load-user",
+          "authenticated") != WYRELOG_E_OK)
+    return 369;
+  if (insert2_symbol (handle, "session_state", "guarded-load-scope",
+          "active") != WYRELOG_E_OK)
+    return 370;
+  if (insert1_symbol (handle, "session_active", "active") != WYRELOG_E_OK)
+    return 371;
+
+  gint64 state_row[4];
+  if (intern4 (handle, "guarded-load-user", "wr.audit.read",
+          "guarded-load-scope", "armed", state_row) != WYRELOG_E_OK)
+    return 372;
+  gint64 permission_row[3];
+  if (intern3 (handle, "guarded-load-user", "wr.audit.read",
+          "guarded-load-scope", permission_row) != WYRELOG_E_OK)
+    return 373;
+  gboolean found = FALSE;
+  if (wyl_handle_engine_contains (handle, "has_permission", permission_row, 3,
+          &found) != WYRELOG_E_OK)
+    return 374;
+  if (!found)
+    return 375;
+
+  if (wyl_handle_engine_contains (handle, "perm_state", state_row, 4, &found)
+      != WYRELOG_E_OK)
+    return 376;
+  if (found)
+    return 377;
+  return 0;
+}
+
+static gint
 check_policy_store_direct_permissions_require_engine_pair (void)
 {
   g_autoptr (WylHandle) handle = NULL;
@@ -2001,6 +2051,9 @@ main (void)
   if ((rc = check_policy_store_role_memberships_require_engine_pair ()) != 0)
     return rc;
   if ((rc = check_policy_store_direct_permissions_autoload_on_open ()) != 0)
+    return rc;
+  if ((rc = check_policy_store_guarded_direct_permissions_do_not_auto_arm ())
+      != 0)
     return rc;
   if ((rc = check_policy_store_direct_permissions_require_engine_pair ()) != 0)
     return rc;

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -722,7 +722,6 @@ insert_policy_store_direct_permission (const gchar *subject_id,
 {
   WylHandle *self = user_data;
   gint64 row[3];
-  gint64 state_row[4];
 
   wyrelog_error_t rc =
       wyl_handle_intern_engine_symbol (self, subject_id, &row[0]);
@@ -735,14 +734,20 @@ insert_policy_store_direct_permission (const gchar *subject_id,
   if (rc != WYRELOG_E_OK)
     return rc;
 
+  rc = wyl_handle_engine_insert (self, "direct_permission", row, 3);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  /* Guarded permissions are granted membership only. Their armed state
+   * comes from request-local guard evaluation, not persisted perm_state. */
+  if (wyl_perm_arm_rule_lookup (perm_id) != NULL)
+    return WYRELOG_E_OK;
+
+  gint64 state_row[4];
   state_row[0] = row[0];
   state_row[1] = row[1];
   state_row[2] = row[2];
   rc = wyl_handle_intern_engine_symbol (self, "armed", &state_row[3]);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-
-  rc = wyl_handle_engine_insert (self, "direct_permission", row, 3);
   if (rc != WYRELOG_E_OK)
     return rc;
   return wyl_handle_engine_insert (self, "perm_state", state_row, 4);


### PR DESCRIPTION
## Summary
- keep guarded direct permissions visible as membership without auto-arming them
- only project persisted `perm_state(..., "armed")` for unguarded direct permissions
- add loader coverage for the guarded direct grant arming boundary

## Tests
- `tools/gst-indent wyrelog/wyl-handle.c tests/test-handle-engine-pair.c`
- `meson test -C builddir wyrelog:handle-engine-pair wyrelog:decide wyrelog:perm`
- `meson test -C builddir-audit wyrelog:handle-engine-pair wyrelog:decide wyrelog:perm`
- `git diff --check`
