### PR TITLE
Add guarded policy mutation ingress

### DIFF
--- a/tests/test-audit-emit.c
+++ b/tests/test-audit-emit.c
@@ -1743,6 +1743,52 @@ check_permission_grant_emits_audit_row (void)
 }
 
 static gint
+check_permission_grant_actor_emits_audit_subject (void)
+{
+  WylHandle *handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 1290;
+
+  g_autoptr (wyl_grant_req_t) grant = wyl_grant_req_new ();
+  wyl_grant_req_set_subject_id (grant, "audit-grant-target");
+  wyl_grant_req_set_action (grant, "wr.audit-grant-actor");
+  wyl_grant_req_set_resource_id (grant, "audit-grant-actor-scope");
+  wyl_grant_req_set_actor_id (grant, "audit-grant-actor");
+  if (wyl_perm_grant (handle, grant) != WYRELOG_E_OK) {
+    g_object_unref (handle);
+    return 1291;
+  }
+
+  duckdb_connection conn =
+      wyl_audit_conn_get_connection (wyl_handle_get_audit_conn (handle));
+  duckdb_result result;
+  if (duckdb_query (conn,
+          "SELECT subject_id FROM audit_events "
+          "WHERE action = 'permission_grant' "
+          "AND deny_origin = 'wr.audit-grant-actor';", &result)
+      != DuckDBSuccess) {
+    duckdb_destroy_result (&result);
+    g_object_unref (handle);
+    return 1292;
+  }
+  if (duckdb_row_count (&result) != 1) {
+    duckdb_destroy_result (&result);
+    g_object_unref (handle);
+    return 1293;
+  }
+
+  gint rc = 0;
+  const gchar *subject = duckdb_value_varchar (&result, 0, 0);
+  if (g_strcmp0 (subject, "audit-grant-actor") != 0)
+    rc = 1294;
+
+  duckdb_free ((void *) subject);
+  duckdb_destroy_result (&result);
+  g_object_unref (handle);
+  return rc;
+}
+
+static gint
 check_permission_revoke_emits_audit_row (void)
 {
   WylHandle *handle = NULL;
@@ -2483,6 +2529,8 @@ main (void)
   if ((rc = check_denied_login_skip_mfa_projects_audit_fact ()) != 0)
     return rc;
   if ((rc = check_permission_grant_emits_audit_row ()) != 0)
+    return rc;
+  if ((rc = check_permission_grant_actor_emits_audit_subject ()) != 0)
     return rc;
   if ((rc = check_permission_revoke_emits_audit_row ()) != 0)
     return rc;

--- a/tests/test-client-smoke.c
+++ b/tests/test-client-smoke.c
@@ -12,10 +12,14 @@ typedef struct
   SoupServer *server;
   GMainLoop *loop;
   const gchar *body;
+  guint status;
   gchar *last_method;
   gchar *last_path;
   gchar *last_user;
+  gchar *last_subject;
   gchar *last_perm;
+  gchar *last_role;
+  gchar *last_scope;
   gchar *last_session_token;
   gchar *last_password;
   gchar *last_skip_mfa;
@@ -60,7 +64,10 @@ test_http_server_handler (SoupServer *server, SoupServerMessage *msg,
   g_free (http->last_method);
   g_free (http->last_path);
   g_free (http->last_user);
+  g_free (http->last_subject);
   g_free (http->last_perm);
+  g_free (http->last_role);
+  g_free (http->last_scope);
   g_free (http->last_session_token);
   g_free (http->last_password);
   g_free (http->last_skip_mfa);
@@ -77,8 +84,14 @@ test_http_server_handler (SoupServer *server, SoupServerMessage *msg,
   } else {
     http->last_user = NULL;
   }
+  http->last_subject =
+      query != NULL ? g_strdup (g_hash_table_lookup (query, "subject")) : NULL;
   http->last_perm =
       query != NULL ? g_strdup (g_hash_table_lookup (query, "perm")) : NULL;
+  http->last_role =
+      query != NULL ? g_strdup (g_hash_table_lookup (query, "role")) : NULL;
+  http->last_scope =
+      query != NULL ? g_strdup (g_hash_table_lookup (query, "scope")) : NULL;
   http->last_session_token =
       query != NULL ? g_strdup (g_hash_table_lookup (query,
           "session_token")) : NULL;
@@ -97,7 +110,8 @@ test_http_server_handler (SoupServer *server, SoupServerMessage *msg,
           "guard_risk")) : NULL;
 
   const gchar *body = http->body != NULL ? http->body : "[]";
-  soup_server_message_set_status (msg, 200, NULL);
+  soup_server_message_set_status (msg, http->status != 0 ? http->status : 200,
+      NULL);
   soup_server_message_set_response (msg, "application/json", SOUP_MEMORY_COPY,
       body, strlen (body));
 }
@@ -214,6 +228,9 @@ main (void)
   if (wyl_client_audit_query_with_guard_context (local_client, NULL, 123,
           "public", 69, &missing_login_iter) != WYRELOG_E_INVALID)
     return 153;
+  if (wyl_client_policy_permission_grant (local_client, "target", "read",
+          "scope", 123, "public", 49) != WYRELOG_E_INVALID)
+    return 510;
 
   http.body = "{\"session_token\":\"session-1\",\"username\":\"alice\","
       "\"principal_state\":\"mfa_required\",\"session_state\":\"active\"}";
@@ -267,6 +284,75 @@ main (void)
       g_strcmp0 (client_principal_state, "authenticated") != 0 ||
       g_strcmp0 (client_session_state, "active") != 0)
     return 152;
+
+  if (wyl_client_policy_permission_grant (NULL, "target", "read", "scope",
+          123, "public", 49) != WYRELOG_E_INVALID)
+    return 511;
+  if (wyl_client_policy_permission_grant (local_client, NULL, "read",
+          "scope", 123, "public", 49) != WYRELOG_E_INVALID)
+    return 512;
+  if (wyl_client_policy_permission_grant (local_client, "target", NULL,
+          "scope", 123, "public", 49) != WYRELOG_E_INVALID)
+    return 513;
+  if (wyl_client_policy_permission_grant (local_client, "target", "read",
+          NULL, 123, "public", 49) != WYRELOG_E_INVALID)
+    return 514;
+  if (wyl_client_policy_permission_grant (local_client, "target", "read",
+          "scope", -1, "public", 49) != WYRELOG_E_INVALID)
+    return 515;
+  if (wyl_client_policy_permission_grant (local_client, "target", "read",
+          "scope", 123, "unknown", 49) != WYRELOG_E_INVALID)
+    return 516;
+
+  http.body = "{\"ok\":true}";
+  if (wyl_client_policy_permission_grant (local_client, "target user",
+          "site.policy.read", "tenant/a", 123, "public", 49) != WYRELOG_E_OK)
+    return 517;
+  if (g_strcmp0 (http.last_method, "POST") != 0 ||
+      g_strcmp0 (http.last_path, "/policy/permissions/grant") != 0 ||
+      g_strcmp0 (http.last_subject, "target user") != 0 ||
+      g_strcmp0 (http.last_perm, "site.policy.read") != 0 ||
+      g_strcmp0 (http.last_scope, "tenant/a") != 0 ||
+      g_strcmp0 (http.last_session_token, "session-2") != 0 ||
+      g_strcmp0 (http.last_guard_timestamp, "123") != 0 ||
+      g_strcmp0 (http.last_guard_loc_class, "public") != 0 ||
+      g_strcmp0 (http.last_guard_risk, "49") != 0)
+    return 518;
+  if (wyl_client_policy_permission_revoke (local_client, "target user",
+          "site.policy.read", "tenant/a", 123, "public", 49) != WYRELOG_E_OK)
+    return 519;
+  if (g_strcmp0 (http.last_path, "/policy/permissions/revoke") != 0)
+    return 520;
+  if (wyl_client_policy_role_grant (local_client, "target user",
+          "site.reader", "tenant/b", 123, "public", 29) != WYRELOG_E_OK)
+    return 521;
+  if (g_strcmp0 (http.last_path, "/policy/roles/grant") != 0 ||
+      g_strcmp0 (http.last_role, "site.reader") != 0 ||
+      g_strcmp0 (http.last_scope, "tenant/b") != 0 ||
+      g_strcmp0 (http.last_guard_risk, "29") != 0)
+    return 522;
+  if (wyl_client_policy_role_revoke (local_client, "target user",
+          "site.reader", "tenant/b", 123, "public", 29) != WYRELOG_E_OK)
+    return 523;
+  if (g_strcmp0 (http.last_path, "/policy/roles/revoke") != 0)
+    return 524;
+  http.status = 400;
+  if (wyl_client_policy_permission_grant (local_client, "target", "read",
+          "scope", 123, "public", 49) != WYRELOG_E_INVALID)
+    return 525;
+  http.status = 401;
+  if (wyl_client_policy_permission_grant (local_client, "target", "read",
+          "scope", 123, "public", 49) != WYRELOG_E_AUTH)
+    return 526;
+  http.status = 403;
+  if (wyl_client_policy_permission_grant (local_client, "target", "read",
+          "scope", 123, "public", 49) != WYRELOG_E_POLICY)
+    return 527;
+  http.status = 500;
+  if (wyl_client_policy_permission_grant (local_client, "target", "read",
+          "scope", 123, "public", 49) != WYRELOG_E_IO)
+    return 528;
+  http.status = 0;
 
   g_autoptr (WylAuditIter) guarded_audit_iter = NULL;
   if (wyl_client_audit_query_with_guard_context (local_client,
@@ -504,7 +590,10 @@ main (void)
   g_clear_pointer (&http.last_method, g_free);
   g_clear_pointer (&http.last_path, g_free);
   g_clear_pointer (&http.last_user, g_free);
+  g_clear_pointer (&http.last_subject, g_free);
   g_clear_pointer (&http.last_perm, g_free);
+  g_clear_pointer (&http.last_role, g_free);
+  g_clear_pointer (&http.last_scope, g_free);
   g_clear_pointer (&http.last_session_token, g_free);
   g_clear_pointer (&http.last_password, g_free);
   g_clear_pointer (&http.last_skip_mfa, g_free);

--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -5,6 +5,7 @@
 
 #include "daemon/http.h"
 #include "wyrelog/client.h"
+#include "wyrelog/policy/store-private.h"
 #include "wyrelog/wyl-handle-private.h"
 
 #ifndef WYL_TEST_TEMPLATE_DIR
@@ -490,6 +491,199 @@ check_raw_login_contract (SoupServer *server, WylHandle *handle,
   return 0;
 }
 
+static gchar *
+build_policy_mutation_uri (const gchar *base_url, const gchar *path,
+    const gchar *query)
+{
+  g_autofree gchar *root = g_strdup (base_url);
+  while (root[0] != '\0' && g_str_has_suffix (root, "/"))
+    root[strlen (root) - 1] = '\0';
+
+  if (query == NULL)
+    return g_strdup_printf ("%s%s", root, path);
+  return g_strdup_printf ("%s%s?%s", root, path, query);
+}
+
+static gint
+send_raw_policy_mutation (SoupSession *session, const gchar *method,
+    const gchar *base_url, const gchar *path, const gchar *query,
+    guint *out_status, gchar **out_body)
+{
+  if (out_status == NULL || out_body == NULL)
+    return 120;
+  *out_status = 0;
+  *out_body = NULL;
+
+  g_autofree gchar *uri = build_policy_mutation_uri (base_url, path, query);
+  g_autoptr (SoupMessage) msg = soup_message_new (method, uri);
+  if (msg == NULL)
+    return 121;
+
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GBytes) bytes = soup_session_send_and_read (session, msg, NULL,
+      &error);
+  if (bytes == NULL)
+    return 122;
+  gsize size = 0;
+  const gchar *data = g_bytes_get_data (bytes, &size);
+  *out_status = soup_message_get_status (msg);
+  *out_body = g_strndup (data, size);
+  return 0;
+}
+
+static wyrelog_error_t
+grant_policy_write_authority (WylHandle *handle, const gchar *subject,
+    const gchar *scope)
+{
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  wyrelog_error_t rc = wyl_policy_store_upsert_permission (store,
+      "wr.policy.write", "policy write", "critical");
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_policy_store_grant_direct_permission (store, subject,
+      "wr.policy.write", scope);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_policy_store_set_session_state (store, scope, "active");
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_reload_engine_pair (handle);
+}
+
+static gboolean
+direct_permission_exists (WylHandle *handle, const gchar *subject,
+    const gchar *perm, const gchar *scope)
+{
+  gboolean exists = FALSE;
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (wyl_policy_store_direct_permission_exists (store, subject, perm, scope,
+          &exists) != WYRELOG_E_OK)
+    return FALSE;
+  return exists;
+}
+
+static gint
+check_policy_permission_mutation_contract (WylHandle *handle,
+    WylClient *client, const gchar *base_url)
+{
+  wyl_handle_set_login_skip_mfa_allowed (handle, TRUE);
+  if (wyl_client_login_skip_mfa (client, "http-policy-admin") != WYRELOG_E_OK)
+    return 123;
+  wyl_handle_set_login_skip_mfa_allowed (handle, FALSE);
+
+  g_autofree gchar *session_token = wyl_client_dup_session_token (client);
+  if (session_token == NULL)
+    return 124;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (wyl_policy_store_upsert_permission (store, "site.policy.read",
+          "site policy read", "basic") != WYRELOG_E_OK)
+    return 125;
+
+  g_autoptr (SoupSession) session = soup_session_new ();
+  guint status = 0;
+  g_autofree gchar *body = NULL;
+
+  gint rc = send_raw_policy_mutation (session, "GET", base_url,
+      "/policy/permissions/grant", "subject=target&perm=site.policy.read"
+      "&scope=tenant-a", &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 405 || strstr (body, "\"method_not_allowed\"") == NULL)
+    return 126;
+  g_clear_pointer (&body, g_free);
+
+  rc = send_raw_policy_mutation (session, "POST", base_url,
+      "/policy/permissions/grant", "perm=site.policy.read&scope=tenant-a",
+      &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 400 || strstr (body, "\"invalid_policy_mutation\"") == NULL)
+    return 127;
+  g_clear_pointer (&body, g_free);
+
+  rc = send_raw_policy_mutation (session, "POST", base_url,
+      "/policy/permissions/grant", "subject=target&perm=site.policy.read"
+      "&scope=tenant-a&session_token=unknown&guard_timestamp=abc"
+      "&guard_loc_class=public&guard_risk=49", &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 400 || strstr (body, "\"invalid_policy_auth\"") == NULL)
+    return 128;
+  g_clear_pointer (&body, g_free);
+
+  rc = send_raw_policy_mutation (session, "POST", base_url,
+      "/policy/permissions/grant", "subject=target&perm=site.policy.read"
+      "&scope=tenant-a&session_token=unknown&guard_timestamp=123"
+      "&guard_loc_class=public&guard_risk=49", &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 401 || strstr (body, "\"policy_auth_required\"") == NULL)
+    return 129;
+  g_clear_pointer (&body, g_free);
+
+  g_autofree gchar *denied_query =
+      g_strdup_printf ("subject=target&perm=site.policy.read&scope=tenant-a"
+      "&session_token=%s&guard_timestamp=123&guard_loc_class=public"
+      "&guard_risk=49", session_token);
+  rc = send_raw_policy_mutation (session, "POST", base_url,
+      "/policy/permissions/grant", denied_query, &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 403 || strstr (body, "\"policy_denied\"") == NULL)
+    return 130;
+  if (direct_permission_exists (handle, "target", "site.policy.read",
+          "tenant-a"))
+    return 131;
+  g_clear_pointer (&body, g_free);
+
+  if (grant_policy_write_authority (handle, "http-policy-admin",
+          "tenant-a") != WYRELOG_E_OK)
+    return 132;
+
+  g_autofree gchar *guard_denied_query =
+      g_strdup_printf ("subject=target&perm=site.policy.read&scope=tenant-a"
+      "&session_token=%s&guard_timestamp=123&guard_loc_class=public"
+      "&guard_risk=50", session_token);
+  rc = send_raw_policy_mutation (session, "POST", base_url,
+      "/policy/permissions/grant", guard_denied_query, &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 403 || strstr (body, "\"policy_denied\"") == NULL)
+    return 133;
+  if (direct_permission_exists (handle, "target", "site.policy.read",
+          "tenant-a"))
+    return 134;
+  g_clear_pointer (&body, g_free);
+
+  g_autofree gchar *grant_query =
+      g_strdup_printf ("subject=target&perm=site.policy.read&scope=tenant-a"
+      "&session_token=%s&guard_timestamp=123&guard_loc_class=public"
+      "&guard_risk=49", session_token);
+  rc = send_raw_policy_mutation (session, "POST", base_url,
+      "/policy/permissions/grant", grant_query, &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 200 || strstr (body, "\"ok\":true") == NULL)
+    return 135;
+  if (!direct_permission_exists (handle, "target", "site.policy.read",
+          "tenant-a"))
+    return 136;
+  g_clear_pointer (&body, g_free);
+
+  rc = send_raw_policy_mutation (session, "POST", base_url,
+      "/policy/permissions/revoke", grant_query, &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 200 || strstr (body, "\"ok\":true") == NULL)
+    return 137;
+  if (direct_permission_exists (handle, "target", "site.policy.read",
+          "tenant-a"))
+    return 138;
+
+  return 0;
+}
+
 #ifdef WYL_HAS_AUDIT
 static wyrelog_error_t
 grant_audit_read (WylHandle *handle, const gchar *subject_id,
@@ -704,6 +898,10 @@ main (void)
   if (decision != WYL_DECISION_DENY)
     return 13;
 
+  raw_rc = check_policy_permission_mutation_contract (handle, client, base_url);
+  if (raw_rc != 0)
+    return raw_rc;
+
 #ifdef WYL_HAS_AUDIT
   wyl_handle_set_login_skip_mfa_allowed (handle, TRUE);
   if (wyl_client_login_skip_mfa (client, "http-audit-user") != WYRELOG_E_OK)
@@ -740,6 +938,18 @@ main (void)
   audit_rc = check_audit_event_present (client, "action(\"wr.audit.read\")",
       "http-guard-user", "wr.audit.read", "http-guard-scope",
       WYL_DECISION_ALLOW, NULL, NULL);
+  if (audit_rc != 0)
+    return audit_rc;
+  audit_rc = check_audit_event_present (client,
+      "action(\"permission_grant\")",
+      "http-policy-admin", "permission_grant", "tenant-a",
+      WYL_DECISION_ALLOW, NULL, "site.policy.read");
+  if (audit_rc != 0)
+    return audit_rc;
+  audit_rc = check_audit_event_present (client,
+      "action(\"permission_revoke\")",
+      "http-policy-admin", "permission_revoke", "tenant-a",
+      WYL_DECISION_ALLOW, NULL, "site.policy.read");
   if (audit_rc != 0)
     return audit_rc;
 #endif

--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -550,6 +550,25 @@ grant_policy_write_authority (WylHandle *handle, const gchar *subject,
   return wyl_handle_reload_engine_pair (handle);
 }
 
+static wyrelog_error_t
+grant_policy_role_authority (WylHandle *handle, const gchar *subject,
+    const gchar *scope)
+{
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  wyrelog_error_t rc = wyl_policy_store_upsert_permission (store,
+      "wr.policy.grant_role", "policy grant role", "critical");
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_policy_store_grant_direct_permission (store, subject,
+      "wr.policy.grant_role", scope);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_policy_store_set_session_state (store, scope, "active");
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_reload_engine_pair (handle);
+}
+
 static gboolean
 direct_permission_exists (WylHandle *handle, const gchar *subject,
     const gchar *perm, const gchar *scope)
@@ -557,6 +576,18 @@ direct_permission_exists (WylHandle *handle, const gchar *subject,
   gboolean exists = FALSE;
   wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
   if (wyl_policy_store_direct_permission_exists (store, subject, perm, scope,
+          &exists) != WYRELOG_E_OK)
+    return FALSE;
+  return exists;
+}
+
+static gboolean
+role_membership_exists (WylHandle *handle, const gchar *subject,
+    const gchar *role, const gchar *scope)
+{
+  gboolean exists = FALSE;
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (wyl_policy_store_role_membership_exists (store, subject, role, scope,
           &exists) != WYRELOG_E_OK)
     return FALSE;
   return exists;
@@ -680,6 +711,67 @@ check_policy_permission_mutation_contract (WylHandle *handle,
   if (direct_permission_exists (handle, "target", "site.policy.read",
           "tenant-a"))
     return 138;
+
+  if (wyl_policy_store_upsert_role (store, "site.reader",
+          "site reader") != WYRELOG_E_OK)
+    return 139;
+
+  g_autofree gchar *role_denied_query =
+      g_strdup_printf ("subject=role-target&role=site.reader&scope=tenant-b"
+      "&session_token=%s&guard_timestamp=123&guard_loc_class=public"
+      "&guard_risk=29", session_token);
+  g_clear_pointer (&body, g_free);
+  rc = send_raw_policy_mutation (session, "POST", base_url,
+      "/policy/roles/grant", role_denied_query, &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 403 || strstr (body, "\"policy_denied\"") == NULL)
+    return 140;
+  if (role_membership_exists (handle, "role-target", "site.reader", "tenant-b"))
+    return 141;
+
+  if (grant_policy_role_authority (handle, "http-policy-admin",
+          "tenant-b") != WYRELOG_E_OK)
+    return 142;
+
+  g_autofree gchar *role_guard_denied_query =
+      g_strdup_printf ("subject=role-target&role=site.reader&scope=tenant-b"
+      "&session_token=%s&guard_timestamp=123&guard_loc_class=public"
+      "&guard_risk=30", session_token);
+  g_clear_pointer (&body, g_free);
+  rc = send_raw_policy_mutation (session, "POST", base_url,
+      "/policy/roles/grant", role_guard_denied_query, &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 403 || strstr (body, "\"policy_denied\"") == NULL)
+    return 143;
+  if (role_membership_exists (handle, "role-target", "site.reader", "tenant-b"))
+    return 144;
+
+  g_autofree gchar *role_grant_query =
+      g_strdup_printf ("subject=role-target&role=site.reader&scope=tenant-b"
+      "&session_token=%s&guard_timestamp=123&guard_loc_class=public"
+      "&guard_risk=29", session_token);
+  g_clear_pointer (&body, g_free);
+  rc = send_raw_policy_mutation (session, "POST", base_url,
+      "/policy/roles/grant", role_grant_query, &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 200 || strstr (body, "\"ok\":true") == NULL)
+    return 145;
+  if (!role_membership_exists (handle, "role-target", "site.reader",
+          "tenant-b"))
+    return 146;
+
+  g_clear_pointer (&body, g_free);
+  rc = send_raw_policy_mutation (session, "POST", base_url,
+      "/policy/roles/revoke", role_grant_query, &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 200 || strstr (body, "\"ok\":true") == NULL)
+    return 147;
+  if (role_membership_exists (handle, "role-target", "site.reader", "tenant-b"))
+    return 148;
 
   return 0;
 }
@@ -950,6 +1042,16 @@ main (void)
       "action(\"permission_revoke\")",
       "http-policy-admin", "permission_revoke", "tenant-a",
       WYL_DECISION_ALLOW, NULL, "site.policy.read");
+  if (audit_rc != 0)
+    return audit_rc;
+  audit_rc = check_audit_event_present (client, "action(\"role_grant\")",
+      "http-policy-admin", "role_grant", "tenant-b",
+      WYL_DECISION_ALLOW, NULL, "site.reader");
+  if (audit_rc != 0)
+    return audit_rc;
+  audit_rc = check_audit_event_present (client, "action(\"role_revoke\")",
+      "http-policy-admin", "role_revoke", "tenant-b",
+      WYL_DECISION_ALLOW, NULL, "site.reader");
   if (audit_rc != 0)
     return audit_rc;
 #endif

--- a/tests/test-perm.c
+++ b/tests/test-perm.c
@@ -675,6 +675,52 @@ check_role_revoke_removes_engine_membership (void)
   return 0;
 }
 
+static gint
+check_role_grant_rolls_back_invalid_snapshot (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 150;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (wyl_policy_store_upsert_role (store, "site.audit-role",
+          "site audit role") != WYRELOG_E_OK)
+    return 151;
+  if (wyl_policy_store_upsert_role (store, "site.grant-role",
+          "site grant role") != WYRELOG_E_OK)
+    return 152;
+  if (wyl_policy_store_upsert_permission (store, "wr.audit.read",
+          "audit read", "critical") != WYRELOG_E_OK)
+    return 153;
+  if (wyl_policy_store_upsert_permission (store, "wr.policy.grant_role",
+          "policy grant role", "critical") != WYRELOG_E_OK)
+    return 154;
+  if (wyl_policy_store_grant_role_permission (store, "site.audit-role",
+          "wr.audit.read") != WYRELOG_E_OK)
+    return 155;
+  if (wyl_policy_store_grant_role_permission (store, "site.grant-role",
+          "wr.policy.grant_role") != WYRELOG_E_OK)
+    return 156;
+  if (wyl_policy_store_grant_role_membership (store, "rollback-sod-user",
+          "site.audit-role", "rollback-sod-scope") != WYRELOG_E_OK)
+    return 157;
+  if (wyl_handle_reload_engine_pair (handle) != WYRELOG_E_OK)
+    return 158;
+
+  g_autoptr (wyl_role_grant_req_t) grant = wyl_role_grant_req_new ();
+  wyl_role_grant_req_set_subject_id (grant, "rollback-sod-user");
+  wyl_role_grant_req_set_role_id (grant, "site.grant-role");
+  wyl_role_grant_req_set_scope (grant, "rollback-sod-scope");
+  if (wyl_role_grant (handle, grant) != WYRELOG_E_POLICY)
+    return 159;
+
+  gboolean exists = TRUE;
+  if (wyl_policy_store_role_membership_exists (store, "rollback-sod-user",
+          "site.grant-role", "rollback-sod-scope", &exists) != WYRELOG_E_OK)
+    return 160;
+  return exists ? 161 : 0;
+}
+
 int
 main (void)
 {
@@ -718,6 +764,8 @@ main (void)
   if ((rc = check_revoke_removes_engine_grant ()) != 0)
     return rc;
   if ((rc = check_role_revoke_removes_engine_membership ()) != 0)
+    return rc;
+  if ((rc = check_role_grant_rolls_back_invalid_snapshot ()) != 0)
     return rc;
   return 0;
 }

--- a/wyrelog/client.h
+++ b/wyrelog/client.h
@@ -73,6 +73,29 @@ wyrelog_error_t wyl_client_audit_query_with_guard_context (WylClient * client,
     const gchar * query_filter,
     gint64 guard_timestamp,
     const gchar * guard_loc_class, gint64 guard_risk, WylAuditIter ** out_iter);
+
+/* Policy mutation */
+wyrelog_error_t wyl_client_policy_permission_grant (WylClient * client,
+    const gchar * subject,
+    const gchar * perm,
+    const gchar * scope,
+    gint64 guard_timestamp, const gchar * guard_loc_class, gint64 guard_risk);
+wyrelog_error_t wyl_client_policy_permission_revoke (WylClient * client,
+    const gchar * subject,
+    const gchar * perm,
+    const gchar * scope,
+    gint64 guard_timestamp, const gchar * guard_loc_class, gint64 guard_risk);
+wyrelog_error_t wyl_client_policy_role_grant (WylClient * client,
+    const gchar * subject,
+    const gchar * role,
+    const gchar * scope,
+    gint64 guard_timestamp, const gchar * guard_loc_class, gint64 guard_risk);
+wyrelog_error_t wyl_client_policy_role_revoke (WylClient * client,
+    const gchar * subject,
+    const gchar * role,
+    const gchar * scope,
+    gint64 guard_timestamp, const gchar * guard_loc_class, gint64 guard_risk);
+
 gchar *wyl_audit_iter_dup_query_filter (const WylAuditIter * iter);
 gchar *wyl_audit_iter_dup_request_uri (const WylAuditIter * iter);
 WylAuditEvent *wyl_audit_iter_ref_event (const WylAuditIter * iter);

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -434,6 +434,70 @@ policy_permission_revoke_handler (SoupServer *server, SoupServerMessage *msg,
 }
 
 static void
+role_membership_mutation_handler (SoupServer *server, SoupServerMessage *msg,
+    const char *path, GHashTable *query, gpointer user_data, gboolean grant)
+{
+  (void) path;
+
+  if (g_strcmp0 (soup_server_message_get_method (msg), "POST") != 0) {
+    set_json_error (msg, 405, "method_not_allowed");
+    return;
+  }
+
+  const gchar *subject = lookup_required_query_string (query, "subject");
+  const gchar *role = lookup_required_query_string (query, "role");
+  const gchar *scope = lookup_required_query_string (query, "scope");
+  if (subject == NULL || role == NULL || scope == NULL) {
+    set_json_error (msg, 400, "invalid_policy_mutation");
+    return;
+  }
+
+  WylDaemonHttpContext *ctx = user_data;
+  g_autofree gchar *actor = NULL;
+  if (!authorize_guarded_session_action (server, msg, query, ctx,
+          "wr.policy.grant_role", scope, "policy_auth_required",
+          "invalid_policy_auth", "policy_denied", "policy_auth_failed", &actor))
+    return;
+
+  wyrelog_error_t rc;
+  if (grant) {
+    g_autoptr (wyl_role_grant_req_t) req = wyl_role_grant_req_new ();
+    wyl_role_grant_req_set_subject_id (req, subject);
+    wyl_role_grant_req_set_role_id (req, role);
+    wyl_role_grant_req_set_scope (req, scope);
+    wyl_role_grant_req_set_actor_id (req, actor);
+    rc = wyl_role_grant (ctx->handle, req);
+  } else {
+    g_autoptr (wyl_role_revoke_req_t) req = wyl_role_revoke_req_new ();
+    wyl_role_revoke_req_set_subject_id (req, subject);
+    wyl_role_revoke_req_set_role_id (req, role);
+    wyl_role_revoke_req_set_scope (req, scope);
+    wyl_role_revoke_req_set_actor_id (req, actor);
+    rc = wyl_role_revoke (ctx->handle, req);
+  }
+  if (rc != WYRELOG_E_OK) {
+    set_policy_mutation_error (msg, rc);
+    return;
+  }
+
+  set_json_ok (msg);
+}
+
+static void
+policy_role_grant_handler (SoupServer *server, SoupServerMessage *msg,
+    const char *path, GHashTable *query, gpointer user_data)
+{
+  role_membership_mutation_handler (server, msg, path, query, user_data, TRUE);
+}
+
+static void
+policy_role_revoke_handler (SoupServer *server, SoupServerMessage *msg,
+    const char *path, GHashTable *query, gpointer user_data)
+{
+  role_membership_mutation_handler (server, msg, path, query, user_data, FALSE);
+}
+
+static void
 login_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
     GHashTable *query, gpointer user_data)
 {
@@ -609,6 +673,10 @@ wyl_daemon_start_http_server (const WylDaemonOptions *opts, WylHandle *handle,
       policy_permission_grant_handler, ctx, NULL);
   soup_server_add_handler (server, "/policy/permissions/revoke",
       policy_permission_revoke_handler, ctx, NULL);
+  soup_server_add_handler (server, "/policy/roles/grant",
+      policy_role_grant_handler, ctx, NULL);
+  soup_server_add_handler (server, "/policy/roles/revoke",
+      policy_role_revoke_handler, ctx, NULL);
   soup_server_add_handler (server, "/audit/events", audit_events_handler,
       ctx, NULL);
   if (!soup_server_listen_local (server, (guint) opts->listen_port, 0, error)) {

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -209,6 +209,84 @@ healthz_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
       strlen (body));
 }
 
+#ifdef WYL_HAS_AUDIT
+static gboolean
+authorize_guarded_session_action (SoupServer *server, SoupServerMessage *msg,
+    GHashTable *query, WylDaemonHttpContext *ctx, const gchar *action,
+    const gchar *resource, const gchar *auth_required_code,
+    const gchar *invalid_code, const gchar *denied_code,
+    const gchar *failed_code, gchar **out_actor)
+{
+  const gchar *session_token = NULL;
+  const gchar *guard_timestamp = NULL;
+  const gchar *guard_loc_class = NULL;
+  const gchar *guard_risk = NULL;
+  if (query != NULL) {
+    session_token = g_hash_table_lookup (query, "session_token");
+    guard_timestamp = g_hash_table_lookup (query, "guard_timestamp");
+    guard_loc_class = g_hash_table_lookup (query, "guard_loc_class");
+    guard_risk = g_hash_table_lookup (query, "guard_risk");
+  }
+  if (session_token == NULL || session_token[0] == '\0') {
+    set_json_error (msg, 401, auth_required_code);
+    return FALSE;
+  }
+  if (guard_timestamp == NULL || guard_loc_class == NULL || guard_risk == NULL) {
+    set_json_error (msg, 400, invalid_code);
+    return FALSE;
+  }
+
+  gint64 timestamp = 0;
+  gint64 risk = 0;
+  if (!parse_int64_query_param (guard_timestamp, &timestamp) ||
+      !parse_int64_query_param (guard_risk, &risk) || timestamp < 0 ||
+      risk < 0 || risk > 100 ||
+      !wyl_guard_loc_class_is_valid (guard_loc_class)) {
+    set_json_error (msg, 400, invalid_code);
+    return FALSE;
+  }
+
+  g_autoptr (WylSession) session =
+      wyl_daemon_http_ref_session (server, session_token);
+  if (session == NULL) {
+    set_json_error (msg, 401, auth_required_code);
+    return FALSE;
+  }
+
+  g_autofree gchar *username = wyl_session_dup_username (session);
+  if (username == NULL || username[0] == '\0') {
+    set_json_error (msg, 401, auth_required_code);
+    return FALSE;
+  }
+
+  g_autoptr (wyl_decide_req_t) req = wyl_decide_req_new ();
+  g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
+  wyl_decide_req_set_subject_id (req, username);
+  wyl_decide_req_set_action (req, action);
+  wyl_decide_req_set_resource_id (req,
+      resource != NULL ? resource : session_token);
+  wyl_decide_req_set_guard_context (req, timestamp, guard_loc_class, risk);
+
+  wyrelog_error_t rc = wyl_decide (ctx->handle, req, resp);
+  if (rc == WYRELOG_E_INVALID) {
+    set_json_error (msg, 400, invalid_code);
+    return FALSE;
+  }
+  if (rc != WYRELOG_E_OK) {
+    set_json_error (msg, 500, failed_code);
+    return FALSE;
+  }
+  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_ALLOW) {
+    set_json_error (msg, 403, denied_code);
+    return FALSE;
+  }
+
+  if (out_actor != NULL)
+    *out_actor = g_steal_pointer (&username);
+  return TRUE;
+}
+#endif
+
 static void
 audit_events_handler (SoupServer *server, SoupServerMessage *msg,
     const char *path, GHashTable *query, gpointer user_data)
@@ -218,75 +296,19 @@ audit_events_handler (SoupServer *server, SoupServerMessage *msg,
 
 #ifdef WYL_HAS_AUDIT
   const gchar *filter = NULL;
-  const gchar *session_token = NULL;
-  const gchar *guard_timestamp = NULL;
-  const gchar *guard_loc_class = NULL;
-  const gchar *guard_risk = NULL;
   if (query != NULL)
     filter = g_hash_table_lookup (query, "filter");
-  if (query != NULL) {
-    session_token = g_hash_table_lookup (query, "session_token");
-    guard_timestamp = g_hash_table_lookup (query, "guard_timestamp");
-    guard_loc_class = g_hash_table_lookup (query, "guard_loc_class");
-    guard_risk = g_hash_table_lookup (query, "guard_risk");
-  }
-  if (session_token == NULL || session_token[0] == '\0') {
-    set_json_error (msg, 401, "audit_auth_required");
-    return;
-  }
-  if (guard_timestamp == NULL || guard_loc_class == NULL || guard_risk == NULL) {
-    set_json_error (msg, 400, "invalid_audit_auth");
-    return;
-  }
-
-  gint64 timestamp = 0;
-  gint64 risk = 0;
-  if (!parse_int64_query_param (guard_timestamp, &timestamp) ||
-      !parse_int64_query_param (guard_risk, &risk) || timestamp < 0 ||
-      risk < 0 || risk > 100 ||
-      !wyl_guard_loc_class_is_valid (guard_loc_class)) {
-    set_json_error (msg, 400, "invalid_audit_auth");
-    return;
-  }
-
-  g_autoptr (WylSession) session =
-      wyl_daemon_http_ref_session (server, session_token);
-  if (session == NULL) {
-    set_json_error (msg, 401, "audit_auth_required");
-    return;
-  }
-
-  g_autofree gchar *username = wyl_session_dup_username (session);
-  if (username == NULL || username[0] == '\0') {
-    set_json_error (msg, 401, "audit_auth_required");
-    return;
-  }
 
   WylDaemonHttpContext *ctx = user_data;
+  if (!authorize_guarded_session_action (server, msg, query, ctx,
+          "wr.audit.read", NULL, "audit_auth_required",
+          "invalid_audit_auth", "audit_denied", "audit_auth_failed", NULL))
+    return;
+
   WylHandle *handle = ctx->handle;
-  g_autoptr (wyl_decide_req_t) req = wyl_decide_req_new ();
-  g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
-  wyl_decide_req_set_subject_id (req, username);
-  wyl_decide_req_set_action (req, "wr.audit.read");
-  wyl_decide_req_set_resource_id (req, session_token);
-  wyl_decide_req_set_guard_context (req, timestamp, guard_loc_class, risk);
-
-  wyrelog_error_t rc = wyl_decide (handle, req, resp);
-  if (rc == WYRELOG_E_INVALID) {
-    set_json_error (msg, 400, "invalid_audit_auth");
-    return;
-  }
-  if (rc != WYRELOG_E_OK) {
-    set_json_error (msg, 500, "audit_auth_failed");
-    return;
-  }
-  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_ALLOW) {
-    set_json_error (msg, 403, "audit_denied");
-    return;
-  }
-
   g_autofree gchar *body = NULL;
-  rc = wyl_audit_conn_query_events_json (wyl_handle_get_audit_conn (handle),
+  wyrelog_error_t rc =
+      wyl_audit_conn_query_events_json (wyl_handle_get_audit_conn (handle),
       filter, &body);
   if (rc == WYRELOG_E_INVALID) {
     const gchar *error_body = "{\"error\":\"invalid_filter\"}";

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -209,7 +209,6 @@ healthz_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
       strlen (body));
 }
 
-#ifdef WYL_HAS_AUDIT
 static gboolean
 authorize_guarded_session_action (SoupServer *server, SoupServerMessage *msg,
     GHashTable *query, WylDaemonHttpContext *ctx, const gchar *action,
@@ -285,7 +284,6 @@ authorize_guarded_session_action (SoupServer *server, SoupServerMessage *msg,
     *out_actor = g_steal_pointer (&username);
   return TRUE;
 }
-#endif
 
 static void
 audit_events_handler (SoupServer *server, SoupServerMessage *msg,
@@ -333,6 +331,106 @@ audit_events_handler (SoupServer *server, SoupServerMessage *msg,
   soup_server_message_set_status (msg, 200, NULL);
   soup_server_message_set_response (msg, "application/json",
       SOUP_MEMORY_COPY, body, strlen (body));
+}
+
+static void
+set_json_ok (SoupServerMessage *msg)
+{
+  const gchar *body = "{\"ok\":true}";
+  soup_server_message_set_status (msg, 200, NULL);
+  soup_server_message_set_response (msg, "application/json",
+      SOUP_MEMORY_COPY, body, strlen (body));
+}
+
+static const gchar *
+lookup_required_query_string (GHashTable *query, const gchar *name)
+{
+  const gchar *value = NULL;
+  if (query != NULL)
+    value = g_hash_table_lookup (query, name);
+  if (value == NULL || value[0] == '\0')
+    return NULL;
+  return value;
+}
+
+static void
+set_policy_mutation_error (SoupServerMessage *msg, wyrelog_error_t rc)
+{
+  if (rc == WYRELOG_E_INVALID) {
+    set_json_error (msg, 400, "invalid_policy_mutation");
+    return;
+  }
+  if (rc == WYRELOG_E_POLICY) {
+    set_json_error (msg, 403, "policy_mutation_denied");
+    return;
+  }
+  set_json_error (msg, 500, "policy_mutation_failed");
+}
+
+static void
+direct_permission_mutation_handler (SoupServer *server, SoupServerMessage *msg,
+    const char *path, GHashTable *query, gpointer user_data, gboolean grant)
+{
+  (void) path;
+
+  if (g_strcmp0 (soup_server_message_get_method (msg), "POST") != 0) {
+    set_json_error (msg, 405, "method_not_allowed");
+    return;
+  }
+
+  const gchar *subject = lookup_required_query_string (query, "subject");
+  const gchar *perm = lookup_required_query_string (query, "perm");
+  const gchar *scope = lookup_required_query_string (query, "scope");
+  if (subject == NULL || perm == NULL || scope == NULL) {
+    set_json_error (msg, 400, "invalid_policy_mutation");
+    return;
+  }
+
+  WylDaemonHttpContext *ctx = user_data;
+  g_autofree gchar *actor = NULL;
+  if (!authorize_guarded_session_action (server, msg, query, ctx,
+          "wr.policy.write", scope, "policy_auth_required",
+          "invalid_policy_auth", "policy_denied", "policy_auth_failed", &actor))
+    return;
+
+  wyrelog_error_t rc;
+  if (grant) {
+    g_autoptr (wyl_grant_req_t) req = wyl_grant_req_new ();
+    wyl_grant_req_set_subject_id (req, subject);
+    wyl_grant_req_set_action (req, perm);
+    wyl_grant_req_set_resource_id (req, scope);
+    wyl_grant_req_set_actor_id (req, actor);
+    rc = wyl_perm_grant (ctx->handle, req);
+  } else {
+    g_autoptr (wyl_revoke_req_t) req = wyl_revoke_req_new ();
+    wyl_revoke_req_set_subject_id (req, subject);
+    wyl_revoke_req_set_action (req, perm);
+    wyl_revoke_req_set_resource_id (req, scope);
+    wyl_revoke_req_set_actor_id (req, actor);
+    rc = wyl_perm_revoke (ctx->handle, req);
+  }
+  if (rc != WYRELOG_E_OK) {
+    set_policy_mutation_error (msg, rc);
+    return;
+  }
+
+  set_json_ok (msg);
+}
+
+static void
+policy_permission_grant_handler (SoupServer *server, SoupServerMessage *msg,
+    const char *path, GHashTable *query, gpointer user_data)
+{
+  direct_permission_mutation_handler (server, msg, path, query, user_data,
+      TRUE);
+}
+
+static void
+policy_permission_revoke_handler (SoupServer *server, SoupServerMessage *msg,
+    const char *path, GHashTable *query, gpointer user_data)
+{
+  direct_permission_mutation_handler (server, msg, path, query, user_data,
+      FALSE);
 }
 
 static void
@@ -507,6 +605,10 @@ wyl_daemon_start_http_server (const WylDaemonOptions *opts, WylHandle *handle,
   soup_server_add_handler (server, "/healthz", healthz_handler, NULL, NULL);
   soup_server_add_handler (server, "/auth/login", login_handler, ctx, NULL);
   soup_server_add_handler (server, "/decide", decide_handler, ctx, NULL);
+  soup_server_add_handler (server, "/policy/permissions/grant",
+      policy_permission_grant_handler, ctx, NULL);
+  soup_server_add_handler (server, "/policy/permissions/revoke",
+      policy_permission_revoke_handler, ctx, NULL);
   soup_server_add_handler (server, "/audit/events", audit_events_handler,
       ctx, NULL);
   if (!soup_server_listen_local (server, (guint) opts->listen_port, 0, error)) {

--- a/wyrelog/perm.h
+++ b/wyrelog/perm.h
@@ -41,6 +41,8 @@ const gchar *wyl_grant_req_get_action (const wyl_grant_req_t * req);
 void wyl_grant_req_set_resource_id (wyl_grant_req_t * req,
     const gchar * resource_id);
 const gchar *wyl_grant_req_get_resource_id (const wyl_grant_req_t * req);
+void wyl_grant_req_set_actor_id (wyl_grant_req_t * req, const gchar * actor_id);
+const gchar *wyl_grant_req_get_actor_id (const wyl_grant_req_t * req);
 
 wyl_revoke_req_t *wyl_revoke_req_new (void);
 void wyl_revoke_req_free (wyl_revoke_req_t * req);
@@ -63,6 +65,9 @@ const gchar *wyl_revoke_req_get_action (const wyl_revoke_req_t * req);
 void wyl_revoke_req_set_resource_id (wyl_revoke_req_t * req,
     const gchar * resource_id);
 const gchar *wyl_revoke_req_get_resource_id (const wyl_revoke_req_t * req);
+void wyl_revoke_req_set_actor_id (wyl_revoke_req_t * req,
+    const gchar * actor_id);
+const gchar *wyl_revoke_req_get_actor_id (const wyl_revoke_req_t * req);
 
 wyrelog_error_t wyl_perm_grant (WylHandle * handle,
     const wyl_grant_req_t * req);
@@ -85,6 +90,9 @@ const gchar *wyl_role_grant_req_get_role_id (const wyl_role_grant_req_t * req);
 void wyl_role_grant_req_set_scope (wyl_role_grant_req_t * req,
     const gchar * scope);
 const gchar *wyl_role_grant_req_get_scope (const wyl_role_grant_req_t * req);
+void wyl_role_grant_req_set_actor_id (wyl_role_grant_req_t * req,
+    const gchar * actor_id);
+const gchar *wyl_role_grant_req_get_actor_id (const wyl_role_grant_req_t * req);
 
 wyl_role_revoke_req_t *wyl_role_revoke_req_new (void);
 void wyl_role_revoke_req_free (wyl_role_revoke_req_t * req);
@@ -103,6 +111,10 @@ const gchar *wyl_role_revoke_req_get_role_id (const wyl_role_revoke_req_t *
 void wyl_role_revoke_req_set_scope (wyl_role_revoke_req_t * req,
     const gchar * scope);
 const gchar *wyl_role_revoke_req_get_scope (const wyl_role_revoke_req_t * req);
+void wyl_role_revoke_req_set_actor_id (wyl_role_revoke_req_t * req,
+    const gchar * actor_id);
+const gchar *wyl_role_revoke_req_get_actor_id (const wyl_role_revoke_req_t *
+    req);
 
 wyrelog_error_t wyl_role_grant (WylHandle * handle,
     const wyl_role_grant_req_t * req);

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -734,6 +734,8 @@ wyrelog_error_t
         audit_resource_id, audit_deny_reason, audit_deny_origin,
         audit_decision);
   }
+  if (rc == WYRELOG_E_OK)
+    rc = wyl_policy_store_validate_snapshot (store);
   if (rc != WYRELOG_E_OK) {
     wyl_policy_store_rollback_mutation (store);
     return rc;
@@ -1409,6 +1411,8 @@ wyrelog_error_t
         audit_resource_id, audit_deny_reason, audit_deny_origin,
         audit_decision);
   }
+  if (rc == WYRELOG_E_OK)
+    rc = wyl_policy_store_validate_snapshot (store);
   if (rc != WYRELOG_E_OK) {
     wyl_policy_store_rollback_mutation (store);
     return rc;

--- a/wyrelog/wyl-client.c
+++ b/wyrelog/wyl-client.c
@@ -235,6 +235,109 @@ wyl_client_mfa_verify (WylClient *client, const gchar *otp)
   return WYRELOG_E_INTERNAL;
 }
 
+static wyrelog_error_t
+client_policy_mutation_request (WylClient *client, const gchar *path,
+    const gchar *subject, const gchar *target_name, const gchar *target_value,
+    const gchar *scope, gint64 guard_timestamp, const gchar *guard_loc_class,
+    gint64 guard_risk)
+{
+  if (client == NULL || !WYL_IS_CLIENT (client) || path == NULL ||
+      subject == NULL || subject[0] == '\0' || target_name == NULL ||
+      target_value == NULL || target_value[0] == '\0' || scope == NULL ||
+      scope[0] == '\0')
+    return WYRELOG_E_INVALID;
+  if (guard_timestamp < 0 || guard_loc_class == NULL || guard_risk < 0 ||
+      guard_risk > 100 || !wyl_guard_loc_class_is_valid (guard_loc_class))
+    return WYRELOG_E_INVALID;
+
+  g_autofree gchar *session_token = wyl_client_dup_session_token (client);
+  if (session_token == NULL || session_token[0] == '\0')
+    return WYRELOG_E_INVALID;
+
+  g_autofree gchar *base_url = wyl_client_dup_base_url (client);
+  if (base_url == NULL)
+    return WYRELOG_E_INVALID;
+  while (base_url[0] != '\0' && g_str_has_suffix (base_url, "/"))
+    base_url[strlen (base_url) - 1] = '\0';
+
+  g_autofree gchar *escaped_subject = g_uri_escape_string (subject, NULL, TRUE);
+  g_autofree gchar *escaped_target =
+      g_uri_escape_string (target_value, NULL, TRUE);
+  g_autofree gchar *escaped_scope = g_uri_escape_string (scope, NULL, TRUE);
+  g_autofree gchar *escaped_session =
+      g_uri_escape_string (session_token, NULL, TRUE);
+  g_autofree gchar *escaped_loc =
+      g_uri_escape_string (guard_loc_class, NULL, TRUE);
+  g_autofree gchar *uri =
+      g_strdup_printf ("%s/%s?subject=%s&%s=%s&scope=%s&session_token=%s"
+      "&guard_timestamp=%" G_GINT64_FORMAT
+      "&guard_loc_class=%s&guard_risk=%" G_GINT64_FORMAT,
+      base_url, path, escaped_subject, target_name, escaped_target,
+      escaped_scope, escaped_session, guard_timestamp, escaped_loc,
+      guard_risk);
+
+  g_autoptr (SoupMessage) message = soup_message_new ("POST", uri);
+  if (message == NULL)
+    return WYRELOG_E_INVALID;
+
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GBytes) body =
+      soup_session_send_and_read (client->session, message, NULL, &error);
+  if (body == NULL)
+    return WYRELOG_E_IO;
+
+  guint status = soup_message_get_status (message);
+  if (status >= 200 && status < 300)
+    return WYRELOG_E_OK;
+  if (status == 400)
+    return WYRELOG_E_INVALID;
+  if (status == 401)
+    return WYRELOG_E_AUTH;
+  if (status == 403)
+    return WYRELOG_E_POLICY;
+  return WYRELOG_E_IO;
+}
+
+wyrelog_error_t
+wyl_client_policy_permission_grant (WylClient *client, const gchar *subject,
+    const gchar *perm, const gchar *scope, gint64 guard_timestamp,
+    const gchar *guard_loc_class, gint64 guard_risk)
+{
+  return client_policy_mutation_request (client, "policy/permissions/grant",
+      subject, "perm", perm, scope, guard_timestamp, guard_loc_class,
+      guard_risk);
+}
+
+wyrelog_error_t
+wyl_client_policy_permission_revoke (WylClient *client, const gchar *subject,
+    const gchar *perm, const gchar *scope, gint64 guard_timestamp,
+    const gchar *guard_loc_class, gint64 guard_risk)
+{
+  return client_policy_mutation_request (client, "policy/permissions/revoke",
+      subject, "perm", perm, scope, guard_timestamp, guard_loc_class,
+      guard_risk);
+}
+
+wyrelog_error_t
+wyl_client_policy_role_grant (WylClient *client, const gchar *subject,
+    const gchar *role, const gchar *scope, gint64 guard_timestamp,
+    const gchar *guard_loc_class, gint64 guard_risk)
+{
+  return client_policy_mutation_request (client, "policy/roles/grant",
+      subject, "role", role, scope, guard_timestamp, guard_loc_class,
+      guard_risk);
+}
+
+wyrelog_error_t
+wyl_client_policy_role_revoke (WylClient *client, const gchar *subject,
+    const gchar *role, const gchar *scope, gint64 guard_timestamp,
+    const gchar *guard_loc_class, gint64 guard_risk)
+{
+  return client_policy_mutation_request (client, "policy/roles/revoke",
+      subject, "role", role, scope, guard_timestamp, guard_loc_class,
+      guard_risk);
+}
+
 typedef struct
 {
   const gchar *data;

--- a/wyrelog/wyl-perm.c
+++ b/wyrelog/wyl-perm.c
@@ -16,6 +16,7 @@ struct _wyl_grant_req
   gchar *subject_id;
   gchar *action;
   gchar *resource_id;
+  gchar *actor_id;
 };
 
 struct _wyl_revoke_req
@@ -23,6 +24,7 @@ struct _wyl_revoke_req
   gchar *subject_id;
   gchar *action;
   gchar *resource_id;
+  gchar *actor_id;
 };
 
 struct _wyl_role_grant_req
@@ -30,6 +32,7 @@ struct _wyl_role_grant_req
   gchar *subject_id;
   gchar *role_id;
   gchar *scope;
+  gchar *actor_id;
 };
 
 struct _wyl_role_revoke_req
@@ -37,6 +40,7 @@ struct _wyl_role_revoke_req
   gchar *subject_id;
   gchar *role_id;
   gchar *scope;
+  gchar *actor_id;
 };
 
 wyl_login_req_t *
@@ -97,6 +101,7 @@ wyl_grant_req_free (wyl_grant_req_t *req)
   g_free (req->subject_id);
   g_free (req->action);
   g_free (req->resource_id);
+  g_free (req->actor_id);
   g_free (req);
 }
 
@@ -145,6 +150,21 @@ wyl_grant_req_get_resource_id (const wyl_grant_req_t *req)
   return req->resource_id;
 }
 
+void
+wyl_grant_req_set_actor_id (wyl_grant_req_t *req, const gchar *actor_id)
+{
+  g_return_if_fail (req != NULL);
+  g_free (req->actor_id);
+  req->actor_id = g_strdup (actor_id);
+}
+
+const gchar *
+wyl_grant_req_get_actor_id (const wyl_grant_req_t *req)
+{
+  g_return_val_if_fail (req != NULL, NULL);
+  return req->actor_id;
+}
+
 wyl_revoke_req_t *
 wyl_revoke_req_new (void)
 {
@@ -159,6 +179,7 @@ wyl_revoke_req_free (wyl_revoke_req_t *req)
   g_free (req->subject_id);
   g_free (req->action);
   g_free (req->resource_id);
+  g_free (req->actor_id);
   g_free (req);
 }
 
@@ -207,6 +228,21 @@ wyl_revoke_req_get_resource_id (const wyl_revoke_req_t *req)
   return req->resource_id;
 }
 
+void
+wyl_revoke_req_set_actor_id (wyl_revoke_req_t *req, const gchar *actor_id)
+{
+  g_return_if_fail (req != NULL);
+  g_free (req->actor_id);
+  req->actor_id = g_strdup (actor_id);
+}
+
+const gchar *
+wyl_revoke_req_get_actor_id (const wyl_revoke_req_t *req)
+{
+  g_return_val_if_fail (req != NULL, NULL);
+  return req->actor_id;
+}
+
 wyl_role_grant_req_t *
 wyl_role_grant_req_new (void)
 {
@@ -221,6 +257,7 @@ wyl_role_grant_req_free (wyl_role_grant_req_t *req)
   g_free (req->subject_id);
   g_free (req->role_id);
   g_free (req->scope);
+  g_free (req->actor_id);
   g_free (req);
 }
 
@@ -270,6 +307,22 @@ wyl_role_grant_req_get_scope (const wyl_role_grant_req_t *req)
   return req->scope;
 }
 
+void
+wyl_role_grant_req_set_actor_id (wyl_role_grant_req_t *req,
+    const gchar *actor_id)
+{
+  g_return_if_fail (req != NULL);
+  g_free (req->actor_id);
+  req->actor_id = g_strdup (actor_id);
+}
+
+const gchar *
+wyl_role_grant_req_get_actor_id (const wyl_role_grant_req_t *req)
+{
+  g_return_val_if_fail (req != NULL, NULL);
+  return req->actor_id;
+}
+
 wyl_role_revoke_req_t *
 wyl_role_revoke_req_new (void)
 {
@@ -284,6 +337,7 @@ wyl_role_revoke_req_free (wyl_role_revoke_req_t *req)
   g_free (req->subject_id);
   g_free (req->role_id);
   g_free (req->scope);
+  g_free (req->actor_id);
   g_free (req);
 }
 
@@ -332,6 +386,22 @@ wyl_role_revoke_req_get_scope (const wyl_role_revoke_req_t *req)
 {
   g_return_val_if_fail (req != NULL, NULL);
   return req->scope;
+}
+
+void
+wyl_role_revoke_req_set_actor_id (wyl_role_revoke_req_t *req,
+    const gchar *actor_id)
+{
+  g_return_if_fail (req != NULL);
+  g_free (req->actor_id);
+  req->actor_id = g_strdup (actor_id);
+}
+
+const gchar *
+wyl_role_revoke_req_get_actor_id (const wyl_role_revoke_req_t *req)
+{
+  g_return_val_if_fail (req != NULL, NULL);
+  return req->actor_id;
 }
 
 static wyrelog_error_t
@@ -433,7 +503,10 @@ wyl_perm_grant (WylHandle *handle, const wyl_grant_req_t *req)
    * part of the policy mutation savepoint. The action column carries
    * operation semantics while deny_origin retains the permission name. */
   g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
-  wyl_audit_event_set_subject_id (ev, wyl_grant_req_get_subject_id (req));
+  wyl_audit_event_set_subject_id (ev,
+      wyl_grant_req_get_actor_id (req) != NULL
+      ? wyl_grant_req_get_actor_id (req)
+      : wyl_grant_req_get_subject_id (req));
   wyl_audit_event_set_action (ev, "permission_grant");
   wyl_audit_event_set_resource_id (ev, wyl_grant_req_get_resource_id (req));
   wyl_audit_event_set_deny_origin (ev, wyl_grant_req_get_action (req));
@@ -462,7 +535,10 @@ wyl_perm_revoke (WylHandle *handle, const wyl_revoke_req_t *req)
 
 #ifdef WYL_HAS_AUDIT
   g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
-  wyl_audit_event_set_subject_id (ev, wyl_revoke_req_get_subject_id (req));
+  wyl_audit_event_set_subject_id (ev,
+      wyl_revoke_req_get_actor_id (req) != NULL
+      ? wyl_revoke_req_get_actor_id (req)
+      : wyl_revoke_req_get_subject_id (req));
   wyl_audit_event_set_action (ev, "permission_revoke");
   wyl_audit_event_set_resource_id (ev, wyl_revoke_req_get_resource_id (req));
   wyl_audit_event_set_deny_origin (ev, wyl_revoke_req_get_action (req));
@@ -491,7 +567,10 @@ wyl_role_grant (WylHandle *handle, const wyl_role_grant_req_t *req)
 
 #ifdef WYL_HAS_AUDIT
   g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
-  wyl_audit_event_set_subject_id (ev, wyl_role_grant_req_get_subject_id (req));
+  wyl_audit_event_set_subject_id (ev,
+      wyl_role_grant_req_get_actor_id (req) != NULL
+      ? wyl_role_grant_req_get_actor_id (req)
+      : wyl_role_grant_req_get_subject_id (req));
   wyl_audit_event_set_action (ev, "role_grant");
   wyl_audit_event_set_resource_id (ev, wyl_role_grant_req_get_scope (req));
   wyl_audit_event_set_deny_origin (ev, wyl_role_grant_req_get_role_id (req));
@@ -521,7 +600,10 @@ wyl_role_revoke (WylHandle *handle, const wyl_role_revoke_req_t *req)
 
 #ifdef WYL_HAS_AUDIT
   g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
-  wyl_audit_event_set_subject_id (ev, wyl_role_revoke_req_get_subject_id (req));
+  wyl_audit_event_set_subject_id (ev,
+      wyl_role_revoke_req_get_actor_id (req) != NULL
+      ? wyl_role_revoke_req_get_actor_id (req)
+      : wyl_role_revoke_req_get_subject_id (req));
   wyl_audit_event_set_action (ev, "role_revoke");
   wyl_audit_event_set_resource_id (ev, wyl_role_revoke_req_get_scope (req));
   wyl_audit_event_set_deny_origin (ev, wyl_role_revoke_req_get_role_id (req));


### PR DESCRIPTION
## Summary

- add guarded daemon HTTP endpoints for direct permission and role membership
  mutations
- validate policy mutation snapshots before durable commit to rollback invalid
  SoD snapshots
- carry stored-session actors into accepted mutation audit events
- add client helpers for guarded permission and role mutation requests

## Tests

- meson test -C builddir perm client-smoke daemon-http-decide wyrelogd-healthz client-audit-daemon --print-errorlogs
- meson test -C builddir-audit perm audit-emit client-smoke daemon-http-decide wyrelogd-healthz client-audit-daemon --print-errorlogs
