### PR TITLE
Tighten policy mutation error contracts

### DIFF
--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -653,6 +653,16 @@ check_policy_permission_mutation_contract (WylHandle *handle,
     return 129;
   g_clear_pointer (&body, g_free);
 
+  rc = send_raw_policy_mutation (session, "POST", base_url,
+      "/policy/permissions/grant", "subject=target&perm=site.missing"
+      "&scope=tenant-a&session_token=unknown&guard_timestamp=123"
+      "&guard_loc_class=public&guard_risk=49", &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 401 || strstr (body, "\"policy_auth_required\"") == NULL)
+    return 153;
+  g_clear_pointer (&body, g_free);
+
   g_autofree gchar *denied_query =
       g_strdup_printf ("subject=target&perm=site.policy.read&scope=tenant-a"
       "&session_token=%s&guard_timestamp=123&guard_loc_class=public"
@@ -668,9 +678,29 @@ check_policy_permission_mutation_contract (WylHandle *handle,
     return 131;
   g_clear_pointer (&body, g_free);
 
+  g_autofree gchar *missing_perm_grant_query =
+      g_strdup_printf ("subject=target&perm=site.missing&scope=tenant-a"
+      "&session_token=%s&guard_timestamp=123&guard_loc_class=public"
+      "&guard_risk=49", session_token);
+  rc = send_raw_policy_mutation (session, "POST", base_url,
+      "/policy/permissions/grant", missing_perm_grant_query, &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 403 || strstr (body, "\"policy_denied\"") == NULL)
+    return 154;
+  g_clear_pointer (&body, g_free);
+
   if (grant_policy_write_authority (handle, "http-policy-admin",
           "tenant-a") != WYRELOG_E_OK)
     return 132;
+
+  rc = send_raw_policy_mutation (session, "POST", base_url,
+      "/policy/permissions/grant", missing_perm_grant_query, &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 400 || strstr (body, "\"invalid_policy_mutation\"") == NULL)
+    return 155;
+  g_clear_pointer (&body, g_free);
 
   g_autofree gchar *guard_denied_query =
       g_strdup_printf ("subject=target&perm=site.policy.read&scope=tenant-a"
@@ -712,9 +742,31 @@ check_policy_permission_mutation_contract (WylHandle *handle,
           "tenant-a"))
     return 138;
 
+  g_autofree gchar *missing_perm_revoke_query =
+      g_strdup_printf ("subject=target&perm=site.missing&scope=tenant-a"
+      "&session_token=%s&guard_timestamp=123&guard_loc_class=public"
+      "&guard_risk=49", session_token);
+  g_clear_pointer (&body, g_free);
+  rc = send_raw_policy_mutation (session, "POST", base_url,
+      "/policy/permissions/revoke", missing_perm_revoke_query, &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 400 || strstr (body, "\"invalid_policy_mutation\"") == NULL)
+    return 149;
+
   if (wyl_policy_store_upsert_role (store, "site.reader",
           "site reader") != WYRELOG_E_OK)
     return 139;
+
+  g_clear_pointer (&body, g_free);
+  rc = send_raw_policy_mutation (session, "POST", base_url,
+      "/policy/roles/grant", "subject=role-target&role=site.missing"
+      "&scope=tenant-b&session_token=unknown&guard_timestamp=123"
+      "&guard_loc_class=public&guard_risk=29", &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 401 || strstr (body, "\"policy_auth_required\"") == NULL)
+    return 150;
 
   g_autofree gchar *role_denied_query =
       g_strdup_printf ("subject=role-target&role=site.reader&scope=tenant-b"
@@ -730,9 +782,29 @@ check_policy_permission_mutation_contract (WylHandle *handle,
   if (role_membership_exists (handle, "role-target", "site.reader", "tenant-b"))
     return 141;
 
+  g_autofree gchar *role_missing_denied_query =
+      g_strdup_printf ("subject=role-target&role=site.missing&scope=tenant-b"
+      "&session_token=%s&guard_timestamp=123&guard_loc_class=public"
+      "&guard_risk=29", session_token);
+  g_clear_pointer (&body, g_free);
+  rc = send_raw_policy_mutation (session, "POST", base_url,
+      "/policy/roles/grant", role_missing_denied_query, &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 403 || strstr (body, "\"policy_denied\"") == NULL)
+    return 151;
+
   if (grant_policy_role_authority (handle, "http-policy-admin",
           "tenant-b") != WYRELOG_E_OK)
     return 142;
+
+  g_clear_pointer (&body, g_free);
+  rc = send_raw_policy_mutation (session, "POST", base_url,
+      "/policy/roles/grant", role_missing_denied_query, &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 400 || strstr (body, "\"invalid_policy_mutation\"") == NULL)
+    return 152;
 
   g_autofree gchar *role_guard_denied_query =
       g_strdup_printf ("subject=role-target&role=site.reader&scope=tenant-b"

--- a/tests/test-policy-store.c
+++ b/tests/test-policy-store.c
@@ -491,6 +491,58 @@ check_store_grants_role_permission (void)
 }
 
 static gint
+check_store_catalog_existence_probes (void)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 218;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 219;
+
+  gboolean exists = TRUE;
+  if (wyl_policy_store_role_exists (store, "wr.missing-role", &exists)
+      != WYRELOG_E_OK)
+    return 220;
+  if (exists)
+    return 221;
+  if (wyl_policy_store_permission_exists (store, "wr.missing-perm", &exists)
+      != WYRELOG_E_OK)
+    return 222;
+  if (exists)
+    return 223;
+
+  if (wyl_policy_store_upsert_role (store, "wr.exists-role",
+          "exists role") != WYRELOG_E_OK)
+    return 224;
+  if (wyl_policy_store_upsert_permission (store, "wr.exists-perm",
+          "exists perm", "basic") != WYRELOG_E_OK)
+    return 225;
+
+  if (wyl_policy_store_role_exists (store, "wr.exists-role", &exists)
+      != WYRELOG_E_OK)
+    return 226;
+  if (!exists)
+    return 227;
+  if (wyl_policy_store_permission_exists (store, "wr.exists-perm", &exists)
+      != WYRELOG_E_OK)
+    return 228;
+  if (!exists)
+    return 229;
+
+  if (wyl_policy_store_role_exists (NULL, "wr.exists-role", &exists)
+      != WYRELOG_E_INVALID)
+    return 230;
+  if (wyl_policy_store_permission_exists (store, NULL, &exists)
+      != WYRELOG_E_INVALID)
+    return 231;
+  if (wyl_policy_store_permission_exists (store, "wr.exists-perm", NULL)
+      != WYRELOG_E_INVALID)
+    return 232;
+  return 0;
+}
+
+static gint
 check_store_grants_role_inheritance (void)
 {
   g_autoptr (wyl_policy_store_t) store = NULL;
@@ -1353,6 +1405,8 @@ main (void)
   if ((rc = check_handle_owns_policy_store ()) != 0)
     return rc;
   if ((rc = check_store_grants_role_permission ()) != 0)
+    return rc;
+  if ((rc = check_store_catalog_existence_probes ()) != 0)
     return rc;
   if ((rc = check_store_grants_role_inheritance ()) != 0)
     return rc;

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -367,6 +367,43 @@ set_policy_mutation_error (SoupServerMessage *msg, wyrelog_error_t rc)
   set_json_error (msg, 500, "policy_mutation_failed");
 }
 
+static gboolean
+ensure_policy_permission_exists (SoupServerMessage *msg,
+    WylDaemonHttpContext *ctx, const gchar *perm)
+{
+  gboolean exists = FALSE;
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (ctx->handle);
+  wyrelog_error_t rc =
+      wyl_policy_store_permission_exists (store, perm, &exists);
+  if (rc != WYRELOG_E_OK) {
+    set_json_error (msg, 500, "policy_mutation_failed");
+    return FALSE;
+  }
+  if (!exists) {
+    set_json_error (msg, 400, "invalid_policy_mutation");
+    return FALSE;
+  }
+  return TRUE;
+}
+
+static gboolean
+ensure_policy_role_exists (SoupServerMessage *msg, WylDaemonHttpContext *ctx,
+    const gchar *role)
+{
+  gboolean exists = FALSE;
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (ctx->handle);
+  wyrelog_error_t rc = wyl_policy_store_role_exists (store, role, &exists);
+  if (rc != WYRELOG_E_OK) {
+    set_json_error (msg, 500, "policy_mutation_failed");
+    return FALSE;
+  }
+  if (!exists) {
+    set_json_error (msg, 400, "invalid_policy_mutation");
+    return FALSE;
+  }
+  return TRUE;
+}
+
 static void
 direct_permission_mutation_handler (SoupServer *server, SoupServerMessage *msg,
     const char *path, GHashTable *query, gpointer user_data, gboolean grant)
@@ -391,6 +428,9 @@ direct_permission_mutation_handler (SoupServer *server, SoupServerMessage *msg,
   if (!authorize_guarded_session_action (server, msg, query, ctx,
           "wr.policy.write", scope, "policy_auth_required",
           "invalid_policy_auth", "policy_denied", "policy_auth_failed", &actor))
+    return;
+
+  if (!ensure_policy_permission_exists (msg, ctx, perm))
     return;
 
   wyrelog_error_t rc;
@@ -457,6 +497,9 @@ role_membership_mutation_handler (SoupServer *server, SoupServerMessage *msg,
   if (!authorize_guarded_session_action (server, msg, query, ctx,
           "wr.policy.grant_role", scope, "policy_auth_required",
           "invalid_policy_auth", "policy_denied", "policy_auth_failed", &actor))
+    return;
+
+  if (!ensure_policy_role_exists (msg, ctx, role))
     return;
 
   wyrelog_error_t rc;

--- a/wyrelog/policy/store-private.h
+++ b/wyrelog/policy/store-private.h
@@ -71,6 +71,10 @@ wyrelog_error_t wyl_policy_store_upsert_role (wyl_policy_store_t * store,
     const gchar * role_id, const gchar * role_name);
 wyrelog_error_t wyl_policy_store_upsert_permission (wyl_policy_store_t * store,
     const gchar * perm_id, const gchar * perm_name, const gchar * klass);
+wyrelog_error_t wyl_policy_store_role_exists (wyl_policy_store_t * store,
+    const gchar * role_id, gboolean * out_exists);
+wyrelog_error_t wyl_policy_store_permission_exists (wyl_policy_store_t * store,
+    const gchar * perm_id, gboolean * out_exists);
 wyrelog_error_t wyl_policy_store_grant_role_permission (wyl_policy_store_t *
     store, const gchar * role_id, const gchar * perm_id);
 wyrelog_error_t wyl_policy_store_foreach_role_permission (wyl_policy_store_t *

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -1192,6 +1192,54 @@ wyl_policy_store_upsert_permission (wyl_policy_store_t *store,
   return (step_rc == SQLITE_DONE) ? WYRELOG_E_OK : WYRELOG_E_IO;
 }
 
+static wyrelog_error_t
+catalog_row_exists (wyl_policy_store_t *store, const gchar *table,
+    const gchar *column, const gchar *value, gboolean *out_exists)
+{
+  sqlite3_stmt *stmt = NULL;
+
+  if (store == NULL || store->db == NULL || table == NULL || column == NULL ||
+      value == NULL || out_exists == NULL)
+    return WYRELOG_E_INVALID;
+
+  *out_exists = FALSE;
+  g_autofree gchar *sql =
+      g_strdup_printf ("SELECT 1 FROM %s WHERE %s = ?;", table, column);
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if ((rc = bind_text (stmt, 1, value)) != WYRELOG_E_OK) {
+    sqlite3_finalize (stmt);
+    return rc;
+  }
+
+  int step_rc = sqlite3_step (stmt);
+  if (step_rc == SQLITE_ROW)
+    *out_exists = TRUE;
+  else if (step_rc != SQLITE_DONE) {
+    sqlite3_finalize (stmt);
+    return WYRELOG_E_IO;
+  }
+
+  sqlite3_finalize (stmt);
+  return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
+wyl_policy_store_role_exists (wyl_policy_store_t *store, const gchar *role_id,
+    gboolean *out_exists)
+{
+  return catalog_row_exists (store, "roles", "role_id", role_id, out_exists);
+}
+
+wyrelog_error_t
+wyl_policy_store_permission_exists (wyl_policy_store_t *store,
+    const gchar *perm_id, gboolean *out_exists)
+{
+  return catalog_row_exists (store, "permissions", "perm_id", perm_id,
+      out_exists);
+}
+
 wyrelog_error_t
 wyl_policy_store_grant_role_permission (wyl_policy_store_t *store,
     const gchar *role_id, const gchar *perm_id)


### PR DESCRIPTION
## Summary
- add private Policy DB catalog existence probes
- preflight authorized policy mutation targets before invoking mutating APIs
- preserve auth and policy-denied precedence before target existence checks

## Tests
- meson test -C builddir policy-store daemon-http-decide client-smoke --print-errorlogs
- meson test -C builddir-audit policy-store daemon-http-decide client-smoke --print-errorlogs
