### PR TITLE
access: expose login principal state probes

### DIFF
--- a/templates/access/decision.dl
+++ b/templates/access/decision.dl
@@ -65,6 +65,7 @@
 .decl audit_event_resource(id: symbol, resource: symbol)
 .decl audit_event_deny_reason(id: symbol, reason: symbol)
 .decl audit_event_deny_origin(id: symbol, origin: symbol)
+.decl principal_state_observed(user: symbol, state: symbol)
 
 .decl allow(user: symbol, perm: symbol, scope: symbol)
 .decl allow_guard_base(user: symbol, perm: symbol, scope: symbol)
@@ -92,6 +93,9 @@ audit_event_deny_reason(ID, Reason) :-
 
 audit_event_deny_origin(ID, Origin) :-
     audit_event_deny_origin_input(ID, Origin).
+
+principal_state_observed(U, State) :-
+    principal_state(U, State).
 
 // --- allow / allow_bool ----------------------------------------------
 

--- a/templates/access/lobac/decision.dl
+++ b/templates/access/lobac/decision.dl
@@ -62,6 +62,7 @@
 .decl audit_event_resource(id: symbol, resource: symbol)
 .decl audit_event_deny_reason(id: symbol, reason: symbol)
 .decl audit_event_deny_origin(id: symbol, origin: symbol)
+.decl principal_state_observed(user: symbol, state: symbol)
 
 .decl allow(user: symbol, perm: symbol, scope: symbol)
 .decl allow_guard_base(user: symbol, perm: symbol, scope: symbol)
@@ -89,6 +90,9 @@ audit_event_deny_reason(ID, Reason) :-
 
 audit_event_deny_origin(ID, Origin) :-
     audit_event_deny_origin_input(ID, Origin).
+
+principal_state_observed(U, State) :-
+    principal_state(U, State).
 
 // --- allow / allow_bool ----------------------------------------------
 

--- a/tests/test-login-projection.c
+++ b/tests/test-login-projection.c
@@ -181,6 +181,39 @@ decide_allows (WylHandle *handle, const gchar *subject, const gchar *action,
 }
 
 static gint
+check_login_projects_mfa_required_principal_state (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 90;
+
+  g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
+  wyl_login_req_set_username (login, "projection-login-user");
+
+  g_autoptr (WylSession) session = NULL;
+  if (wyl_session_login (handle, login, &session) != WYRELOG_E_OK)
+    return 91;
+  if (session == NULL)
+    return 92;
+
+  gint64 count = -1;
+  if (!policy_count_rows (wyl_handle_get_policy_store (handle),
+          "SELECT COUNT(*) FROM principal_states "
+          "WHERE subject_id = 'projection-login-user' "
+          "AND state = 'mfa_required';", &count))
+    return 94;
+  if (count != 1) {
+    g_printerr ("store principal state count=%" G_GINT64_FORMAT "\n", count);
+    return 95;
+  }
+  if (!engine_contains_symbol_row2 (handle, "principal_state",
+          "projection-login-user", "mfa_required"))
+    return 93;
+  return 0;
+}
+
+static gint
 check_login_reload_failure_keeps_durable_state_repairable (void)
 {
   g_autoptr (WylHandle) handle = NULL;
@@ -459,6 +492,8 @@ main (void)
 {
   gint rc;
 
+  if ((rc = check_login_projects_mfa_required_principal_state ()) != 0)
+    return rc;
   if ((rc = check_login_reload_failure_keeps_durable_state_repairable ()) != 0)
     return rc;
   if ((rc = check_anonymous_login_reload_failure_keeps_session_state ()) != 0)

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -1063,6 +1063,7 @@ wyl_handle_load_policy_store_audit_facts (WylHandle *self)
 typedef struct
 {
   const gchar *relation;
+  const gchar *snapshot_relation;
   const gint64 *row;
   gsize ncols;
   gboolean matched;
@@ -1074,7 +1075,7 @@ wyl_handle_row_snapshot_cb (const gchar *relation, const gint64 *row,
 {
   WylRowProbe *probe = user_data;
 
-  if (g_strcmp0 (relation, probe->relation) != 0)
+  if (g_strcmp0 (relation, probe->snapshot_relation) != 0)
     return;
   if (ncols != probe->ncols)
     return;
@@ -1096,9 +1097,15 @@ wyl_handle_engine_contains (WylHandle *self, const gchar *relation,
   if (self->read_engine == NULL || self->delta_engine == NULL)
     return WYRELOG_E_INVALID;
 
-  WylRowProbe probe = { relation, row, ncols, FALSE };
+  const gchar *snapshot_relation = relation;
+  /* The engine snapshots derived outputs, so principal_state probes use
+   * the template mirror while preserving the handle-level relation name. */
+  if (g_strcmp0 (relation, "principal_state") == 0)
+    snapshot_relation = "principal_state_observed";
+
+  WylRowProbe probe = { relation, snapshot_relation, row, ncols, FALSE };
   wyrelog_error_t rc = wyl_engine_snapshot (self->read_engine,
-      relation, wyl_handle_row_snapshot_cb, &probe);
+      snapshot_relation, wyl_handle_row_snapshot_cb, &probe);
   if (rc != WYRELOG_E_OK)
     return rc;
 


### PR DESCRIPTION
## Summary
- add a derived principal-state mirror for read-engine probes
- keep handle-level `principal_state` probes compatible with existing callers
- cover normal login projection visibility for `mfa_required`

## Tests
- `tools/gst-indent wyrelog/wyl-handle.c tests/test-login-projection.c`
- `meson test -C builddir-audit wyrelog:login-projection wyrelog:session-username wyrelog:daemon-checks`
- `meson test -C builddir wyrelog:session-username wyrelog:decide wyrelog:handle-engine-pair`
- `meson test -C builddir wyrelog:dl-static wyrelog:engine wyrelog:access-decision wyrelog:fsm-bisim`
- `meson test -C builddir-audit wyrelog:audit-emit`
- `git diff --check`
