### PR TITLE
Validate Policy DB snapshots before engine reload

### DIFF
--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -2734,6 +2734,64 @@ check_policy_store_direct_audit_write_sod_fails_open (void)
 }
 
 static gint
+check_policy_store_direct_audit_role_admin_sod_fails_open (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 543;
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (wyl_policy_store_upsert_role (store, "wr.service_admin",
+          "service admin") != WYRELOG_E_OK)
+    return 544;
+  if (wyl_policy_store_upsert_permission (store, "wr.audit.read",
+          "audit read", "sensitive") != WYRELOG_E_OK)
+    return 545;
+  if (wyl_policy_store_grant_role_membership (store, "mixed-sod-user",
+          "wr.service_admin", "mixed-scope") != WYRELOG_E_OK)
+    return 546;
+  if (wyl_policy_store_grant_direct_permission (store, "mixed-sod-user",
+          "wr.audit.read", "mixed-scope") != WYRELOG_E_OK)
+    return 547;
+
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_POLICY)
+    return 548;
+  if (wyl_handle_get_read_engine (handle) != NULL)
+    return 549;
+  return wyl_handle_get_delta_engine (handle) == NULL ? 0 : 550;
+}
+
+static gint
+check_policy_store_auditor_role_direct_admin_sod_fails_open (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 551;
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (wyl_policy_store_upsert_role (store, "wr.auditor", "auditor")
+      != WYRELOG_E_OK)
+    return 552;
+  if (wyl_policy_store_upsert_permission (store, "wr.policy.write",
+          "policy write", "critical") != WYRELOG_E_OK)
+    return 553;
+  if (wyl_policy_store_grant_role_membership (store, "mixed-sod-user",
+          "wr.auditor", "mixed-scope") != WYRELOG_E_OK)
+    return 554;
+  if (wyl_policy_store_grant_direct_permission (store, "mixed-sod-user",
+          "wr.policy.write", "mixed-scope") != WYRELOG_E_OK)
+    return 555;
+
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_POLICY)
+    return 556;
+  if (wyl_handle_get_read_engine (handle) != NULL)
+    return 557;
+  return wyl_handle_get_delta_engine (handle) == NULL ? 0 : 558;
+}
+
+static gint
 check_policy_store_audit_facts_reload_failure_preserves_pair (void)
 {
   g_autoptr (WylHandle) handle = NULL;
@@ -2943,6 +3001,11 @@ main (void)
   if ((rc = check_policy_store_direct_permission_sod_fails_reload ()) != 0)
     return rc;
   if ((rc = check_policy_store_direct_audit_write_sod_fails_open ()) != 0)
+    return rc;
+  if ((rc = check_policy_store_direct_audit_role_admin_sod_fails_open ()) != 0)
+    return rc;
+  if ((rc = check_policy_store_auditor_role_direct_admin_sod_fails_open ())
+      != 0)
     return rc;
   if ((rc = check_policy_store_audit_facts_reload_failure_preserves_pair ())
       != 0)

--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -2630,6 +2630,47 @@ check_policy_store_auditor_admin_cross_scope_allows_open (void)
 }
 
 static gint
+check_policy_store_inherited_auditor_admin_membership_fails_open (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 514;
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (wyl_policy_store_upsert_role (store, "wr.service_admin",
+          "service admin") != WYRELOG_E_OK)
+    return 515;
+  if (wyl_policy_store_upsert_role (store, "wr.auditor", "auditor")
+      != WYRELOG_E_OK)
+    return 516;
+  if (wyl_policy_store_upsert_role (store, "site.admin", "site admin")
+      != WYRELOG_E_OK)
+    return 517;
+  if (wyl_policy_store_upsert_role (store, "site.audit", "site audit")
+      != WYRELOG_E_OK)
+    return 518;
+  if (wyl_policy_store_grant_role_inheritance (store, "site.admin",
+          "wr.service_admin") != WYRELOG_E_OK)
+    return 519;
+  if (wyl_policy_store_grant_role_inheritance (store, "site.audit",
+          "wr.auditor") != WYRELOG_E_OK)
+    return 520;
+  if (wyl_policy_store_grant_role_membership (store, "sod-user",
+          "site.admin", "sod-scope") != WYRELOG_E_OK)
+    return 521;
+  if (wyl_policy_store_grant_role_membership (store, "sod-user",
+          "site.audit", "sod-scope") != WYRELOG_E_OK)
+    return 522;
+
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_POLICY)
+    return 523;
+  if (wyl_handle_get_read_engine (handle) != NULL)
+    return 524;
+  return wyl_handle_get_delta_engine (handle) == NULL ? 0 : 525;
+}
+
+static gint
 check_policy_store_audit_facts_reload_failure_preserves_pair (void)
 {
   g_autoptr (WylHandle) handle = NULL;
@@ -2832,6 +2873,9 @@ main (void)
       != 0)
     return rc;
   if ((rc = check_policy_store_auditor_admin_cross_scope_allows_open ()) != 0)
+    return rc;
+  if ((rc = check_policy_store_inherited_auditor_admin_membership_fails_open ())
+      != 0)
     return rc;
   if ((rc = check_policy_store_audit_facts_reload_failure_preserves_pair ())
       != 0)

--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -2448,6 +2448,70 @@ check_policy_store_session_events_reload_failure_preserves_pair (void)
 }
 
 static gint
+check_policy_store_inheritance_cycle_fails_open (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 467;
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (wyl_policy_store_upsert_role (store, "wr.cycle-a", "cycle a")
+      != WYRELOG_E_OK)
+    return 468;
+  if (wyl_policy_store_upsert_role (store, "wr.cycle-b", "cycle b")
+      != WYRELOG_E_OK)
+    return 469;
+  if (wyl_policy_store_grant_role_inheritance (store, "wr.cycle-a",
+          "wr.cycle-b") != WYRELOG_E_OK)
+    return 470;
+  if (wyl_policy_store_grant_role_inheritance (store, "wr.cycle-b",
+          "wr.cycle-a") != WYRELOG_E_OK)
+    return 471;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_POLICY)
+    return 472;
+  if (wyl_handle_get_read_engine (handle) != NULL)
+    return 473;
+  return wyl_handle_get_delta_engine (handle) == NULL ? 0 : 474;
+}
+
+static gint
+check_policy_store_inheritance_depth_fails_reload_and_preserves_pair (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 475;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 476;
+  WylEngine *read_engine = wyl_handle_get_read_engine (handle);
+  WylEngine *delta_engine = wyl_handle_get_delta_engine (handle);
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  for (guint i = 0; i < 5; i++) {
+    g_autofree gchar *role_id = g_strdup_printf ("wr.depth-%u", i);
+    g_autofree gchar *role_name = g_strdup_printf ("depth %u", i);
+    if (wyl_policy_store_upsert_role (store, role_id, role_name)
+        != WYRELOG_E_OK)
+      return 477;
+  }
+  for (guint i = 0; i < 4; i++) {
+    g_autofree gchar *child = g_strdup_printf ("wr.depth-%u", i);
+    g_autofree gchar *parent = g_strdup_printf ("wr.depth-%u", i + 1);
+    if (wyl_policy_store_grant_role_inheritance (store, child, parent)
+        != WYRELOG_E_OK)
+      return 478;
+  }
+
+  if (wyl_handle_reload_engine_pair (handle) != WYRELOG_E_POLICY)
+    return 479;
+  if (wyl_handle_get_read_engine (handle) != read_engine)
+    return 480;
+  return wyl_handle_get_delta_engine (handle) == delta_engine ? 0 : 481;
+}
+
+static gint
 check_policy_store_audit_facts_reload_failure_preserves_pair (void)
 {
   g_autoptr (WylHandle) handle = NULL;
@@ -2635,6 +2699,12 @@ main (void)
     return rc;
   if ((rc = check_policy_store_session_events_reload_failure_preserves_pair ())
       != 0)
+    return rc;
+  if ((rc = check_policy_store_inheritance_cycle_fails_open ()) != 0)
+    return rc;
+  if ((rc =
+          check_policy_store_inheritance_depth_fails_reload_and_preserves_pair
+          ()) != 0)
     return rc;
   if ((rc = check_policy_store_audit_facts_reload_failure_preserves_pair ())
       != 0)

--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -2671,6 +2671,69 @@ check_policy_store_inherited_auditor_admin_membership_fails_open (void)
 }
 
 static gint
+check_policy_store_direct_permission_sod_fails_reload (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 526;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 527;
+  WylEngine *read_engine = wyl_handle_get_read_engine (handle);
+  WylEngine *delta_engine = wyl_handle_get_delta_engine (handle);
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (wyl_policy_store_upsert_permission (store, "wr.audit.read",
+          "audit read", "sensitive") != WYRELOG_E_OK)
+    return 528;
+  if (wyl_policy_store_upsert_permission (store, "wr.policy.grant_role",
+          "policy grant role", "critical") != WYRELOG_E_OK)
+    return 529;
+  if (wyl_policy_store_grant_direct_permission (store, "direct-sod-user",
+          "wr.audit.read", "direct-sod-scope") != WYRELOG_E_OK)
+    return 530;
+  if (wyl_policy_store_grant_direct_permission (store, "direct-sod-user",
+          "wr.policy.grant_role", "direct-sod-scope") != WYRELOG_E_OK)
+    return 531;
+
+  if (wyl_handle_reload_engine_pair (handle) != WYRELOG_E_POLICY)
+    return 532;
+  if (wyl_handle_get_read_engine (handle) != read_engine)
+    return 533;
+  return wyl_handle_get_delta_engine (handle) == delta_engine ? 0 : 534;
+}
+
+static gint
+check_policy_store_direct_audit_write_sod_fails_open (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 535;
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (wyl_policy_store_upsert_permission (store, "wr.audit.write",
+          "audit write", "critical") != WYRELOG_E_OK)
+    return 536;
+  if (wyl_policy_store_upsert_permission (store, "wr.policy.write",
+          "policy write", "critical") != WYRELOG_E_OK)
+    return 537;
+  if (wyl_policy_store_grant_direct_permission (store, "direct-write-user",
+          "wr.audit.write", "direct-write-scope") != WYRELOG_E_OK)
+    return 538;
+  if (wyl_policy_store_grant_direct_permission (store, "direct-write-user",
+          "wr.policy.write", "direct-write-scope") != WYRELOG_E_OK)
+    return 539;
+
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_POLICY)
+    return 540;
+  if (wyl_handle_get_read_engine (handle) != NULL)
+    return 541;
+  return wyl_handle_get_delta_engine (handle) == NULL ? 0 : 542;
+}
+
+static gint
 check_policy_store_audit_facts_reload_failure_preserves_pair (void)
 {
   g_autoptr (WylHandle) handle = NULL;
@@ -2876,6 +2939,10 @@ main (void)
     return rc;
   if ((rc = check_policy_store_inherited_auditor_admin_membership_fails_open ())
       != 0)
+    return rc;
+  if ((rc = check_policy_store_direct_permission_sod_fails_reload ()) != 0)
+    return rc;
+  if ((rc = check_policy_store_direct_audit_write_sod_fails_open ()) != 0)
     return rc;
   if ((rc = check_policy_store_audit_facts_reload_failure_preserves_pair ())
       != 0)

--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -2512,6 +2512,124 @@ check_policy_store_inheritance_depth_fails_reload_and_preserves_pair (void)
 }
 
 static gint
+check_policy_store_break_glass_audit_write_fails_reload (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 482;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 483;
+  WylEngine *read_engine = wyl_handle_get_read_engine (handle);
+  WylEngine *delta_engine = wyl_handle_get_delta_engine (handle);
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (wyl_policy_store_upsert_role (store, "wr.break_glass", "break glass")
+      != WYRELOG_E_OK)
+    return 484;
+  if (wyl_policy_store_upsert_permission (store, "wr.audit.write",
+          "audit write", "critical") != WYRELOG_E_OK)
+    return 485;
+  if (wyl_policy_store_grant_role_permission (store, "wr.break_glass",
+          "wr.audit.write") != WYRELOG_E_OK)
+    return 486;
+
+  if (wyl_handle_reload_engine_pair (handle) != WYRELOG_E_POLICY)
+    return 487;
+  if (wyl_handle_get_read_engine (handle) != read_engine)
+    return 488;
+  return wyl_handle_get_delta_engine (handle) == delta_engine ? 0 : 489;
+}
+
+static gint
+check_policy_store_admin_auditor_membership_fails_open (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 490;
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (wyl_policy_store_upsert_role (store, "wr.system_admin",
+          "system admin") != WYRELOG_E_OK)
+    return 491;
+  if (wyl_policy_store_upsert_role (store, "wr.auditor", "auditor")
+      != WYRELOG_E_OK)
+    return 492;
+  if (wyl_policy_store_grant_role_membership (store, "sod-user",
+          "wr.system_admin", "sod-scope") != WYRELOG_E_OK)
+    return 493;
+  if (wyl_policy_store_grant_role_membership (store, "sod-user",
+          "wr.auditor", "sod-scope") != WYRELOG_E_OK)
+    return 494;
+
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_POLICY)
+    return 495;
+  if (wyl_handle_get_read_engine (handle) != NULL)
+    return 496;
+  return wyl_handle_get_delta_engine (handle) == NULL ? 0 : 497;
+}
+
+static gint
+check_policy_store_service_admin_auditor_membership_fails_open (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 498;
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (wyl_policy_store_upsert_role (store, "wr.service_admin",
+          "service admin") != WYRELOG_E_OK)
+    return 499;
+  if (wyl_policy_store_upsert_role (store, "wr.auditor", "auditor")
+      != WYRELOG_E_OK)
+    return 500;
+  if (wyl_policy_store_grant_role_membership (store, "sod-user",
+          "wr.service_admin", "sod-scope") != WYRELOG_E_OK)
+    return 501;
+  if (wyl_policy_store_grant_role_membership (store, "sod-user",
+          "wr.auditor", "sod-scope") != WYRELOG_E_OK)
+    return 502;
+
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_POLICY)
+    return 503;
+  if (wyl_handle_get_read_engine (handle) != NULL)
+    return 504;
+  return wyl_handle_get_delta_engine (handle) == NULL ? 0 : 505;
+}
+
+static gint
+check_policy_store_auditor_admin_cross_scope_allows_open (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 506;
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (wyl_policy_store_upsert_role (store, "wr.service_admin",
+          "service admin") != WYRELOG_E_OK)
+    return 507;
+  if (wyl_policy_store_upsert_role (store, "wr.auditor", "auditor")
+      != WYRELOG_E_OK)
+    return 508;
+  if (wyl_policy_store_grant_role_membership (store, "sod-user",
+          "wr.service_admin", "admin-scope") != WYRELOG_E_OK)
+    return 509;
+  if (wyl_policy_store_grant_role_membership (store, "sod-user",
+          "wr.auditor", "audit-scope") != WYRELOG_E_OK)
+    return 510;
+
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 511;
+  if (wyl_handle_get_read_engine (handle) == NULL)
+    return 512;
+  return wyl_handle_get_delta_engine (handle) != NULL ? 0 : 513;
+}
+
+static gint
 check_policy_store_audit_facts_reload_failure_preserves_pair (void)
 {
   g_autoptr (WylHandle) handle = NULL;
@@ -2705,6 +2823,15 @@ main (void)
   if ((rc =
           check_policy_store_inheritance_depth_fails_reload_and_preserves_pair
           ()) != 0)
+    return rc;
+  if ((rc = check_policy_store_break_glass_audit_write_fails_reload ()) != 0)
+    return rc;
+  if ((rc = check_policy_store_admin_auditor_membership_fails_open ()) != 0)
+    return rc;
+  if ((rc = check_policy_store_service_admin_auditor_membership_fails_open ())
+      != 0)
+    return rc;
+  if ((rc = check_policy_store_auditor_admin_cross_scope_allows_open ()) != 0)
     return rc;
   if ((rc = check_policy_store_audit_facts_reload_failure_preserves_pair ())
       != 0)

--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -2792,6 +2792,47 @@ check_policy_store_auditor_role_direct_admin_sod_fails_open (void)
 }
 
 static gint
+check_policy_store_custom_role_permission_sod_fails_open (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 559;
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (wyl_policy_store_upsert_role (store, "site.audit-role",
+          "site audit role") != WYRELOG_E_OK)
+    return 560;
+  if (wyl_policy_store_upsert_role (store, "site.grant-role",
+          "site grant role") != WYRELOG_E_OK)
+    return 561;
+  if (wyl_policy_store_upsert_permission (store, "wr.audit.read",
+          "audit read", "sensitive") != WYRELOG_E_OK)
+    return 562;
+  if (wyl_policy_store_upsert_permission (store, "wr.policy.grant_role",
+          "policy grant role", "critical") != WYRELOG_E_OK)
+    return 563;
+  if (wyl_policy_store_grant_role_permission (store, "site.audit-role",
+          "wr.audit.read") != WYRELOG_E_OK)
+    return 564;
+  if (wyl_policy_store_grant_role_permission (store, "site.grant-role",
+          "wr.policy.grant_role") != WYRELOG_E_OK)
+    return 565;
+  if (wyl_policy_store_grant_role_membership (store, "custom-sod-user",
+          "site.audit-role", "custom-scope") != WYRELOG_E_OK)
+    return 566;
+  if (wyl_policy_store_grant_role_membership (store, "custom-sod-user",
+          "site.grant-role", "custom-scope") != WYRELOG_E_OK)
+    return 567;
+
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_POLICY)
+    return 568;
+  if (wyl_handle_get_read_engine (handle) != NULL)
+    return 569;
+  return wyl_handle_get_delta_engine (handle) == NULL ? 0 : 570;
+}
+
+static gint
 check_policy_store_audit_facts_reload_failure_preserves_pair (void)
 {
   g_autoptr (WylHandle) handle = NULL;
@@ -3006,6 +3047,8 @@ main (void)
     return rc;
   if ((rc = check_policy_store_auditor_role_direct_admin_sod_fails_open ())
       != 0)
+    return rc;
+  if ((rc = check_policy_store_custom_role_permission_sod_fails_open ()) != 0)
     return rc;
   if ((rc = check_policy_store_audit_facts_reload_failure_preserves_pair ())
       != 0)

--- a/wyrelog/policy/store-private.h
+++ b/wyrelog/policy/store-private.h
@@ -60,6 +60,7 @@ wyrelog_error_t wyl_policy_store_commit_mutation (wyl_policy_store_t * store);
 void wyl_policy_store_rollback_mutation (wyl_policy_store_t * store);
 
 wyrelog_error_t wyl_policy_store_create_schema (wyl_policy_store_t * store);
+wyrelog_error_t wyl_policy_store_validate_snapshot (wyl_policy_store_t * store);
 wyrelog_error_t wyl_policy_store_table_exists (wyl_policy_store_t * store,
     const gchar * table_name, gboolean * out_exists);
 wyrelog_error_t wyl_policy_store_set_deployment_mode (wyl_policy_store_t *

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -491,13 +491,25 @@ wyl_policy_store_validate_snapshot (wyl_policy_store_t *store)
     return WYRELOG_E_POLICY;
 
   static const gchar *role_membership_sod_sql =
-      "SELECT 1 FROM role_memberships privileged "
-      "JOIN role_memberships auditor "
+      "WITH RECURSIVE role_closure(role_id, effective_role_id) AS ("
+      "  SELECT role_id, role_id FROM roles "
+      "  UNION "
+      "  SELECT role_closure.role_id, ri.parent_role_id "
+      "  FROM role_closure "
+      "  JOIN role_inheritances ri "
+      "    ON ri.child_role_id = role_closure.effective_role_id"
+      "), effective_membership(subject_id, scope, effective_role_id) AS ("
+      "  SELECT rm.subject_id, rm.scope, rc.effective_role_id "
+      "  FROM role_memberships rm "
+      "  JOIN role_closure rc ON rc.role_id = rm.role_id"
+      ") "
+      "SELECT 1 FROM effective_membership privileged "
+      "JOIN effective_membership auditor "
       "  ON auditor.subject_id = privileged.subject_id "
       " AND auditor.scope = privileged.scope "
-      "WHERE privileged.role_id IN ("
+      "WHERE privileged.effective_role_id IN ("
       "    'wr.system_admin', 'wr.service_admin', 'wr.break_glass') "
-      "  AND auditor.role_id = 'wr.auditor' " "LIMIT 1;";
+      "  AND auditor.effective_role_id = 'wr.auditor' " "LIMIT 1;";
   rc = query_has_rows (store->db, role_membership_sod_sql, &found);
   if (rc != WYRELOG_E_OK)
     return rc;

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -570,6 +570,40 @@ wyl_policy_store_validate_snapshot (wyl_policy_store_t *store)
   if (found)
     return WYRELOG_E_POLICY;
 
+  static const gchar *effective_permission_sod_sql =
+      "WITH RECURSIVE role_closure(role_id, effective_role_id) AS ("
+      "  SELECT role_id, role_id FROM roles "
+      "  UNION "
+      "  SELECT role_closure.role_id, ri.parent_role_id "
+      "  FROM role_closure "
+      "  JOIN role_inheritances ri "
+      "    ON ri.child_role_id = role_closure.effective_role_id"
+      "), role_subject_permission(subject_id, scope, perm_id) AS ("
+      "  SELECT rm.subject_id, rm.scope, rp.perm_id "
+      "  FROM role_memberships rm "
+      "  JOIN role_closure rc ON rc.role_id = rm.role_id "
+      "  JOIN role_permissions rp ON rp.role_id = rc.effective_role_id"
+      "), subject_permission(subject_id, scope, perm_id) AS ("
+      "  SELECT subject_id, scope, perm_id FROM direct_permissions "
+      "  UNION "
+      "  SELECT subject_id, scope, perm_id FROM role_subject_permission"
+      ") "
+      "SELECT 1 FROM subject_permission audit "
+      "JOIN subject_permission privileged "
+      "  ON privileged.subject_id = audit.subject_id "
+      " AND privileged.scope = audit.scope "
+      "WHERE audit.perm_id IN ("
+      "    'wr.audit.read', 'wr.audit.explain', 'wr.audit.write') "
+      "  AND privileged.perm_id IN ("
+      "    'wr.sys.admin', 'wr.svc.admin', "
+      "    'wr.policy.write', 'wr.policy.grant_role', "
+      "    'wr.svc.grant_role') " "LIMIT 1;";
+  rc = query_has_rows (store->db, effective_permission_sod_sql, &found);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if (found)
+    return WYRELOG_E_POLICY;
+
   return WYRELOG_E_OK;
 }
 

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -533,6 +533,43 @@ wyl_policy_store_validate_snapshot (wyl_policy_store_t *store)
   if (found)
     return WYRELOG_E_POLICY;
 
+  static const gchar *mixed_permission_role_sod_sql =
+      "WITH RECURSIVE role_closure(role_id, effective_role_id) AS ("
+      "  SELECT role_id, role_id FROM roles "
+      "  UNION "
+      "  SELECT role_closure.role_id, ri.parent_role_id "
+      "  FROM role_closure "
+      "  JOIN role_inheritances ri "
+      "    ON ri.child_role_id = role_closure.effective_role_id"
+      "), effective_membership(subject_id, scope, effective_role_id) AS ("
+      "  SELECT rm.subject_id, rm.scope, rc.effective_role_id "
+      "  FROM role_memberships rm "
+      "  JOIN role_closure rc ON rc.role_id = rm.role_id"
+      ") "
+      "SELECT 1 FROM direct_permissions audit "
+      "JOIN effective_membership privileged "
+      "  ON privileged.subject_id = audit.subject_id "
+      " AND privileged.scope = audit.scope "
+      "WHERE audit.perm_id IN ("
+      "    'wr.audit.read', 'wr.audit.explain', 'wr.audit.write') "
+      "  AND privileged.effective_role_id IN ("
+      "    'wr.system_admin', 'wr.service_admin', 'wr.break_glass') "
+      "UNION ALL "
+      "SELECT 1 FROM effective_membership auditor "
+      "JOIN direct_permissions privileged "
+      "  ON privileged.subject_id = auditor.subject_id "
+      " AND privileged.scope = auditor.scope "
+      "WHERE auditor.effective_role_id = 'wr.auditor' "
+      "  AND privileged.perm_id IN ("
+      "    'wr.sys.admin', 'wr.svc.admin', "
+      "    'wr.policy.write', 'wr.policy.grant_role', "
+      "    'wr.svc.grant_role') " "LIMIT 1;";
+  rc = query_has_rows (store->db, mixed_permission_role_sod_sql, &found);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if (found)
+    return WYRELOG_E_POLICY;
+
   return WYRELOG_E_OK;
 }
 

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -64,6 +64,29 @@ deployment_mode_is_valid (const gchar *mode)
       || g_strcmp0 (mode, "development") == 0 || g_strcmp0 (mode, "demo") == 0;
 }
 
+static wyrelog_error_t
+query_has_rows (sqlite3 *db, const gchar *sql, gboolean *out_has_rows)
+{
+  if (db == NULL || sql == NULL || out_has_rows == NULL)
+    return WYRELOG_E_INVALID;
+  *out_has_rows = FALSE;
+
+  sqlite3_stmt *stmt = NULL;
+  wyrelog_error_t rc = prepare_stmt (db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  int step_rc = sqlite3_step (stmt);
+  if (step_rc == SQLITE_ROW) {
+    *out_has_rows = TRUE;
+    sqlite3_finalize (stmt);
+    return WYRELOG_E_OK;
+  }
+
+  sqlite3_finalize (stmt);
+  return (step_rc == SQLITE_DONE) ? WYRELOG_E_OK : WYRELOG_E_IO;
+}
+
 wyrelog_error_t
 wyl_policy_store_begin_mutation (wyl_policy_store_t *store)
 {
@@ -405,6 +428,55 @@ wyl_policy_store_table_exists (wyl_policy_store_t *store,
   }
 
   sqlite3_finalize (stmt);
+  return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
+wyl_policy_store_validate_snapshot (wyl_policy_store_t *store)
+{
+  if (store == NULL || store->db == NULL)
+    return WYRELOG_E_INVALID;
+
+  gboolean found = FALSE;
+  static const gchar *cycle_sql =
+      "WITH RECURSIVE walk(root, node, depth, path) AS ("
+      "  SELECT child_role_id, parent_role_id, 1,"
+      "    '|' || child_role_id || '|' || parent_role_id || '|' "
+      "  FROM role_inheritances"
+      "  UNION ALL "
+      "  SELECT walk.root, ri.parent_role_id, walk.depth + 1,"
+      "    walk.path || ri.parent_role_id || '|' "
+      "  FROM walk "
+      "  JOIN role_inheritances ri ON ri.child_role_id = walk.node "
+      "  WHERE walk.depth < 32 "
+      "    AND instr(walk.path, '|' || ri.parent_role_id || '|') = 0"
+      ") "
+      "SELECT 1 FROM walk WHERE root = node "
+      "UNION ALL "
+      "SELECT 1 FROM walk "
+      "JOIN role_inheritances ri ON ri.child_role_id = walk.node "
+      "WHERE ri.parent_role_id = walk.root " "LIMIT 1;";
+  wyrelog_error_t rc = query_has_rows (store->db, cycle_sql, &found);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if (found)
+    return WYRELOG_E_POLICY;
+
+  static const gchar *depth_sql =
+      "WITH RECURSIVE walk(child, parent, depth) AS ("
+      "  SELECT child_role_id, parent_role_id, 1 FROM role_inheritances"
+      "  UNION ALL "
+      "  SELECT walk.child, ri.parent_role_id, walk.depth + 1 "
+      "  FROM walk "
+      "  JOIN role_inheritances ri ON ri.child_role_id = walk.parent "
+      "  WHERE walk.depth < 4"
+      ") " "SELECT 1 FROM walk WHERE depth > 3 LIMIT 1;";
+  rc = query_has_rows (store->db, depth_sql, &found);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if (found)
+    return WYRELOG_E_POLICY;
+
   return WYRELOG_E_OK;
 }
 

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -477,6 +477,33 @@ wyl_policy_store_validate_snapshot (wyl_policy_store_t *store)
   if (found)
     return WYRELOG_E_POLICY;
 
+  static const gchar *role_permission_sod_sql =
+      "SELECT 1 FROM role_permissions "
+      "WHERE (role_id = 'wr.break_glass' AND perm_id = 'wr.audit.write') "
+      "   OR (role_id = 'wr.system_admin' AND perm_id GLOB 'wr.audit.*') "
+      "   OR (role_id = 'wr.auditor' AND perm_id IN ("
+      "        'wr.policy.write', 'wr.policy.grant_role', "
+      "        'wr.svc.grant_role')) " "LIMIT 1;";
+  rc = query_has_rows (store->db, role_permission_sod_sql, &found);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if (found)
+    return WYRELOG_E_POLICY;
+
+  static const gchar *role_membership_sod_sql =
+      "SELECT 1 FROM role_memberships privileged "
+      "JOIN role_memberships auditor "
+      "  ON auditor.subject_id = privileged.subject_id "
+      " AND auditor.scope = privileged.scope "
+      "WHERE privileged.role_id IN ("
+      "    'wr.system_admin', 'wr.service_admin', 'wr.break_glass') "
+      "  AND auditor.role_id = 'wr.auditor' " "LIMIT 1;";
+  rc = query_has_rows (store->db, role_membership_sod_sql, &found);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if (found)
+    return WYRELOG_E_POLICY;
+
   return WYRELOG_E_OK;
 }
 

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -516,6 +516,23 @@ wyl_policy_store_validate_snapshot (wyl_policy_store_t *store)
   if (found)
     return WYRELOG_E_POLICY;
 
+  static const gchar *direct_permission_sod_sql =
+      "SELECT 1 FROM direct_permissions audit "
+      "JOIN direct_permissions privileged "
+      "  ON privileged.subject_id = audit.subject_id "
+      " AND privileged.scope = audit.scope "
+      "WHERE audit.perm_id IN ("
+      "    'wr.audit.read', 'wr.audit.explain', 'wr.audit.write') "
+      "  AND privileged.perm_id IN ("
+      "    'wr.sys.admin', 'wr.svc.admin', "
+      "    'wr.policy.write', 'wr.policy.grant_role', "
+      "    'wr.svc.grant_role') " "LIMIT 1;";
+  rc = query_has_rows (store->db, direct_permission_sod_sql, &found);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if (found)
+    return WYRELOG_E_POLICY;
+
   return WYRELOG_E_OK;
 }
 

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -437,6 +437,10 @@ load_current_engine_pair (WylHandle *self)
 static wyrelog_error_t
 replace_engine_pair (WylHandle *self, const gchar *template_dir)
 {
+  wyrelog_error_t rc = wyl_policy_store_validate_snapshot (self->policy_store);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
   WylEngine *old_read_engine = self->read_engine;
   WylEngine *old_delta_engine = self->delta_engine;
   WylEngine *old_guard_context_compound_engine =
@@ -446,7 +450,7 @@ replace_engine_pair (WylHandle *self, const gchar *template_dir)
   gchar *old_template_dir = self->template_dir;
 
   WylEngine *new_read_engine = NULL;
-  wyrelog_error_t rc = wyl_engine_open (template_dir, 1, &new_read_engine);
+  rc = wyl_engine_open (template_dir, 1, &new_read_engine);
   if (rc != WYRELOG_E_OK)
     return rc;
 


### PR DESCRIPTION
## Summary

- validate role inheritance snapshots before engine open or reload
- reject same-scope SoD conflicts across built-in roles, inherited roles, direct permissions, and custom role-derived permissions
- preserve the active engine pair when invalid snapshots are detected during reload

## Tests

- meson test -C builddir handle-engine-pair policy-store perm decide check-public-headers-no-novelty-tokens --print-errorlogs
- meson test -C builddir-audit handle-engine-pair policy-store perm decide daemon-checks audit-emit check-public-headers-no-novelty-tokens --print-errorlogs
