### PR TITLE
Gate audit queries with LoBAC policy

### DIFF
--- a/tests/check-wyrelogd-healthz.sh
+++ b/tests/check-wyrelogd-healthz.sh
@@ -39,15 +39,15 @@ expect_audit = sys.argv[2] == "1"
 base = f"http://127.0.0.1:{port}"
 last_error = None
 
-def invalid_filter_is_rejected():
+def audit_endpoint_requires_auth():
     try:
         urllib.request.urlopen(
             f"{base}/audit/events?filter=action%28%29",
             timeout=1,
         ).read()
-        return False
+        return not expect_audit
     except urllib.error.HTTPError as exc:
-        return exc.code == 400
+        return exc.code == 401 if expect_audit else False
 
 def audit_events_match_startup_readiness(payload):
     events = json.loads(payload)
@@ -97,41 +97,26 @@ def decide_denies_unseeded_user():
         and "deny_origin" in body
     )
 
-def decide_audit_event_is_visible():
-    if not expect_audit:
-        return True
-    payload = urllib.request.urlopen(
-        f"{base}/audit/events?filter=action%28%22wr.audit.read%22%29",
-        timeout=1,
-    ).read()
-    events = json.loads(payload)
-    return any(
-        event.get("subject_id") == "healthz-user"
-        and event.get("action") == "wr.audit.read"
-        and event.get("resource_id") == "healthz-scope"
-        and event.get("decision") == 0
-        for event in events
-    )
-
 for _ in range(50):
     try:
         health = urllib.request.urlopen(f"{base}/healthz", timeout=1).read()
-        events = urllib.request.urlopen(
-            f"{base}/audit/events?filter=decision%3Ddeny",
-            timeout=1,
-        ).read()
-        if health != b"ok\n" or not audit_events_match_startup_readiness(
-                events):
+        if health != b"ok\n":
             sys.exit(1)
+        if expect_audit:
+            if not audit_endpoint_requires_auth():
+                sys.exit(1)
+        else:
+            events = urllib.request.urlopen(
+                f"{base}/audit/events?filter=decision%3Ddeny",
+                timeout=1,
+            ).read()
+            if not audit_events_match_startup_readiness(events):
+                sys.exit(1)
         if not invalid_decide_is_rejected():
             sys.exit(1)
         if not decide_requires_post():
             sys.exit(1)
         if not decide_denies_unseeded_user():
-            sys.exit(1)
-        if not decide_audit_event_is_visible():
-            sys.exit(1)
-        if expect_audit and not invalid_filter_is_rejected():
             sys.exit(1)
         sys.exit(0)
     except Exception as exc:

--- a/tests/test-client-audit-daemon.c
+++ b/tests/test-client-audit-daemon.c
@@ -18,6 +18,11 @@ main (int argc, char **argv)
     return 3;
 
   gboolean has_next = TRUE;
+#ifdef WYL_TEST_HAS_AUDIT
+  if (wyl_audit_iter_next (iter, &has_next) != WYRELOG_E_IO)
+    return 4;
+  return 0;
+#else
   if (wyl_audit_iter_next (iter, &has_next) != WYRELOG_E_OK)
     return 4;
   if (has_next)
@@ -28,30 +33,6 @@ main (int argc, char **argv)
     return 6;
   if (has_next)
     return 7;
-
-#ifdef WYL_TEST_HAS_AUDIT
-  g_autoptr (WylAuditIter) start_iter = NULL;
-  if (wyl_client_audit_query (client, "action(\"daemon_start\")", &start_iter)
-      != WYRELOG_E_OK)
-    return 8;
-
-  has_next = FALSE;
-  if (wyl_audit_iter_next (start_iter, &has_next) != WYRELOG_E_OK)
-    return 9;
-  if (!has_next)
-    return 10;
-  g_autoptr (WylAuditEvent) start_event = wyl_audit_iter_ref_event (start_iter);
-  if (start_event == NULL)
-    return 13;
-  if (g_strcmp0 (wyl_audit_event_get_action (start_event), "daemon_start")
-      != 0)
-    return 14;
-
-  has_next = TRUE;
-  if (wyl_audit_iter_next (start_iter, &has_next) != WYRELOG_E_OK)
-    return 11;
-  if (has_next)
-    return 12;
 #endif
 
   return 0;

--- a/tests/test-client-smoke.c
+++ b/tests/test-client-smoke.c
@@ -210,6 +210,10 @@ main (void)
     return 144;
   if (wyl_client_login_skip_mfa (local_client, "") != WYRELOG_E_INVALID)
     return 145;
+  g_autoptr (WylAuditIter) missing_login_iter = NULL;
+  if (wyl_client_audit_query_with_guard_context (local_client, NULL, 123,
+          "public", 69, &missing_login_iter) != WYRELOG_E_INVALID)
+    return 153;
 
   http.body = "{\"session_token\":\"session-1\",\"username\":\"alice\","
       "\"principal_state\":\"mfa_required\",\"session_state\":\"active\"}";
@@ -263,6 +267,45 @@ main (void)
       g_strcmp0 (client_principal_state, "authenticated") != 0 ||
       g_strcmp0 (client_session_state, "active") != 0)
     return 152;
+
+  g_autoptr (WylAuditIter) guarded_audit_iter = NULL;
+  if (wyl_client_audit_query_with_guard_context (local_client,
+          "decision=deny", 123, "public", 69, &guarded_audit_iter)
+      != WYRELOG_E_OK)
+    return 154;
+  g_autoptr (WylAuditIter) invalid_guard_iter = NULL;
+  if (wyl_client_audit_query_with_guard_context (local_client, NULL, 123,
+          "unknown", 69, &invalid_guard_iter) != WYRELOG_E_INVALID)
+    return 161;
+
+  http.body = "{\"session_token\":\"session-3\",\"username\":\"alice\","
+      "\"principal_state\":\"authenticated\",\"session_state\":\"active\"}";
+  if (wyl_client_login_skip_mfa (local_client, "alice") != WYRELOG_E_OK)
+    return 162;
+
+  g_autofree gchar *guarded_audit_uri =
+      wyl_audit_iter_dup_request_uri (guarded_audit_iter);
+  if (strstr (guarded_audit_uri, "/audit/events?") == NULL ||
+      strstr (guarded_audit_uri, "session_token=session-2") == NULL ||
+      strstr (guarded_audit_uri, "guard_timestamp=123") == NULL ||
+      strstr (guarded_audit_uri, "guard_loc_class=public") == NULL ||
+      strstr (guarded_audit_uri, "guard_risk=69") == NULL ||
+      strstr (guarded_audit_uri, "filter=decision%3Ddeny") == NULL)
+    return 155;
+  g_autoptr (SoupMessage) guarded_audit_message =
+      wyl_audit_iter_new_request_message (guarded_audit_iter);
+  g_clear_pointer (&body, g_bytes_unref);
+  if (wyl_client_send_message (local_client, guarded_audit_message, &body) !=
+      WYRELOG_E_OK)
+    return 156;
+  if (g_strcmp0 (http.last_session_token, "session-2") != 0)
+    return 157;
+  if (g_strcmp0 (http.last_guard_timestamp, "123") != 0)
+    return 158;
+  if (g_strcmp0 (http.last_guard_loc_class, "public") != 0)
+    return 159;
+  if (g_strcmp0 (http.last_guard_risk, "69") != 0)
+    return 160;
 
   if (wyl_client_mfa_verify (local_client, NULL) == WYRELOG_E_OK)
     return 140;

--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -491,13 +491,138 @@ check_raw_login_contract (SoupServer *server, WylHandle *handle,
 }
 
 #ifdef WYL_HAS_AUDIT
+static wyrelog_error_t
+grant_audit_read (WylHandle *handle, const gchar *subject_id,
+    const gchar *scope)
+{
+  wyrelog_error_t rc =
+      insert_symbol_row2 (handle, "role_permission", "wr.http-audit-role",
+      "wr.audit.read");
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = insert_symbol_row3 (handle, "member_of", subject_id,
+      "wr.http-audit-role", scope);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = insert_symbol_row2 (handle, "principal_state", subject_id,
+      "authenticated");
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = insert_symbol_row2 (handle, "session_state", scope, "active");
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return insert_symbol_row1 (handle, "session_active", "active");
+}
+
+static gchar *
+build_audit_uri (const gchar *base_url, const gchar *query)
+{
+  g_autofree gchar *root = g_strdup (base_url);
+  while (root[0] != '\0' && g_str_has_suffix (root, "/"))
+    root[strlen (root) - 1] = '\0';
+
+  if (query == NULL)
+    return g_strdup_printf ("%s/audit/events", root);
+  return g_strdup_printf ("%s/audit/events?%s", root, query);
+}
+
+static gint
+send_raw_audit (SoupSession *session, const gchar *base_url,
+    const gchar *query, guint *out_status, gchar **out_body)
+{
+  if (out_status == NULL || out_body == NULL)
+    return 90;
+  *out_status = 0;
+  *out_body = NULL;
+
+  g_autofree gchar *uri = build_audit_uri (base_url, query);
+  g_autoptr (SoupMessage) msg = soup_message_new ("GET", uri);
+  if (msg == NULL)
+    return 91;
+
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GBytes) bytes = soup_session_send_and_read (session, msg, NULL,
+      &error);
+  if (bytes == NULL)
+    return 92;
+  gsize size = 0;
+  const gchar *data = g_bytes_get_data (bytes, &size);
+  *out_status = soup_message_get_status (msg);
+  *out_body = g_strndup (data, size);
+  return 0;
+}
+
+static gint
+check_raw_audit_contract (WylClient *client, const gchar *base_url,
+    const gchar *session_token)
+{
+  g_autoptr (SoupSession) session = soup_session_new ();
+  guint status = 0;
+  g_autofree gchar *body = NULL;
+
+  gint rc = send_raw_audit (session, base_url, NULL, &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 401 || strstr (body, "\"audit_auth_required\"") == NULL)
+    return 93;
+
+  g_clear_pointer (&body, g_free);
+  rc = send_raw_audit (session, base_url,
+      "session_token=unknown&guard_timestamp=123&guard_loc_class=public"
+      "&guard_risk=69", &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 401 || strstr (body, "\"audit_auth_required\"") == NULL)
+    return 94;
+
+  g_clear_pointer (&body, g_free);
+  rc = send_raw_audit (session, base_url,
+      "session_token=unknown&guard_timestamp=abc&guard_loc_class=public"
+      "&guard_risk=69", &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 400 || strstr (body, "\"invalid_audit_auth\"") == NULL)
+    return 101;
+
+  g_clear_pointer (&body, g_free);
+  g_autofree gchar *malformed =
+      g_strdup_printf ("session_token=%s&guard_timestamp=abc"
+      "&guard_loc_class=public&guard_risk=69", session_token);
+  rc = send_raw_audit (session, base_url, malformed, &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 400 || strstr (body, "\"invalid_audit_auth\"") == NULL)
+    return 95;
+
+  g_clear_pointer (&body, g_free);
+  g_autofree gchar *denied =
+      g_strdup_printf ("session_token=%s&guard_timestamp=123"
+      "&guard_loc_class=public&guard_risk=70", session_token);
+  rc = send_raw_audit (session, base_url, denied, &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 403 || strstr (body, "\"audit_denied\"") == NULL)
+    return 98;
+
+  g_autoptr (WylAuditIter) invalid_filter = NULL;
+  if (wyl_client_audit_query_with_guard_context (client, "action()", 123,
+          "public", 69, &invalid_filter) != WYRELOG_E_OK)
+    return 99;
+  gboolean has_next = FALSE;
+  if (wyl_audit_iter_next (invalid_filter, &has_next) != WYRELOG_E_IO)
+    return 100;
+
+  return 0;
+}
+
 static gint
 check_audit_event_present (WylClient *client, const gchar *filter,
     const gchar *subject, const gchar *action, const gchar *resource,
     wyl_decision_t decision, const gchar *deny_reason, const gchar *deny_origin)
 {
   g_autoptr (WylAuditIter) iter = NULL;
-  if (wyl_client_audit_query (client, filter, &iter) != WYRELOG_E_OK)
+  if (wyl_client_audit_query_with_guard_context (client, filter, 123,
+          "public", 69, &iter) != WYRELOG_E_OK)
     return 80;
 
   while (TRUE) {
@@ -580,6 +705,22 @@ main (void)
     return 13;
 
 #ifdef WYL_HAS_AUDIT
+  wyl_handle_set_login_skip_mfa_allowed (handle, TRUE);
+  if (wyl_client_login_skip_mfa (client, "http-audit-user") != WYRELOG_E_OK)
+    return 84;
+  g_autofree gchar *audit_session_token = wyl_client_dup_session_token (client);
+  if (audit_session_token == NULL)
+    return 85;
+  if (grant_audit_read (handle, "http-audit-user", audit_session_token) !=
+      WYRELOG_E_OK)
+    return 86;
+  wyl_handle_set_login_skip_mfa_allowed (handle, FALSE);
+
+  gint audit_auth_rc = check_raw_audit_contract (client, base_url,
+      audit_session_token);
+  if (audit_auth_rc != 0)
+    return audit_auth_rc;
+
   gint audit_rc = check_audit_event_present (client,
       "action(\"http.not_armed\")",
       "http-deny-user", "http.not_armed", "http-deny-scope",

--- a/wyrelog/audit/iter.c
+++ b/wyrelog/audit/iter.c
@@ -2,6 +2,7 @@
 #include "wyrelog/audit/iter-private.h"
 #include "wyrelog/client.h"
 #include "wyrelog/wyl-client-private.h"
+#include "wyrelog/wyl-permission-scope-private.h"
 
 #include <string.h>
 
@@ -12,6 +13,11 @@ struct _WylAuditIter
   GObject parent_instance;
   WylClient *client;
   gchar *query_filter;
+  gchar *session_token;
+  gboolean has_guard_context;
+  gint64 guard_timestamp;
+  gchar *guard_loc_class;
+  gint64 guard_risk;
   GPtrArray *events;
   guint event_index;
   WylAuditEvent *current_event;
@@ -29,6 +35,8 @@ wyl_audit_iter_finalize (GObject *object)
   g_clear_pointer (&self->events, g_ptr_array_unref);
   g_clear_object (&self->current_event);
   g_free (self->query_filter);
+  g_free (self->session_token);
+  g_free (self->guard_loc_class);
 
   G_OBJECT_CLASS (wyl_audit_iter_parent_class)->finalize (object);
 }
@@ -64,6 +72,36 @@ wyl_client_audit_query (WylClient *client, const gchar *query_filter,
   return WYRELOG_E_OK;
 }
 
+wyrelog_error_t
+wyl_client_audit_query_with_guard_context (WylClient *client,
+    const gchar *query_filter, gint64 guard_timestamp,
+    const gchar *guard_loc_class, gint64 guard_risk, WylAuditIter **out_iter)
+{
+  if (out_iter == NULL)
+    return WYRELOG_E_INVALID;
+  *out_iter = NULL;
+  if (client == NULL || !WYL_IS_CLIENT (client))
+    return WYRELOG_E_INVALID;
+  if (guard_timestamp < 0 || guard_loc_class == NULL || guard_risk < 0 ||
+      guard_risk > 100 || !wyl_guard_loc_class_is_valid (guard_loc_class))
+    return WYRELOG_E_INVALID;
+
+  g_autofree gchar *session_token = wyl_client_dup_session_token (client);
+  if (session_token == NULL || session_token[0] == '\0')
+    return WYRELOG_E_INVALID;
+
+  WylAuditIter *iter = g_object_new (WYL_TYPE_AUDIT_ITER, NULL);
+  iter->client = g_object_ref (client);
+  iter->query_filter = g_strdup (query_filter);
+  iter->session_token = g_steal_pointer (&session_token);
+  iter->has_guard_context = TRUE;
+  iter->guard_timestamp = guard_timestamp;
+  iter->guard_loc_class = g_strdup (guard_loc_class);
+  iter->guard_risk = guard_risk;
+  *out_iter = iter;
+  return WYRELOG_E_OK;
+}
+
 gchar *
 wyl_audit_iter_dup_query_filter (const WylAuditIter *iter)
 {
@@ -80,12 +118,32 @@ wyl_audit_iter_dup_request_uri (const WylAuditIter *iter)
   const gchar *separator = g_str_has_suffix (base_url, "/") ? "" : "/";
   g_autofree gchar *path =
       g_strdup_printf ("%s%saudit/events", base_url, separator);
-  if (iter->query_filter == NULL || iter->query_filter[0] == '\0')
-    return g_steal_pointer (&path);
+  g_autoptr (GString) query = g_string_new (NULL);
+
+  if (iter->has_guard_context) {
+    g_autofree gchar *escaped_session =
+        g_uri_escape_string (iter->session_token, NULL, TRUE);
+    g_autofree gchar *escaped_loc =
+        g_uri_escape_string (iter->guard_loc_class, NULL, TRUE);
+    g_string_append_printf (query,
+        "session_token=%s&guard_timestamp=%" G_GINT64_FORMAT
+        "&guard_loc_class=%s&guard_risk=%" G_GINT64_FORMAT,
+        escaped_session, iter->guard_timestamp, escaped_loc, iter->guard_risk);
+  }
+
+  if (iter->query_filter == NULL || iter->query_filter[0] == '\0') {
+    if (query->len == 0)
+      return g_steal_pointer (&path);
+    return g_strdup_printf ("%s?%s", path, query->str);
+  }
+
+  if (query->len > 0)
+    g_string_append_c (query, '&');
 
   g_autofree gchar *escaped =
       g_uri_escape_string (iter->query_filter, NULL, TRUE);
-  return g_strdup_printf ("%s?filter=%s", path, escaped);
+  g_string_append_printf (query, "filter=%s", escaped);
+  return g_strdup_printf ("%s?%s", path, query->str);
 }
 
 SoupMessage *

--- a/wyrelog/client.h
+++ b/wyrelog/client.h
@@ -64,6 +64,15 @@ wyrelog_error_t wyl_client_decide_with_guard_context (WylClient * client,
 /* Audit query (iterator) */
 wyrelog_error_t wyl_client_audit_query (WylClient * client,
     const gchar * query_filter, WylAuditIter ** out_iter);
+/*
+ * Builds an audit query that carries the current login session token and a
+ * request guard context. Daemons may require this form for guarded audit read
+ * authorization.
+ */
+wyrelog_error_t wyl_client_audit_query_with_guard_context (WylClient * client,
+    const gchar * query_filter,
+    gint64 guard_timestamp,
+    const gchar * guard_loc_class, gint64 guard_risk, WylAuditIter ** out_iter);
 gchar *wyl_audit_iter_dup_query_filter (const WylAuditIter * iter);
 gchar *wyl_audit_iter_dup_request_uri (const WylAuditIter * iter);
 WylAuditEvent *wyl_audit_iter_ref_event (const WylAuditIter * iter);

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -218,14 +218,75 @@ audit_events_handler (SoupServer *server, SoupServerMessage *msg,
 
 #ifdef WYL_HAS_AUDIT
   const gchar *filter = NULL;
+  const gchar *session_token = NULL;
+  const gchar *guard_timestamp = NULL;
+  const gchar *guard_loc_class = NULL;
+  const gchar *guard_risk = NULL;
   if (query != NULL)
     filter = g_hash_table_lookup (query, "filter");
+  if (query != NULL) {
+    session_token = g_hash_table_lookup (query, "session_token");
+    guard_timestamp = g_hash_table_lookup (query, "guard_timestamp");
+    guard_loc_class = g_hash_table_lookup (query, "guard_loc_class");
+    guard_risk = g_hash_table_lookup (query, "guard_risk");
+  }
+  if (session_token == NULL || session_token[0] == '\0') {
+    set_json_error (msg, 401, "audit_auth_required");
+    return;
+  }
+  if (guard_timestamp == NULL || guard_loc_class == NULL || guard_risk == NULL) {
+    set_json_error (msg, 400, "invalid_audit_auth");
+    return;
+  }
+
+  gint64 timestamp = 0;
+  gint64 risk = 0;
+  if (!parse_int64_query_param (guard_timestamp, &timestamp) ||
+      !parse_int64_query_param (guard_risk, &risk) || timestamp < 0 ||
+      risk < 0 || risk > 100 ||
+      !wyl_guard_loc_class_is_valid (guard_loc_class)) {
+    set_json_error (msg, 400, "invalid_audit_auth");
+    return;
+  }
+
+  g_autoptr (WylSession) session =
+      wyl_daemon_http_ref_session (server, session_token);
+  if (session == NULL) {
+    set_json_error (msg, 401, "audit_auth_required");
+    return;
+  }
+
+  g_autofree gchar *username = wyl_session_dup_username (session);
+  if (username == NULL || username[0] == '\0') {
+    set_json_error (msg, 401, "audit_auth_required");
+    return;
+  }
 
   WylDaemonHttpContext *ctx = user_data;
   WylHandle *handle = ctx->handle;
+  g_autoptr (wyl_decide_req_t) req = wyl_decide_req_new ();
+  g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
+  wyl_decide_req_set_subject_id (req, username);
+  wyl_decide_req_set_action (req, "wr.audit.read");
+  wyl_decide_req_set_resource_id (req, session_token);
+  wyl_decide_req_set_guard_context (req, timestamp, guard_loc_class, risk);
+
+  wyrelog_error_t rc = wyl_decide (handle, req, resp);
+  if (rc == WYRELOG_E_INVALID) {
+    set_json_error (msg, 400, "invalid_audit_auth");
+    return;
+  }
+  if (rc != WYRELOG_E_OK) {
+    set_json_error (msg, 500, "audit_auth_failed");
+    return;
+  }
+  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_ALLOW) {
+    set_json_error (msg, 403, "audit_denied");
+    return;
+  }
+
   g_autofree gchar *body = NULL;
-  wyrelog_error_t rc =
-      wyl_audit_conn_query_events_json (wyl_handle_get_audit_conn (handle),
+  rc = wyl_audit_conn_query_events_json (wyl_handle_get_audit_conn (handle),
       filter, &body);
   if (rc == WYRELOG_E_INVALID) {
     const gchar *error_body = "{\"error\":\"invalid_filter\"}";


### PR DESCRIPTION
## Summary

- add a guarded audit query helper that carries the current session token
- require daemon audit reads to pass wr.audit.read with guard context
- update daemon smoke and HTTP tests for the fail-closed audit query contract

## Tests

- meson test -C builddir daemon-http-decide client-audit-daemon wyrelogd-healthz client-smoke check-public-headers-no-novelty-tokens --print-errorlogs
- meson test -C builddir-audit daemon-http-decide client-audit-daemon wyrelogd-healthz client-smoke check-public-headers-no-novelty-tokens --print-errorlogs
