### PR TITLE
decision: preserve guarded miss deny tags

### DIFF
--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -1643,6 +1643,63 @@ check_policy_store_guarded_direct_permission_decides_with_context (void)
 }
 
 static gint
+check_policy_store_guarded_direct_permission_tags_miss_after_allow (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 420;
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (wyl_policy_store_upsert_permission (store, "wr.audit.read",
+          "audit read", "sensitive") != WYRELOG_E_OK)
+    return 421;
+  if (wyl_policy_store_grant_direct_permission (store, "guarded-seq-user",
+          "wr.audit.read", "guarded-seq-scope") != WYRELOG_E_OK)
+    return 422;
+  if (wyl_policy_store_set_principal_state (store, "guarded-seq-user",
+          "authenticated") != WYRELOG_E_OK)
+    return 423;
+  if (wyl_policy_store_set_session_state (store, "guarded-seq-scope",
+          "active") != WYRELOG_E_OK)
+    return 424;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 425;
+
+  g_autoptr (wyl_decide_req_t) req = wyl_decide_req_new ();
+  wyl_decide_req_set_subject_id (req, "guarded-seq-user");
+  wyl_decide_req_set_action (req, "wr.audit.read");
+  wyl_decide_req_set_resource_id (req, "guarded-seq-scope");
+  wyl_decide_req_set_guard_context (req, 123, "public", 69);
+
+  g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
+  if (wyl_decide (handle, req, resp) != WYRELOG_E_OK)
+    return 426;
+  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_ALLOW)
+    return 427;
+  if (wyl_decide_resp_get_deny_reason (resp) != NULL)
+    return 428;
+  if (wyl_decide_resp_get_deny_origin (resp) != NULL)
+    return 429;
+
+  wyl_decide_req_set_guard_context (req, 123, "public", 70);
+  wyl_decide_resp_set_decision (resp, WYL_DECISION_ALLOW);
+  if (wyl_decide (handle, req, resp) != WYRELOG_E_OK)
+    return 430;
+  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_DENY)
+    return 431;
+  if (g_strcmp0 (wyl_decide_resp_get_deny_reason (resp), "not_armed") != 0)
+    return 432;
+  if (g_strcmp0 (wyl_decide_resp_get_deny_origin (resp), "perm_state") != 0)
+    return 433;
+  gint residue = expect_guard_bridge_absent (handle, "guarded-seq-user",
+      "wr.audit.read", "guarded-seq-scope", 434);
+  if (residue != 0)
+    return residue;
+  return 0;
+}
+
+static gint
 check_policy_store_guarded_direct_permission_denies_without_context (void)
 {
   g_autoptr (WylHandle) handle = NULL;
@@ -2261,6 +2318,10 @@ main (void)
     return rc;
   if ((rc =
           check_policy_store_guarded_direct_permission_decides_with_context ())
+      != 0)
+    return rc;
+  if ((rc =
+          check_policy_store_guarded_direct_permission_tags_miss_after_allow ())
       != 0)
     return rc;
   if ((rc =

--- a/wyrelog/wyl-decide.c
+++ b/wyrelog/wyl-decide.c
@@ -409,6 +409,29 @@ find_deny_reason (WylHandle *handle, const gint64 row[3],
   return WYRELOG_E_OK;
 }
 
+static wyrelog_error_t
+fill_guard_miss_deny_reason (WylHandle *handle, const gint64 row[3],
+    const gint64 names[WYL_DENY_REASON_LAST_],
+    const gint64 origins[WYL_DENY_REASON_LAST_],
+    wyl_deny_reason_code_t *out_code)
+{
+  if (out_code == NULL)
+    return WYRELOG_E_INVALID;
+
+  wyrelog_error_t rc = find_deny_reason (handle, row, names, origins, out_code);
+  if (rc != WYRELOG_E_OK || *out_code != WYL_DENY_REASON_LAST_)
+    return rc;
+
+  gboolean base_allowed = FALSE;
+  rc = wyl_handle_engine_contains (handle, "allow_guard_base", row, 3,
+      &base_allowed);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if (base_allowed)
+    *out_code = WYL_DENY_REASON_NOT_ARMED;
+  return WYRELOG_E_OK;
+}
+
 #ifdef WYL_HAS_AUDIT
 static void
 fail_closed_for_audit (wyl_decide_resp_t *resp)
@@ -463,8 +486,8 @@ wyl_decide (WylHandle *handle, const wyl_decide_req_t *req,
     if (guard != NULL) {
       if (!guard_is_satisfied (guard, req)) {
         wyl_deny_reason_code_t code = WYL_DENY_REASON_LAST_;
-        rc = find_deny_reason (handle, row, reason_names, reason_origins,
-            &code);
+        rc = fill_guard_miss_deny_reason (handle, row, reason_names,
+            reason_origins, &code);
         if (rc != WYRELOG_E_OK)
           return rc;
         deny_reason = wyl_deny_reason_name (code);


### PR DESCRIPTION
## Summary
- preserve deny tags when a guarded allow is followed by a failing guard context
- keep existing deny-reason priority before applying the guarded miss fallback
- limit the fallback to tuples that satisfy the non-armed allow preconditions

## Tests
- tools/gst-indent wyrelog/wyl-decide.c tests/test-handle-engine-pair.c
- meson test -C builddir wyrelog:handle-engine-pair wyrelog:session-username wyrelog:decide --print-errorlogs
- meson test -C builddir-audit wyrelog:handle-engine-pair wyrelog:session-username wyrelog:decide --print-errorlogs
- git diff --check
