### PR TITLE
session: gate proof-bearing MFA verification

### DIFF
--- a/tests/test-client-smoke.c
+++ b/tests/test-client-smoke.c
@@ -225,6 +225,12 @@ main (void)
       g_strcmp0 (client_principal_state, "mfa_required") != 0 ||
       g_strcmp0 (client_session_state, "active") != 0)
     return 138;
+  if (wyl_client_mfa_verify (local_client, NULL) == WYRELOG_E_OK)
+    return 140;
+  if (wyl_client_mfa_verify (local_client, "") == WYRELOG_E_OK)
+    return 141;
+  if (wyl_client_mfa_verify (local_client, "123456") == WYRELOG_E_OK)
+    return 142;
 
   http.body = "{\"session_token\":\"session-1\"}";
   if (wyl_client_login (local_client, "alice", NULL) != WYRELOG_E_IO)

--- a/tests/test-session-username.c
+++ b/tests/test-session-username.c
@@ -705,6 +705,120 @@ check_login_session_id_is_active_decision_scope (void)
   return 0;
 }
 
+static wyrelog_error_t
+allow_mfa_validator (WylHandle *handle, WylSession *session,
+    const gchar *proof, gpointer user_data)
+{
+  const gchar *expected_proof = user_data;
+
+  (void) handle;
+
+  g_autofree gchar *username = wyl_session_dup_username (session);
+  if (g_strcmp0 (username, "mfa-proof-user") != 0)
+    return WYRELOG_E_INTERNAL;
+  if (g_strcmp0 (proof, expected_proof) != 0)
+    return WYRELOG_E_POLICY;
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+reject_mfa_validator (WylHandle *handle, WylSession *session,
+    const gchar *proof, gpointer user_data)
+{
+  guint *calls = user_data;
+
+  (void) handle;
+  (void) session;
+  (void) proof;
+
+  (*calls)++;
+  return WYRELOG_E_POLICY;
+}
+
+static gint
+check_mfa_verify_with_proof_requires_validator (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 100;
+
+  if (store_active_scope (handle, "mfa-proof-scope") != WYRELOG_E_OK)
+    return 101;
+  if (grant_direct (handle, "mfa-proof-user", "wr.mfa-proof-permission",
+          "mfa-proof-scope") != WYRELOG_E_OK)
+    return 102;
+
+  g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
+  wyl_login_req_set_username (login, "mfa-proof-user");
+  g_autoptr (WylSession) session = NULL;
+  if (wyl_session_login (handle, login, &session) != WYRELOG_E_OK)
+    return 103;
+
+  if (wyl_session_mfa_verify_with_proof (NULL, session, "123456",
+          allow_mfa_validator, "123456") != WYRELOG_E_INVALID)
+    return 104;
+  if (wyl_session_mfa_verify_with_proof (handle, NULL, "123456",
+          allow_mfa_validator, "123456") != WYRELOG_E_INVALID)
+    return 105;
+  if (wyl_session_mfa_verify_with_proof (handle, session, NULL,
+          allow_mfa_validator, "123456") != WYRELOG_E_INVALID)
+    return 106;
+  if (wyl_session_mfa_verify_with_proof (handle, session, "",
+          allow_mfa_validator, "123456") != WYRELOG_E_INVALID)
+    return 107;
+  if (wyl_session_mfa_verify_with_proof (handle, session, "123456",
+          NULL, "123456") != WYRELOG_E_INVALID)
+    return 108;
+
+  guint reject_calls = 0;
+  if (wyl_session_mfa_verify_with_proof (handle, session, "123456",
+          reject_mfa_validator, &reject_calls) != WYRELOG_E_POLICY)
+    return 109;
+  if (reject_calls != 1)
+    return 110;
+
+  PrincipalStateExpect required = {
+    .subject_id = "mfa-proof-user",
+    .state = "mfa_required",
+  };
+  if (wyl_policy_store_foreach_principal_state (wyl_handle_get_policy_store
+          (handle), principal_state_expect_cb, &required) != WYRELOG_E_OK)
+    return 111;
+  if (required.matches != 1)
+    return 112;
+
+  PrincipalStateExpect authenticated = {
+    .subject_id = "mfa-proof-user",
+    .state = "authenticated",
+  };
+  if (wyl_policy_store_foreach_principal_state (wyl_handle_get_policy_store
+          (handle), principal_state_expect_cb, &authenticated)
+      != WYRELOG_E_OK)
+    return 113;
+  if (authenticated.matches != 0)
+    return 114;
+
+  g_autoptr (wyl_decide_req_t) decide = wyl_decide_req_new ();
+  wyl_decide_req_set_subject_id (decide, "mfa-proof-user");
+  wyl_decide_req_set_action (decide, "wr.mfa-proof-permission");
+  wyl_decide_req_set_resource_id (decide, "mfa-proof-scope");
+  g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
+  if (wyl_decide (handle, decide, resp) != WYRELOG_E_OK)
+    return 115;
+  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_DENY)
+    return 116;
+
+  if (wyl_session_mfa_verify_with_proof (handle, session, "123456",
+          allow_mfa_validator, "123456") != WYRELOG_E_OK)
+    return 117;
+  if (wyl_decide (handle, decide, resp) != WYRELOG_E_OK)
+    return 118;
+  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_ALLOW)
+    return 119;
+
+  return 0;
+}
+
 static gint
 check_login_skip_mfa_rejected_by_default (void)
 {
@@ -1536,6 +1650,8 @@ main (void)
   if ((rc = check_mfa_delta_callback_survives_state_reload ()) != 0)
     return rc;
   if ((rc = check_mfa_verify_rejects_invalid_args ()) != 0)
+    return rc;
+  if ((rc = check_mfa_verify_with_proof_requires_validator ()) != 0)
     return rc;
   if ((rc = check_login_persists_mfa_required_state ()) != 0)
     return rc;

--- a/wyrelog/session.h
+++ b/wyrelog/session.h
@@ -32,6 +32,9 @@ typedef guint64 wyl_session_id_t;
  */
 typedef struct _wyl_login_req wyl_login_req_t;
 
+typedef wyrelog_error_t (*WylMfaValidator) (WylHandle * handle,
+    WylSession * session, const gchar * proof, gpointer user_data);
+
 wyl_login_req_t *wyl_login_req_new (void);
 void wyl_login_req_free (wyl_login_req_t * req);
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (wyl_login_req_t, wyl_login_req_free);
@@ -64,8 +67,23 @@ gboolean wyl_login_req_get_skip_mfa (const wyl_login_req_t * req);
 
 wyrelog_error_t wyl_session_login (WylHandle * handle,
     const wyl_login_req_t * req, WylSession ** out_session);
+
+/*
+ * Trusted host-side transition primitive. This function records that MFA was
+ * already verified by external trusted code; it does not inspect OTP material
+ * and must not be wired directly to user-supplied HTTP or client proof.
+ */
 wyrelog_error_t wyl_session_mfa_verify (WylHandle * handle,
     WylSession * session);
+
+/*
+ * Proof-bearing MFA boundary. The principal transition is applied only after
+ * |validator| accepts |proof|. Missing or empty proof and missing validator
+ * fail before any Policy DB, audit, or read-engine mutation is attempted.
+ */
+wyrelog_error_t wyl_session_mfa_verify_with_proof (WylHandle * handle,
+    WylSession * session, const gchar * proof, WylMfaValidator validator,
+    gpointer user_data);
 wyrelog_error_t wyl_session_elevate (WylHandle * handle, WylSession * session);
 wyrelog_error_t wyl_session_drop_elevation (WylHandle * handle,
     WylSession * session);

--- a/wyrelog/wyl-session.c
+++ b/wyrelog/wyl-session.c
@@ -628,8 +628,8 @@ wyl_session_login (WylHandle *handle, const wyl_login_req_t *req,
   return WYRELOG_E_OK;
 }
 
-wyrelog_error_t
-wyl_session_mfa_verify (WylHandle *handle, WylSession *session)
+static wyrelog_error_t
+mark_session_mfa_verified (WylHandle *handle, WylSession *session)
 {
   if (handle == NULL || session == NULL || !WYL_IS_SESSION (session))
     return WYRELOG_E_INVALID;
@@ -644,6 +644,29 @@ wyl_session_mfa_verify (WylHandle *handle, WylSession *session)
 
   return transition_principal_state (handle, session->username,
       WYL_PRINCIPAL_STATE_MFA_REQUIRED, state);
+}
+
+wyrelog_error_t
+wyl_session_mfa_verify (WylHandle *handle, WylSession *session)
+{
+  return mark_session_mfa_verified (handle, session);
+}
+
+wyrelog_error_t
+wyl_session_mfa_verify_with_proof (WylHandle *handle, WylSession *session,
+    const gchar *proof, WylMfaValidator validator, gpointer user_data)
+{
+  if (handle == NULL || session == NULL || !WYL_IS_SESSION (session) ||
+      session->username == NULL)
+    return WYRELOG_E_INVALID;
+  if (proof == NULL || proof[0] == '\0' || validator == NULL)
+    return WYRELOG_E_INVALID;
+
+  wyrelog_error_t rc = validator (handle, session, proof, user_data);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  return mark_session_mfa_verified (handle, session);
 }
 
 wyrelog_error_t


### PR DESCRIPTION
## Summary
- add a validator-backed MFA verification boundary for proof-bearing callers
- document the existing proofless session API as a trusted host transition
- keep the client MFA verify path fail-closed until transport validation exists

## Tests
- tools/gst-indent wyrelog/wyl-session.c tests/test-session-username.c tests/test-client-smoke.c
- meson test -C builddir wyrelog:session-username wyrelog:client-smoke wyrelog:login-req
- meson test -C builddir-audit wyrelog:session-username wyrelog:client-smoke wyrelog:audit-emit
- git diff --check
