### PR TITLE
LoBAC guard context compound bridge

### DIFF
--- a/templates/access/fsm/permission_scope.dl
+++ b/templates/access/fsm/permission_scope.dl
@@ -31,10 +31,10 @@
 
 .decl perm_state(user: symbol, perm: symbol, scope: symbol, state: symbol)
 .decl perm_arm_rule(perm: symbol, guard_handle: symbol)
-.decl context_now(user: symbol, scope: symbol, ctx: symbol)
-.decl guard_context(ctx: symbol, user: symbol, scope: symbol,
+.decl context_now(user: symbol, scope: symbol, ctx: scope/2 side)
+.decl guard_context(ctx: scope/2 side, user: symbol, scope: symbol,
     timestamp: int64, loc_class: symbol, risk: int64)
-.decl eval_guard(user: symbol, perm: symbol, scope: symbol, ctx: symbol)
+.decl eval_guard(user: symbol, perm: symbol, scope: symbol, ctx: scope/2 side)
 .decl armed(user: symbol, perm: symbol, scope: symbol)
 
 // --- perm_arm_rule catalogue mirror ----------------------------------

--- a/tests/test-engine-intern.c
+++ b/tests/test-engine-intern.c
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #include <glib.h>
+#include <glib/gstdio.h>
 #include <string.h>
 
 #include "wyrelog/engine.h"
@@ -26,6 +27,110 @@ static wyrelog_error_t
 open_engine_from_real_templates (WylEngine **out)
 {
   return wyl_engine_open (WYL_TEST_TEMPLATE_DIR, 1, out);
+}
+
+typedef struct
+{
+  gint64 expected_id;
+  guint matches;
+} SeenSnapshotExpect;
+
+static gchar *
+make_tmpdir (void)
+{
+  g_autoptr (GError) err = NULL;
+  gchar *dir = g_dir_make_tmp ("wyl-engine-compound-test-XXXXXX", &err);
+  if (dir == NULL) {
+    g_printerr ("make_tmpdir: %s\n", err ? err->message : "?");
+    return NULL;
+  }
+  return dir;
+}
+
+static gboolean
+write_file_in_dir (const gchar *dir, const gchar *filename,
+    const gchar *contents)
+{
+  g_autofree gchar *path = g_build_filename (dir, filename, NULL);
+  g_autoptr (GError) err = NULL;
+  return g_file_set_contents (path, contents, -1, &err);
+}
+
+static void
+rmdir_recursive (const gchar *dir)
+{
+  g_autoptr (GDir) d = g_dir_open (dir, 0, NULL);
+  if (d == NULL) {
+    g_rmdir (dir);
+    return;
+  }
+
+  const gchar *name;
+  while ((name = g_dir_read_name (d)) != NULL) {
+    g_autofree gchar *path = g_build_filename (dir, name, NULL);
+    if (g_file_test (path, G_FILE_TEST_IS_DIR))
+      rmdir_recursive (path);
+    else
+      g_unlink (path);
+  }
+  g_rmdir (dir);
+}
+
+static gboolean
+write_compound_templates (const gchar *dir)
+{
+  g_autofree gchar *fsm_dir = g_build_filename (dir, "fsm", NULL);
+  if (g_mkdir (fsm_dir, 0755) != 0)
+    return FALSE;
+  g_autofree gchar *lobac_dir = g_build_filename (dir, "lobac", NULL);
+  if (g_mkdir (lobac_dir, 0755) != 0)
+    return FALSE;
+
+  return write_file_in_dir (dir, "bootstrap.dl",
+      ".decl event(id: int64, payload: scope_ctx/3 side)\n"
+      ".decl seen(id: int64)\n" "seen(ID) :- event(ID, scope_ctx(_, _, _)).\n")
+      && write_file_in_dir (dir, "fsm/principal.dl", "// principal stub\n")
+      && write_file_in_dir (dir, "fsm/session.dl", "// session stub\n")
+      && write_file_in_dir (dir, "fsm/permission_scope.dl",
+      "// permission scope stub\n")
+      && write_file_in_dir (dir, "lobac/decision.dl", "// decision stub\n");
+}
+
+static wyrelog_error_t
+open_engine_from_compound_templates (gchar **tmpdir_out, WylEngine **out)
+{
+  *tmpdir_out = NULL;
+  *out = NULL;
+
+  g_autofree gchar *tmpdir = make_tmpdir ();
+  if (tmpdir == NULL)
+    return WYRELOG_E_IO;
+  if (!write_compound_templates (tmpdir)) {
+    rmdir_recursive (tmpdir);
+    return WYRELOG_E_IO;
+  }
+
+  wyrelog_error_t rc = wyl_engine_open (tmpdir, 1, out);
+  if (rc != WYRELOG_E_OK) {
+    rmdir_recursive (tmpdir);
+    return rc;
+  }
+
+  *tmpdir_out = g_steal_pointer (&tmpdir);
+  return WYRELOG_E_OK;
+}
+
+static void
+seen_snapshot_cb (const gchar *relation, const gint64 *row, guint ncols,
+    gpointer user_data)
+{
+  SeenSnapshotExpect *expect = user_data;
+
+  if (g_strcmp0 (relation, "seen") != 0 || ncols != 1)
+    return;
+
+  if (row[0] == expect->expected_id)
+    expect->matches++;
 }
 
 /* ------------------------------------------------------------------ */
@@ -267,6 +372,171 @@ test_intern_after_close (void)
   return 0;
 }
 
+static gint
+test_make_compound_invalid_args (void)
+{
+  WylEngine *engine = NULL;
+  wyrelog_error_t rc = open_engine_from_real_templates (&engine);
+  if (rc != WYRELOG_E_OK || engine == NULL) {
+    g_printerr ("test_make_compound_invalid_args: open failed: %d\n", (int) rc);
+    return 70;
+  }
+
+  wirelog_compound_arg_t args[1] = {
+    {WIRELOG_TYPE_INT64, 123},
+  };
+  gint64 out = -1;
+
+  if (wyl_engine_make_compound (NULL, "ctx", args, 1, &out)
+      != WYRELOG_E_INVALID) {
+    wyl_engine_close (engine);
+    return 71;
+  }
+  if (wyl_engine_make_compound (engine, NULL, args, 1, &out)
+      != WYRELOG_E_INVALID) {
+    wyl_engine_close (engine);
+    return 72;
+  }
+  if (wyl_engine_make_compound (engine, "", args, 1, &out)
+      != WYRELOG_E_INVALID) {
+    wyl_engine_close (engine);
+    return 73;
+  }
+  if (wyl_engine_make_compound (engine, "ctx", NULL, 1, &out)
+      != WYRELOG_E_INVALID) {
+    wyl_engine_close (engine);
+    return 74;
+  }
+  if (wyl_engine_make_compound (engine, "ctx", args, 0, &out)
+      != WYRELOG_E_INVALID) {
+    wyl_engine_close (engine);
+    return 75;
+  }
+  if (wyl_engine_make_compound (engine, "ctx", args, 1, NULL)
+      != WYRELOG_E_INVALID) {
+    wyl_engine_close (engine);
+    return 76;
+  }
+
+  wyl_engine_close (engine);
+  return 0;
+}
+
+static gint
+test_make_compound_side_relation_contract (void)
+{
+  WylEngine *engine = NULL;
+  g_autofree gchar *tmpdir = NULL;
+  wyrelog_error_t rc = open_engine_from_compound_templates (&tmpdir, &engine);
+  if (rc != WYRELOG_E_OK || engine == NULL) {
+    g_printerr ("test_make_compound_side_relation_contract: "
+        "open failed: %d\n", (int) rc);
+    return 80;
+  }
+
+  gint64 loc_class = -1;
+  rc = wyl_engine_intern_symbol (engine, "trusted", &loc_class);
+  if (rc != WYRELOG_E_OK) {
+    wyl_engine_close (engine);
+    rmdir_recursive (tmpdir);
+    return 81;
+  }
+
+  wirelog_compound_arg_t args[3] = {
+    {WIRELOG_TYPE_INT64, 1700000000},
+    {WIRELOG_TYPE_STRING, loc_class},
+    {WIRELOG_TYPE_INT64, 20},
+  };
+  gint64 handle = -1;
+  rc = wyl_engine_make_compound (engine, "scope_ctx", args, 3, &handle);
+  if (rc != WYRELOG_E_OK || handle <= 0) {
+    g_printerr ("test_make_compound_side_relation_contract: "
+        "compound failed: %d handle=%" G_GINT64_FORMAT "\n", (int) rc, handle);
+    wyl_engine_close (engine);
+    rmdir_recursive (tmpdir);
+    return 82;
+  }
+
+  const gint64 row[2] = { 42, handle };
+  rc = wyl_engine_insert (engine, "event", row, G_N_ELEMENTS (row));
+  if (rc != WYRELOG_E_OK) {
+    g_printerr ("test_make_compound_side_relation_contract: "
+        "insert failed: %d\n", (int) rc);
+    wyl_engine_close (engine);
+    rmdir_recursive (tmpdir);
+    return 83;
+  }
+
+  SeenSnapshotExpect expect = {
+    .expected_id = row[0],
+    .matches = 0,
+  };
+  rc = wyl_engine_snapshot (engine, "seen", seen_snapshot_cb, &expect);
+  if (rc != WYRELOG_E_OK) {
+    g_printerr ("test_make_compound_side_relation_contract: "
+        "snapshot failed: %d\n", (int) rc);
+    wyl_engine_close (engine);
+    rmdir_recursive (tmpdir);
+    return 84;
+  }
+
+  wyl_engine_close (engine);
+  rmdir_recursive (tmpdir);
+  if (expect.matches != 1) {
+    g_printerr ("test_make_compound_side_relation_contract: "
+        "matches=%u\n", expect.matches);
+    return 85;
+  }
+
+  return 0;
+}
+
+static gint
+test_make_nested_compound_contract (void)
+{
+  WylEngine *engine = NULL;
+  wyrelog_error_t rc = open_engine_from_real_templates (&engine);
+  if (rc != WYRELOG_E_OK || engine == NULL) {
+    g_printerr ("test_make_nested_compound_contract: open failed: %d\n",
+        (int) rc);
+    return 90;
+  }
+
+  gint64 loc_class = -1;
+  rc = wyl_engine_intern_symbol (engine, "public", &loc_class);
+  if (rc != WYRELOG_E_OK) {
+    wyl_engine_close (engine);
+    return 91;
+  }
+
+  wirelog_compound_arg_t metadata_args[3] = {
+    {WIRELOG_TYPE_INT64, 1700000001},
+    {WIRELOG_TYPE_STRING, loc_class},
+    {WIRELOG_TYPE_INT64, 70},
+  };
+  gint64 metadata = -1;
+  rc = wyl_engine_make_compound (engine, "metadata", metadata_args, 3,
+      &metadata);
+  if (rc != WYRELOG_E_OK || metadata <= 0) {
+    wyl_engine_close (engine);
+    return 92;
+  }
+
+  wirelog_compound_arg_t scope_args[2] = {
+    {WIRELOG_TYPE_INT64, metadata},
+    {WIRELOG_TYPE_INT64, 7},
+  };
+  gint64 scope = -1;
+  rc = wyl_engine_make_compound (engine, "scope", scope_args, 2, &scope);
+  if (rc != WYRELOG_E_OK || scope <= 0 || scope == metadata) {
+    wyl_engine_close (engine);
+    return 93;
+  }
+
+  wyl_engine_close (engine);
+  return 0;
+}
+
 /* ------------------------------------------------------------------ */
 /* main                                                                */
 /* ------------------------------------------------------------------ */
@@ -295,6 +565,15 @@ main (void)
     return rc;
 
   if ((rc = test_intern_after_close ()) != 0)
+    return rc;
+
+  if ((rc = test_make_compound_invalid_args ()) != 0)
+    return rc;
+
+  if ((rc = test_make_compound_side_relation_contract ()) != 0)
+    return rc;
+
+  if ((rc = test_make_nested_compound_contract ()) != 0)
     return rc;
 
   return 0;

--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #include <glib.h>
+#include <glib/gstdio.h>
 
 #include "wyrelog/wyrelog.h"
 #include "wyrelog/policy/store-private.h"
@@ -55,6 +56,78 @@ typedef struct
   const gint64 *row;
   guint matches;
 } GuardBridgeExpect;
+
+typedef struct
+{
+  gint64 expected_id;
+  guint matches;
+} SeenExpect;
+
+static gchar *
+make_tmpdir (void)
+{
+  g_autoptr (GError) err = NULL;
+  gchar *dir = g_dir_make_tmp ("wyl-handle-compound-test-XXXXXX", &err);
+  if (dir == NULL) {
+    g_printerr ("make_tmpdir: %s\n", err ? err->message : "?");
+    return NULL;
+  }
+  return dir;
+}
+
+static gboolean
+write_file_in_dir (const gchar *dir, const gchar *filename,
+    const gchar *contents)
+{
+  g_autofree gchar *path = g_build_filename (dir, filename, NULL);
+  g_autoptr (GError) err = NULL;
+  return g_file_set_contents (path, contents, -1, &err);
+}
+
+static void
+rmdir_recursive (const gchar *dir)
+{
+  g_autoptr (GDir) d = g_dir_open (dir, 0, NULL);
+  if (d == NULL) {
+    g_rmdir (dir);
+    return;
+  }
+
+  const gchar *name;
+  while ((name = g_dir_read_name (d)) != NULL) {
+    g_autofree gchar *path = g_build_filename (dir, name, NULL);
+    if (g_file_test (path, G_FILE_TEST_IS_DIR))
+      rmdir_recursive (path);
+    else
+      g_unlink (path);
+  }
+  g_rmdir (dir);
+}
+
+static gboolean
+write_compound_templates (const gchar *dir)
+{
+  g_autofree gchar *fsm_dir = g_build_filename (dir, "fsm", NULL);
+  if (g_mkdir (fsm_dir, 0755) != 0)
+    return FALSE;
+  g_autofree gchar *lobac_dir = g_build_filename (dir, "lobac", NULL);
+  if (g_mkdir (lobac_dir, 0755) != 0)
+    return FALSE;
+
+  return write_file_in_dir (dir, "bootstrap.dl",
+      ".decl event(id: int64, payload: scope/1 side)\n"
+      ".decl seen(id: int64)\n" "seen(ID) :- event(ID, scope(_)).\n")
+      && write_file_in_dir (dir, "fsm/principal.dl",
+      ".decl principal_transition(from_state: symbol, event: symbol,"
+      " to_state: symbol)\n")
+      && write_file_in_dir (dir, "fsm/session.dl",
+      ".decl session_active(state: symbol)\n"
+      ".decl session_transition(from_state: symbol, event: symbol,"
+      " to_state: symbol)\n")
+      && write_file_in_dir (dir, "fsm/permission_scope.dl",
+      ".decl perm_arm_rule(perm: symbol, guard_handle: symbol)\n")
+      && write_file_in_dir (dir, "lobac/decision.dl", "// decision stub\n");
+}
 
 static void
 snapshot_expect_cb (const gchar *relation, const gint64 *row, guint ncols,
@@ -159,6 +232,18 @@ eval_guard_count_cb (const gchar *relation, const gint64 *row, guint ncols,
 
   if (ncols == 4 && row[0] == expect->row[0] && row[1] == expect->row[1]
       && row[2] == expect->row[2])
+    expect->matches++;
+}
+
+static void
+seen_expect_cb (const gchar *relation, const gint64 *row, guint ncols,
+    gpointer user_data)
+{
+  SeenExpect *expect = user_data;
+
+  if (g_strcmp0 (relation, "seen") != 0 || ncols != 1)
+    return;
+  if (row[0] == expect->expected_id)
     expect->matches++;
 }
 
@@ -691,6 +776,155 @@ check_symbol_intern_rejects_missing_pair (void)
     return 81;
   if (id != -1)
     return 82;
+  return 0;
+}
+
+static gint
+check_compound_make_rejects_invalid_args (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  gint64 id = -1;
+  wirelog_compound_arg_t args[1] = {
+    {WIRELOG_TYPE_INT64, 123},
+  };
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 83;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 84;
+  if (wyl_handle_make_engine_compound (NULL, "scope", args, 1, &id)
+      != WYRELOG_E_INVALID)
+    return 85;
+  if (id != 0)
+    return 86;
+  id = -1;
+  if (wyl_handle_make_engine_compound (handle, NULL, args, 1, &id)
+      != WYRELOG_E_INVALID)
+    return 87;
+  if (id != 0)
+    return 88;
+  id = -1;
+  if (wyl_handle_make_engine_compound (handle, "", args, 1, &id)
+      != WYRELOG_E_INVALID)
+    return 89;
+  if (id != 0)
+    return 90;
+  id = -1;
+  if (wyl_handle_make_engine_compound (handle, "scope", NULL, 1, &id)
+      != WYRELOG_E_INVALID)
+    return 91;
+  if (id != 0)
+    return 92;
+  id = -1;
+  if (wyl_handle_make_engine_compound (handle, "scope", args, 0, &id)
+      != WYRELOG_E_INVALID)
+    return 93;
+  if (id != 0)
+    return 94;
+  if (wyl_handle_make_engine_compound (handle, "scope", args, 1, NULL)
+      != WYRELOG_E_INVALID)
+    return 95;
+  return 0;
+}
+
+static gint
+check_compound_make_rejects_missing_pair (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  gint64 id = -1;
+  wirelog_compound_arg_t args[1] = {
+    {WIRELOG_TYPE_INT64, 123},
+  };
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 96;
+  if (wyl_handle_make_engine_compound (handle, "scope", args, 1, &id)
+      != WYRELOG_E_INVALID)
+    return 97;
+  if (id != 0)
+    return 98;
+  return 0;
+}
+
+static gint
+check_compound_make_reaches_engine_pair (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  gint64 loc_class = -1;
+  gint64 compound = -1;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 99;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 100;
+  if (wyl_handle_intern_engine_symbol (handle, "trusted", &loc_class)
+      != WYRELOG_E_OK)
+    return 101;
+
+  wirelog_compound_arg_t args[3] = {
+    {WIRELOG_TYPE_INT64, 1700000000},
+    {WIRELOG_TYPE_STRING, loc_class},
+    {WIRELOG_TYPE_INT64, 10},
+  };
+  if (wyl_handle_make_engine_compound (handle, "metadata", args,
+          G_N_ELEMENTS (args), &compound) != WYRELOG_E_OK)
+    return 102;
+  if (compound <= 0)
+    return 103;
+  return 0;
+}
+
+static gint
+check_compound_make_result_is_insertable (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  g_autofree gchar *tmpdir = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 104;
+  tmpdir = make_tmpdir ();
+  if (tmpdir == NULL)
+    return 105;
+  if (!write_compound_templates (tmpdir)) {
+    rmdir_recursive (tmpdir);
+    return 106;
+  }
+  if (wyl_handle_open_engine_pair (handle, tmpdir) != WYRELOG_E_OK) {
+    rmdir_recursive (tmpdir);
+    return 107;
+  }
+
+  gint64 payload = -1;
+  wirelog_compound_arg_t args[1] = {
+    {WIRELOG_TYPE_INT64, 42},
+  };
+  if (wyl_handle_make_engine_compound (handle, "scope", args,
+          G_N_ELEMENTS (args), &payload) != WYRELOG_E_OK) {
+    rmdir_recursive (tmpdir);
+    return 108;
+  }
+
+  const gint64 row[2] = { 7, payload };
+  if (wyl_handle_engine_insert (handle, "event", row, G_N_ELEMENTS (row))
+      != WYRELOG_E_OK) {
+    rmdir_recursive (tmpdir);
+    return 109;
+  }
+
+  SeenExpect expect = {
+    .expected_id = row[0],
+    .matches = 0,
+  };
+  if (wyl_engine_snapshot (wyl_handle_get_read_engine (handle), "seen",
+          seen_expect_cb, &expect) != WYRELOG_E_OK) {
+    rmdir_recursive (tmpdir);
+    return 110;
+  }
+  rmdir_recursive (tmpdir);
+  if (expect.matches != 1)
+    return 111;
   return 0;
 }
 
@@ -2286,6 +2520,14 @@ main (void)
   if ((rc = check_symbol_intern_can_be_reversed ()) != 0)
     return rc;
   if ((rc = check_symbol_intern_rejects_missing_pair ()) != 0)
+    return rc;
+  if ((rc = check_compound_make_rejects_invalid_args ()) != 0)
+    return rc;
+  if ((rc = check_compound_make_rejects_missing_pair ()) != 0)
+    return rc;
+  if ((rc = check_compound_make_reaches_engine_pair ()) != 0)
+    return rc;
+  if ((rc = check_compound_make_result_is_insertable ()) != 0)
     return rc;
   if ((rc = check_insert_fanout_reaches_read_engine ()) != 0)
     return rc;

--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -4,6 +4,7 @@
 
 #include "wyrelog/wyrelog.h"
 #include "wyrelog/policy/store-private.h"
+#include "wyrelog/wyl-handle-compound-private.h"
 #include "wyrelog/wyl-handle-private.h"
 
 #ifndef WYL_TEST_TEMPLATE_DIR

--- a/wyrelog/wyl-decide.c
+++ b/wyrelog/wyl-decide.c
@@ -4,6 +4,7 @@
 #include "wyrelog/wyrelog.h"
 
 #include "access/decision-private.h"
+#include "wyl-handle-compound-private.h"
 #include "wyl-handle-private.h"
 #include "wyl-permission-scope-private.h"
 
@@ -258,16 +259,6 @@ guard_is_satisfied (const wyl_guard_expr_t *guard, const wyl_decide_req_t *req)
   return wyl_eval_guard (guard, &scope);
 }
 
-static gchar *
-build_guard_context_symbol (const wyl_decide_req_t *req)
-{
-  static gint next_id = 0;
-  gint id = g_atomic_int_add (&next_id, 1) + 1;
-  return g_strdup_printf ("scope(metadata(%" G_GINT64_FORMAT ",%s,%"
-      G_GINT64_FORMAT "),request(%d))", req->guard_timestamp,
-      req->guard_loc_class, req->guard_risk, id);
-}
-
 static wyrelog_error_t
 remove_guard_eval_facts (WylHandle *handle, const guard_eval_facts_t *facts)
 {
@@ -301,16 +292,14 @@ insert_guard_eval_facts (WylHandle *handle, const gint64 row[3],
 {
   memset (facts, 0, sizeof (*facts));
 
-  g_autofree gchar *context_symbol = build_guard_context_symbol (req);
-  gint64 context_id = 0;
-  wyrelog_error_t rc =
-      wyl_handle_intern_engine_symbol (handle, context_symbol, &context_id);
+  gint64 loc_class_id = 0;
+  wyrelog_error_t rc = wyl_handle_intern_engine_symbol (handle,
+      req->guard_loc_class, &loc_class_id);
   if (rc != WYRELOG_E_OK)
     return rc;
 
-  gint64 loc_class_id = 0;
-  rc = wyl_handle_intern_engine_symbol (handle, req->guard_loc_class,
-      &loc_class_id);
+  gint64 context_id = 0;
+  rc = wyl_handle_get_guard_context_compound (handle, &context_id);
   if (rc != WYRELOG_E_OK)
     return rc;
 

--- a/wyrelog/wyl-engine-private.h
+++ b/wyrelog/wyl-engine-private.h
@@ -64,4 +64,24 @@ wyrelog_error_t wyl_engine_map_wirelog_error (wirelog_error_t wl_err);
 wyrelog_error_t wyl_engine_load_templates (const gchar * template_dir,
     gchar ** dl_src_out, gsize * dl_src_len_out);
 
+/*
+ * wyl_engine_make_compound:
+ * @self: A `WylEngine` instance. Must not be NULL.
+ * @functor: Compound functor name. Must not be NULL or empty.
+ * @args: (array length=nargs): Typed compound arguments. Must not be NULL.
+ * @nargs: Compound arity. Must be > 0.
+ * @out_id: (out) Receives a session-local compound handle. Must not be NULL.
+ *
+ * Allocates a wirelog side-tier compound term in @self's evaluator session and
+ * returns its handle. The handle is meaningful only within the owning engine
+ * session and must not be persisted across engine reloads.
+ *
+ * Returns: WYRELOG_E_OK on success; WYRELOG_E_INVALID for invalid arguments
+ * or a sessionless engine; WYRELOG_E_EXEC if the evaluator rejects the
+ * allocation; WYRELOG_E_NOMEM for allocation failure.
+ */
+wyrelog_error_t wyl_engine_make_compound (WylEngine * self,
+    const gchar * functor, const wirelog_compound_arg_t * args, gsize nargs,
+    gint64 * out_id);
+
 G_END_DECLS;

--- a/wyrelog/wyl-engine.c
+++ b/wyrelog/wyl-engine.c
@@ -121,6 +121,9 @@ wyl_engine_map_wirelog_error (wirelog_error_t wl_err)
       return WYRELOG_E_NOMEM;
     case WIRELOG_ERR_IO:
       return WYRELOG_E_IO;
+    case WIRELOG_ERR_COMPOUND_SATURATED:
+    case WIRELOG_ERR_COMPOUND_BUSY:
+      return WYRELOG_E_EXEC;
     case WIRELOG_ERR_UNKNOWN:
       return WYRELOG_E_INTERNAL;
     default:
@@ -280,6 +283,44 @@ wyl_engine_intern_symbol (WylEngine *self, const gchar *symbol, gint64 *out_id)
   }
 
   *out_id = id;
+  return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
+wyl_engine_make_compound (WylEngine *self, const gchar *functor,
+    const wirelog_compound_arg_t *args, gsize nargs, gint64 *out_id)
+{
+  if (out_id != NULL)
+    *out_id = (gint64) WIRELOG_COMPOUND_HANDLE_NULL;
+
+  if (self == NULL || !WYL_IS_ENGINE (self))
+    return WYRELOG_E_INVALID;
+  if (functor == NULL || functor[0] == '\0' || args == NULL || out_id == NULL)
+    return WYRELOG_E_INVALID;
+  if (nargs == 0 || nargs > G_MAXUINT32)
+    return WYRELOG_E_INVALID;
+  if (self->session == NULL)
+    return WYRELOG_E_INVALID;
+
+  uint64_t handle = WIRELOG_COMPOUND_HANDLE_NULL;
+  wirelog_error_t wl_rc =
+      wirelog_easy_make_compound (self->session, functor, (uint32_t) nargs,
+      args, &handle);
+  wyrelog_error_t rc = wyl_engine_map_wirelog_error (wl_rc);
+  if (rc != WYRELOG_E_OK) {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_POLICY,
+        "engine: compound allocation failed for functor '%s/%" G_GSIZE_FORMAT
+        "' (rc=%d)", functor, nargs, (int) rc);
+    return rc;
+  }
+
+  if (handle == WIRELOG_COMPOUND_HANDLE_NULL || handle > (uint64_t) G_MAXINT64) {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_POLICY,
+        "engine: compound allocation returned an invalid handle");
+    return WYRELOG_E_INTERNAL;
+  }
+
+  *out_id = (gint64) handle;
   return WYRELOG_E_OK;
 }
 

--- a/wyrelog/wyl-handle-compound-private.h
+++ b/wyrelog/wyl-handle-compound-private.h
@@ -1,0 +1,21 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+
+#include <glib.h>
+
+#include "wyrelog/handle.h"
+#include "wyl-engine-private.h"
+
+G_BEGIN_DECLS;
+
+/*
+ * Allocates the same side-tier compound term in both handle-owned policy
+ * engines and returns the shared handle. Rejected unless both engines are
+ * open and both evaluators return the same session-local handle id. The
+ * returned id is pair-local scratch state and must not be persisted.
+ */
+wyrelog_error_t wyl_handle_make_engine_compound (WylHandle * self,
+    const gchar * functor, const wirelog_compound_arg_t * args, gsize nargs,
+    gint64 * out_id);
+
+G_END_DECLS;

--- a/wyrelog/wyl-handle-compound-private.h
+++ b/wyrelog/wyl-handle-compound-private.h
@@ -18,4 +18,21 @@ wyrelog_error_t wyl_handle_make_engine_compound (WylHandle * self,
     const gchar * functor, const wirelog_compound_arg_t * args, gsize nargs,
     gint64 * out_id);
 
+/*
+ * Allocates a side-tier compound term only in the handle-owned read engine.
+ * This is intended for request-local snapshot bridge facts that are never
+ * fanned out to the delta engine.
+ */
+wyrelog_error_t wyl_handle_make_read_engine_compound (WylHandle * self,
+    const gchar * functor, const wirelog_compound_arg_t * args, gsize nargs,
+    gint64 * out_id);
+
+/*
+ * Returns the cached read-engine guard context compound used as the
+ * request-local bridge key for context_now/guard_context/eval_guard facts.
+ * The cache is invalidated with the handle-owned engine pair lifecycle.
+ */
+wyrelog_error_t wyl_handle_get_guard_context_compound (WylHandle * self,
+    gint64 * out_id);
+
 G_END_DECLS;

--- a/wyrelog/wyl-handle-private.h
+++ b/wyrelog/wyl-handle-private.h
@@ -4,7 +4,7 @@
 #include <glib.h>
 
 #include "wyrelog/handle.h"
-#include "wyrelog/engine.h"
+#include "wyl-engine-private.h"
 #include "policy/store-private.h"
 
 #ifdef WYL_HAS_AUDIT
@@ -68,6 +68,16 @@ wyrelog_error_t wyl_handle_reload_engine_pair (WylHandle * self);
 wyrelog_error_t wyl_handle_intern_engine_symbol (WylHandle * self,
     const gchar * symbol, gint64 * out_id);
 gchar *wyl_handle_dup_engine_symbol (WylHandle * self, gint64 id);
+
+/*
+ * Allocates the same side-tier compound term in both handle-owned policy
+ * engines and returns the shared handle. Rejected unless both engines are
+ * open and both evaluators return the same session-local handle id. The
+ * returned id is pair-local scratch state and must not be persisted.
+ */
+wyrelog_error_t wyl_handle_make_engine_compound (WylHandle * self,
+    const gchar * functor, const wirelog_compound_arg_t * args, gsize nargs,
+    gint64 * out_id);
 
 /*
  * Applies an EDB row update to both handle-owned policy engines. Rejected

--- a/wyrelog/wyl-handle-private.h
+++ b/wyrelog/wyl-handle-private.h
@@ -4,7 +4,7 @@
 #include <glib.h>
 
 #include "wyrelog/handle.h"
-#include "wyl-engine-private.h"
+#include "wyrelog/engine.h"
 #include "policy/store-private.h"
 
 #ifdef WYL_HAS_AUDIT
@@ -68,16 +68,6 @@ wyrelog_error_t wyl_handle_reload_engine_pair (WylHandle * self);
 wyrelog_error_t wyl_handle_intern_engine_symbol (WylHandle * self,
     const gchar * symbol, gint64 * out_id);
 gchar *wyl_handle_dup_engine_symbol (WylHandle * self, gint64 id);
-
-/*
- * Allocates the same side-tier compound term in both handle-owned policy
- * engines and returns the shared handle. Rejected unless both engines are
- * open and both evaluators return the same session-local handle id. The
- * returned id is pair-local scratch state and must not be persisted.
- */
-wyrelog_error_t wyl_handle_make_engine_compound (WylHandle * self,
-    const gchar * functor, const wirelog_compound_arg_t * args, gsize nargs,
-    gint64 * out_id);
 
 /*
  * Applies an EDB row update to both handle-owned policy engines. Rejected

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -6,6 +6,7 @@
 #include "wyrelog/engine.h"
 #include "wyl-fsm-principal-private.h"
 #include "wyl-fsm-session-private.h"
+#include "wyl-handle-compound-private.h"
 #include "wyl-handle-private.h"
 #include "wyl-id-private.h"
 #include "wyl-log-private.h"

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -546,6 +546,40 @@ wyl_handle_dup_engine_symbol (WylHandle *self, gint64 id)
   return g_strdup (symbol);
 }
 
+wyrelog_error_t
+wyl_handle_make_engine_compound (WylHandle *self, const gchar *functor,
+    const wirelog_compound_arg_t *args, gsize nargs, gint64 *out_id)
+{
+  if (out_id != NULL)
+    *out_id = (gint64) WIRELOG_COMPOUND_HANDLE_NULL;
+
+  if (self == NULL || !WYL_IS_HANDLE (self))
+    return WYRELOG_E_INVALID;
+  if (functor == NULL || functor[0] == '\0' || args == NULL || out_id == NULL)
+    return WYRELOG_E_INVALID;
+  if (nargs == 0 || nargs > G_MAXUINT32)
+    return WYRELOG_E_INVALID;
+  if (self->read_engine == NULL || self->delta_engine == NULL)
+    return WYRELOG_E_INVALID;
+
+  gint64 read_id = 0;
+  wyrelog_error_t rc = wyl_engine_make_compound (self->read_engine,
+      functor, args, nargs, &read_id);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  gint64 delta_id = 0;
+  rc = wyl_engine_make_compound (self->delta_engine, functor, args, nargs,
+      &delta_id);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if (read_id != delta_id)
+    return WYRELOG_E_INTERNAL;
+
+  *out_id = read_id;
+  return WYRELOG_E_OK;
+}
+
 static gboolean
 relation_fans_out_to_delta (const gchar *relation)
 {

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -24,6 +24,8 @@ struct _WylHandle
   gint64 created_at_us;
   WylEngine *read_engine;
   WylEngine *delta_engine;
+  WylEngine *guard_context_compound_engine;
+  gint64 guard_context_compound_id;
   GHashTable *engine_symbols_by_id;
   gchar *template_dir;
   WylDeltaCallback delta_callback;
@@ -256,6 +258,8 @@ wyl_shutdown (WylHandle *handle)
   g_clear_pointer (&handle->policy_store, wyl_policy_store_close);
   g_clear_object (&handle->read_engine);
   g_clear_object (&handle->delta_engine);
+  handle->guard_context_compound_engine = NULL;
+  handle->guard_context_compound_id = 0;
   g_clear_pointer (&handle->template_dir, g_free);
   g_object_set_qdata (G_OBJECT (handle),
       wyl_handle_engine_remove_fault_once_quark (), NULL);
@@ -419,6 +423,9 @@ replace_engine_pair (WylHandle *self, const gchar *template_dir)
 {
   WylEngine *old_read_engine = self->read_engine;
   WylEngine *old_delta_engine = self->delta_engine;
+  WylEngine *old_guard_context_compound_engine =
+      self->guard_context_compound_engine;
+  gint64 old_guard_context_compound_id = self->guard_context_compound_id;
   GHashTable *old_symbols = self->engine_symbols_by_id;
   gchar *old_template_dir = self->template_dir;
 
@@ -436,6 +443,8 @@ replace_engine_pair (WylHandle *self, const gchar *template_dir)
 
   self->read_engine = new_read_engine;
   self->delta_engine = new_delta_engine;
+  self->guard_context_compound_engine = NULL;
+  self->guard_context_compound_id = 0;
   self->engine_symbols_by_id = new_engine_symbol_map ();
   self->template_dir = g_strdup (template_dir);
 
@@ -447,6 +456,8 @@ replace_engine_pair (WylHandle *self, const gchar *template_dir)
     g_clear_pointer (&self->template_dir, g_free);
     self->read_engine = old_read_engine;
     self->delta_engine = old_delta_engine;
+    self->guard_context_compound_engine = old_guard_context_compound_engine;
+    self->guard_context_compound_id = old_guard_context_compound_id;
     self->engine_symbols_by_id = old_symbols;
     self->template_dir = old_template_dir;
     return rc;
@@ -461,6 +472,8 @@ replace_engine_pair (WylHandle *self, const gchar *template_dir)
       g_clear_pointer (&self->template_dir, g_free);
       self->read_engine = old_read_engine;
       self->delta_engine = old_delta_engine;
+      self->guard_context_compound_engine = old_guard_context_compound_engine;
+      self->guard_context_compound_id = old_guard_context_compound_id;
       self->engine_symbols_by_id = old_symbols;
       self->template_dir = old_template_dir;
       return rc;
@@ -578,6 +591,76 @@ wyl_handle_make_engine_compound (WylHandle *self, const gchar *functor,
     return WYRELOG_E_INTERNAL;
 
   *out_id = read_id;
+  return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
+wyl_handle_make_read_engine_compound (WylHandle *self, const gchar *functor,
+    const wirelog_compound_arg_t *args, gsize nargs, gint64 *out_id)
+{
+  if (out_id != NULL)
+    *out_id = (gint64) WIRELOG_COMPOUND_HANDLE_NULL;
+
+  if (self == NULL || !WYL_IS_HANDLE (self))
+    return WYRELOG_E_INVALID;
+  if (functor == NULL || functor[0] == '\0' || args == NULL || out_id == NULL)
+    return WYRELOG_E_INVALID;
+  if (nargs == 0 || nargs > G_MAXUINT32)
+    return WYRELOG_E_INVALID;
+  if (self->read_engine == NULL)
+    return WYRELOG_E_INVALID;
+
+  return wyl_engine_make_compound (self->read_engine, functor, args, nargs,
+      out_id);
+}
+
+wyrelog_error_t
+wyl_handle_get_guard_context_compound (WylHandle *self, gint64 *out_id)
+{
+  if (out_id != NULL)
+    *out_id = (gint64) WIRELOG_COMPOUND_HANDLE_NULL;
+
+  if (self == NULL || !WYL_IS_HANDLE (self) || out_id == NULL)
+    return WYRELOG_E_INVALID;
+  if (self->read_engine == NULL || self->delta_engine == NULL)
+    return WYRELOG_E_INVALID;
+
+  if (self->guard_context_compound_engine == self->read_engine
+      && self->guard_context_compound_id != 0) {
+    *out_id = self->guard_context_compound_id;
+    return WYRELOG_E_OK;
+  }
+
+  gint64 context_symbol = 0;
+  wyrelog_error_t rc = wyl_handle_intern_engine_symbol (self,
+      "_request_context", &context_symbol);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  wirelog_compound_arg_t metadata_args[3] = {
+    {WIRELOG_TYPE_INT64, 0},
+    {WIRELOG_TYPE_STRING, context_symbol},
+    {WIRELOG_TYPE_INT64, 0},
+  };
+  gint64 metadata_id = 0;
+  rc = wyl_handle_make_read_engine_compound (self, "metadata", metadata_args,
+      G_N_ELEMENTS (metadata_args), &metadata_id);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  wirelog_compound_arg_t scope_args[2] = {
+    {WIRELOG_TYPE_INT64, metadata_id},
+    {WIRELOG_TYPE_INT64, 0},
+  };
+  gint64 context_id = 0;
+  rc = wyl_handle_make_read_engine_compound (self, "scope", scope_args,
+      G_N_ELEMENTS (scope_args), &context_id);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  self->guard_context_compound_engine = self->read_engine;
+  self->guard_context_compound_id = context_id;
+  *out_id = context_id;
   return WYRELOG_E_OK;
 }
 


### PR DESCRIPTION
## Summary

- add private engine and handle helpers for wirelog compound term allocation
- isolate compound-specific private includes from broad handle internals
- migrate guard bridge ctx rows to a read-engine-local `scope/2 side` compound key
- keep request timestamp, location class, and risk in decomposed `guard_context` fields

## Verification

- `meson test -C builddir engine engine-intern handle-engine-pair decide fsm-permission-scope daemon-http-decide client-smoke check-private-headers-not-installed --print-errorlogs`
- `meson test -C builddir-audit engine engine-intern handle-engine-pair decide fsm-permission-scope daemon-http-decide client-smoke check-private-headers-not-installed --print-errorlogs`
- `git diff --check`
