### PR TITLE
Wire LoBAC policy audit storage paths

### DIFF
--- a/tests/check-wyrelogd-healthz.sh
+++ b/tests/check-wyrelogd-healthz.sh
@@ -8,12 +8,22 @@ TEMPLATE_DIR=$2
 PYTHON=$3
 EXPECT_AUDIT=${4:-0}
 PORT=$((39000 + $$ % 20000))
+TMPDIR=$(mktemp -d)
+POLICY_DB="$TMPDIR/policy.sqlite"
+AUDIT_DB="$TMPDIR/audit.duckdb"
+AUDIT_ARGS=
+if [ "$EXPECT_AUDIT" = "1" ]; then
+  AUDIT_ARGS="--audit-db $AUDIT_DB"
+fi
 
-"$WYRELOGD" --template-dir "$TEMPLATE_DIR" --listen-port "$PORT" &
+# shellcheck disable=SC2086
+"$WYRELOGD" --template-dir "$TEMPLATE_DIR" --policy-db "$POLICY_DB" \
+  $AUDIT_ARGS --listen-port "$PORT" &
 PID=$!
 
 cleanup() {
   kill "$PID" 2>/dev/null || true
+  rm -rf "$TMPDIR"
 }
 trap cleanup EXIT INT TERM
 
@@ -135,3 +145,4 @@ PY
 kill -TERM "$PID"
 wait "$PID"
 trap - EXIT INT TERM
+rm -rf "$TMPDIR"

--- a/tests/check-wyrelogd-startup-readiness.sh
+++ b/tests/check-wyrelogd-startup-readiness.sh
@@ -10,6 +10,7 @@ PORT=$((20000 + $$ % 15000))
 TMPDIR=$(mktemp -d)
 PID=
 RC_FILE="$TMPDIR/daemon.rc"
+POLICY_DB="$TMPDIR/policy.sqlite"
 
 cleanup() {
   if [ -n "$PID" ]; then
@@ -41,14 +42,16 @@ for rel in ("decision.dl", "lobac/decision.dl"):
     path.write_text(text.replace(old, new))
 PY
 
-if "$WYRELOGD" --template-dir "$TMPDIR/access" --check; then
+if "$WYRELOGD" --template-dir "$TMPDIR/access" --policy-db "$POLICY_DB" \
+    --check; then
   echo "readiness fixture unexpectedly passed --check" >&2
   exit 1
 fi
 
 (
   set +e
-  "$WYRELOGD" --template-dir "$TMPDIR/access" --listen-port "$PORT"
+  "$WYRELOGD" --template-dir "$TMPDIR/access" --policy-db "$POLICY_DB" \
+    --listen-port "$PORT"
   rc=$?
   printf '%s\n' "$rc" > "$RC_FILE"
   exit "$rc"

--- a/tests/test-client-smoke.c
+++ b/tests/test-client-smoke.c
@@ -18,6 +18,7 @@ typedef struct
   gchar *last_perm;
   gchar *last_session_token;
   gchar *last_password;
+  gchar *last_skip_mfa;
   gchar *last_guard_timestamp;
   gchar *last_guard_loc_class;
   gchar *last_guard_risk;
@@ -62,6 +63,7 @@ test_http_server_handler (SoupServer *server, SoupServerMessage *msg,
   g_free (http->last_perm);
   g_free (http->last_session_token);
   g_free (http->last_password);
+  g_free (http->last_skip_mfa);
   g_free (http->last_guard_timestamp);
   g_free (http->last_guard_loc_class);
   g_free (http->last_guard_risk);
@@ -82,6 +84,8 @@ test_http_server_handler (SoupServer *server, SoupServerMessage *msg,
           "session_token")) : NULL;
   http->last_password =
       query != NULL ? g_strdup (g_hash_table_lookup (query, "password")) : NULL;
+  http->last_skip_mfa =
+      query != NULL ? g_strdup (g_hash_table_lookup (query, "skip_mfa")) : NULL;
   http->last_guard_timestamp =
       query != NULL ? g_strdup (g_hash_table_lookup (query,
           "guard_timestamp")) : NULL;
@@ -200,6 +204,12 @@ main (void)
     return 40;
   if (wyl_client_login (local_client, "alice", "secret") != WYRELOG_E_INVALID)
     return 41;
+  if (wyl_client_login_skip_mfa (NULL, "alice") != WYRELOG_E_INVALID)
+    return 143;
+  if (wyl_client_login_skip_mfa (local_client, NULL) != WYRELOG_E_INVALID)
+    return 144;
+  if (wyl_client_login_skip_mfa (local_client, "") != WYRELOG_E_INVALID)
+    return 145;
 
   http.body = "{\"session_token\":\"session-1\",\"username\":\"alice\","
       "\"principal_state\":\"mfa_required\",\"session_state\":\"active\"}";
@@ -213,6 +223,8 @@ main (void)
     return 45;
   if (http.last_password != NULL)
     return 46;
+  if (http.last_skip_mfa != NULL)
+    return 146;
   g_autofree gchar *client_session_token =
       wyl_client_dup_session_token (local_client);
   g_autofree gchar *client_username = wyl_client_dup_username (local_client);
@@ -225,6 +237,33 @@ main (void)
       g_strcmp0 (client_principal_state, "mfa_required") != 0 ||
       g_strcmp0 (client_session_state, "active") != 0)
     return 138;
+
+  http.body = "{\"session_token\":\"session-2\",\"username\":\"alice\","
+      "\"principal_state\":\"authenticated\",\"session_state\":\"active\"}";
+  if (wyl_client_login_skip_mfa (local_client, "alice") != WYRELOG_E_OK)
+    return 147;
+  if (g_strcmp0 (http.last_method, "POST") != 0)
+    return 148;
+  if (g_strcmp0 (http.last_path, "/auth/login") != 0)
+    return 149;
+  if (g_strcmp0 (http.last_user, "alice") != 0)
+    return 150;
+  if (g_strcmp0 (http.last_skip_mfa, "true") != 0)
+    return 151;
+  g_clear_pointer (&client_session_token, g_free);
+  g_clear_pointer (&client_username, g_free);
+  g_clear_pointer (&client_principal_state, g_free);
+  g_clear_pointer (&client_session_state, g_free);
+  client_session_token = wyl_client_dup_session_token (local_client);
+  client_username = wyl_client_dup_username (local_client);
+  client_principal_state = wyl_client_dup_principal_state (local_client);
+  client_session_state = wyl_client_dup_session_state (local_client);
+  if (g_strcmp0 (client_session_token, "session-2") != 0 ||
+      g_strcmp0 (client_username, "alice") != 0 ||
+      g_strcmp0 (client_principal_state, "authenticated") != 0 ||
+      g_strcmp0 (client_session_state, "active") != 0)
+    return 152;
+
   if (wyl_client_mfa_verify (local_client, NULL) == WYRELOG_E_OK)
     return 140;
   if (wyl_client_mfa_verify (local_client, "") == WYRELOG_E_OK)
@@ -425,6 +464,7 @@ main (void)
   g_clear_pointer (&http.last_perm, g_free);
   g_clear_pointer (&http.last_session_token, g_free);
   g_clear_pointer (&http.last_password, g_free);
+  g_clear_pointer (&http.last_skip_mfa, g_free);
   g_clear_pointer (&http.last_guard_timestamp, g_free);
   g_clear_pointer (&http.last_guard_loc_class, g_free);
   g_clear_pointer (&http.last_guard_risk, g_free);

--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -373,7 +373,8 @@ extract_json_string (const gchar *body, const gchar *name)
 }
 
 static gint
-check_raw_login_contract (SoupServer *server, const gchar *base_url)
+check_raw_login_contract (SoupServer *server, WylHandle *handle,
+    const gchar *base_url)
 {
   g_autoptr (SoupSession) session = soup_session_new ();
   guint status = 0;
@@ -405,17 +406,51 @@ check_raw_login_contract (SoupServer *server, const gchar *base_url)
       "username=login-user&skip_mfa=true", &status, &body);
   if (rc != 0)
     return rc;
-  if (status != 400 || strstr (body, "\"invalid_login_request\"") == NULL)
+  if (status != 403 || strstr (body, "\"login_denied\"") == NULL)
     return 473;
+  g_clear_pointer (&body, g_free);
+
+  rc = send_raw_login (session, "POST", base_url,
+      "username=login-user&skip_mfa=false", &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 200 ||
+      strstr (body, "\"session_token\":\"") == NULL ||
+      strstr (body, "\"principal_state\":\"mfa_required\"") == NULL)
+    return 474;
+  g_clear_pointer (&body, g_free);
+
+  rc = send_raw_login (session, "POST", base_url,
+      "username=login-user&skip_mfa=maybe", &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 400 || strstr (body, "\"invalid_login_request\"") == NULL)
+    return 481;
+  g_clear_pointer (&body, g_free);
+
+  wyl_handle_set_login_skip_mfa_allowed (handle, TRUE);
+
+  rc = send_raw_login (session, "POST", base_url,
+      "username=login-user&skip_mfa=true", &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 200 ||
+      strstr (body, "\"session_token\":\"") == NULL ||
+      strstr (body, "\"principal_state\":\"authenticated\"") == NULL)
+    return 482;
   g_clear_pointer (&body, g_free);
 
   rc = send_raw_login (session, "POST", base_url,
       "username=login-user&skip_mfa=1", &status, &body);
   if (rc != 0)
     return rc;
-  if (status != 400 || strstr (body, "\"invalid_login_request\"") == NULL)
-    return 474;
+  if (status != 200 ||
+      strstr (body, "\"session_token\":\"") == NULL ||
+      strstr (body, "\"principal_state\":\"authenticated\"") == NULL)
+    return 483;
   g_clear_pointer (&body, g_free);
+
+  wyl_handle_set_login_skip_mfa_allowed (handle, FALSE);
 
   rc = send_raw_login (session, "POST", base_url,
       "username=login-user&password=secret", &status, &body);
@@ -568,7 +603,7 @@ main (void)
     return audit_rc;
 #endif
 
-  raw_rc = check_raw_login_contract (http.server, base_url);
+  raw_rc = check_raw_login_contract (http.server, handle, base_url);
   if (raw_rc != 0)
     return raw_rc;
 

--- a/tests/test-login-projection.c
+++ b/tests/test-login-projection.c
@@ -1,8 +1,10 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #include <glib.h>
+#include <glib/gstdio.h>
 #include <sqlite3.h>
 
 #include "wyrelog/wyrelog.h"
+#include "wyrelog/audit/conn-private.h"
 #include "wyrelog/wyl-handle-private.h"
 #include "wyrelog/policy/store-private.h"
 
@@ -24,6 +26,25 @@ policy_count_rows (wyl_policy_store_t *store, const gchar *sql,
   if (ok)
     *out_count = sqlite3_column_int64 (stmt, 0);
   sqlite3_finalize (stmt);
+  return ok;
+}
+
+static gboolean
+runtime_count_rows (WylHandle *handle, const gchar *sql, gint64 *out_count)
+{
+  duckdb_connection conn =
+      wyl_audit_conn_get_connection (wyl_handle_get_audit_conn (handle));
+  duckdb_result result = { 0 };
+
+  if (duckdb_query (conn, sql, &result) != DuckDBSuccess) {
+    duckdb_destroy_result (&result);
+    return FALSE;
+  }
+
+  gboolean ok = duckdb_row_count (&result) == 1;
+  if (ok)
+    *out_count = duckdb_value_int64 (&result, 0, 0);
+  duckdb_destroy_result (&result);
   return ok;
 }
 
@@ -487,6 +508,131 @@ check_skip_mfa_login_projects_authority_state (void)
   return 0;
 }
 
+static gint
+check_handle_reopens_persistent_policy_and_audit_paths (void)
+{
+  static const gchar *username = "projection-persistent-user";
+  static const gchar *perm_id = "wr.projection.persistent.read";
+
+  g_autoptr (GError) error = NULL;
+  g_autofree gchar *dir = g_dir_make_tmp ("wyrelog-persist-XXXXXX", &error);
+  if (dir == NULL)
+    return 110;
+
+  g_autofree gchar *policy_path = g_build_filename (dir, "policy.sqlite", NULL);
+  g_autofree gchar *audit_path = g_build_filename (dir, "audit.duckdb", NULL);
+  g_autofree gchar *session_id = NULL;
+  g_autofree gchar *audit_id = NULL;
+  gint64 audit_created_at_us = -1;
+
+  {
+    g_autoptr (WylHandle) handle = NULL;
+    WylHandleOpenOptions opts = {
+      .template_dir = WYL_TEST_TEMPLATE_DIR,
+      .policy_store_path = policy_path,
+      .audit_store_path = audit_path,
+    };
+    if (wyl_handle_open_with_options (&opts, &handle) != WYRELOG_E_OK)
+      return 111;
+    wyl_handle_set_login_skip_mfa_allowed (handle, TRUE);
+
+    g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
+    wyl_login_req_set_username (login, username);
+    wyl_login_req_set_skip_mfa (login, TRUE);
+
+    g_autoptr (WylSession) session = NULL;
+    if (wyl_session_login (handle, login, &session) != WYRELOG_E_OK)
+      return 112;
+    if (session == NULL)
+      return 113;
+    session_id = wyl_session_dup_id_string (session);
+    if (session_id == NULL)
+      return 114;
+
+    wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+    if (wyl_policy_store_upsert_permission (store, perm_id,
+            "persistent projection read", "basic") != WYRELOG_E_OK)
+      return 115;
+    if (wyl_policy_store_grant_direct_permission (store, username, perm_id,
+            session_id) != WYRELOG_E_OK)
+      return 116;
+    if (wyl_handle_reload_engine_pair (handle) != WYRELOG_E_OK)
+      return 117;
+    if (!decide_allows (handle, username, perm_id, session_id))
+      return 118;
+
+    if (!policy_select_text_params (store,
+            "SELECT id FROM audit_events "
+            "WHERE subject_id = ? AND action = 'principal_state' "
+            "AND resource_id = 'authenticated' "
+            "AND deny_reason = 'login_skip_mfa';", &username, 1, &audit_id))
+      return 119;
+    const gchar *audit_param[] = { audit_id };
+    if (!policy_select_int64_params (store,
+            "SELECT created_at_us FROM audit_events WHERE id = ?;",
+            audit_param, G_N_ELEMENTS (audit_param), &audit_created_at_us))
+      return 120;
+
+    gint64 runtime_count = -1;
+    if (!runtime_count_rows (handle,
+            "SELECT COUNT(*) FROM audit_events "
+            "WHERE action = 'principal_state' "
+            "AND subject_id = 'projection-persistent-user';", &runtime_count))
+      return 121;
+    if (runtime_count != 1)
+      return 122;
+  }
+
+  {
+    g_autoptr (WylHandle) handle = NULL;
+    WylHandleOpenOptions opts = {
+      .template_dir = WYL_TEST_TEMPLATE_DIR,
+      .policy_store_path = policy_path,
+      .audit_store_path = audit_path,
+    };
+    if (wyl_handle_open_with_options (&opts, &handle) != WYRELOG_E_OK)
+      return 123;
+
+    if (!decide_allows (handle, username, perm_id, session_id))
+      return 124;
+    if (!engine_contains_symbol_row2 (handle, "principal_state", username,
+            "authenticated"))
+      return 125;
+    const gchar *session_param[] = { session_id };
+    gint64 state_count = -1;
+    if (!policy_count_rows_params (wyl_handle_get_policy_store (handle),
+            "SELECT COUNT(*) FROM session_states "
+            "WHERE session_id = ? AND state = 'active';",
+            session_param, G_N_ELEMENTS (session_param), &state_count))
+      return 126;
+    if (state_count != 1)
+      return 132;
+    if (!engine_contains_audit_event (handle, audit_id, audit_created_at_us,
+            "allow"))
+      return 127;
+    if (!engine_contains_audit_attr (handle, "audit_event_subject", audit_id,
+            username))
+      return 128;
+    if (!engine_contains_audit_attr (handle, "audit_event_action", audit_id,
+            "principal_state"))
+      return 129;
+
+    gint64 runtime_count = -1;
+    if (!runtime_count_rows (handle,
+            "SELECT COUNT(*) FROM audit_events "
+            "WHERE action = 'principal_state' "
+            "AND subject_id = 'projection-persistent-user';", &runtime_count))
+      return 130;
+    if (runtime_count != 1)
+      return 131;
+  }
+
+  g_remove (audit_path);
+  g_remove (policy_path);
+  g_rmdir (dir);
+  return 0;
+}
+
 int
 main (void)
 {
@@ -499,6 +645,8 @@ main (void)
   if ((rc = check_anonymous_login_reload_failure_keeps_session_state ()) != 0)
     return rc;
   if ((rc = check_skip_mfa_login_projects_authority_state ()) != 0)
+    return rc;
+  if ((rc = check_handle_reopens_persistent_policy_and_audit_paths ()) != 0)
     return rc;
   return 0;
 }

--- a/wyrelog/client.h
+++ b/wyrelog/client.h
@@ -37,6 +37,12 @@ gchar *wyl_client_dup_base_url (const WylClient * client);
 /* Authentication */
 wyrelog_error_t wyl_client_login (WylClient * client,
     const gchar * username, const gchar * password);
+/*
+ * Requests a daemon-side skip-MFA login. The daemon remains authoritative and
+ * may deny this request according to its deployment mode and ingress policy.
+ */
+wyrelog_error_t wyl_client_login_skip_mfa (WylClient * client,
+    const gchar * username);
 gchar *wyl_client_dup_session_token (const WylClient * client);
 gchar *wyl_client_dup_username (const WylClient * client);
 gchar *wyl_client_dup_principal_state (const WylClient * client);

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -280,15 +280,22 @@ login_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
     set_json_error (msg, 400, "invalid_login_request");
     return;
   }
+  gboolean skip_mfa_requested = FALSE;
   if (skip_mfa != NULL) {
-    set_json_error (msg, 400, "invalid_login_request");
-    return;
+    if (g_strcmp0 (skip_mfa, "true") == 0 || g_strcmp0 (skip_mfa, "1") == 0)
+      skip_mfa_requested = TRUE;
+    else if (g_strcmp0 (skip_mfa, "false") != 0
+        && g_strcmp0 (skip_mfa, "0") != 0) {
+      set_json_error (msg, 400, "invalid_login_request");
+      return;
+    }
   }
 
   WylDaemonHttpContext *ctx = user_data;
   WylHandle *handle = ctx->handle;
   g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
   wyl_login_req_set_username (login, username);
+  wyl_login_req_set_skip_mfa (login, skip_mfa_requested);
 
   g_autoptr (WylSession) session = NULL;
   wyrelog_error_t rc = wyl_session_login (handle, login, &session);
@@ -315,8 +322,8 @@ login_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
     return;
   }
 
-  g_autofree gchar *body =
-      build_login_json (session_token, username, "mfa_required");
+  g_autofree gchar *body = build_login_json (session_token, username,
+      skip_mfa_requested ? "authenticated" : "mfa_required");
   soup_server_message_set_status (msg, 200, NULL);
   soup_server_message_set_response (msg, "application/json",
       SOUP_MEMORY_COPY, body, strlen (body));

--- a/wyrelog/daemon/options.c
+++ b/wyrelog/daemon/options.c
@@ -8,6 +8,12 @@ wyl_daemon_parse_options (gint *argc, gchar ***argv, WylDaemonOptions *opts,
   GOptionEntry entries[] = {
     {"template-dir", 0, 0, G_OPTION_ARG_STRING, &opts->template_dir,
         "Access policy template directory", "DIR"},
+    {"policy-db", 0, 0, G_OPTION_ARG_STRING, &opts->policy_store_path,
+        "Policy authority database path", "PATH"},
+#ifdef WYL_HAS_AUDIT
+    {"audit-db", 0, 0, G_OPTION_ARG_STRING, &opts->audit_store_path,
+        "Runtime audit sink database path", "PATH"},
+#endif
 #ifdef WYL_HAS_DAEMON_HTTP
     {"listen-port", 0, 0, G_OPTION_ARG_INT, &opts->listen_port,
         "HTTP listen port", "PORT"},

--- a/wyrelog/daemon/options.h
+++ b/wyrelog/daemon/options.h
@@ -6,6 +6,10 @@
 typedef struct
 {
   const gchar *template_dir;
+  const gchar *policy_store_path;
+#ifdef WYL_HAS_AUDIT
+  const gchar *audit_store_path;
+#endif
   gint listen_port;
   gboolean check_only;
   gboolean show_version;

--- a/wyrelog/daemon/runtime.c
+++ b/wyrelog/daemon/runtime.c
@@ -8,6 +8,33 @@
 #include "daemon/http.h"
 #include "daemon/signals.h"
 #include "wyrelog/wyrelog.h"
+#include "wyrelog/wyl-handle-private.h"
+
+static wyrelog_error_t
+open_runtime_handle (const WylDaemonOptions *opts, WylHandle **out_handle)
+{
+  WylHandleOpenOptions open_opts = {
+    .template_dir = opts->template_dir,
+    .policy_store_path = opts->policy_store_path,
+#ifdef WYL_HAS_AUDIT
+    .audit_store_path = opts->audit_store_path,
+#endif
+  };
+
+  return wyl_handle_open_with_options (&open_opts, out_handle);
+}
+
+static wyrelog_error_t
+open_readiness_handle (const WylDaemonOptions *opts, WylHandle **out_handle)
+{
+  /* Readiness probes intentionally run against scratch stores: the checks
+   * exercise mutation paths and must not seed configured authority data. */
+  WylHandleOpenOptions open_opts = {
+    .template_dir = opts->template_dir,
+  };
+
+  return wyl_handle_open_with_options (&open_opts, out_handle);
+}
 
 int
 wyl_daemon_run_runtime (const WylDaemonOptions *opts)
@@ -23,7 +50,7 @@ wyl_daemon_run_runtime (const WylDaemonOptions *opts)
 
     g_autoptr (WylHandle) readiness_handle = NULL;
     wyrelog_error_t readiness_rc =
-        wyl_init (opts->template_dir, &readiness_handle);
+        open_readiness_handle (opts, &readiness_handle);
     if (readiness_rc != WYRELOG_E_OK) {
       if (wyl_daemon_early_signal_received ())
         return 0;
@@ -40,7 +67,9 @@ wyl_daemon_run_runtime (const WylDaemonOptions *opts)
   }
 
   g_autoptr (WylHandle) handle = NULL;
-  wyrelog_error_t rc = wyl_init (opts->template_dir, &handle);
+  wyrelog_error_t rc = opts->check_only ?
+      open_readiness_handle (opts, &handle) : open_runtime_handle (opts,
+      &handle);
   if (rc != WYRELOG_E_OK) {
     g_printerr ("wyrelogd: init failed: %s\n", wyrelog_error_string (rc));
     return 1;

--- a/wyrelog/wyl-client.c
+++ b/wyrelog/wyl-client.c
@@ -147,12 +147,14 @@ wyl_client_send_message (WylClient *client, SoupMessage *message,
   return WYRELOG_E_OK;
 }
 
-wyrelog_error_t
-wyl_client_login (WylClient *client, const gchar *username,
-    const gchar *password)
+static wyrelog_error_t
+client_login_internal (WylClient *client, const gchar *username,
+    const gchar *password, gboolean skip_mfa)
 {
   if (client == NULL || !WYL_IS_CLIENT (client) || username == NULL ||
       username[0] == '\0')
+    return WYRELOG_E_INVALID;
+  if (skip_mfa && password != NULL)
     return WYRELOG_E_INVALID;
   if (password != NULL && password[0] != '\0')
     return WYRELOG_E_INVALID;
@@ -165,9 +167,14 @@ wyl_client_login (WylClient *client, const gchar *username,
 
   g_autofree gchar *escaped_username =
       g_uri_escape_string (username, NULL, TRUE);
-  g_autofree gchar *uri =
-      g_strdup_printf ("%s/auth/login?username=%s", base_url,
-      escaped_username);
+  g_autofree gchar *uri = NULL;
+  if (skip_mfa) {
+    uri = g_strdup_printf ("%s/auth/login?username=%s&skip_mfa=true",
+        base_url, escaped_username);
+  } else {
+    uri = g_strdup_printf ("%s/auth/login?username=%s", base_url,
+        escaped_username);
+  }
 
   g_autoptr (SoupMessage) message = soup_message_new ("POST", uri);
   if (message == NULL)
@@ -198,6 +205,19 @@ wyl_client_login (WylClient *client, const gchar *username,
   client->principal_state = g_steal_pointer (&principal_state);
   client->session_state = g_steal_pointer (&session_state);
   return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
+wyl_client_login (WylClient *client, const gchar *username,
+    const gchar *password)
+{
+  return client_login_internal (client, username, password, FALSE);
+}
+
+wyrelog_error_t
+wyl_client_login_skip_mfa (WylClient *client, const gchar *username)
+{
+  return client_login_internal (client, username, NULL, TRUE);
 }
 
 wyrelog_error_t

--- a/wyrelog/wyl-handle-private.h
+++ b/wyrelog/wyl-handle-private.h
@@ -13,6 +13,24 @@
 
 G_BEGIN_DECLS;
 
+typedef struct
+{
+  const gchar *template_dir;
+  const gchar *policy_store_path;
+#ifdef WYL_HAS_AUDIT
+  const gchar *audit_store_path;
+#endif
+} WylHandleOpenOptions;
+
+/*
+ * Opens a handle with private storage paths. Public wyl_init() keeps its
+ * historical in-memory store contract and delegates here with NULL paths.
+ * A non-NULL template_dir opens the read/delta engine pair after the policy
+ * store is ready, then replays durable rows into wirelog facts.
+ */
+wyrelog_error_t wyl_handle_open_with_options (const WylHandleOpenOptions *
+    opts, WylHandle ** out_handle);
+
 #ifdef WYL_HAS_AUDIT
 /*
  * Returns the borrowed audit connection owned by |self|. Lifetime

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -190,6 +190,17 @@ wyl_handle_seed_session_transitions (WylHandle *self)
 wyrelog_error_t
 wyl_init (const gchar *config_path, WylHandle **out_handle)
 {
+  WylHandleOpenOptions opts = {
+    .template_dir = config_path,
+  };
+
+  return wyl_handle_open_with_options (&opts, out_handle);
+}
+
+wyrelog_error_t
+wyl_handle_open_with_options (const WylHandleOpenOptions *opts,
+    WylHandle **out_handle)
+{
   /* Eagerly initialise the log subsystem before any other library code
    * runs so that log sites in boot phases see the correct thresholds
    * and file sink from the very first message. */
@@ -199,9 +210,13 @@ wyl_init (const gchar *config_path, WylHandle **out_handle)
     return WYRELOG_E_INVALID;
   *out_handle = NULL;
 
+  if (opts == NULL)
+    return WYRELOG_E_INVALID;
+
   WylHandle *self = g_object_new (WYL_TYPE_HANDLE, NULL);
 
-  wyrelog_error_t rc = wyl_policy_store_open (NULL, &self->policy_store);
+  wyrelog_error_t rc =
+      wyl_policy_store_open (opts->policy_store_path, &self->policy_store);
   if (rc != WYRELOG_E_OK) {
     g_object_unref (self);
     return rc;
@@ -212,17 +227,18 @@ wyl_init (const gchar *config_path, WylHandle **out_handle)
     return rc;
   }
 
-  if (config_path != NULL) {
-    rc = wyl_handle_open_engine_pair (self, config_path);
+  if (opts->template_dir != NULL) {
+    rc = wyl_handle_open_engine_pair (self, opts->template_dir);
     if (rc != WYRELOG_E_OK) {
       g_object_unref (self);
       return rc;
     }
   }
 #ifdef WYL_HAS_AUDIT
-  /* Open an in-memory audit database and create the audit_events
-   * schema. Audit persistence is not wired to config_path yet. */
-  rc = wyl_audit_conn_open (NULL, &self->audit_conn);
+  /* Open the runtime audit sink and replay durable Policy DB audit rows into
+   * it. Public wyl_init() passes NULL and therefore keeps the sink in-memory;
+   * private daemon/test callers may pass a file path through opts. */
+  rc = wyl_audit_conn_open (opts->audit_store_path, &self->audit_conn);
   if (rc != WYRELOG_E_OK) {
     g_object_unref (self);
     return rc;


### PR DESCRIPTION
## Summary

- add private handle open options for file-backed Policy DB and audit sink paths
- route daemon runtime storage options through the private initializer
- connect HTTP and client skip-MFA login requests to the guarded login path

## Validation

- meson test -C builddir policy-store decide handle-engine-pair daemon-http-decide client-smoke wyrelogd-check wyrelogd-healthz wyrelogd-startup-readiness check-public-headers-no-novelty-tokens check-private-headers-not-installed --print-errorlogs
- meson test -C builddir-audit policy-store audit-conn audit-emit daemon-checks login-projection daemon-delta decide handle-engine-pair daemon-http-decide client-smoke client-audit-daemon wyrelogd-check wyrelogd-healthz wyrelogd-startup-readiness check-public-headers-no-novelty-tokens check-private-headers-not-installed --print-errorlogs
