### PR TITLE
Bootstrap built-in policy catalog targets

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -240,7 +240,7 @@ test_template_tree = executable('test-template-tree',
   c_args : [
     '-DWYL_TEST_TEMPLATE_DIR="' + meson.project_source_root() / 'templates' / 'access' + '"',
   ],
-  dependencies : [glib_dep],
+  dependencies : [wyrelog_dep],
 )
 
 test('template-tree', test_template_tree)

--- a/tests/test-audit-emit.c
+++ b/tests/test-audit-emit.c
@@ -904,7 +904,7 @@ check_permission_grant_rolls_back_on_store_audit_failure (void)
 
   g_autoptr (wyl_grant_req_t) req = wyl_grant_req_new ();
   wyl_grant_req_set_subject_id (req, "audit-grant-rollback-user");
-  wyl_grant_req_set_action (req, "wr.audit-grant-rollback");
+  wyl_grant_req_set_action (req, "site.audit-grant-rollback");
   wyl_grant_req_set_resource_id (req, "audit-grant-rollback-scope");
   if (wyl_perm_grant (handle, req) != WYRELOG_E_IO) {
     g_object_unref (handle);
@@ -913,7 +913,7 @@ check_permission_grant_rolls_back_on_store_audit_failure (void)
 
   gboolean exists = TRUE;
   if (wyl_policy_store_direct_permission_exists (store,
-          "audit-grant-rollback-user", "wr.audit-grant-rollback",
+          "audit-grant-rollback-user", "site.audit-grant-rollback",
           "audit-grant-rollback-scope", &exists) != WYRELOG_E_OK) {
     g_object_unref (handle);
     return 60;
@@ -933,8 +933,8 @@ check_role_grant_rolls_back_on_store_audit_failure (void)
   WylHandle *handle = NULL;
   if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
     return 246;
-  if (seed_audit_role_permission (handle, "wr.audit-role-rollback",
-          "wr.audit-role-rollback.read") != 0) {
+  if (seed_audit_role_permission (handle, "site.audit-role-rollback",
+          "site.audit-role-rollback.read") != 0) {
     g_object_unref (handle);
     return 69;
   }
@@ -951,7 +951,7 @@ check_role_grant_rolls_back_on_store_audit_failure (void)
 
   g_autoptr (wyl_role_grant_req_t) req = wyl_role_grant_req_new ();
   wyl_role_grant_req_set_subject_id (req, "audit-role-rollback-user");
-  wyl_role_grant_req_set_role_id (req, "wr.audit-role-rollback");
+  wyl_role_grant_req_set_role_id (req, "site.audit-role-rollback");
   wyl_role_grant_req_set_scope (req, "audit-role-rollback-scope");
   if (wyl_role_grant (handle, req) != WYRELOG_E_IO) {
     g_object_unref (handle);
@@ -960,7 +960,7 @@ check_role_grant_rolls_back_on_store_audit_failure (void)
 
   gboolean exists = TRUE;
   if (wyl_policy_store_role_membership_exists (store,
-          "audit-role-rollback-user", "wr.audit-role-rollback",
+          "audit-role-rollback-user", "site.audit-role-rollback",
           "audit-role-rollback-scope", &exists) != WYRELOG_E_OK) {
     g_object_unref (handle);
     return 72;
@@ -994,7 +994,7 @@ check_permission_grant_survives_runtime_audit_failure (void)
 
   g_autoptr (wyl_grant_req_t) req = wyl_grant_req_new ();
   wyl_grant_req_set_subject_id (req, "audit-grant-runtime-user");
-  wyl_grant_req_set_action (req, "wr.audit-grant-runtime");
+  wyl_grant_req_set_action (req, "site.audit-grant-runtime");
   wyl_grant_req_set_resource_id (req, "audit-grant-runtime-scope");
   if (wyl_perm_grant (handle, req) != WYRELOG_E_OK) {
     g_object_unref (handle);
@@ -1692,7 +1692,7 @@ check_permission_grant_emits_audit_row (void)
 
   g_autoptr (wyl_grant_req_t) grant = wyl_grant_req_new ();
   wyl_grant_req_set_subject_id (grant, "audit-grant-user");
-  wyl_grant_req_set_action (grant, "wr.audit-grant");
+  wyl_grant_req_set_action (grant, "site.audit-grant");
   wyl_grant_req_set_resource_id (grant, "audit-grant-scope");
   if (wyl_perm_grant (handle, grant) != WYRELOG_E_OK) {
     g_object_unref (handle);
@@ -1728,7 +1728,7 @@ check_permission_grant_emits_audit_row (void)
     rc = 125;
   else if (g_strcmp0 (resource, "audit-grant-scope") != 0)
     rc = 126;
-  else if (g_strcmp0 (permission, "wr.audit-grant") != 0)
+  else if (g_strcmp0 (permission, "site.audit-grant") != 0)
     rc = 127;
   else if (decision != WYL_DECISION_ALLOW)
     rc = 128;
@@ -1751,7 +1751,7 @@ check_permission_grant_actor_emits_audit_subject (void)
 
   g_autoptr (wyl_grant_req_t) grant = wyl_grant_req_new ();
   wyl_grant_req_set_subject_id (grant, "audit-grant-target");
-  wyl_grant_req_set_action (grant, "wr.audit-grant-actor");
+  wyl_grant_req_set_action (grant, "site.audit-grant-actor");
   wyl_grant_req_set_resource_id (grant, "audit-grant-actor-scope");
   wyl_grant_req_set_actor_id (grant, "audit-grant-actor");
   if (wyl_perm_grant (handle, grant) != WYRELOG_E_OK) {
@@ -1765,7 +1765,7 @@ check_permission_grant_actor_emits_audit_subject (void)
   if (duckdb_query (conn,
           "SELECT subject_id FROM audit_events "
           "WHERE action = 'permission_grant' "
-          "AND deny_origin = 'wr.audit-grant-actor';", &result)
+          "AND deny_origin = 'site.audit-grant-actor';", &result)
       != DuckDBSuccess) {
     duckdb_destroy_result (&result);
     g_object_unref (handle);
@@ -1797,7 +1797,7 @@ check_permission_revoke_emits_audit_row (void)
 
   g_autoptr (wyl_grant_req_t) grant = wyl_grant_req_new ();
   wyl_grant_req_set_subject_id (grant, "audit-revoke-user");
-  wyl_grant_req_set_action (grant, "wr.audit-revoke");
+  wyl_grant_req_set_action (grant, "site.audit-revoke");
   wyl_grant_req_set_resource_id (grant, "audit-revoke-scope");
   if (wyl_perm_grant (handle, grant) != WYRELOG_E_OK) {
     g_object_unref (handle);
@@ -1806,7 +1806,7 @@ check_permission_revoke_emits_audit_row (void)
 
   g_autoptr (wyl_revoke_req_t) revoke = wyl_revoke_req_new ();
   wyl_revoke_req_set_subject_id (revoke, "audit-revoke-user");
-  wyl_revoke_req_set_action (revoke, "wr.audit-revoke");
+  wyl_revoke_req_set_action (revoke, "site.audit-revoke");
   wyl_revoke_req_set_resource_id (revoke, "audit-revoke-scope");
   if (wyl_perm_revoke (handle, revoke) != WYRELOG_E_OK) {
     g_object_unref (handle);
@@ -1842,7 +1842,7 @@ check_permission_revoke_emits_audit_row (void)
     rc = 136;
   else if (g_strcmp0 (resource, "audit-revoke-scope") != 0)
     rc = 137;
-  else if (g_strcmp0 (permission, "wr.audit-revoke") != 0)
+  else if (g_strcmp0 (permission, "site.audit-revoke") != 0)
     rc = 138;
   else if (decision != WYL_DECISION_ALLOW)
     rc = 139;
@@ -1881,15 +1881,15 @@ check_role_grant_emits_audit_row (void)
   WylHandle *handle = NULL;
   if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
     return 140;
-  if (seed_audit_role_permission (handle, "wr.audit-role-grant",
-          "wr.audit-role-grant.read") != 0) {
+  if (seed_audit_role_permission (handle, "site.audit-role-grant",
+          "site.audit-role-grant.read") != 0) {
     g_object_unref (handle);
     return 141;
   }
 
   g_autoptr (wyl_role_grant_req_t) grant = wyl_role_grant_req_new ();
   wyl_role_grant_req_set_subject_id (grant, "audit-role-grant-user");
-  wyl_role_grant_req_set_role_id (grant, "wr.audit-role-grant");
+  wyl_role_grant_req_set_role_id (grant, "site.audit-role-grant");
   wyl_role_grant_req_set_scope (grant, "audit-role-grant-scope");
   if (wyl_role_grant (handle, grant) != WYRELOG_E_OK) {
     g_object_unref (handle);
@@ -1925,7 +1925,7 @@ check_role_grant_emits_audit_row (void)
     rc = 146;
   else if (g_strcmp0 (resource, "audit-role-grant-scope") != 0)
     rc = 147;
-  else if (g_strcmp0 (role, "wr.audit-role-grant") != 0)
+  else if (g_strcmp0 (role, "site.audit-role-grant") != 0)
     rc = 148;
   else if (decision != WYL_DECISION_ALLOW)
     rc = 149;
@@ -1945,15 +1945,15 @@ check_role_revoke_emits_audit_row (void)
   WylHandle *handle = NULL;
   if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
     return 150;
-  if (seed_audit_role_permission (handle, "wr.audit-role-revoke",
-          "wr.audit-role-revoke.read") != 0) {
+  if (seed_audit_role_permission (handle, "site.audit-role-revoke",
+          "site.audit-role-revoke.read") != 0) {
     g_object_unref (handle);
     return 151;
   }
 
   g_autoptr (wyl_role_grant_req_t) grant = wyl_role_grant_req_new ();
   wyl_role_grant_req_set_subject_id (grant, "audit-role-revoke-user");
-  wyl_role_grant_req_set_role_id (grant, "wr.audit-role-revoke");
+  wyl_role_grant_req_set_role_id (grant, "site.audit-role-revoke");
   wyl_role_grant_req_set_scope (grant, "audit-role-revoke-scope");
   if (wyl_role_grant (handle, grant) != WYRELOG_E_OK) {
     g_object_unref (handle);
@@ -1962,7 +1962,7 @@ check_role_revoke_emits_audit_row (void)
 
   g_autoptr (wyl_role_revoke_req_t) revoke = wyl_role_revoke_req_new ();
   wyl_role_revoke_req_set_subject_id (revoke, "audit-role-revoke-user");
-  wyl_role_revoke_req_set_role_id (revoke, "wr.audit-role-revoke");
+  wyl_role_revoke_req_set_role_id (revoke, "site.audit-role-revoke");
   wyl_role_revoke_req_set_scope (revoke, "audit-role-revoke-scope");
   if (wyl_role_revoke (handle, revoke) != WYRELOG_E_OK) {
     g_object_unref (handle);
@@ -1998,7 +1998,7 @@ check_role_revoke_emits_audit_row (void)
     rc = 157;
   else if (g_strcmp0 (resource, "audit-role-revoke-scope") != 0)
     rc = 158;
-  else if (g_strcmp0 (role, "wr.audit-role-revoke") != 0)
+  else if (g_strcmp0 (role, "site.audit-role-revoke") != 0)
     rc = 159;
   else if (decision != WYL_DECISION_ALLOW)
     rc = 160;

--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -536,11 +536,7 @@ grant_policy_write_authority (WylHandle *handle, const gchar *subject,
     const gchar *scope)
 {
   wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
-  wyrelog_error_t rc = wyl_policy_store_upsert_permission (store,
-      "wr.policy.write", "policy write", "critical");
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  rc = wyl_policy_store_grant_direct_permission (store, subject,
+  wyrelog_error_t rc = wyl_policy_store_grant_direct_permission (store, subject,
       "wr.policy.write", scope);
   if (rc != WYRELOG_E_OK)
     return rc;
@@ -555,11 +551,7 @@ grant_policy_role_authority (WylHandle *handle, const gchar *subject,
     const gchar *scope)
 {
   wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
-  wyrelog_error_t rc = wyl_policy_store_upsert_permission (store,
-      "wr.policy.grant_role", "policy grant role", "critical");
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  rc = wyl_policy_store_grant_direct_permission (store, subject,
+  wyrelog_error_t rc = wyl_policy_store_grant_direct_permission (store, subject,
       "wr.policy.grant_role", scope);
   if (rc != WYRELOG_E_OK)
     return rc;
@@ -732,6 +724,32 @@ check_policy_permission_mutation_contract (WylHandle *handle,
     return 136;
   g_clear_pointer (&body, g_free);
 
+  g_autofree gchar *builtin_grant_query =
+      g_strdup_printf ("subject=builtin-target&perm=wr.stream.read"
+      "&scope=tenant-a&session_token=%s&guard_timestamp=123"
+      "&guard_loc_class=public&guard_risk=49", session_token);
+  rc = send_raw_policy_mutation (session, "POST", base_url,
+      "/policy/permissions/grant", builtin_grant_query, &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 200 || strstr (body, "\"ok\":true") == NULL)
+    return 156;
+  if (!direct_permission_exists (handle, "builtin-target", "wr.stream.read",
+          "tenant-a"))
+    return 157;
+  g_clear_pointer (&body, g_free);
+
+  rc = send_raw_policy_mutation (session, "POST", base_url,
+      "/policy/permissions/revoke", builtin_grant_query, &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 200 || strstr (body, "\"ok\":true") == NULL)
+    return 158;
+  if (direct_permission_exists (handle, "builtin-target", "wr.stream.read",
+          "tenant-a"))
+    return 159;
+  g_clear_pointer (&body, g_free);
+
   rc = send_raw_policy_mutation (session, "POST", base_url,
       "/policy/permissions/revoke", grant_query, &status, &body);
   if (rc != 0)
@@ -834,6 +852,32 @@ check_policy_permission_mutation_contract (WylHandle *handle,
   if (!role_membership_exists (handle, "role-target", "site.reader",
           "tenant-b"))
     return 146;
+
+  g_autofree gchar *builtin_role_query =
+      g_strdup_printf ("subject=builtin-role-target&role=wr.auditor"
+      "&scope=tenant-b&session_token=%s&guard_timestamp=123"
+      "&guard_loc_class=public&guard_risk=29", session_token);
+  g_clear_pointer (&body, g_free);
+  rc = send_raw_policy_mutation (session, "POST", base_url,
+      "/policy/roles/grant", builtin_role_query, &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 200 || strstr (body, "\"ok\":true") == NULL)
+    return 160;
+  if (!role_membership_exists (handle, "builtin-role-target", "wr.auditor",
+          "tenant-b"))
+    return 161;
+
+  g_clear_pointer (&body, g_free);
+  rc = send_raw_policy_mutation (session, "POST", base_url,
+      "/policy/roles/revoke", builtin_role_query, &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 200 || strstr (body, "\"ok\":true") == NULL)
+    return 162;
+  if (role_membership_exists (handle, "builtin-role-target", "wr.auditor",
+          "tenant-b"))
+    return 163;
 
   g_clear_pointer (&body, g_free);
   rc = send_raw_policy_mutation (session, "POST", base_url,

--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -648,19 +648,19 @@ check_reload_loads_policy_store_snapshot (void)
     return 59;
 
   wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
-  if (wyl_policy_store_upsert_role (store, "wr.reload-role", "reload role")
+  if (wyl_policy_store_upsert_role (store, "site.reload-role", "reload role")
       != WYRELOG_E_OK)
     return 53;
-  if (wyl_policy_store_upsert_permission (store, "wr.reload.read",
+  if (wyl_policy_store_upsert_permission (store, "site.reload.read",
           "reload read", "basic") != WYRELOG_E_OK)
     return 54;
-  if (wyl_policy_store_grant_role_permission (store, "wr.reload-role",
-          "wr.reload.read") != WYRELOG_E_OK)
+  if (wyl_policy_store_grant_role_permission (store, "site.reload-role",
+          "site.reload.read") != WYRELOG_E_OK)
     return 45;
   if (wyl_handle_reload_engine_pair (handle) != WYRELOG_E_OK)
     return 46;
 
-  if (insert3_symbol (handle, "member_of", "reload-user", "wr.reload-role",
+  if (insert3_symbol (handle, "member_of", "reload-user", "site.reload-role",
           "reload-scope") != WYRELOG_E_OK)
     return 47;
   if (insert2_symbol (handle, "principal_state", "reload-user",
@@ -669,12 +669,12 @@ check_reload_loads_policy_store_snapshot (void)
   if (insert2_symbol (handle, "session_state", "reload-scope", "active")
       != WYRELOG_E_OK)
     return 49;
-  if (insert4_symbol (handle, "perm_state", "reload-user", "wr.reload.read",
+  if (insert4_symbol (handle, "perm_state", "reload-user", "site.reload.read",
           "reload-scope", "armed") != WYRELOG_E_OK)
     return 44;
 
   gint64 decision_row[3];
-  if (intern3 (handle, "reload-user", "wr.reload.read", "reload-scope",
+  if (intern3 (handle, "reload-user", "site.reload.read", "reload-scope",
           decision_row) != WYRELOG_E_OK)
     return 33;
   gboolean allowed = FALSE;
@@ -1169,10 +1169,10 @@ check_role_permission_insert_skips_delta_engine (void)
   if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
       != WYRELOG_E_OK)
     return 188;
-  if (wyl_handle_intern_engine_symbol (handle, "wr.snapshot-role", &row[0])
+  if (wyl_handle_intern_engine_symbol (handle, "site.snapshot-role", &row[0])
       != WYRELOG_E_OK)
     return 189;
-  if (wyl_handle_intern_engine_symbol (handle, "wr.snapshot-role.read",
+  if (wyl_handle_intern_engine_symbol (handle, "site.snapshot-role.read",
           &row[1]) != WYRELOG_E_OK)
     return 190;
   if (wyl_handle_engine_set_delta_callback (handle, delta_count_cb, &deltas)
@@ -1279,7 +1279,7 @@ check_perm_state_insert_skips_delta_engine (void)
   if (drain_delta_callbacks (handle, &deltas) != WYRELOG_E_OK)
     return 219;
   if (insert4_symbol (handle, "perm_state", "snapshot-perm-user",
-          "wr.snapshot-perm", "snapshot-perm-scope", "armed")
+          "site.snapshot-perm", "snapshot-perm-scope", "armed")
       != WYRELOG_E_OK)
     return 216;
   if (wyl_handle_engine_step_delta (handle) != WYRELOG_E_OK)
@@ -1550,21 +1550,21 @@ check_policy_store_role_permissions_load_into_engine (void)
     return 320;
 
   wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
-  if (wyl_policy_store_upsert_role (store, "wr.store-role", "store role")
+  if (wyl_policy_store_upsert_role (store, "site.store-role", "store role")
       != WYRELOG_E_OK)
     return 321;
-  if (wyl_policy_store_upsert_permission (store, "wr.store.read",
+  if (wyl_policy_store_upsert_permission (store, "site.store.read",
           "store read", "basic") != WYRELOG_E_OK)
     return 322;
-  if (wyl_policy_store_grant_role_permission (store, "wr.store-role",
-          "wr.store.read") != WYRELOG_E_OK)
+  if (wyl_policy_store_grant_role_permission (store, "site.store-role",
+          "site.store.read") != WYRELOG_E_OK)
     return 323;
   if (wyl_handle_load_policy_store_role_permissions (handle) != WYRELOG_E_OK)
     return 324;
 
   gint64 decision_row[3];
-  if (insert_decision_fixture (handle, "store-user", "wr.store-role",
-          "wr.store.read", "store-scope", "authenticated", "active",
+  if (insert_decision_fixture (handle, "store-user", "site.store-role",
+          "site.store.read", "store-scope", "authenticated", "active",
           decision_row) != WYRELOG_E_OK)
     return 325;
   gboolean allowed = FALSE;
@@ -1585,22 +1585,22 @@ check_policy_store_role_permissions_autoload_on_open (void)
     return 340;
 
   wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
-  if (wyl_policy_store_upsert_role (store, "wr.autoload-role",
+  if (wyl_policy_store_upsert_role (store, "site.autoload-role",
           "autoload role") != WYRELOG_E_OK)
     return 341;
-  if (wyl_policy_store_upsert_permission (store, "wr.autoload.read",
+  if (wyl_policy_store_upsert_permission (store, "site.autoload.read",
           "autoload read", "basic") != WYRELOG_E_OK)
     return 342;
-  if (wyl_policy_store_grant_role_permission (store, "wr.autoload-role",
-          "wr.autoload.read") != WYRELOG_E_OK)
+  if (wyl_policy_store_grant_role_permission (store, "site.autoload-role",
+          "site.autoload.read") != WYRELOG_E_OK)
     return 343;
   if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
       != WYRELOG_E_OK)
     return 344;
 
   gint64 decision_row[3];
-  if (insert_decision_fixture (handle, "autoload-user", "wr.autoload-role",
-          "wr.autoload.read", "autoload-scope", "authenticated", "active",
+  if (insert_decision_fixture (handle, "autoload-user", "site.autoload-role",
+          "site.autoload.read", "autoload-scope", "authenticated", "active",
           decision_row) != WYRELOG_E_OK)
     return 345;
   gboolean allowed = FALSE;
@@ -1621,27 +1621,27 @@ check_policy_store_role_inheritances_autoload_on_open (void)
     return 348;
 
   wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
-  if (wyl_policy_store_upsert_role (store, "wr.inherit-child",
+  if (wyl_policy_store_upsert_role (store, "site.inherit-child",
           "inherit child") != WYRELOG_E_OK)
     return 349;
-  if (wyl_policy_store_upsert_role (store, "wr.inherit-parent",
+  if (wyl_policy_store_upsert_role (store, "site.inherit-parent",
           "inherit parent") != WYRELOG_E_OK)
     return 350;
-  if (wyl_policy_store_upsert_permission (store, "wr.inherit.read",
+  if (wyl_policy_store_upsert_permission (store, "site.inherit.read",
           "inherit read", "basic") != WYRELOG_E_OK)
     return 351;
-  if (wyl_policy_store_grant_role_permission (store, "wr.inherit-parent",
-          "wr.inherit.read") != WYRELOG_E_OK)
+  if (wyl_policy_store_grant_role_permission (store, "site.inherit-parent",
+          "site.inherit.read") != WYRELOG_E_OK)
     return 352;
-  if (wyl_policy_store_grant_role_inheritance (store, "wr.inherit-child",
-          "wr.inherit-parent") != WYRELOG_E_OK)
+  if (wyl_policy_store_grant_role_inheritance (store, "site.inherit-child",
+          "site.inherit-parent") != WYRELOG_E_OK)
     return 353;
   if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
       != WYRELOG_E_OK)
     return 354;
 
   if (insert3_symbol (handle, "member_of", "inherit-user",
-          "wr.inherit-child", "inherit-scope") != WYRELOG_E_OK)
+          "site.inherit-child", "inherit-scope") != WYRELOG_E_OK)
     return 355;
   if (insert2_symbol (handle, "principal_state", "inherit-user",
           "authenticated") != WYRELOG_E_OK)
@@ -1650,11 +1650,11 @@ check_policy_store_role_inheritances_autoload_on_open (void)
       != WYRELOG_E_OK)
     return 357;
   if (insert4_symbol (handle, "perm_state", "inherit-user",
-          "wr.inherit.read", "inherit-scope", "armed") != WYRELOG_E_OK)
+          "site.inherit.read", "inherit-scope", "armed") != WYRELOG_E_OK)
     return 358;
 
   gint64 decision_row[3];
-  if (intern3 (handle, "inherit-user", "wr.inherit.read", "inherit-scope",
+  if (intern3 (handle, "inherit-user", "site.inherit.read", "inherit-scope",
           decision_row) != WYRELOG_E_OK)
     return 359;
   gboolean allowed = FALSE;
@@ -1691,17 +1691,17 @@ check_policy_store_role_memberships_autoload_on_open (void)
     return 333;
 
   wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
-  if (wyl_policy_store_upsert_role (store, "wr.member-load-role",
+  if (wyl_policy_store_upsert_role (store, "site.member-load-role",
           "member load role") != WYRELOG_E_OK)
     return 334;
-  if (wyl_policy_store_upsert_permission (store, "wr.member-load.read",
+  if (wyl_policy_store_upsert_permission (store, "site.member-load.read",
           "member load read", "basic") != WYRELOG_E_OK)
     return 335;
-  if (wyl_policy_store_grant_role_permission (store, "wr.member-load-role",
-          "wr.member-load.read") != WYRELOG_E_OK)
+  if (wyl_policy_store_grant_role_permission (store, "site.member-load-role",
+          "site.member-load.read") != WYRELOG_E_OK)
     return 336;
   if (wyl_policy_store_grant_role_membership (store, "member-load-user",
-          "wr.member-load-role", "member-load-scope") != WYRELOG_E_OK)
+          "site.member-load-role", "member-load-scope") != WYRELOG_E_OK)
     return 337;
   if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
       != WYRELOG_E_OK)
@@ -1714,12 +1714,12 @@ check_policy_store_role_memberships_autoload_on_open (void)
           "active") != WYRELOG_E_OK)
     return 340;
   if (insert4_symbol (handle, "perm_state", "member-load-user",
-          "wr.member-load.read", "member-load-scope", "armed")
+          "site.member-load.read", "member-load-scope", "armed")
       != WYRELOG_E_OK)
     return 341;
 
   gint64 decision_row[3];
-  if (intern3 (handle, "member-load-user", "wr.member-load.read",
+  if (intern3 (handle, "member-load-user", "site.member-load.read",
           "member-load-scope", decision_row) != WYRELOG_E_OK)
     return 342;
   gboolean allowed = FALSE;
@@ -1754,11 +1754,11 @@ check_policy_store_direct_permissions_autoload_on_open (void)
     return 350;
 
   wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
-  if (wyl_policy_store_upsert_permission (store, "wr.direct.autoload",
+  if (wyl_policy_store_upsert_permission (store, "site.direct.autoload",
           "direct autoload", "basic") != WYRELOG_E_OK)
     return 351;
   if (wyl_policy_store_grant_direct_permission (store, "direct-load-user",
-          "wr.direct.autoload", "direct-load-scope") != WYRELOG_E_OK)
+          "site.direct.autoload", "direct-load-scope") != WYRELOG_E_OK)
     return 352;
   if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
       != WYRELOG_E_OK)
@@ -1774,7 +1774,7 @@ check_policy_store_direct_permissions_autoload_on_open (void)
     return 356;
 
   gint64 decision_row[3];
-  if (intern3 (handle, "direct-load-user", "wr.direct.autoload",
+  if (intern3 (handle, "direct-load-user", "site.direct.autoload",
           "direct-load-scope", decision_row) != WYRELOG_E_OK)
     return 357;
   gboolean allowed = FALSE;
@@ -2455,17 +2455,17 @@ check_policy_store_inheritance_cycle_fails_open (void)
   if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
     return 467;
   wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
-  if (wyl_policy_store_upsert_role (store, "wr.cycle-a", "cycle a")
+  if (wyl_policy_store_upsert_role (store, "site.cycle-a", "cycle a")
       != WYRELOG_E_OK)
     return 468;
-  if (wyl_policy_store_upsert_role (store, "wr.cycle-b", "cycle b")
+  if (wyl_policy_store_upsert_role (store, "site.cycle-b", "cycle b")
       != WYRELOG_E_OK)
     return 469;
-  if (wyl_policy_store_grant_role_inheritance (store, "wr.cycle-a",
-          "wr.cycle-b") != WYRELOG_E_OK)
+  if (wyl_policy_store_grant_role_inheritance (store, "site.cycle-a",
+          "site.cycle-b") != WYRELOG_E_OK)
     return 470;
-  if (wyl_policy_store_grant_role_inheritance (store, "wr.cycle-b",
-          "wr.cycle-a") != WYRELOG_E_OK)
+  if (wyl_policy_store_grant_role_inheritance (store, "site.cycle-b",
+          "site.cycle-a") != WYRELOG_E_OK)
     return 471;
   if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
       != WYRELOG_E_POLICY)
@@ -2490,15 +2490,15 @@ check_policy_store_inheritance_depth_fails_reload_and_preserves_pair (void)
 
   wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
   for (guint i = 0; i < 5; i++) {
-    g_autofree gchar *role_id = g_strdup_printf ("wr.depth-%u", i);
+    g_autofree gchar *role_id = g_strdup_printf ("site.depth-%u", i);
     g_autofree gchar *role_name = g_strdup_printf ("depth %u", i);
     if (wyl_policy_store_upsert_role (store, role_id, role_name)
         != WYRELOG_E_OK)
       return 477;
   }
   for (guint i = 0; i < 4; i++) {
-    g_autofree gchar *child = g_strdup_printf ("wr.depth-%u", i);
-    g_autofree gchar *parent = g_strdup_printf ("wr.depth-%u", i + 1);
+    g_autofree gchar *child = g_strdup_printf ("site.depth-%u", i);
+    g_autofree gchar *parent = g_strdup_printf ("site.depth-%u", i + 1);
     if (wyl_policy_store_grant_role_inheritance (store, child, parent)
         != WYRELOG_E_OK)
       return 478;

--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -2688,7 +2688,7 @@ check_policy_store_direct_permission_sod_fails_reload (void)
           "audit read", "sensitive") != WYRELOG_E_OK)
     return 528;
   if (wyl_policy_store_upsert_permission (store, "wr.policy.grant_role",
-          "policy grant role", "critical") != WYRELOG_E_OK)
+          "policy role grant", "critical") != WYRELOG_E_OK)
     return 529;
   if (wyl_policy_store_grant_direct_permission (store, "direct-sod-user",
           "wr.audit.read", "direct-sod-scope") != WYRELOG_E_OK)
@@ -2809,7 +2809,7 @@ check_policy_store_custom_role_permission_sod_fails_open (void)
           "audit read", "sensitive") != WYRELOG_E_OK)
     return 562;
   if (wyl_policy_store_upsert_permission (store, "wr.policy.grant_role",
-          "policy grant role", "critical") != WYRELOG_E_OK)
+          "policy role grant", "critical") != WYRELOG_E_OK)
     return 563;
   if (wyl_policy_store_grant_role_permission (store, "site.audit-role",
           "wr.audit.read") != WYRELOG_E_OK)

--- a/tests/test-login-projection.c
+++ b/tests/test-login-projection.c
@@ -345,7 +345,7 @@ static gint
 check_skip_mfa_login_projects_authority_state (void)
 {
   static const gchar *username = "projection-skip-mfa-user";
-  static const gchar *perm_id = "wr.projection.skip_mfa.read";
+  static const gchar *perm_id = "site.projection.skip_mfa.read";
   g_autoptr (WylHandle) handle = NULL;
 
   if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
@@ -512,7 +512,7 @@ static gint
 check_handle_reopens_persistent_policy_and_audit_paths (void)
 {
   static const gchar *username = "projection-persistent-user";
-  static const gchar *perm_id = "wr.projection.persistent.read";
+  static const gchar *perm_id = "site.projection.persistent.read";
 
   g_autoptr (GError) error = NULL;
   g_autofree gchar *dir = g_dir_make_tmp ("wyrelog-persist-XXXXXX", &error);

--- a/tests/test-perm.c
+++ b/tests/test-perm.c
@@ -690,10 +690,10 @@ check_role_grant_rolls_back_invalid_snapshot (void)
           "site grant role") != WYRELOG_E_OK)
     return 152;
   if (wyl_policy_store_upsert_permission (store, "wr.audit.read",
-          "audit read", "critical") != WYRELOG_E_OK)
+          "audit read", "sensitive") != WYRELOG_E_OK)
     return 153;
   if (wyl_policy_store_upsert_permission (store, "wr.policy.grant_role",
-          "policy grant role", "critical") != WYRELOG_E_OK)
+          "policy role grant", "critical") != WYRELOG_E_OK)
     return 154;
   if (wyl_policy_store_grant_role_permission (store, "site.audit-role",
           "wr.audit.read") != WYRELOG_E_OK)

--- a/tests/test-perm.c
+++ b/tests/test-perm.c
@@ -299,7 +299,7 @@ check_grant_allows_engine_decide (void)
 
   g_autoptr (wyl_grant_req_t) grant = wyl_grant_req_new ();
   wyl_grant_req_set_subject_id (grant, "grant-user");
-  wyl_grant_req_set_action (grant, "wr.grant-permission");
+  wyl_grant_req_set_action (grant, "site.grant-permission");
   wyl_grant_req_set_resource_id (grant, "grant-scope");
   if (wyl_perm_grant (handle, grant) != WYRELOG_E_OK)
     return 51;
@@ -330,7 +330,7 @@ check_grant_allows_engine_decide (void)
 
   g_autoptr (wyl_decide_req_t) decide = wyl_decide_req_new ();
   wyl_decide_req_set_subject_id (decide, "grant-user");
-  wyl_decide_req_set_action (decide, "wr.grant-permission");
+  wyl_decide_req_set_action (decide, "site.grant-permission");
   wyl_decide_req_set_resource_id (decide, "grant-scope");
   g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
   if (wyl_decide (handle, decide, resp) != WYRELOG_E_OK)
@@ -346,13 +346,13 @@ check_role_grant_allows_engine_decide (void)
   g_autoptr (WylHandle) handle = NULL;
   if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
     return 110;
-  if (seed_role_permission (handle, "wr.role-grant-role",
-          "wr.role-grant-permission") != 0)
+  if (seed_role_permission (handle, "site.role-grant-role",
+          "site.role-grant-permission") != 0)
     return 111;
 
   g_autoptr (wyl_role_grant_req_t) grant = wyl_role_grant_req_new ();
   wyl_role_grant_req_set_subject_id (grant, "role-grant-user");
-  wyl_role_grant_req_set_role_id (grant, "wr.role-grant-role");
+  wyl_role_grant_req_set_role_id (grant, "site.role-grant-role");
   wyl_role_grant_req_set_scope (grant, "role-grant-scope");
   if (wyl_role_grant (handle, grant) != WYRELOG_E_OK)
     return 112;
@@ -381,12 +381,12 @@ check_role_grant_allows_engine_decide (void)
       != WYRELOG_E_OK)
     return 118;
   if (insert_perm_state (handle, "role-grant-user",
-          "wr.role-grant-permission", "role-grant-scope", "armed") != 0)
+          "site.role-grant-permission", "role-grant-scope", "armed") != 0)
     return 119;
 
   g_autoptr (wyl_decide_req_t) decide = wyl_decide_req_new ();
   wyl_decide_req_set_subject_id (decide, "role-grant-user");
-  wyl_decide_req_set_action (decide, "wr.role-grant-permission");
+  wyl_decide_req_set_action (decide, "site.role-grant-permission");
   wyl_decide_req_set_resource_id (decide, "role-grant-scope");
   g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
   if (wyl_decide (handle, decide, resp) != WYRELOG_E_OK)
@@ -421,14 +421,14 @@ check_grant_persists_direct_permission (void)
 
   g_autoptr (wyl_grant_req_t) req = wyl_grant_req_new ();
   wyl_grant_req_set_subject_id (req, "store-user");
-  wyl_grant_req_set_action (req, "wr.store-direct");
+  wyl_grant_req_set_action (req, "site.store-direct");
   wyl_grant_req_set_resource_id (req, "store-scope");
   if (wyl_perm_grant (handle, req) != WYRELOG_E_OK)
     return 71;
 
   gboolean exists = FALSE;
   if (wyl_policy_store_direct_permission_exists (wyl_handle_get_policy_store
-          (handle), "store-user", "wr.store-direct", "store-scope",
+          (handle), "store-user", "site.store-direct", "store-scope",
           &exists) != WYRELOG_E_OK)
     return 72;
   if (!exists)
@@ -436,7 +436,7 @@ check_grant_persists_direct_permission (void)
 
   DirectPermissionEventExpect expect = {
     .subject_id = "store-user",
-    .perm_id = "wr.store-direct",
+    .perm_id = "site.store-direct",
     .scope = "store-scope",
     .operation = "grant",
   };
@@ -458,21 +458,21 @@ check_revoke_removes_store_grant (void)
 
   g_autoptr (wyl_grant_req_t) grant = wyl_grant_req_new ();
   wyl_grant_req_set_subject_id (grant, "store-revoke-user");
-  wyl_grant_req_set_action (grant, "wr.store-revoke");
+  wyl_grant_req_set_action (grant, "site.store-revoke");
   wyl_grant_req_set_resource_id (grant, "store-revoke-scope");
   if (wyl_perm_grant (handle, grant) != WYRELOG_E_OK)
     return 81;
 
   g_autoptr (wyl_revoke_req_t) revoke = wyl_revoke_req_new ();
   wyl_revoke_req_set_subject_id (revoke, "store-revoke-user");
-  wyl_revoke_req_set_action (revoke, "wr.store-revoke");
+  wyl_revoke_req_set_action (revoke, "site.store-revoke");
   wyl_revoke_req_set_resource_id (revoke, "store-revoke-scope");
   if (wyl_perm_revoke (handle, revoke) != WYRELOG_E_OK)
     return 82;
 
   gboolean exists = TRUE;
   if (wyl_policy_store_direct_permission_exists (wyl_handle_get_policy_store
-          (handle), "store-revoke-user", "wr.store-revoke",
+          (handle), "store-revoke-user", "site.store-revoke",
           "store-revoke-scope", &exists)
       != WYRELOG_E_OK)
     return 83;
@@ -480,7 +480,7 @@ check_revoke_removes_store_grant (void)
     return 84;
   DirectPermissionEventExpect grant_expect = {
     .subject_id = "store-revoke-user",
-    .perm_id = "wr.store-revoke",
+    .perm_id = "site.store-revoke",
     .scope = "store-revoke-scope",
     .operation = "grant",
   };
@@ -492,7 +492,7 @@ check_revoke_removes_store_grant (void)
     return 86;
   DirectPermissionEventExpect revoke_expect = {
     .subject_id = "store-revoke-user",
-    .perm_id = "wr.store-revoke",
+    .perm_id = "site.store-revoke",
     .scope = "store-revoke-scope",
     .operation = "revoke",
   };
@@ -511,20 +511,20 @@ check_role_grant_persists_membership (void)
   g_autoptr (WylHandle) handle = NULL;
   if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
     return 121;
-  if (seed_role_permission (handle, "wr.store-role", "wr.store-role.read")
+  if (seed_role_permission (handle, "site.store-role", "site.store-role.read")
       != 0)
     return 122;
 
   g_autoptr (wyl_role_grant_req_t) req = wyl_role_grant_req_new ();
   wyl_role_grant_req_set_subject_id (req, "store-role-user");
-  wyl_role_grant_req_set_role_id (req, "wr.store-role");
+  wyl_role_grant_req_set_role_id (req, "site.store-role");
   wyl_role_grant_req_set_scope (req, "store-role-scope");
   if (wyl_role_grant (handle, req) != WYRELOG_E_OK)
     return 123;
 
   gboolean exists = FALSE;
   if (wyl_policy_store_role_membership_exists (wyl_handle_get_policy_store
-          (handle), "store-role-user", "wr.store-role", "store-role-scope",
+          (handle), "store-role-user", "site.store-role", "store-role-scope",
           &exists) != WYRELOG_E_OK)
     return 124;
   if (!exists)
@@ -532,7 +532,7 @@ check_role_grant_persists_membership (void)
 
   RoleMembershipEventExpect expect = {
     .subject_id = "store-role-user",
-    .role_id = "wr.store-role",
+    .role_id = "site.store-role",
     .scope = "store-role-scope",
     .operation = "grant",
   };
@@ -551,34 +551,34 @@ check_role_revoke_removes_store_membership (void)
   g_autoptr (WylHandle) handle = NULL;
   if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
     return 128;
-  if (seed_role_permission (handle, "wr.store-revoke-role",
-          "wr.store-revoke-role.read") != 0)
+  if (seed_role_permission (handle, "site.store-revoke-role",
+          "site.store-revoke-role.read") != 0)
     return 129;
 
   g_autoptr (wyl_role_grant_req_t) grant = wyl_role_grant_req_new ();
   wyl_role_grant_req_set_subject_id (grant, "store-role-revoke-user");
-  wyl_role_grant_req_set_role_id (grant, "wr.store-revoke-role");
+  wyl_role_grant_req_set_role_id (grant, "site.store-revoke-role");
   wyl_role_grant_req_set_scope (grant, "store-role-revoke-scope");
   if (wyl_role_grant (handle, grant) != WYRELOG_E_OK)
     return 130;
 
   g_autoptr (wyl_role_revoke_req_t) revoke = wyl_role_revoke_req_new ();
   wyl_role_revoke_req_set_subject_id (revoke, "store-role-revoke-user");
-  wyl_role_revoke_req_set_role_id (revoke, "wr.store-revoke-role");
+  wyl_role_revoke_req_set_role_id (revoke, "site.store-revoke-role");
   wyl_role_revoke_req_set_scope (revoke, "store-role-revoke-scope");
   if (wyl_role_revoke (handle, revoke) != WYRELOG_E_OK)
     return 131;
 
   gboolean exists = TRUE;
   if (wyl_policy_store_role_membership_exists (wyl_handle_get_policy_store
-          (handle), "store-role-revoke-user", "wr.store-revoke-role",
+          (handle), "store-role-revoke-user", "site.store-revoke-role",
           "store-role-revoke-scope", &exists) != WYRELOG_E_OK)
     return 132;
   if (exists)
     return 133;
   RoleMembershipEventExpect revoke_expect = {
     .subject_id = "store-role-revoke-user",
-    .role_id = "wr.store-revoke-role",
+    .role_id = "site.store-revoke-role",
     .scope = "store-role-revoke-scope",
     .operation = "revoke",
   };
@@ -600,14 +600,14 @@ check_revoke_removes_engine_grant (void)
 
   g_autoptr (wyl_grant_req_t) grant = wyl_grant_req_new ();
   wyl_grant_req_set_subject_id (grant, "revoke-user");
-  wyl_grant_req_set_action (grant, "wr.revoke-permission");
+  wyl_grant_req_set_action (grant, "site.revoke-permission");
   wyl_grant_req_set_resource_id (grant, "revoke-scope");
   if (wyl_perm_grant (handle, grant) != WYRELOG_E_OK)
     return 61;
 
   g_autoptr (wyl_revoke_req_t) revoke = wyl_revoke_req_new ();
   wyl_revoke_req_set_subject_id (revoke, "revoke-user");
-  wyl_revoke_req_set_action (revoke, "wr.revoke-permission");
+  wyl_revoke_req_set_action (revoke, "site.revoke-permission");
   wyl_revoke_req_set_resource_id (revoke, "revoke-scope");
   if (wyl_perm_revoke (handle, revoke) != WYRELOG_E_OK)
     return 62;
@@ -616,7 +616,7 @@ check_revoke_removes_engine_grant (void)
   if (wyl_handle_intern_engine_symbol (handle, "revoke-user", &row[0])
       != WYRELOG_E_OK)
     return 63;
-  if (wyl_handle_intern_engine_symbol (handle, "wr.revoke-permission",
+  if (wyl_handle_intern_engine_symbol (handle, "site.revoke-permission",
           &row[1]) != WYRELOG_E_OK)
     return 64;
   if (wyl_handle_intern_engine_symbol (handle, "revoke-scope", &row[2])
@@ -636,32 +636,32 @@ check_role_revoke_removes_engine_membership (void)
   g_autoptr (WylHandle) handle = NULL;
   if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
     return 140;
-  if (seed_role_permission (handle, "wr.role-revoke-role",
-          "wr.role-revoke-permission") != 0)
+  if (seed_role_permission (handle, "site.role-revoke-role",
+          "site.role-revoke-permission") != 0)
     return 141;
 
   g_autoptr (wyl_role_grant_req_t) grant = wyl_role_grant_req_new ();
   wyl_role_grant_req_set_subject_id (grant, "role-revoke-user");
-  wyl_role_grant_req_set_role_id (grant, "wr.role-revoke-role");
+  wyl_role_grant_req_set_role_id (grant, "site.role-revoke-role");
   wyl_role_grant_req_set_scope (grant, "role-revoke-scope");
   if (wyl_role_grant (handle, grant) != WYRELOG_E_OK)
     return 142;
 
   g_autoptr (wyl_role_revoke_req_t) revoke = wyl_role_revoke_req_new ();
   wyl_role_revoke_req_set_subject_id (revoke, "role-revoke-user");
-  wyl_role_revoke_req_set_role_id (revoke, "wr.role-revoke-role");
+  wyl_role_revoke_req_set_role_id (revoke, "site.role-revoke-role");
   wyl_role_revoke_req_set_scope (revoke, "role-revoke-scope");
   if (wyl_role_revoke (handle, revoke) != WYRELOG_E_OK)
     return 143;
   if (insert_perm_state (handle, "role-revoke-user",
-          "wr.role-revoke-permission", "role-revoke-scope", "armed") != 0)
+          "site.role-revoke-permission", "role-revoke-scope", "armed") != 0)
     return 149;
 
   gint64 row[3];
   if (wyl_handle_intern_engine_symbol (handle, "role-revoke-user", &row[0])
       != WYRELOG_E_OK)
     return 144;
-  if (wyl_handle_intern_engine_symbol (handle, "wr.role-revoke-permission",
+  if (wyl_handle_intern_engine_symbol (handle, "site.role-revoke-permission",
           &row[1]) != WYRELOG_E_OK)
     return 145;
   if (wyl_handle_intern_engine_symbol (handle, "role-revoke-scope", &row[2])

--- a/tests/test-policy-store.c
+++ b/tests/test-policy-store.c
@@ -288,6 +288,37 @@ check_store_seeds_builtin_catalog (void)
   return 0;
 }
 
+static gint
+check_store_rejects_builtin_catalog_drift (void)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 216;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 217;
+  if (sqlite3_exec (wyl_policy_store_get_db (store),
+          "UPDATE roles SET role_name = 'changed auditor' "
+          "WHERE role_id = 'wr.auditor';", NULL, NULL, NULL) != SQLITE_OK)
+    return 218;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_POLICY)
+    return 219;
+
+  g_clear_pointer (&store, wyl_policy_store_close);
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 220;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 221;
+  if (sqlite3_exec (wyl_policy_store_get_db (store),
+          "UPDATE permissions SET class = 'basic' "
+          "WHERE perm_id = 'wr.audit.read';", NULL, NULL, NULL) != SQLITE_OK)
+    return 222;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_POLICY)
+    return 223;
+
+  return 0;
+}
+
 typedef struct
 {
   const gchar *subject_id;
@@ -1480,6 +1511,8 @@ main (void)
   if ((rc = check_handle_owns_policy_store ()) != 0)
     return rc;
   if ((rc = check_store_seeds_builtin_catalog ()) != 0)
+    return rc;
+  if ((rc = check_store_rejects_builtin_catalog_drift ()) != 0)
     return rc;
   if ((rc = check_store_grants_role_permission ()) != 0)
     return rc;

--- a/tests/test-policy-store.c
+++ b/tests/test-policy-store.c
@@ -213,6 +213,81 @@ check_handle_owns_policy_store (void)
   return 0;
 }
 
+static gint
+count_rows (wyl_policy_store_t *store, const gchar *sql, gint *out_count)
+{
+  sqlite3_stmt *stmt = NULL;
+
+  if (sqlite3_prepare_v2 (wyl_policy_store_get_db (store), sql, -1, &stmt,
+          NULL) != SQLITE_OK)
+    return 1;
+
+  int rc = sqlite3_step (stmt);
+  if (rc != SQLITE_ROW) {
+    sqlite3_finalize (stmt);
+    return 2;
+  }
+
+  *out_count = sqlite3_column_int (stmt, 0);
+  sqlite3_finalize (stmt);
+  return 0;
+}
+
+static gint
+check_store_seeds_builtin_catalog (void)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 200;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 201;
+
+  gboolean exists = FALSE;
+  if (wyl_policy_store_role_exists (store, "wr.auditor", &exists)
+      != WYRELOG_E_OK)
+    return 202;
+  if (!exists)
+    return 203;
+  if (wyl_policy_store_permission_exists (store, "wr.audit.read", &exists)
+      != WYRELOG_E_OK)
+    return 204;
+  if (!exists)
+    return 205;
+
+  gint matches = 0;
+  if (count_rows (store, "SELECT COUNT(*) FROM roles "
+          "WHERE role_id = 'wr.auditor';", &matches) != 0)
+    return 206;
+  if (matches != 1)
+    return 207;
+
+  if (count_rows (store, "SELECT COUNT(*) FROM permissions "
+          "WHERE perm_id = 'wr.audit.read';", &matches) != 0)
+    return 208;
+  if (matches != 1)
+    return 209;
+
+  if (wyl_policy_store_upsert_role (store, "site.local-admin",
+          "local admin") != WYRELOG_E_OK)
+    return 210;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 211;
+  if (wyl_policy_store_role_exists (store, "site.local-admin", &exists)
+      != WYRELOG_E_OK)
+    return 212;
+  if (!exists)
+    return 213;
+
+  if (count_rows (store, "SELECT COUNT(*) FROM roles "
+          "WHERE role_id = 'wr.auditor';", &matches) != 0)
+    return 214;
+  if (matches != 1)
+    return 215;
+
+  return 0;
+}
+
 typedef struct
 {
   const gchar *subject_id;
@@ -1403,6 +1478,8 @@ main (void)
   if ((rc = check_store_sets_deployment_mode ()) != 0)
     return rc;
   if ((rc = check_handle_owns_policy_store ()) != 0)
+    return rc;
+  if ((rc = check_store_seeds_builtin_catalog ()) != 0)
     return rc;
   if ((rc = check_store_grants_role_permission ()) != 0)
     return rc;

--- a/tests/test-policy-store.c
+++ b/tests/test-policy-store.c
@@ -316,6 +316,32 @@ check_store_rejects_builtin_catalog_drift (void)
   if (wyl_policy_store_create_schema (store) != WYRELOG_E_POLICY)
     return 223;
 
+  g_clear_pointer (&store, wyl_policy_store_close);
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 224;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 225;
+  if (sqlite3_exec (wyl_policy_store_get_db (store),
+          "INSERT INTO roles (role_id, role_name, description, created_at, "
+          "modified_at) VALUES ('wr.unregistered', 'unregistered', "
+          "'raw', unixepoch(), unixepoch());", NULL, NULL, NULL) != SQLITE_OK)
+    return 226;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_POLICY)
+    return 227;
+
+  g_clear_pointer (&store, wyl_policy_store_close);
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 228;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 229;
+  if (sqlite3_exec (wyl_policy_store_get_db (store),
+          "INSERT INTO permissions (perm_id, perm_name, class, created_at) "
+          "VALUES ('wr.unregistered.read', 'unregistered read', 'basic', "
+          "unixepoch());", NULL, NULL, NULL) != SQLITE_OK)
+    return 230;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_POLICY)
+    return 231;
+
   return 0;
 }
 
@@ -325,35 +351,35 @@ check_store_rejects_builtin_catalog_upsert_drift (void)
   g_autoptr (wyl_policy_store_t) store = NULL;
 
   if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
-    return 224;
+    return 232;
   if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
-    return 225;
+    return 233;
 
   if (wyl_policy_store_upsert_role (store, "wr.auditor", "auditor")
       != WYRELOG_E_OK)
-    return 226;
+    return 234;
   if (wyl_policy_store_upsert_role (store, "wr.auditor", "changed auditor")
       != WYRELOG_E_POLICY)
-    return 227;
+    return 235;
 
   if (wyl_policy_store_upsert_permission (store, "wr.audit.read",
           "audit read", "sensitive") != WYRELOG_E_OK)
-    return 228;
+    return 236;
   if (wyl_policy_store_upsert_permission (store, "wr.audit.read",
           "changed audit read", "sensitive") != WYRELOG_E_POLICY)
-    return 229;
+    return 237;
   if (wyl_policy_store_upsert_permission (store, "wr.audit.read",
           "audit read", "basic") != WYRELOG_E_POLICY)
-    return 230;
+    return 238;
   if (wyl_policy_store_upsert_role (store, "wr.unregistered",
           "unregistered") != WYRELOG_E_POLICY)
-    return 231;
+    return 239;
   if (wyl_policy_store_upsert_permission (store, "wr.unregistered.read",
           "unregistered read", "basic") != WYRELOG_E_POLICY)
-    return 232;
+    return 240;
   if (wyl_policy_store_apply_direct_permission_mutation (store, "subject",
           "wr.unregistered.read", "scope", TRUE) != WYRELOG_E_POLICY)
-    return 233;
+    return 241;
 
   return 0;
 }

--- a/tests/test-policy-store.c
+++ b/tests/test-policy-store.c
@@ -319,6 +319,36 @@ check_store_rejects_builtin_catalog_drift (void)
   return 0;
 }
 
+static gint
+check_store_rejects_builtin_catalog_upsert_drift (void)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 224;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 225;
+
+  if (wyl_policy_store_upsert_role (store, "wr.auditor", "auditor")
+      != WYRELOG_E_OK)
+    return 226;
+  if (wyl_policy_store_upsert_role (store, "wr.auditor", "changed auditor")
+      != WYRELOG_E_POLICY)
+    return 227;
+
+  if (wyl_policy_store_upsert_permission (store, "wr.audit.read",
+          "audit read", "sensitive") != WYRELOG_E_OK)
+    return 228;
+  if (wyl_policy_store_upsert_permission (store, "wr.audit.read",
+          "changed audit read", "sensitive") != WYRELOG_E_POLICY)
+    return 229;
+  if (wyl_policy_store_upsert_permission (store, "wr.audit.read",
+          "audit read", "basic") != WYRELOG_E_POLICY)
+    return 230;
+
+  return 0;
+}
+
 typedef struct
 {
   const gchar *subject_id;
@@ -1513,6 +1543,8 @@ main (void)
   if ((rc = check_store_seeds_builtin_catalog ()) != 0)
     return rc;
   if ((rc = check_store_rejects_builtin_catalog_drift ()) != 0)
+    return rc;
+  if ((rc = check_store_rejects_builtin_catalog_upsert_drift ()) != 0)
     return rc;
   if ((rc = check_store_grants_role_permission ()) != 0)
     return rc;

--- a/tests/test-policy-store.c
+++ b/tests/test-policy-store.c
@@ -345,6 +345,15 @@ check_store_rejects_builtin_catalog_upsert_drift (void)
   if (wyl_policy_store_upsert_permission (store, "wr.audit.read",
           "audit read", "basic") != WYRELOG_E_POLICY)
     return 230;
+  if (wyl_policy_store_upsert_role (store, "wr.unregistered",
+          "unregistered") != WYRELOG_E_POLICY)
+    return 231;
+  if (wyl_policy_store_upsert_permission (store, "wr.unregistered.read",
+          "unregistered read", "basic") != WYRELOG_E_POLICY)
+    return 232;
+  if (wyl_policy_store_apply_direct_permission_mutation (store, "subject",
+          "wr.unregistered.read", "scope", TRUE) != WYRELOG_E_POLICY)
+    return 233;
 
   return 0;
 }
@@ -601,22 +610,22 @@ check_store_grants_role_permission (void)
     return 40;
   if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
     return 41;
-  if (wyl_policy_store_upsert_role (store, "wr.test-role", "test role")
+  if (wyl_policy_store_upsert_role (store, "site.test-role", "test role")
       != WYRELOG_E_OK)
     return 42;
-  if (wyl_policy_store_upsert_permission (store, "wr.test.read", "test read",
+  if (wyl_policy_store_upsert_permission (store, "site.test.read", "test read",
           "basic") != WYRELOG_E_OK)
     return 43;
-  if (wyl_policy_store_grant_role_permission (store, "wr.test-role",
-          "wr.test.read") != WYRELOG_E_OK)
+  if (wyl_policy_store_grant_role_permission (store, "site.test-role",
+          "site.test.read") != WYRELOG_E_OK)
     return 44;
-  if (wyl_policy_store_grant_role_permission (store, "wr.test-role",
-          "wr.test.read") != WYRELOG_E_OK)
+  if (wyl_policy_store_grant_role_permission (store, "site.test-role",
+          "site.test.read") != WYRELOG_E_OK)
     return 45;
 
   RolePermissionExpect expect = {
-    .role_id = "wr.test-role",
-    .perm_id = "wr.test.read",
+    .role_id = "site.test-role",
+    .perm_id = "site.test.read",
   };
   if (wyl_policy_store_foreach_role_permission (store,
           role_permission_expect_cb, &expect) != WYRELOG_E_OK)
@@ -648,31 +657,31 @@ check_store_catalog_existence_probes (void)
   if (exists)
     return 223;
 
-  if (wyl_policy_store_upsert_role (store, "wr.exists-role",
+  if (wyl_policy_store_upsert_role (store, "site.exists-role",
           "exists role") != WYRELOG_E_OK)
     return 224;
-  if (wyl_policy_store_upsert_permission (store, "wr.exists-perm",
+  if (wyl_policy_store_upsert_permission (store, "site.exists-perm",
           "exists perm", "basic") != WYRELOG_E_OK)
     return 225;
 
-  if (wyl_policy_store_role_exists (store, "wr.exists-role", &exists)
+  if (wyl_policy_store_role_exists (store, "site.exists-role", &exists)
       != WYRELOG_E_OK)
     return 226;
   if (!exists)
     return 227;
-  if (wyl_policy_store_permission_exists (store, "wr.exists-perm", &exists)
+  if (wyl_policy_store_permission_exists (store, "site.exists-perm", &exists)
       != WYRELOG_E_OK)
     return 228;
   if (!exists)
     return 229;
 
-  if (wyl_policy_store_role_exists (NULL, "wr.exists-role", &exists)
+  if (wyl_policy_store_role_exists (NULL, "site.exists-role", &exists)
       != WYRELOG_E_INVALID)
     return 230;
   if (wyl_policy_store_permission_exists (store, NULL, &exists)
       != WYRELOG_E_INVALID)
     return 231;
-  if (wyl_policy_store_permission_exists (store, "wr.exists-perm", NULL)
+  if (wyl_policy_store_permission_exists (store, "site.exists-perm", NULL)
       != WYRELOG_E_INVALID)
     return 232;
   return 0;
@@ -687,28 +696,28 @@ check_store_grants_role_inheritance (void)
     return 48;
   if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
     return 49;
-  if (wyl_policy_store_upsert_role (store, "wr.child-role", "child role")
+  if (wyl_policy_store_upsert_role (store, "site.child-role", "child role")
       != WYRELOG_E_OK)
     return 58;
-  if (wyl_policy_store_upsert_role (store, "wr.parent-role", "parent role")
+  if (wyl_policy_store_upsert_role (store, "site.parent-role", "parent role")
       != WYRELOG_E_OK)
     return 59;
-  if (wyl_policy_store_grant_role_inheritance (store, "wr.child-role",
-          "wr.parent-role") != WYRELOG_E_OK)
+  if (wyl_policy_store_grant_role_inheritance (store, "site.child-role",
+          "site.parent-role") != WYRELOG_E_OK)
     return 60;
-  if (wyl_policy_store_grant_role_inheritance (store, "wr.child-role",
-          "wr.parent-role") != WYRELOG_E_OK)
+  if (wyl_policy_store_grant_role_inheritance (store, "site.child-role",
+          "site.parent-role") != WYRELOG_E_OK)
     return 61;
-  if (wyl_policy_store_upsert_permission (store, "wr.inherited.read",
+  if (wyl_policy_store_upsert_permission (store, "site.inherited.read",
           "inherited read", "basic") != WYRELOG_E_OK)
     return 62;
-  if (wyl_policy_store_grant_role_permission (store, "wr.parent-role",
-          "wr.inherited.read") != WYRELOG_E_OK)
+  if (wyl_policy_store_grant_role_permission (store, "site.parent-role",
+          "site.inherited.read") != WYRELOG_E_OK)
     return 63;
 
   RoleInheritanceExpect expect = {
-    .child_role_id = "wr.child-role",
-    .parent_role_id = "wr.parent-role",
+    .child_role_id = "site.child-role",
+    .parent_role_id = "site.parent-role",
   };
   if (wyl_policy_store_foreach_role_inheritance (store,
           role_inheritance_expect_cb, &expect) != WYRELOG_E_OK)
@@ -717,8 +726,8 @@ check_store_grants_role_inheritance (void)
     return 65;
 
   RolePermissionExpect permission_expect = {
-    .role_id = "wr.child-role",
-    .perm_id = "wr.inherited.read",
+    .role_id = "site.child-role",
+    .perm_id = "site.inherited.read",
   };
   if (wyl_policy_store_foreach_role_permission (store,
           role_permission_expect_cb, &permission_expect) != WYRELOG_E_OK)
@@ -737,22 +746,22 @@ check_store_grants_role_membership (void)
     return 68;
   if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
     return 69;
-  if (wyl_policy_store_upsert_role (store, "wr.member-role", "member role")
+  if (wyl_policy_store_upsert_role (store, "site.member-role", "member role")
       != WYRELOG_E_OK)
     return 70;
   if (wyl_policy_store_grant_role_membership (store, "member-user",
-          "wr.member-role", "member-scope") != WYRELOG_E_OK)
+          "site.member-role", "member-scope") != WYRELOG_E_OK)
     return 71;
   if (wyl_policy_store_append_role_membership_event (store, "member-user",
-          "wr.member-role", "member-scope", "grant") != WYRELOG_E_OK)
+          "site.member-role", "member-scope", "grant") != WYRELOG_E_OK)
     return 100;
   if (wyl_policy_store_grant_role_membership (store, "member-user",
-          "wr.member-role", "member-scope") != WYRELOG_E_OK)
+          "site.member-role", "member-scope") != WYRELOG_E_OK)
     return 72;
 
   RoleMembershipExpect expect = {
     .subject_id = "member-user",
-    .role_id = "wr.member-role",
+    .role_id = "site.member-role",
     .scope = "member-scope",
   };
   if (wyl_policy_store_foreach_role_membership (store,
@@ -762,14 +771,14 @@ check_store_grants_role_membership (void)
     return 74;
   gboolean exists = FALSE;
   if (wyl_policy_store_role_membership_exists (store, "member-user",
-          "wr.member-role", "member-scope", &exists) != WYRELOG_E_OK)
+          "site.member-role", "member-scope", &exists) != WYRELOG_E_OK)
     return 101;
   if (!exists)
     return 102;
 
   RoleMembershipEventExpect event_expect = {
     .subject_id = "member-user",
-    .role_id = "wr.member-role",
+    .role_id = "site.member-role",
     .scope = "member-scope",
     .operation = "grant",
   };
@@ -779,14 +788,14 @@ check_store_grants_role_membership (void)
   if (event_expect.matches != 1)
     return 104;
   if (wyl_policy_store_revoke_role_membership (store, "member-user",
-          "wr.member-role", "member-scope") != WYRELOG_E_OK)
+          "site.member-role", "member-scope") != WYRELOG_E_OK)
     return 105;
   if (wyl_policy_store_append_role_membership_event (store, "member-user",
-          "wr.member-role", "member-scope", "revoke") != WYRELOG_E_OK)
+          "site.member-role", "member-scope", "revoke") != WYRELOG_E_OK)
     return 106;
   exists = TRUE;
   if (wyl_policy_store_role_membership_exists (store, "member-user",
-          "wr.member-role", "member-scope", &exists) != WYRELOG_E_OK)
+          "site.member-role", "member-scope", &exists) != WYRELOG_E_OK)
     return 107;
   if (exists)
     return 108;
@@ -802,25 +811,25 @@ check_store_grants_direct_permission (void)
     return 60;
   if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
     return 61;
-  if (wyl_policy_store_upsert_permission (store, "wr.direct.read",
+  if (wyl_policy_store_upsert_permission (store, "site.direct.read",
           "direct read", "basic") != WYRELOG_E_OK)
     return 62;
   if (wyl_policy_store_grant_direct_permission (store, "direct-user",
-          "wr.direct.read", "direct-scope") != WYRELOG_E_OK)
+          "site.direct.read", "direct-scope") != WYRELOG_E_OK)
     return 63;
   if (wyl_policy_store_grant_direct_permission (store, "direct-user",
-          "wr.direct.read", "direct-scope") != WYRELOG_E_OK)
+          "site.direct.read", "direct-scope") != WYRELOG_E_OK)
     return 64;
 
   gboolean exists = FALSE;
   if (wyl_policy_store_direct_permission_exists (store, "direct-user",
-          "wr.direct.read", "direct-scope", &exists) != WYRELOG_E_OK)
+          "site.direct.read", "direct-scope", &exists) != WYRELOG_E_OK)
     return 65;
   if (!exists)
     return 66;
   DirectPermissionExpect expect = {
     .subject_id = "direct-user",
-    .perm_id = "wr.direct.read",
+    .perm_id = "site.direct.read",
     .scope = "direct-scope",
   };
   if (wyl_policy_store_foreach_direct_permission (store,
@@ -829,10 +838,10 @@ check_store_grants_direct_permission (void)
   if (expect.matches != 1)
     return 79;
   if (wyl_policy_store_revoke_direct_permission (store, "direct-user",
-          "wr.direct.read", "direct-scope") != WYRELOG_E_OK)
+          "site.direct.read", "direct-scope") != WYRELOG_E_OK)
     return 67;
   if (wyl_policy_store_direct_permission_exists (store, "direct-user",
-          "wr.direct.read", "direct-scope", &exists) != WYRELOG_E_OK)
+          "site.direct.read", "direct-scope", &exists) != WYRELOG_E_OK)
     return 68;
   if (exists)
     return 69;
@@ -848,7 +857,7 @@ check_role_membership_mutation_rolls_back_on_event_failure (void)
     return 197;
   if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
     return 198;
-  if (wyl_policy_store_upsert_role (store, "wr.rollback-role",
+  if (wyl_policy_store_upsert_role (store, "site.rollback-role",
           "rollback role") != WYRELOG_E_OK)
     return 199;
   if (sqlite3_exec (wyl_policy_store_get_db (store),
@@ -859,13 +868,13 @@ check_role_membership_mutation_rolls_back_on_event_failure (void)
     return 200;
 
   if (wyl_policy_store_apply_role_membership_mutation (store,
-          "rollback-role-user", "wr.rollback-role", "rollback-role-scope",
+          "rollback-role-user", "site.rollback-role", "rollback-role-scope",
           TRUE) != WYRELOG_E_IO)
     return 201;
 
   gboolean exists = TRUE;
   if (wyl_policy_store_role_membership_exists (store, "rollback-role-user",
-          "wr.rollback-role", "rollback-role-scope", &exists)
+          "site.rollback-role", "rollback-role-scope", &exists)
       != WYRELOG_E_OK)
     return 202;
   if (exists)
@@ -873,7 +882,7 @@ check_role_membership_mutation_rolls_back_on_event_failure (void)
 
   RoleMembershipEventExpect expect = {
     .subject_id = "rollback-role-user",
-    .role_id = "wr.rollback-role",
+    .role_id = "site.rollback-role",
     .scope = "rollback-role-scope",
     .operation = "grant",
   };
@@ -894,11 +903,11 @@ check_role_membership_revoke_rolls_back_on_event_failure (void)
     return 206;
   if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
     return 207;
-  if (wyl_policy_store_upsert_role (store, "wr.rollback-role-revoke",
+  if (wyl_policy_store_upsert_role (store, "site.rollback-role-revoke",
           "rollback role revoke") != WYRELOG_E_OK)
     return 208;
   if (wyl_policy_store_grant_role_membership (store,
-          "rollback-role-revoke-user", "wr.rollback-role-revoke",
+          "rollback-role-revoke-user", "site.rollback-role-revoke",
           "rollback-role-revoke-scope") != WYRELOG_E_OK)
     return 209;
   if (sqlite3_exec (wyl_policy_store_get_db (store),
@@ -909,13 +918,13 @@ check_role_membership_revoke_rolls_back_on_event_failure (void)
     return 210;
 
   if (wyl_policy_store_apply_role_membership_mutation (store,
-          "rollback-role-revoke-user", "wr.rollback-role-revoke",
+          "rollback-role-revoke-user", "site.rollback-role-revoke",
           "rollback-role-revoke-scope", FALSE) != WYRELOG_E_IO)
     return 211;
 
   gboolean exists = FALSE;
   if (wyl_policy_store_role_membership_exists (store,
-          "rollback-role-revoke-user", "wr.rollback-role-revoke",
+          "rollback-role-revoke-user", "site.rollback-role-revoke",
           "rollback-role-revoke-scope", &exists) != WYRELOG_E_OK)
     return 212;
   if (!exists)
@@ -933,12 +942,12 @@ check_store_appends_direct_permission_event (void)
   if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
     return 93;
   if (wyl_policy_store_append_direct_permission_event (store, "direct-user",
-          "wr.direct.read", "direct-scope", "grant") != WYRELOG_E_OK)
+          "site.direct.read", "direct-scope", "grant") != WYRELOG_E_OK)
     return 94;
 
   DirectPermissionExpect expect = {
     .subject_id = "direct-user",
-    .perm_id = "wr.direct.read",
+    .perm_id = "site.direct.read",
     .scope = "direct-scope",
     .operation = "grant",
   };
@@ -967,20 +976,20 @@ check_direct_permission_mutation_rolls_back_on_event_failure (void)
     return 182;
 
   if (wyl_policy_store_apply_direct_permission_mutation (store,
-          "rollback-user", "wr.rollback-direct", "rollback-scope", TRUE)
+          "rollback-user", "site.rollback-direct", "rollback-scope", TRUE)
       != WYRELOG_E_IO)
     return 183;
 
   gboolean exists = TRUE;
   if (wyl_policy_store_direct_permission_exists (store, "rollback-user",
-          "wr.rollback-direct", "rollback-scope", &exists) != WYRELOG_E_OK)
+          "site.rollback-direct", "rollback-scope", &exists) != WYRELOG_E_OK)
     return 184;
   if (exists)
     return 185;
 
   DirectPermissionExpect expect = {
     .subject_id = "rollback-user",
-    .perm_id = "wr.rollback-direct",
+    .perm_id = "site.rollback-direct",
     .scope = "rollback-scope",
     .operation = "grant",
   };
@@ -999,7 +1008,7 @@ check_direct_permission_mutation_rolls_back_on_event_failure (void)
           "SELECT 1 FROM permissions WHERE perm_id = ?;", -1, &stmt,
           NULL) != SQLITE_OK)
     return 214;
-  if (sqlite3_bind_text (stmt, 1, "wr.rollback-direct", -1,
+  if (sqlite3_bind_text (stmt, 1, "site.rollback-direct", -1,
           SQLITE_TRANSIENT) != SQLITE_OK) {
     sqlite3_finalize (stmt);
     return 215;
@@ -1022,11 +1031,11 @@ check_direct_permission_revoke_rolls_back_on_event_failure (void)
     return 189;
   if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
     return 190;
-  if (wyl_policy_store_upsert_permission (store, "wr.rollback-revoke",
+  if (wyl_policy_store_upsert_permission (store, "site.rollback-revoke",
           "rollback revoke", "basic") != WYRELOG_E_OK)
     return 191;
   if (wyl_policy_store_grant_direct_permission (store, "rollback-revoke-user",
-          "wr.rollback-revoke", "rollback-revoke-scope") != WYRELOG_E_OK)
+          "site.rollback-revoke", "rollback-revoke-scope") != WYRELOG_E_OK)
     return 192;
   if (sqlite3_exec (wyl_policy_store_get_db (store),
           "CREATE TRIGGER fail_direct_permission_revoke_event "
@@ -1036,13 +1045,13 @@ check_direct_permission_revoke_rolls_back_on_event_failure (void)
     return 193;
 
   if (wyl_policy_store_apply_direct_permission_mutation (store,
-          "rollback-revoke-user", "wr.rollback-revoke",
+          "rollback-revoke-user", "site.rollback-revoke",
           "rollback-revoke-scope", FALSE) != WYRELOG_E_IO)
     return 194;
 
   gboolean exists = FALSE;
   if (wyl_policy_store_direct_permission_exists (store,
-          "rollback-revoke-user", "wr.rollback-revoke",
+          "rollback-revoke-user", "site.rollback-revoke",
           "rollback-revoke-scope", &exists) != WYRELOG_E_OK)
     return 195;
   if (!exists)

--- a/tests/test-session-username.c
+++ b/tests/test-session-username.c
@@ -32,13 +32,24 @@ grant_role_permission (WylHandle *handle, const gchar *subject_id,
     const gchar *role_id, const gchar *permission, const gchar *scope)
 {
   wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
-  wyrelog_error_t rc = wyl_policy_store_upsert_role (store, role_id, role_id);
+  gboolean exists = FALSE;
+  wyrelog_error_t rc = wyl_policy_store_role_exists (store, role_id, &exists);
   if (rc != WYRELOG_E_OK)
     return rc;
-  rc = wyl_policy_store_upsert_permission (store, permission, permission,
-      "basic");
+  if (!exists) {
+    rc = wyl_policy_store_upsert_role (store, role_id, role_id);
+    if (rc != WYRELOG_E_OK)
+      return rc;
+  }
+  rc = wyl_policy_store_permission_exists (store, permission, &exists);
   if (rc != WYRELOG_E_OK)
     return rc;
+  if (!exists) {
+    rc = wyl_policy_store_upsert_permission (store, permission, permission,
+        "basic");
+    if (rc != WYRELOG_E_OK)
+      return rc;
+  }
   rc = wyl_policy_store_grant_role_permission (store, role_id, permission);
   if (rc != WYRELOG_E_OK)
     return rc;
@@ -417,7 +428,7 @@ check_login_requires_mfa_before_allow (void)
 
   if (store_active_scope (handle, "login-scope") != WYRELOG_E_OK)
     return 71;
-  if (grant_direct (handle, "login-user", "wr.login-permission",
+  if (grant_direct (handle, "login-user", "site.login-permission",
           "login-scope") != WYRELOG_E_OK)
     return 72;
 
@@ -431,7 +442,7 @@ check_login_requires_mfa_before_allow (void)
 
   g_autoptr (wyl_decide_req_t) decide = wyl_decide_req_new ();
   wyl_decide_req_set_subject_id (decide, "login-user");
-  wyl_decide_req_set_action (decide, "wr.login-permission");
+  wyl_decide_req_set_action (decide, "site.login-permission");
   wyl_decide_req_set_resource_id (decide, "login-scope");
 
   g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
@@ -451,7 +462,7 @@ check_mfa_verify_authenticates_engine_principal (void)
 
   if (store_active_scope (handle, "login-scope") != WYRELOG_E_OK)
     return 81;
-  if (grant_direct (handle, "login-user", "wr.login-permission",
+  if (grant_direct (handle, "login-user", "site.login-permission",
           "login-scope") != WYRELOG_E_OK)
     return 82;
 
@@ -467,7 +478,7 @@ check_mfa_verify_authenticates_engine_principal (void)
 
   g_autoptr (wyl_decide_req_t) decide = wyl_decide_req_new ();
   wyl_decide_req_set_subject_id (decide, "login-user");
-  wyl_decide_req_set_action (decide, "wr.login-permission");
+  wyl_decide_req_set_action (decide, "site.login-permission");
   wyl_decide_req_set_resource_id (decide, "login-scope");
 
   g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
@@ -688,13 +699,13 @@ check_login_session_id_is_active_decision_scope (void)
   g_autofree gchar *session_id = wyl_session_dup_id_string (session);
   if (session_id == NULL)
     return 144;
-  if (grant_direct (handle, "session-id-user", "wr.session-id-permission",
+  if (grant_direct (handle, "session-id-user", "site.session-id-permission",
           session_id) != WYRELOG_E_OK)
     return 145;
 
   g_autoptr (wyl_decide_req_t) decide = wyl_decide_req_new ();
   wyl_decide_req_set_subject_id (decide, "session-id-user");
-  wyl_decide_req_set_action (decide, "wr.session-id-permission");
+  wyl_decide_req_set_action (decide, "site.session-id-permission");
   wyl_decide_req_set_resource_id (decide, session_id);
 
   g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
@@ -744,7 +755,7 @@ check_mfa_verify_with_proof_requires_validator (void)
 
   if (store_active_scope (handle, "mfa-proof-scope") != WYRELOG_E_OK)
     return 101;
-  if (grant_direct (handle, "mfa-proof-user", "wr.mfa-proof-permission",
+  if (grant_direct (handle, "mfa-proof-user", "site.mfa-proof-permission",
           "mfa-proof-scope") != WYRELOG_E_OK)
     return 102;
 
@@ -800,7 +811,7 @@ check_mfa_verify_with_proof_requires_validator (void)
 
   g_autoptr (wyl_decide_req_t) decide = wyl_decide_req_new ();
   wyl_decide_req_set_subject_id (decide, "mfa-proof-user");
-  wyl_decide_req_set_action (decide, "wr.mfa-proof-permission");
+  wyl_decide_req_set_action (decide, "site.mfa-proof-permission");
   wyl_decide_req_set_resource_id (decide, "mfa-proof-scope");
   g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
   if (wyl_decide (handle, decide, resp) != WYRELOG_E_OK)
@@ -858,7 +869,7 @@ check_login_skip_mfa_authenticates_principal (void)
 
   if (store_active_scope (handle, "skip-mfa-scope") != WYRELOG_E_OK)
     return 151;
-  if (grant_direct (handle, "skip-mfa-user", "wr.skip-mfa-permission",
+  if (grant_direct (handle, "skip-mfa-user", "site.skip-mfa-permission",
           "skip-mfa-scope") != WYRELOG_E_OK)
     return 152;
 
@@ -893,7 +904,7 @@ check_login_skip_mfa_authenticates_principal (void)
 
   g_autoptr (wyl_decide_req_t) decide = wyl_decide_req_new ();
   wyl_decide_req_set_subject_id (decide, "skip-mfa-user");
-  wyl_decide_req_set_action (decide, "wr.skip-mfa-permission");
+  wyl_decide_req_set_action (decide, "site.skip-mfa-permission");
   wyl_decide_req_set_resource_id (decide, "skip-mfa-scope");
 
   g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
@@ -1014,7 +1025,7 @@ check_login_skip_mfa_does_not_bypass_guarded_permission (void)
   if (store_active_scope (handle, "skip-mfa-guarded-scope") != WYRELOG_E_OK)
     return 167;
   if (grant_role_permission (handle, "skip-mfa-guarded-user",
-          "wr.skip-mfa-guarded-role", "wr.audit.read",
+          "site.skip-mfa-guarded-role", "wr.audit.read",
           "skip-mfa-guarded-scope") != WYRELOG_E_OK)
     return 168;
 
@@ -1117,7 +1128,7 @@ check_session_close_deactivates_decision_scope (void)
   g_autofree gchar *session_id = wyl_session_dup_id_string (session);
   if (session_id == NULL)
     return 173;
-  if (grant_direct (handle, "close-user", "wr.close-permission",
+  if (grant_direct (handle, "close-user", "site.close-permission",
           session_id) != WYRELOG_E_OK)
     return 174;
 
@@ -1126,7 +1137,7 @@ check_session_close_deactivates_decision_scope (void)
 
   g_autoptr (wyl_decide_req_t) after = wyl_decide_req_new ();
   wyl_decide_req_set_subject_id (after, "close-user");
-  wyl_decide_req_set_action (after, "wr.close-permission");
+  wyl_decide_req_set_action (after, "site.close-permission");
   wyl_decide_req_set_resource_id (after, session_id);
   g_autoptr (wyl_decide_resp_t) after_resp = wyl_decide_resp_new ();
   if (wyl_decide (handle, after, after_resp) != WYRELOG_E_OK)
@@ -1269,13 +1280,13 @@ check_elevated_session_remains_active_decision_scope (void)
   g_autofree gchar *session_id = wyl_session_dup_id_string (session);
   if (session_id == NULL)
     return 224;
-  if (grant_direct (handle, "elevate-user", "wr.elevate-permission",
+  if (grant_direct (handle, "elevate-user", "site.elevate-permission",
           session_id) != WYRELOG_E_OK)
     return 225;
 
   g_autoptr (wyl_decide_req_t) decide = wyl_decide_req_new ();
   wyl_decide_req_set_subject_id (decide, "elevate-user");
-  wyl_decide_req_set_action (decide, "wr.elevate-permission");
+  wyl_decide_req_set_action (decide, "site.elevate-permission");
   wyl_decide_req_set_resource_id (decide, session_id);
   g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
   if (wyl_decide (handle, decide, resp) != WYRELOG_E_OK)
@@ -1306,7 +1317,7 @@ check_elevated_session_close_deactivates_decision_scope (void)
   if (session_id == NULL)
     return 234;
   if (grant_direct (handle, "elevated-close-user",
-          "wr.elevated-close-permission", session_id) != WYRELOG_E_OK)
+          "site.elevated-close-permission", session_id) != WYRELOG_E_OK)
     return 235;
 
   if (wyl_session_close (handle, session) != WYRELOG_E_OK)
@@ -1314,7 +1325,7 @@ check_elevated_session_close_deactivates_decision_scope (void)
 
   g_autoptr (wyl_decide_req_t) decide = wyl_decide_req_new ();
   wyl_decide_req_set_subject_id (decide, "elevated-close-user");
-  wyl_decide_req_set_action (decide, "wr.elevated-close-permission");
+  wyl_decide_req_set_action (decide, "site.elevated-close-permission");
   wyl_decide_req_set_resource_id (decide, session_id);
   g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
   if (wyl_decide (handle, decide, resp) != WYRELOG_E_OK)
@@ -1375,7 +1386,7 @@ check_idle_session_deactivates_decision_scope (void)
   g_autofree gchar *session_id = wyl_session_dup_id_string (session);
   if (session_id == NULL)
     return 273;
-  if (grant_direct (handle, "idle-user", "wr.idle-permission",
+  if (grant_direct (handle, "idle-user", "site.idle-permission",
           session_id) != WYRELOG_E_OK)
     return 274;
 
@@ -1384,7 +1395,7 @@ check_idle_session_deactivates_decision_scope (void)
 
   g_autoptr (wyl_decide_req_t) decide = wyl_decide_req_new ();
   wyl_decide_req_set_subject_id (decide, "idle-user");
-  wyl_decide_req_set_action (decide, "wr.idle-permission");
+  wyl_decide_req_set_action (decide, "site.idle-permission");
   wyl_decide_req_set_resource_id (decide, session_id);
   g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
   if (wyl_decide (handle, decide, resp) != WYRELOG_E_OK)
@@ -1418,7 +1429,7 @@ check_elevated_session_idle_timeout_deactivates_scope (void)
   if (session_id == NULL)
     return 284;
   if (grant_direct (handle, "elevated-idle-user",
-          "wr.elevated-idle-permission", session_id) != WYRELOG_E_OK)
+          "site.elevated-idle-permission", session_id) != WYRELOG_E_OK)
     return 285;
 
   if (wyl_session_idle_timeout (handle, session) != WYRELOG_E_OK)
@@ -1426,7 +1437,7 @@ check_elevated_session_idle_timeout_deactivates_scope (void)
 
   g_autoptr (wyl_decide_req_t) decide = wyl_decide_req_new ();
   wyl_decide_req_set_subject_id (decide, "elevated-idle-user");
-  wyl_decide_req_set_action (decide, "wr.elevated-idle-permission");
+  wyl_decide_req_set_action (decide, "site.elevated-idle-permission");
   wyl_decide_req_set_resource_id (decide, session_id);
   g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
   if (wyl_decide (handle, decide, resp) != WYRELOG_E_OK)
@@ -1487,7 +1498,7 @@ check_expiring_session_deactivates_decision_scope (void)
   g_autofree gchar *session_id = wyl_session_dup_id_string (session);
   if (session_id == NULL)
     return 313;
-  if (grant_direct (handle, "expiry-user", "wr.expiry-permission",
+  if (grant_direct (handle, "expiry-user", "site.expiry-permission",
           session_id) != WYRELOG_E_OK)
     return 314;
 
@@ -1496,7 +1507,7 @@ check_expiring_session_deactivates_decision_scope (void)
 
   g_autoptr (wyl_decide_req_t) decide = wyl_decide_req_new ();
   wyl_decide_req_set_subject_id (decide, "expiry-user");
-  wyl_decide_req_set_action (decide, "wr.expiry-permission");
+  wyl_decide_req_set_action (decide, "site.expiry-permission");
   wyl_decide_req_set_resource_id (decide, session_id);
   g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
   if (wyl_decide (handle, decide, resp) != WYRELOG_E_OK)

--- a/tests/test-template-tree.c
+++ b/tests/test-template-tree.c
@@ -1,6 +1,8 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #include <glib.h>
 
+#include "wyrelog/policy/store-private.h"
+
 #ifndef WYL_TEST_TEMPLATE_DIR
 #error "WYL_TEST_TEMPLATE_DIR must be defined by the build."
 #endif
@@ -26,8 +28,90 @@ template_tree_has_backup (const gchar *dir_path)
   return FALSE;
 }
 
+static gint
+collect_template_facts (const gchar *contents, const gchar *prefix,
+    GHashTable *out)
+{
+  g_auto (GStrv) lines = g_strsplit (contents, "\n", -1);
+
+  for (gsize i = 0; lines[i] != NULL; i++) {
+    g_autofree gchar *line = g_strdup (lines[i]);
+    g_strstrip (line);
+    if (!g_str_has_prefix (line, prefix))
+      continue;
+
+    const gchar *start = strchr (line, '"');
+    if (start == NULL)
+      return 10;
+    const gchar *end = strchr (start + 1, '"');
+    if (end == NULL || end == start + 1)
+      return 11;
+
+    g_hash_table_add (out, g_strndup (start + 1, (gsize) (end - start - 1)));
+  }
+
+  return 0;
+}
+
+static gint
+check_seed_list (GHashTable *template_ids, gsize count,
+    const gchar *(*id_at) (gsize))
+{
+  if (g_hash_table_size (template_ids) != count)
+    return 20;
+
+  for (gsize i = 0; i < count; i++) {
+    const gchar *id = id_at (i);
+    if (id == NULL)
+      return 21;
+    if (!g_hash_table_contains (template_ids, id))
+      return 22;
+  }
+
+  return 0;
+}
+
+static gint
+check_bootstrap_seed_consistency (void)
+{
+  g_autofree gchar *path =
+      g_build_filename (WYL_TEST_TEMPLATE_DIR, "bootstrap.dl", NULL);
+  g_autofree gchar *contents = NULL;
+  gsize len = 0;
+  g_autoptr (GError) error = NULL;
+
+  if (!g_file_get_contents (path, &contents, &len, &error))
+    return 30;
+
+  g_autoptr (GHashTable) roles = g_hash_table_new_full (g_str_hash,
+      g_str_equal, g_free, NULL);
+  g_autoptr (GHashTable) permissions = g_hash_table_new_full (g_str_hash,
+      g_str_equal, g_free, NULL);
+
+  gint rc = collect_template_facts (contents, "role(", roles);
+  if (rc != 0)
+    return 31;
+  rc = collect_template_facts (contents, "permission(", permissions);
+  if (rc != 0)
+    return 32;
+
+  rc = check_seed_list (roles, wyl_policy_store_builtin_role_count (),
+      wyl_policy_store_builtin_role_id);
+  if (rc != 0)
+    return 40 + rc;
+  rc = check_seed_list (permissions,
+      wyl_policy_store_builtin_permission_count (),
+      wyl_policy_store_builtin_permission_id);
+  if (rc != 0)
+    return 60 + rc;
+
+  return 0;
+}
+
 int
 main (void)
 {
-  return template_tree_has_backup (WYL_TEST_TEMPLATE_DIR) ? 1 : 0;
+  if (template_tree_has_backup (WYL_TEST_TEMPLATE_DIR))
+    return 1;
+  return check_bootstrap_seed_consistency ();
 }

--- a/wyrelog/daemon/checks.c
+++ b/wyrelog/daemon/checks.c
@@ -336,11 +336,11 @@ wyl_daemon_check_role_permission_snapshot_reload_ready (WylHandle *handle)
     return WYRELOG_E_INTERNAL;
 
   wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
-  rc = wyl_policy_store_upsert_role (store, "wr.snapshot-child",
+  rc = wyl_policy_store_upsert_role (store, "site.snapshot-child",
       "snapshot child");
   if (rc != WYRELOG_E_OK)
     return rc;
-  rc = wyl_policy_store_upsert_role (store, "wr.snapshot-parent",
+  rc = wyl_policy_store_upsert_role (store, "site.snapshot-parent",
       "snapshot parent");
   if (rc != WYRELOG_E_OK)
     return rc;
@@ -348,12 +348,12 @@ wyl_daemon_check_role_permission_snapshot_reload_ready (WylHandle *handle)
       "role read", "basic");
   if (rc != WYRELOG_E_OK)
     return rc;
-  rc = wyl_policy_store_grant_role_permission (store, "wr.snapshot-parent",
+  rc = wyl_policy_store_grant_role_permission (store, "site.snapshot-parent",
       "wyrelogd.role.read");
   if (rc != WYRELOG_E_OK)
     return rc;
-  rc = wyl_policy_store_grant_role_inheritance (store, "wr.snapshot-child",
-      "wr.snapshot-parent");
+  rc = wyl_policy_store_grant_role_inheritance (store, "site.snapshot-child",
+      "site.snapshot-parent");
   if (rc != WYRELOG_E_OK)
     return rc;
   rc = wyl_handle_reload_engine_pair (handle);
@@ -362,7 +362,7 @@ wyl_daemon_check_role_permission_snapshot_reload_ready (WylHandle *handle)
 
   const gchar *member_row[] = {
     "wyrelogd-role-user",
-    "wr.snapshot-child",
+    "site.snapshot-child",
     session_id,
   };
   rc = insert_symbol_row (handle, "member_of", member_row,

--- a/wyrelog/policy/store-private.h
+++ b/wyrelog/policy/store-private.h
@@ -61,6 +61,10 @@ void wyl_policy_store_rollback_mutation (wyl_policy_store_t * store);
 
 wyrelog_error_t wyl_policy_store_create_schema (wyl_policy_store_t * store);
 wyrelog_error_t wyl_policy_store_validate_snapshot (wyl_policy_store_t * store);
+gsize wyl_policy_store_builtin_role_count (void);
+const gchar *wyl_policy_store_builtin_role_id (gsize idx);
+gsize wyl_policy_store_builtin_permission_count (void);
+const gchar *wyl_policy_store_builtin_permission_id (gsize idx);
 wyrelog_error_t wyl_policy_store_table_exists (wyl_policy_store_t * store,
     const gchar * table_name, gboolean * out_exists);
 wyrelog_error_t wyl_policy_store_set_deployment_mode (wyl_policy_store_t *

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -8,6 +8,57 @@ struct wyl_policy_store_t
   sqlite3 *db;
 };
 
+typedef struct
+{
+  const gchar *id;
+  const gchar *name;
+} BuiltinRole;
+
+typedef struct
+{
+  const gchar *id;
+  const gchar *name;
+  const gchar *klass;
+} BuiltinPermission;
+
+static const BuiltinRole builtin_roles[] = {
+  {"wr.system_admin", "system admin"},
+  {"wr.auditor", "auditor"},
+  {"wr.system_agent", "system agent"},
+  {"wr.break_glass", "break glass"},
+  {"wr.service_admin", "service admin"},
+  {"wr.operator", "operator"},
+  {"wr.analyst", "analyst"},
+  {"wr.viewer", "viewer"},
+  {"wr.svc_agent", "service agent"},
+  {"wr.security_officer", "security officer"},
+};
+
+static const BuiltinPermission builtin_permissions[] = {
+  {"wr.sys.admin", "system admin", "critical"},
+  {"wr.sys.key_rotate", "system key rotate", "critical"},
+  {"wr.sys.merkle_seal", "system merkle seal", "critical"},
+  {"wr.sys.reload_template", "system template reload", "critical"},
+  {"wr.policy.read", "policy read", "sensitive"},
+  {"wr.policy.write", "policy write", "critical"},
+  {"wr.policy.grant_role", "policy role grant", "critical"},
+  {"wr.stream.read", "stream read", "basic"},
+  {"wr.stream.write_reserved", "reserved stream write", "critical"},
+  {"wr.stream.list", "stream list", "basic"},
+  {"wr.svc.admin", "service admin", "critical"},
+  {"wr.svc.reload", "service reload", "sensitive"},
+  {"wr.svc.flush_cache", "service cache flush", "sensitive"},
+  {"wr.svc.grant_role", "service role grant", "critical"},
+  {"wr.svc.freeze", "service freeze", "critical"},
+  {"wr.svc.unfreeze", "service unfreeze", "critical"},
+  {"wr.svc.read_decision", "service decision read", "basic"},
+  {"wr.explain.read", "explanation read", "sensitive"},
+  {"wr.explain.read_sensitive", "sensitive explanation read", "sensitive"},
+  {"wr.audit.read", "audit read", "sensitive"},
+  {"wr.audit.explain", "audit explanation read", "sensitive"},
+  {"wr.audit.write", "audit write", "critical"},
+};
+
 static wyrelog_error_t
 exec_sql (sqlite3 *db, const gchar *sql)
 {
@@ -85,6 +136,79 @@ query_has_rows (sqlite3 *db, const gchar *sql, gboolean *out_has_rows)
 
   sqlite3_finalize (stmt);
   return (step_rc == SQLITE_DONE) ? WYRELOG_E_OK : WYRELOG_E_IO;
+}
+
+static wyrelog_error_t
+seed_builtin_roles (sqlite3 *db)
+{
+  sqlite3_stmt *stmt = NULL;
+  static const gchar *sql =
+      "INSERT OR IGNORE INTO roles "
+      "  (role_id, role_name, description, created_at, modified_at) "
+      "VALUES (?, ?, 'built-in', unixepoch(), unixepoch());";
+  wyrelog_error_t rc = prepare_stmt (db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  for (gsize i = 0; i < G_N_ELEMENTS (builtin_roles); i++) {
+    sqlite3_reset (stmt);
+    sqlite3_clear_bindings (stmt);
+    if ((rc = bind_text (stmt, 1, builtin_roles[i].id)) != WYRELOG_E_OK
+        || (rc = bind_text (stmt, 2, builtin_roles[i].name))
+        != WYRELOG_E_OK) {
+      sqlite3_finalize (stmt);
+      return rc;
+    }
+    if (sqlite3_step (stmt) != SQLITE_DONE) {
+      sqlite3_finalize (stmt);
+      return WYRELOG_E_IO;
+    }
+  }
+
+  sqlite3_finalize (stmt);
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+seed_builtin_permissions (sqlite3 *db)
+{
+  sqlite3_stmt *stmt = NULL;
+  static const gchar *sql =
+      "INSERT OR IGNORE INTO permissions "
+      "  (perm_id, perm_name, class, created_at) "
+      "VALUES (?, ?, ?, unixepoch());";
+  wyrelog_error_t rc = prepare_stmt (db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  for (gsize i = 0; i < G_N_ELEMENTS (builtin_permissions); i++) {
+    sqlite3_reset (stmt);
+    sqlite3_clear_bindings (stmt);
+    if ((rc = bind_text (stmt, 1, builtin_permissions[i].id)) != WYRELOG_E_OK
+        || (rc = bind_text (stmt, 2, builtin_permissions[i].name))
+        != WYRELOG_E_OK
+        || (rc = bind_text (stmt, 3, builtin_permissions[i].klass))
+        != WYRELOG_E_OK) {
+      sqlite3_finalize (stmt);
+      return rc;
+    }
+    if (sqlite3_step (stmt) != SQLITE_DONE) {
+      sqlite3_finalize (stmt);
+      return WYRELOG_E_IO;
+    }
+  }
+
+  sqlite3_finalize (stmt);
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+seed_builtin_catalog (sqlite3 *db)
+{
+  wyrelog_error_t rc = seed_builtin_roles (db);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return seed_builtin_permissions (db);
 }
 
 wyrelog_error_t
@@ -329,7 +453,10 @@ wyl_policy_store_create_schema (wyl_policy_store_t *store)
 
   if (store == NULL || store->db == NULL)
     return WYRELOG_E_INVALID;
-  return exec_sql (store->db, ddl);
+  wyrelog_error_t rc = exec_sql (store->db, ddl);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return seed_builtin_catalog (store->db);
 }
 
 wyrelog_error_t

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -83,6 +83,12 @@ find_builtin_permission (const gchar *perm_id)
   return NULL;
 }
 
+static gboolean
+is_reserved_catalog_id (const gchar *id)
+{
+  return g_str_has_prefix (id, "wr.");
+}
+
 static wyrelog_error_t
 exec_sql (sqlite3 *db, const gchar *sql)
 {
@@ -890,6 +896,8 @@ wyl_policy_store_upsert_role (wyl_policy_store_t *store, const gchar *role_id,
   const BuiltinRole *builtin = find_builtin_role (role_id);
   if (builtin != NULL && g_strcmp0 (role_name, builtin->name) != 0)
     return WYRELOG_E_POLICY;
+  if (builtin == NULL && is_reserved_catalog_id (role_id))
+    return WYRELOG_E_POLICY;
 
   static const gchar *sql =
       "INSERT INTO roles (role_id, role_name, created_at, modified_at) "
@@ -990,6 +998,8 @@ wyrelog_error_t
   if (insert) {
     gboolean exists = FALSE;
     rc = wyl_policy_store_permission_exists (store, perm_id, &exists);
+    if (rc == WYRELOG_E_OK && !exists && is_reserved_catalog_id (perm_id))
+      rc = WYRELOG_E_POLICY;
     if (rc == WYRELOG_E_OK && !exists)
       rc = wyl_policy_store_upsert_permission (store, perm_id, perm_id,
           "basic");
@@ -1454,6 +1464,8 @@ wyl_policy_store_upsert_permission (wyl_policy_store_t *store,
   const BuiltinPermission *builtin = find_builtin_permission (perm_id);
   if (builtin != NULL && (g_strcmp0 (perm_name, builtin->name) != 0
           || g_strcmp0 (klass, builtin->klass) != 0))
+    return WYRELOG_E_POLICY;
+  if (builtin == NULL && is_reserved_catalog_id (perm_id))
     return WYRELOG_E_POLICY;
 
   static const gchar *sql =

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -550,6 +550,34 @@ wyl_policy_store_create_schema (wyl_policy_store_t *store)
   return seed_builtin_catalog (store->db);
 }
 
+gsize
+wyl_policy_store_builtin_role_count (void)
+{
+  return G_N_ELEMENTS (builtin_roles);
+}
+
+const gchar *
+wyl_policy_store_builtin_role_id (gsize idx)
+{
+  if (idx >= G_N_ELEMENTS (builtin_roles))
+    return NULL;
+  return builtin_roles[idx].id;
+}
+
+gsize
+wyl_policy_store_builtin_permission_count (void)
+{
+  return G_N_ELEMENTS (builtin_permissions);
+}
+
+const gchar *
+wyl_policy_store_builtin_permission_id (gsize idx)
+{
+  if (idx >= G_N_ELEMENTS (builtin_permissions))
+    return NULL;
+  return builtin_permissions[idx].id;
+}
+
 wyrelog_error_t
 wyl_policy_store_set_deployment_mode (wyl_policy_store_t *store,
     const gchar *mode)

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -139,6 +139,94 @@ query_has_rows (sqlite3 *db, const gchar *sql, gboolean *out_has_rows)
 }
 
 static wyrelog_error_t
+query_single_text (sqlite3 *db, const gchar *sql, const gchar *id,
+    gchar **out_value)
+{
+  sqlite3_stmt *stmt = NULL;
+
+  if (db == NULL || sql == NULL || id == NULL || out_value == NULL)
+    return WYRELOG_E_INVALID;
+  *out_value = NULL;
+
+  wyrelog_error_t rc = prepare_stmt (db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if ((rc = bind_text (stmt, 1, id)) != WYRELOG_E_OK) {
+    sqlite3_finalize (stmt);
+    return rc;
+  }
+
+  int step_rc = sqlite3_step (stmt);
+  if (step_rc == SQLITE_ROW) {
+    if (sqlite3_column_type (stmt, 0) == SQLITE_NULL) {
+      sqlite3_finalize (stmt);
+      return WYRELOG_E_POLICY;
+    }
+    *out_value = g_strdup ((const gchar *) sqlite3_column_text (stmt, 0));
+    sqlite3_finalize (stmt);
+    return *out_value == NULL ? WYRELOG_E_IO : WYRELOG_E_OK;
+  }
+
+  sqlite3_finalize (stmt);
+  return (step_rc == SQLITE_DONE) ? WYRELOG_E_POLICY : WYRELOG_E_IO;
+}
+
+static wyrelog_error_t
+validate_builtin_roles (sqlite3 *db)
+{
+  static const gchar *sql = "SELECT role_name FROM roles WHERE role_id = ?;";
+
+  for (gsize i = 0; i < G_N_ELEMENTS (builtin_roles); i++) {
+    g_autofree gchar *name = NULL;
+    wyrelog_error_t rc = query_single_text (db, sql, builtin_roles[i].id,
+        &name);
+    if (rc != WYRELOG_E_OK)
+      return rc;
+    if (g_strcmp0 (name, builtin_roles[i].name) != 0)
+      return WYRELOG_E_POLICY;
+  }
+
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+validate_builtin_permissions (sqlite3 *db)
+{
+  static const gchar *name_sql =
+      "SELECT perm_name FROM permissions WHERE perm_id = ?;";
+  static const gchar *class_sql =
+      "SELECT class FROM permissions WHERE perm_id = ?;";
+
+  for (gsize i = 0; i < G_N_ELEMENTS (builtin_permissions); i++) {
+    g_autofree gchar *name = NULL;
+    wyrelog_error_t rc = query_single_text (db, name_sql,
+        builtin_permissions[i].id, &name);
+    if (rc != WYRELOG_E_OK)
+      return rc;
+    if (g_strcmp0 (name, builtin_permissions[i].name) != 0)
+      return WYRELOG_E_POLICY;
+
+    g_autofree gchar *klass = NULL;
+    rc = query_single_text (db, class_sql, builtin_permissions[i].id, &klass);
+    if (rc != WYRELOG_E_OK)
+      return rc;
+    if (g_strcmp0 (klass, builtin_permissions[i].klass) != 0)
+      return WYRELOG_E_POLICY;
+  }
+
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+validate_builtin_catalog (sqlite3 *db)
+{
+  wyrelog_error_t rc = validate_builtin_roles (db);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return validate_builtin_permissions (db);
+}
+
+static wyrelog_error_t
 seed_builtin_roles (sqlite3 *db)
 {
   sqlite3_stmt *stmt = NULL;
@@ -208,7 +296,10 @@ seed_builtin_catalog (sqlite3 *db)
   wyrelog_error_t rc = seed_builtin_roles (db);
   if (rc != WYRELOG_E_OK)
     return rc;
-  return seed_builtin_permissions (db);
+  rc = seed_builtin_permissions (db);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return validate_builtin_catalog (db);
 }
 
 wyrelog_error_t

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -248,12 +248,64 @@ validate_builtin_permissions (sqlite3 *db)
 }
 
 static wyrelog_error_t
+validate_reserved_roles (sqlite3 *db)
+{
+  sqlite3_stmt *stmt = NULL;
+  static const gchar *sql =
+      "SELECT role_id FROM roles WHERE substr(role_id, 1, 3) = 'wr.';";
+  wyrelog_error_t rc = prepare_stmt (db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  int step_rc;
+  while ((step_rc = sqlite3_step (stmt)) == SQLITE_ROW) {
+    const gchar *role_id = (const gchar *) sqlite3_column_text (stmt, 0);
+    if (find_builtin_role (role_id) == NULL) {
+      sqlite3_finalize (stmt);
+      return WYRELOG_E_POLICY;
+    }
+  }
+
+  sqlite3_finalize (stmt);
+  return (step_rc == SQLITE_DONE) ? WYRELOG_E_OK : WYRELOG_E_IO;
+}
+
+static wyrelog_error_t
+validate_reserved_permissions (sqlite3 *db)
+{
+  sqlite3_stmt *stmt = NULL;
+  static const gchar *sql =
+      "SELECT perm_id FROM permissions WHERE substr(perm_id, 1, 3) = 'wr.';";
+  wyrelog_error_t rc = prepare_stmt (db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  int step_rc;
+  while ((step_rc = sqlite3_step (stmt)) == SQLITE_ROW) {
+    const gchar *perm_id = (const gchar *) sqlite3_column_text (stmt, 0);
+    if (find_builtin_permission (perm_id) == NULL) {
+      sqlite3_finalize (stmt);
+      return WYRELOG_E_POLICY;
+    }
+  }
+
+  sqlite3_finalize (stmt);
+  return (step_rc == SQLITE_DONE) ? WYRELOG_E_OK : WYRELOG_E_IO;
+}
+
+static wyrelog_error_t
 validate_builtin_catalog (sqlite3 *db)
 {
   wyrelog_error_t rc = validate_builtin_roles (db);
   if (rc != WYRELOG_E_OK)
     return rc;
-  return validate_builtin_permissions (db);
+  rc = validate_builtin_permissions (db);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = validate_reserved_roles (db);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return validate_reserved_permissions (db);
 }
 
 static wyrelog_error_t

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -59,6 +59,30 @@ static const BuiltinPermission builtin_permissions[] = {
   {"wr.audit.write", "audit write", "critical"},
 };
 
+static const BuiltinRole *
+find_builtin_role (const gchar *role_id)
+{
+  if (role_id == NULL)
+    return NULL;
+  for (gsize i = 0; i < G_N_ELEMENTS (builtin_roles); i++) {
+    if (g_strcmp0 (builtin_roles[i].id, role_id) == 0)
+      return &builtin_roles[i];
+  }
+  return NULL;
+}
+
+static const BuiltinPermission *
+find_builtin_permission (const gchar *perm_id)
+{
+  if (perm_id == NULL)
+    return NULL;
+  for (gsize i = 0; i < G_N_ELEMENTS (builtin_permissions); i++) {
+    if (g_strcmp0 (builtin_permissions[i].id, perm_id) == 0)
+      return &builtin_permissions[i];
+  }
+  return NULL;
+}
+
 static wyrelog_error_t
 exec_sql (sqlite3 *db, const gchar *sql)
 {
@@ -863,6 +887,10 @@ wyl_policy_store_upsert_role (wyl_policy_store_t *store, const gchar *role_id,
       || role_name == NULL)
     return WYRELOG_E_INVALID;
 
+  const BuiltinRole *builtin = find_builtin_role (role_id);
+  if (builtin != NULL && g_strcmp0 (role_name, builtin->name) != 0)
+    return WYRELOG_E_POLICY;
+
   static const gchar *sql =
       "INSERT INTO roles (role_id, role_name, created_at, modified_at) "
       "VALUES (?, ?, unixepoch(), unixepoch()) "
@@ -959,10 +987,15 @@ wyrelog_error_t
   if (rc != WYRELOG_E_OK)
     return rc;
 
-  if (insert)
-    rc = wyl_policy_store_upsert_permission (store, perm_id, perm_id, "basic");
-  else
+  if (insert) {
+    gboolean exists = FALSE;
+    rc = wyl_policy_store_permission_exists (store, perm_id, &exists);
+    if (rc == WYRELOG_E_OK && !exists)
+      rc = wyl_policy_store_upsert_permission (store, perm_id, perm_id,
+          "basic");
+  } else {
     rc = WYRELOG_E_OK;
+  }
   if (rc == WYRELOG_E_OK) {
     rc = insert
         ? wyl_policy_store_grant_direct_permission (store, subject_id, perm_id,
@@ -1417,6 +1450,11 @@ wyl_policy_store_upsert_permission (wyl_policy_store_t *store,
   if (store == NULL || store->db == NULL || perm_id == NULL
       || perm_name == NULL || klass == NULL)
     return WYRELOG_E_INVALID;
+
+  const BuiltinPermission *builtin = find_builtin_permission (perm_id);
+  if (builtin != NULL && (g_strcmp0 (perm_name, builtin->name) != 0
+          || g_strcmp0 (klass, builtin->klass) != 0))
+    return WYRELOG_E_POLICY;
 
   static const gchar *sql =
       "INSERT INTO permissions (perm_id, perm_name, class, created_at) "


### PR DESCRIPTION
## Summary
- seed built-in role and permission catalog targets in fresh Policy DB schemas
- reject built-in catalog drift and reserved non-built-in wr.* catalog creation
- add static template/seed consistency and daemon runtime coverage for seeded targets

## Tests
- meson test -C builddir wyrelogd-check wyrelogd-sigterm wyrelogd-healthz wyrelogd-startup-readiness client-smoke daemon-http-decide policy-store template-tree handle-engine-pair perm --print-errorlogs
- meson test -C builddir-audit wyrelogd-check wyrelogd-sigterm wyrelogd-healthz wyrelogd-startup-readiness client-smoke daemon-http-decide policy-store template-tree handle-engine-pair perm daemon-checks audit-emit --print-errorlogs
