### PR TITLE
Harden Policy DB-backed audit projection

### DIFF
--- a/tests/test-audit-emit.c
+++ b/tests/test-audit-emit.c
@@ -225,6 +225,62 @@ count_audit_attr_facts (WylHandle *handle, const gchar *relation,
   return WYRELOG_E_OK;
 }
 
+static gint
+check_live_audit_projection_for_action (WylHandle *handle, const gchar *action,
+    const gchar *subject, const gchar *resource, const gchar *origin,
+    gint base_code)
+{
+  duckdb_connection conn =
+      wyl_audit_conn_get_connection (wyl_handle_get_audit_conn (handle));
+  duckdb_prepared_statement stmt = NULL;
+  duckdb_result result = { 0 };
+
+  static const gchar *sql =
+      "SELECT id, created_at_us FROM audit_events WHERE action = ?;";
+  if (duckdb_prepare (conn, sql, &stmt) != DuckDBSuccess)
+    return base_code;
+  if (duckdb_bind_varchar (stmt, 1, action) != DuckDBSuccess) {
+    duckdb_destroy_prepare (&stmt);
+    return base_code + 1;
+  }
+  if (duckdb_execute_prepared (stmt, &result) != DuckDBSuccess) {
+    duckdb_destroy_prepare (&stmt);
+    duckdb_destroy_result (&result);
+    return base_code + 2;
+  }
+  duckdb_destroy_prepare (&stmt);
+  if (duckdb_row_count (&result) != 1) {
+    duckdb_destroy_result (&result);
+    return base_code + 3;
+  }
+
+  gchar *id = duckdb_value_varchar (&result, 0, 0);
+  gint64 created_at_us = duckdb_value_int64 (&result, 1, 0);
+  gint rc = 0;
+  gboolean contains = FALSE;
+
+  if (contains_audit_event_fact (handle, id, created_at_us, "allow",
+          &contains) != WYRELOG_E_OK || !contains)
+    rc = base_code + 4;
+  else if (contains_audit_event_attr_fact (handle, "audit_event_subject", id,
+          subject, &contains) != WYRELOG_E_OK || !contains)
+    rc = base_code + 5;
+  else if (contains_audit_event_attr_fact (handle, "audit_event_action", id,
+          action, &contains) != WYRELOG_E_OK || !contains)
+    rc = base_code + 6;
+  else if (contains_audit_event_attr_fact (handle, "audit_event_resource", id,
+          resource, &contains) != WYRELOG_E_OK || !contains)
+    rc = base_code + 7;
+  else if (contains_audit_event_attr_fact (handle,
+          "audit_event_deny_origin", id, origin, &contains) != WYRELOG_E_OK
+      || !contains)
+    rc = base_code + 8;
+
+  duckdb_free (id);
+  duckdb_destroy_result (&result);
+  return rc;
+}
+
 static wyrelog_error_t
 insert_not_armed_decide_fixture (WylHandle *handle)
 {
@@ -1738,6 +1794,9 @@ check_permission_grant_emits_audit_row (void)
   duckdb_free ((void *) resource);
   duckdb_free ((void *) permission);
   duckdb_destroy_result (&result);
+  if (rc == 0)
+    rc = check_live_audit_projection_for_action (handle, "permission_grant",
+        "audit-grant-user", "audit-grant-scope", "site.audit-grant", 129);
   g_object_unref (handle);
   return rc;
 }
@@ -1852,6 +1911,9 @@ check_permission_revoke_emits_audit_row (void)
   duckdb_free ((void *) resource);
   duckdb_free ((void *) permission);
   duckdb_destroy_result (&result);
+  if (rc == 0)
+    rc = check_live_audit_projection_for_action (handle, "permission_revoke",
+        "audit-revoke-user", "audit-revoke-scope", "site.audit-revoke", 1390);
   g_object_unref (handle);
   return rc;
 }
@@ -1935,6 +1997,10 @@ check_role_grant_emits_audit_row (void)
   duckdb_free ((void *) resource);
   duckdb_free ((void *) role);
   duckdb_destroy_result (&result);
+  if (rc == 0)
+    rc = check_live_audit_projection_for_action (handle, "role_grant",
+        "audit-role-grant-user", "audit-role-grant-scope",
+        "site.audit-role-grant", 1490);
   g_object_unref (handle);
   return rc;
 }
@@ -2008,6 +2074,10 @@ check_role_revoke_emits_audit_row (void)
   duckdb_free ((void *) resource);
   duckdb_free ((void *) role);
   duckdb_destroy_result (&result);
+  if (rc == 0)
+    rc = check_live_audit_projection_for_action (handle, "role_revoke",
+        "audit-role-revoke-user", "audit-role-revoke-scope",
+        "site.audit-role-revoke", 1600);
   g_object_unref (handle);
   return rc;
 }

--- a/tests/test-audit-emit.c
+++ b/tests/test-audit-emit.c
@@ -948,6 +948,15 @@ check_decide_fail_closes_on_audit_append_failure (void)
     return 52;
   }
   duckdb_destroy_result (&result);
+  memset (&result, 0, sizeof (result));
+  if (duckdb_query (conn,
+          "CREATE TABLE audit_events (id VARCHAR PRIMARY KEY);", &result)
+      != DuckDBSuccess) {
+    duckdb_destroy_result (&result);
+    g_object_unref (handle);
+    return 52;
+  }
+  duckdb_destroy_result (&result);
 
   g_autoptr (wyl_decide_req_t) req = wyl_decide_req_new ();
   wyl_decide_req_set_subject_id (req, "audit-allow-user");

--- a/tests/test-audit-emit.c
+++ b/tests/test-audit-emit.c
@@ -622,6 +622,13 @@ check_policy_store_audit_replay_loads_runtime_query (void)
     g_object_unref (handle);
     return 172;
   }
+  static const gchar *full_replay_id = "01890c10-2e3f-7000-8000-000000000012";
+  if (wyl_policy_store_append_audit_event (store, full_replay_id, 790,
+          "replay-user", "audit.replay.full", "replay-full-resource",
+          "not_armed", "perm_state", WYL_DECISION_DENY) != WYRELOG_E_OK) {
+    g_object_unref (handle);
+    return 205;
+  }
   if (wyl_handle_load_policy_store_audit_events (handle) != WYRELOG_E_OK) {
     g_object_unref (handle);
     return 173;
@@ -673,6 +680,34 @@ check_policy_store_audit_replay_loads_runtime_query (void)
     rc = 180;
   else if (g_strstr_len (json, -1, "\"decision\":1") == NULL)
     rc = 181;
+  if (rc != 0) {
+    g_object_unref (handle);
+    return rc;
+  }
+
+  g_clear_pointer (&json, g_free);
+  if (wyl_audit_conn_query_events_json (wyl_handle_get_audit_conn (handle),
+          "action(\"audit.replay.full\")", &json) != WYRELOG_E_OK) {
+    g_object_unref (handle);
+    return 206;
+  }
+
+  if (g_strstr_len (json, -1,
+          "\"id\":\"01890c10-2e3f-7000-8000-000000000012\"") == NULL)
+    rc = 207;
+  else if (g_strstr_len (json, -1, "\"created_at_us\":790") == NULL)
+    rc = 208;
+  else if (g_strstr_len (json, -1, "\"subject_id\":\"replay-user\"") == NULL)
+    rc = 209;
+  else if (g_strstr_len (json, -1,
+          "\"resource_id\":\"replay-full-resource\"") == NULL)
+    rc = 210;
+  else if (g_strstr_len (json, -1, "\"deny_reason\":\"not_armed\"") == NULL)
+    rc = 211;
+  else if (g_strstr_len (json, -1, "\"deny_origin\":\"perm_state\"") == NULL)
+    rc = 212;
+  else if (g_strstr_len (json, -1, "\"decision\":0") == NULL)
+    rc = 213;
 
   g_object_unref (handle);
   return rc;

--- a/tests/test-daemon-delta.c
+++ b/tests/test-daemon-delta.c
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <string.h>
+
 #include <glib.h>
 #include <duckdb.h>
 
@@ -25,13 +27,22 @@ intern3 (WylHandle *handle, const gchar *a, const gchar *b, const gchar *c,
 }
 
 static wyrelog_error_t
-drop_audit_events_table (WylHandle *handle)
+break_audit_events_table (WylHandle *handle)
 {
   duckdb_connection conn =
       wyl_audit_conn_get_connection (wyl_handle_get_audit_conn (handle));
   duckdb_result result = { 0 };
 
   if (duckdb_query (conn, "DROP TABLE audit_events;", &result)
+      != DuckDBSuccess) {
+    duckdb_destroy_result (&result);
+    return WYRELOG_E_IO;
+  }
+  duckdb_destroy_result (&result);
+
+  memset (&result, 0, sizeof (result));
+  if (duckdb_query (conn,
+          "CREATE TABLE audit_events (id VARCHAR PRIMARY KEY);", &result)
       != DuckDBSuccess) {
     duckdb_destroy_result (&result);
     return WYRELOG_E_IO;
@@ -52,7 +63,7 @@ check_delta_callback_counts_audit_failure (void)
   runtime.handle = handle;
   if (wyl_daemon_start_delta_callbacks (handle, &runtime) != WYRELOG_E_OK)
     return 11;
-  if (drop_audit_events_table (handle) != WYRELOG_E_OK)
+  if (break_audit_events_table (handle) != WYRELOG_E_OK)
     return 12;
   if (intern3 (handle, "daemon-delta-audit-user", "wr.viewer",
           "daemon-delta-audit-scope", row) != WYRELOG_E_OK)
@@ -80,7 +91,7 @@ check_delta_readiness_fails_on_audit_failure (void)
 
   if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
     return 30;
-  if (drop_audit_events_table (handle) != WYRELOG_E_OK)
+  if (break_audit_events_table (handle) != WYRELOG_E_OK)
     return 31;
   if (wyl_daemon_check_delta_ready (handle) != WYRELOG_E_IO)
     return 32;

--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -2,6 +2,9 @@
 #include <string.h>
 
 #include <glib.h>
+#ifdef WYL_HAS_AUDIT
+#include <duckdb.h>
+#endif
 
 #include "daemon/http.h"
 #include "wyrelog/client.h"
@@ -1017,6 +1020,23 @@ check_raw_audit_contract (WylClient *client, const gchar *base_url,
   return 0;
 }
 
+static wyrelog_error_t
+drop_runtime_audit_events_table (WylHandle *handle)
+{
+  duckdb_connection conn =
+      wyl_audit_conn_get_connection (wyl_handle_get_audit_conn (handle));
+  duckdb_result result = { 0 };
+
+  if (duckdb_query (conn, "DROP TABLE audit_events;", &result)
+      != DuckDBSuccess) {
+    duckdb_destroy_result (&result);
+    return WYRELOG_E_IO;
+  }
+
+  duckdb_destroy_result (&result);
+  return WYRELOG_E_OK;
+}
+
 static gint
 check_audit_event_present (WylClient *client, const gchar *filter,
     const gchar *subject, const gchar *action, const gchar *resource,
@@ -1122,10 +1142,16 @@ main (void)
     return 86;
   wyl_handle_set_login_skip_mfa_allowed (handle, FALSE);
 
+  if (drop_runtime_audit_events_table (handle) != WYRELOG_E_OK)
+    return 87;
+
   gint audit_auth_rc = check_raw_audit_contract (client, base_url,
       audit_session_token);
   if (audit_auth_rc != 0)
     return audit_auth_rc;
+
+  if (drop_runtime_audit_events_table (handle) != WYRELOG_E_OK)
+    return 88;
 
   gint audit_rc = check_audit_event_present (client,
       "action(\"http.not_armed\")",

--- a/wyrelog/audit/event.c
+++ b/wyrelog/audit/event.c
@@ -227,6 +227,9 @@ wyl_audit_mirror_event (WylHandle *handle, const WylAuditEvent *event)
   audit_conn = wyl_handle_get_audit_conn (handle);
   if (audit_conn == NULL)
     return WYRELOG_E_INTERNAL;
+  wyrelog_error_t rc = wyl_audit_conn_create_schema (audit_conn);
+  if (rc != WYRELOG_E_OK)
+    return rc;
 
   if (wyl_id_format (&event->id, id_buf, sizeof id_buf) != WYRELOG_E_OK)
     return WYRELOG_E_INTERNAL;
@@ -259,7 +262,11 @@ wyl_audit_emit (WylHandle *handle, const WylAuditEvent *event)
   if (audit_conn == NULL)
     return WYRELOG_E_INTERNAL;
 
-  wyrelog_error_t rc = wyl_audit_conn_insert_event_full (audit_conn, id_buf,
+  wyrelog_error_t rc = wyl_audit_conn_create_schema (audit_conn);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  rc = wyl_audit_conn_insert_event_full (audit_conn, id_buf,
       event->created_at_us, event->subject_id, event->action,
       event->resource_id, event->deny_reason, event->deny_origin,
       event->decision, &inserted);

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -285,6 +285,19 @@ authorize_guarded_session_action (SoupServer *server, SoupServerMessage *msg,
   return TRUE;
 }
 
+#ifdef WYL_HAS_AUDIT
+static wyrelog_error_t
+reconcile_audit_query_projection (WylHandle *handle)
+{
+  wyrelog_error_t rc =
+      wyl_audit_conn_create_schema (wyl_handle_get_audit_conn (handle));
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  return wyl_handle_load_policy_store_audit_events (handle);
+}
+#endif
+
 static void
 audit_events_handler (SoupServer *server, SoupServerMessage *msg,
     const char *path, GHashTable *query, gpointer user_data)
@@ -305,9 +318,10 @@ audit_events_handler (SoupServer *server, SoupServerMessage *msg,
 
   WylHandle *handle = ctx->handle;
   g_autofree gchar *body = NULL;
-  wyrelog_error_t rc =
-      wyl_audit_conn_query_events_json (wyl_handle_get_audit_conn (handle),
-      filter, &body);
+  wyrelog_error_t rc = reconcile_audit_query_projection (handle);
+  if (rc == WYRELOG_E_OK)
+    rc = wyl_audit_conn_query_events_json (wyl_handle_get_audit_conn (handle),
+        filter, &body);
   if (rc == WYRELOG_E_INVALID) {
     const gchar *error_body = "{\"error\":\"invalid_filter\"}";
     soup_server_message_set_status (msg, 400, NULL);


### PR DESCRIPTION
## Summary

- assert policy mutation audit rows are projected into live wirelog audit facts
- cover full Policy DB audit replay fidelity into the runtime query projection
- reconcile authorized daemon audit queries from durable Policy DB audit rows
- recover missing runtime audit schema while preserving fail-closed corruption paths

## Tests

- `meson test -C builddir-audit daemon-http-decide audit-emit --print-errorlogs`
- `meson test -C builddir-audit daemon-http-decide daemon-checks audit-emit perm login-projection --print-errorlogs`
- `meson test -C builddir daemon-http-decide --print-errorlogs`
- `git diff --check origin/main..HEAD`
