### PR TITLE
Wire guard context payloads into LoBAC arm rules

### DIFF
--- a/templates/access/decision.dl
+++ b/templates/access/decision.dl
@@ -108,7 +108,7 @@ allow_guard_base(U, P, S) :-
     !disabled_role_for(U, P),
     !policy_violation("sod", U, P, _).
 
-guarded_perm(P) :- perm_arm_rule(P, G).
+guarded_perm(P) :- perm_arm_rule(P, _).
 
 allow(U, P, S) :-
     allow_guard_base(U, P, S),

--- a/templates/access/fsm/permission_scope.dl
+++ b/templates/access/fsm/permission_scope.dl
@@ -25,10 +25,10 @@
 //                 loc_class, risk)                  context payload
 //   eval_guard(user, perm, scope, ctx)           -- host guard result
 //
-// Row order in any future perm_arm_rule block will be load-bearing:
-// the test harness compares the perm-id list line by line against
-// the C catalogue, so reordering one side without the other will
-// fail the build.
+// perm_arm_rule rows are runtime-seeded from the C catalogue so the
+// session-local guard-handle column can later move to side-tier
+// compounds without static template handles. Static perm_arm_rule
+// facts are intentionally absent.
 
 .decl perm_state(user: symbol, perm: symbol, scope: symbol, state: symbol)
 .decl perm_arm_rule(perm: symbol, guard_handle: symbol)
@@ -36,30 +36,21 @@
 .decl guard_context(ctx: scope/2 side, user: symbol, scope: symbol,
     timestamp: int64, loc_class: symbol, risk: int64)
 .decl eval_guard(user: symbol, perm: symbol, scope: symbol, ctx: scope/2 side)
+.decl perm_arm_rule_observed(perm: symbol, guard_handle: symbol)
 .decl armed(user: symbol, perm: symbol, scope: symbol)
 
-// --- perm_arm_rule catalogue mirror ----------------------------------
+// --- perm_arm_rule catalogue seed ------------------------------------
 //
-// Row order is load-bearing: the test harness compares the perm-id
-// list line by line against the C catalogue at
-// wyrelog/wyl-permission-scope.c, so reordering one side without the
-// other will fail the build. The second argument is a guard handle —
-// the compound-term guard payload itself lives in the C catalogue,
-// keyed by perm-id; the `_v0_deferred` placeholder pins the row count
-// while the host bridge exposes satisfied guard decisions as
-// eval_guard/4 facts tied to a structured guard_context/6 row.
+// Runtime seed order is load-bearing: the test harness compares the
+// C catalogue at wyrelog/wyl-permission-scope.c against the opened
+// engine snapshot, so missing, duplicate, or variant rows fail the
+// build. The second argument is intentionally `_v0_deferred` in the
+// compatibility seed until perm_arm_rule consumes runtime guard
+// handles. The placeholder pins the row count while the host bridge
+// exposes satisfied guard decisions as eval_guard/4 facts tied to a
+// structured guard_context/6 row.
 
-perm_arm_rule("wr.sys.admin",        "_v0_deferred").
-perm_arm_rule("wr.sys.key_rotate",   "_v0_deferred").
-perm_arm_rule("wr.sys.merkle_seal",  "_v0_deferred").
-perm_arm_rule("wr.policy.write",     "_v0_deferred").
-perm_arm_rule("wr.policy.grant_role","_v0_deferred").
-perm_arm_rule("wr.svc.freeze",       "_v0_deferred").
-perm_arm_rule("wr.svc.unfreeze",     "_v0_deferred").
-perm_arm_rule("wr.svc.grant_role",   "_v0_deferred").
-perm_arm_rule("wr.audit.read",       "_v0_deferred").
-perm_arm_rule("wr.audit.explain",    "_v0_deferred").
-perm_arm_rule("wr.stream.write_reserved", "_v0_deferred").
+perm_arm_rule_observed(P, G) :- perm_arm_rule(P, G).
 
 // --- armed/3 derivation ----------------------------------------------
 

--- a/templates/access/fsm/permission_scope.dl
+++ b/templates/access/fsm/permission_scope.dl
@@ -8,9 +8,9 @@
 // IDB rule set with no transition lifecycle: the host must inject
 // perm_state(user, perm, scope, "armed") for unguarded permissions
 // that are ready to participate in allow/3. Guarded permissions are
-// armed only when the host injects request-local context_now/3,
-// guard_context/6, and eval_guard/4 bridge facts for a satisfied
-// guard expression.
+// armed only when the host injects a payload-bearing request-local
+// context_now/3 compound, guard_context/6, and eval_guard/4 bridge
+// facts for a satisfied guard expression.
 //
 // EDB schemas (host-populated, no clauses below):
 //   perm_state(user, perm, scope, state)        -- v0 row count = 0
@@ -18,8 +18,9 @@
 //                                                   bootstrap.dl
 //   perm_arm_rule(perm, guard_handle)            -- compound guard
 //                                                   payload key
-//   context_now(user, scope, ctx)                -- request context
-//                                                   activation
+//   context_now(user, scope, ctx)                -- scope(metadata(ts,
+//                                                   loc_class, risk),
+//                                                   scope) activation
 //   guard_context(ctx, user, scope, timestamp,   -- structured request
 //                 loc_class, risk)                  context payload
 //   eval_guard(user, perm, scope, ctx)           -- host guard result

--- a/templates/access/fsm/permission_scope.dl
+++ b/templates/access/fsm/permission_scope.dl
@@ -16,8 +16,8 @@
 //   perm_state(user, perm, scope, state)        -- v0 row count = 0
 //   has_permission(user, perm, scope)            -- declared in
 //                                                   bootstrap.dl
-//   perm_arm_rule(perm, guard_handle)            -- compound guard
-//                                                   payload key
+//   perm_arm_rule(perm, guard_handle)            -- guard(root) side
+//                                                   payload handle
 //   context_now(user, scope, ctx)                -- scope(metadata(ts,
 //                                                   loc_class, risk),
 //                                                   scope) activation
@@ -31,12 +31,12 @@
 // facts are intentionally absent.
 
 .decl perm_state(user: symbol, perm: symbol, scope: symbol, state: symbol)
-.decl perm_arm_rule(perm: symbol, guard_handle: symbol)
+.decl perm_arm_rule(perm: symbol, guard_handle: int64)
 .decl context_now(user: symbol, scope: symbol, ctx: scope/2 side)
 .decl guard_context(ctx: scope/2 side, user: symbol, scope: symbol,
     timestamp: int64, loc_class: symbol, risk: int64)
 .decl eval_guard(user: symbol, perm: symbol, scope: symbol, ctx: scope/2 side)
-.decl perm_arm_rule_observed(perm: symbol, guard_handle: symbol)
+.decl perm_arm_rule_observed(perm: symbol, guard_handle: int64)
 .decl armed(user: symbol, perm: symbol, scope: symbol)
 
 // --- perm_arm_rule catalogue seed ------------------------------------
@@ -44,11 +44,10 @@
 // Runtime seed order is load-bearing: the test harness compares the
 // C catalogue at wyrelog/wyl-permission-scope.c against the opened
 // engine snapshot, so missing, duplicate, or variant rows fail the
-// build. The second argument is intentionally `_v0_deferred` in the
-// compatibility seed until perm_arm_rule consumes runtime guard
-// handles. The placeholder pins the row count while the host bridge
-// exposes satisfied guard decisions as eval_guard/4 facts tied to a
-// structured guard_context/6 row.
+// build. The host still evaluates guard expressions in C and exposes
+// satisfied guard decisions as eval_guard/4 facts tied to a structured
+// guard_context/6 row; the guard compound payload is an observable
+// mirror, not an evaluator input yet.
 
 perm_arm_rule_observed(P, G) :- perm_arm_rule(P, G).
 

--- a/templates/access/lobac/decision.dl
+++ b/templates/access/lobac/decision.dl
@@ -105,7 +105,7 @@ allow_guard_base(U, P, S) :-
     !disabled_role_for(U, P),
     !policy_violation("sod", U, P, _).
 
-guarded_perm(P) :- perm_arm_rule(P, G).
+guarded_perm(P) :- perm_arm_rule(P, _).
 
 allow(U, P, S) :-
     allow_guard_base(U, P, S),

--- a/tests/check-wyrelogd-startup-readiness.sh
+++ b/tests/check-wyrelogd-startup-readiness.sh
@@ -29,9 +29,9 @@ src = pathlib.Path(sys.argv[1])
 dst = pathlib.Path(sys.argv[2])
 shutil.copytree(src, dst)
 
-old = "guarded_perm(P) :- perm_arm_rule(P, G)."
+old = "guarded_perm(P) :- perm_arm_rule(P, _)."
 new = (
-    'guarded_perm(P) :- perm_arm_rule(P, G), '
+    'guarded_perm(P) :- perm_arm_rule(P, _), '
     'permission("__wyrelog_test_missing_permission").'
 )
 for rel in ("decision.dl", "lobac/decision.dl"):

--- a/tests/test-access-decision.c
+++ b/tests/test-access-decision.c
@@ -371,7 +371,7 @@ check_decision_rule_bodies (void)
         "    !frozen(S),\n"
         "    !disabled_role_for(U, P),\n"
         "    !policy_violation(\"sod\", U, P, _).",
-    "guarded_perm(P) :- perm_arm_rule(P, G).",
+    "guarded_perm(P) :- perm_arm_rule(P, _).",
     "allow(U, P, S) :-\n"
         "    allow_guard_base(U, P, S),\n" "    armed(U, P, S).",
     "allow_bool(U, P, S) :- allow(U, P, S).",

--- a/tests/test-fsm-permission-scope.c
+++ b/tests/test-fsm-permission-scope.c
@@ -380,17 +380,17 @@ check_argument_validation (void)
   return 0;
 }
 
-/* --- .dl <-> C name mirror oracle ------------------------------- */
+/* --- .dl static fact guard -------------------------------------- */
 
 /*
- * Parses the perm_arm_rule(...) lines from the .dl source and
- * asserts that the perm-id list matches the C catalogue row by
- * row. Structural equality of the guard expression is deferred to
- * a future bisimulation oracle; this v0 mirror only pins ordering
- * and identity of the perm ids.
+ * perm_arm_rule rows are runtime-seeded from the C catalogue. The
+ * template may declare and reference the relation, but it must not
+ * also carry static facts; otherwise runtime seeding produces
+ * duplicate placeholder rows before guard payload handles are
+ * introduced.
  */
 static gboolean
-extract_perm_id (const gchar *line, gchar **out_id)
+line_is_static_perm_arm_rule_fact (const gchar *line)
 {
   const gchar *prefix = "perm_arm_rule";
   if (!g_str_has_prefix (line, prefix))
@@ -403,18 +403,11 @@ extract_perm_id (const gchar *line, gchar **out_id)
   p++;
   while (*p == ' ' || *p == '\t')
     p++;
-  if (*p != '"')
-    return FALSE;
-  p++;
-  const gchar *end = strchr (p, '"');
-  if (end == NULL)
-    return FALSE;
-  *out_id = g_strndup (p, (gsize) (end - p));
-  return TRUE;
+  return *p == '"';
 }
 
 static gint
-check_name_mirror (void)
+check_template_omits_static_perm_arm_rule_facts (void)
 {
   g_autofree gchar *contents = NULL;
   gsize len = 0;
@@ -426,30 +419,15 @@ check_name_mirror (void)
     return 200;
   }
   g_auto (GStrv) lines = g_strsplit (contents, "\n", -1);
-  gsize parsed = 0;
-  gsize expected = wyl_perm_arm_rule_count ();
   for (gsize i = 0; lines[i] != NULL; i++) {
     g_autofree gchar *trimmed = g_strdup (g_strchug (lines[i]));
     if (trimmed[0] == '%' || trimmed[0] == '\0'
         || g_str_has_prefix (trimmed, "//")
         || g_str_has_prefix (trimmed, ".decl"))
       continue;
-    /* Catalogue rows always quote the perm id immediately. The
-     * rule-3 body has `perm_arm_rule(P, G)` which would otherwise
-     * trip the parser; this stricter prefix skips it. */
-    if (!g_str_has_prefix (trimmed, "perm_arm_rule(\""))
-      continue;
-    g_autofree gchar *id = NULL;
-    if (!extract_perm_id (trimmed, &id))
-      return (gint) (210 + parsed);
-    if (parsed >= expected)
-      return 220;
-    if (g_strcmp0 (id, wyl_perm_arm_rule_perm_id (parsed)) != 0)
-      return (gint) (230 + parsed);
-    parsed++;
+    if (line_is_static_perm_arm_rule_fact (trimmed))
+      return 210;
   }
-  if (parsed != expected)
-    return 240;
   return 0;
 }
 
@@ -471,7 +449,7 @@ main (void)
     return rc;
   if ((rc = check_argument_validation ()) != 0)
     return rc;
-  if ((rc = check_name_mirror ()) != 0)
+  if ((rc = check_template_omits_static_perm_arm_rule_facts ()) != 0)
     return rc;
   return 0;
 }

--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -86,11 +86,37 @@ typedef struct
 {
   const gint64 *perm_ids;
   guint *seen_counts;
+  gint64 *guard_handles;
   gsize nperms;
   gint64 placeholder_id;
   guint total;
-  guint unexpected_guard_handle;
+  guint invalid_guard_handle;
+  guint placeholder_guard_handle;
 } PermArmRuleSnapshotExpect;
+
+typedef struct
+{
+  gint64 guard_handle;
+  gint64 root_handle;
+  guint matches;
+} GuardWrapperExpect;
+
+typedef struct
+{
+  gint64 cmp_handle;
+  gint64 field_id;
+  gint64 op_id;
+  gint64 value_id;
+  guint matches;
+} GuardCmpExpect;
+
+typedef struct
+{
+  gint64 and_handle;
+  gint64 left_handle;
+  gint64 right_handle;
+  guint matches;
+} GuardAndExpect;
 
 static gchar *
 make_tmpdir (void)
@@ -154,7 +180,7 @@ write_compound_templates (const gchar *dir)
       ".decl session_transition(from_state: symbol, event: symbol,"
       " to_state: symbol)\n")
       && write_file_in_dir (dir, "fsm/permission_scope.dl",
-      ".decl perm_arm_rule(perm: symbol, guard_handle: symbol)\n")
+      ".decl perm_arm_rule(perm: symbol, guard_handle: int64)\n")
       && write_file_in_dir (dir, "lobac/decision.dl", "// decision stub\n");
 }
 
@@ -184,7 +210,39 @@ write_guard_context_compound_templates (const gchar *dir)
       ".decl session_transition(from_state: symbol, event: symbol,"
       " to_state: symbol)\n")
       && write_file_in_dir (dir, "fsm/permission_scope.dl",
-      ".decl perm_arm_rule(perm: symbol, guard_handle: symbol)\n")
+      ".decl perm_arm_rule(perm: symbol, guard_handle: int64)\n")
+      && write_file_in_dir (dir, "lobac/decision.dl", "// decision stub\n");
+}
+
+static gboolean
+write_guard_payload_templates (const gchar *dir)
+{
+  g_autofree gchar *fsm_dir = g_build_filename (dir, "fsm", NULL);
+  if (g_mkdir (fsm_dir, 0755) != 0)
+    return FALSE;
+  g_autofree gchar *lobac_dir = g_build_filename (dir, "lobac", NULL);
+  if (g_mkdir (lobac_dir, 0755) != 0)
+    return FALSE;
+
+  return write_file_in_dir (dir, "bootstrap.dl",
+      ".decl perm_arm_rule_observed(perm: symbol, guard_handle: int64)\n"
+      ".decl guard_row(handle: int64, root: int64)\n"
+      ".decl guard_cmp_row(handle: int64, field: symbol, op: symbol,"
+      " value: symbol)\n"
+      ".decl guard_and_row(handle: int64, left: int64, right: int64)\n"
+      "perm_arm_rule_observed(P, G) :- perm_arm_rule(P, G).\n"
+      "guard_row(H, R) :- __compound_guard_1(H, R).\n"
+      "guard_cmp_row(H, F, O, V) :- __compound_guard_cmp_3(H, F, O, V).\n"
+      "guard_and_row(H, L, R) :- __compound_guard_and_2(H, L, R).\n")
+      && write_file_in_dir (dir, "fsm/principal.dl",
+      ".decl principal_transition(from_state: symbol, event: symbol,"
+      " to_state: symbol)\n")
+      && write_file_in_dir (dir, "fsm/session.dl",
+      ".decl session_active(state: symbol)\n"
+      ".decl session_transition(from_state: symbol, event: symbol,"
+      " to_state: symbol)\n")
+      && write_file_in_dir (dir, "fsm/permission_scope.dl",
+      ".decl perm_arm_rule(perm: symbol, guard_handle: int64)\n")
       && write_file_in_dir (dir, "lobac/decision.dl", "// decision stub\n");
 }
 
@@ -349,15 +407,66 @@ perm_arm_rule_snapshot_cb (const gchar *relation, const gint64 *row,
     return;
 
   expect->total++;
-  if (row[1] != expect->placeholder_id)
-    expect->unexpected_guard_handle++;
+  if (row[1] <= 0)
+    expect->invalid_guard_handle++;
+  if (row[1] == expect->placeholder_id)
+    expect->placeholder_guard_handle++;
 
   for (gsize i = 0; i < expect->nperms; i++) {
     if (row[0] == expect->perm_ids[i]) {
       expect->seen_counts[i]++;
+      expect->guard_handles[i] = row[1];
       return;
     }
   }
+}
+
+static void
+guard_wrapper_cb (const gchar *relation, const gint64 *row, guint ncols,
+    gpointer user_data)
+{
+  GuardWrapperExpect *expect = user_data;
+
+  if (g_strcmp0 (relation, "guard_row") != 0 || ncols != 2)
+    return;
+  if (row[0] != expect->guard_handle)
+    return;
+
+  expect->root_handle = row[1];
+  expect->matches++;
+}
+
+static void
+guard_cmp_cb (const gchar *relation, const gint64 *row, guint ncols,
+    gpointer user_data)
+{
+  GuardCmpExpect *expect = user_data;
+
+  if (g_strcmp0 (relation, "guard_cmp_row") != 0 || ncols != 4)
+    return;
+  if (row[0] != expect->cmp_handle)
+    return;
+  if (row[1] != expect->field_id || row[2] != expect->op_id
+      || row[3] != expect->value_id)
+    return;
+
+  expect->matches++;
+}
+
+static void
+guard_and_cb (const gchar *relation, const gint64 *row, guint ncols,
+    gpointer user_data)
+{
+  GuardAndExpect *expect = user_data;
+
+  if (g_strcmp0 (relation, "guard_and_row") != 0 || ncols != 3)
+    return;
+  if (row[0] != expect->and_handle)
+    return;
+
+  expect->left_handle = row[1];
+  expect->right_handle = row[2];
+  expect->matches++;
 }
 
 static void
@@ -1184,11 +1293,12 @@ check_guard_context_compound_carries_request_payload (void)
 }
 
 static gint
-assert_perm_arm_rule_placeholder_snapshot (WylHandle *handle, gint base_code)
+assert_perm_arm_rule_guard_payload_snapshot (WylHandle *handle, gint base_code)
 {
   gsize nperms = wyl_perm_arm_rule_count ();
   g_autofree gint64 *perm_ids = g_new0 (gint64, nperms);
   g_autofree guint *seen_counts = g_new0 (guint, nperms);
+  g_autofree gint64 *guard_handles = g_new0 (gint64, nperms);
 
   for (gsize i = 0; i < nperms; i++) {
     if (wyl_handle_intern_engine_symbol (handle, wyl_perm_arm_rule_perm_id (i),
@@ -1204,29 +1314,33 @@ assert_perm_arm_rule_placeholder_snapshot (WylHandle *handle, gint base_code)
   PermArmRuleSnapshotExpect expect = {
     .perm_ids = perm_ids,
     .seen_counts = seen_counts,
+    .guard_handles = guard_handles,
     .nperms = nperms,
     .placeholder_id = placeholder_id,
     .total = 0,
-    .unexpected_guard_handle = 0,
+    .invalid_guard_handle = 0,
+    .placeholder_guard_handle = 0,
   };
   if (wyl_engine_snapshot (wyl_handle_get_read_engine (handle),
           "perm_arm_rule_observed", perm_arm_rule_snapshot_cb, &expect)
       != WYRELOG_E_OK)
     return base_code + 2;
 
-  if (expect.unexpected_guard_handle != 0)
+  if (expect.invalid_guard_handle != 0)
     return base_code + 3;
-  if (expect.total != nperms)
+  if (expect.placeholder_guard_handle != 0)
     return base_code + 4;
+  if (expect.total != nperms)
+    return base_code + 5;
   for (gsize i = 0; i < nperms; i++) {
-    if (seen_counts[i] != 1)
-      return base_code + 5 + (gint) i;
+    if (seen_counts[i] != 1 || guard_handles[i] <= 0)
+      return base_code + 6 + (gint) i;
   }
   return 0;
 }
 
 static gint
-check_perm_arm_rule_placeholder_contract (void)
+check_perm_arm_rule_guard_payload_contract (void)
 {
   g_autoptr (WylHandle) handle = NULL;
 
@@ -1235,11 +1349,11 @@ check_perm_arm_rule_placeholder_contract (void)
   if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
       != WYRELOG_E_OK)
     return 134;
-  return assert_perm_arm_rule_placeholder_snapshot (handle, 135);
+  return assert_perm_arm_rule_guard_payload_snapshot (handle, 135);
 }
 
 static gint
-check_perm_arm_rule_placeholder_contract_after_reload (void)
+check_perm_arm_rule_guard_payload_contract_after_reload (void)
 {
   g_autoptr (WylHandle) handle = NULL;
 
@@ -1250,7 +1364,226 @@ check_perm_arm_rule_placeholder_contract_after_reload (void)
     return 152;
   if (wyl_handle_reload_engine_pair (handle) != WYRELOG_E_OK)
     return 153;
-  return assert_perm_arm_rule_placeholder_snapshot (handle, 154);
+  return assert_perm_arm_rule_guard_payload_snapshot (handle, 154);
+}
+
+static gint
+find_perm_arm_rule_index (const gchar *perm_id)
+{
+  for (gsize i = 0; i < wyl_perm_arm_rule_count (); i++) {
+    if (g_strcmp0 (wyl_perm_arm_rule_perm_id (i), perm_id) == 0)
+      return (gint) i;
+  }
+  return -1;
+}
+
+static gint
+check_perm_arm_rule_guard_payload_projection (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  g_autofree gchar *tmpdir = NULL;
+  gsize nperms = wyl_perm_arm_rule_count ();
+  g_autofree gint64 *perm_ids = g_new0 (gint64, nperms);
+  g_autofree guint *seen_counts = g_new0 (guint, nperms);
+  g_autofree gint64 *guard_handles = g_new0 (gint64, nperms);
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 171;
+  tmpdir = make_tmpdir ();
+  if (tmpdir == NULL)
+    return 172;
+  if (!write_guard_payload_templates (tmpdir)) {
+    rmdir_recursive (tmpdir);
+    return 173;
+  }
+  if (wyl_handle_open_engine_pair (handle, tmpdir) != WYRELOG_E_OK) {
+    rmdir_recursive (tmpdir);
+    return 174;
+  }
+
+  for (gsize i = 0; i < nperms; i++) {
+    if (wyl_handle_intern_engine_symbol (handle, wyl_perm_arm_rule_perm_id (i),
+            &perm_ids[i]) != WYRELOG_E_OK) {
+      rmdir_recursive (tmpdir);
+      return 175;
+    }
+  }
+
+  gint64 placeholder_id = -1;
+  gint64 risk_id = -1;
+  gint64 loc_class_id = -1;
+  gint64 lt_id = -1;
+  gint64 eq_id = -1;
+  gint64 value_70_id = -1;
+  gint64 value_30_id = -1;
+  gint64 trusted_id = -1;
+  if (wyl_handle_intern_engine_symbol (handle, "_v0_deferred",
+          &placeholder_id) != WYRELOG_E_OK) {
+    rmdir_recursive (tmpdir);
+    return 176;
+  }
+  if (wyl_handle_intern_engine_symbol (handle, "risk", &risk_id)
+      != WYRELOG_E_OK) {
+    rmdir_recursive (tmpdir);
+    return 177;
+  }
+  if (wyl_handle_intern_engine_symbol (handle, "loc_class", &loc_class_id)
+      != WYRELOG_E_OK) {
+    rmdir_recursive (tmpdir);
+    return 178;
+  }
+  if (wyl_handle_intern_engine_symbol (handle, "lt", &lt_id) != WYRELOG_E_OK) {
+    rmdir_recursive (tmpdir);
+    return 179;
+  }
+  if (wyl_handle_intern_engine_symbol (handle, "eq", &eq_id) != WYRELOG_E_OK) {
+    rmdir_recursive (tmpdir);
+    return 180;
+  }
+  if (wyl_handle_intern_engine_symbol (handle, "70", &value_70_id)
+      != WYRELOG_E_OK) {
+    rmdir_recursive (tmpdir);
+    return 181;
+  }
+  if (wyl_handle_intern_engine_symbol (handle, "30", &value_30_id)
+      != WYRELOG_E_OK) {
+    rmdir_recursive (tmpdir);
+    return 182;
+  }
+  if (wyl_handle_intern_engine_symbol (handle, "trusted", &trusted_id)
+      != WYRELOG_E_OK) {
+    rmdir_recursive (tmpdir);
+    return 183;
+  }
+
+  PermArmRuleSnapshotExpect expect = {
+    .perm_ids = perm_ids,
+    .seen_counts = seen_counts,
+    .guard_handles = guard_handles,
+    .nperms = nperms,
+    .placeholder_id = placeholder_id,
+    .total = 0,
+    .invalid_guard_handle = 0,
+    .placeholder_guard_handle = 0,
+  };
+  if (wyl_engine_snapshot (wyl_handle_get_read_engine (handle),
+          "perm_arm_rule_observed", perm_arm_rule_snapshot_cb, &expect)
+      != WYRELOG_E_OK) {
+    rmdir_recursive (tmpdir);
+    return 184;
+  }
+
+  gint audit_idx = find_perm_arm_rule_index ("wr.audit.read");
+  gint admin_idx = find_perm_arm_rule_index ("wr.sys.admin");
+  if (audit_idx < 0 || admin_idx < 0) {
+    rmdir_recursive (tmpdir);
+    return 185;
+  }
+  if (guard_handles[audit_idx] <= 0 || guard_handles[admin_idx] <= 0) {
+    rmdir_recursive (tmpdir);
+    return 186;
+  }
+
+  GuardWrapperExpect audit_wrapper = {
+    .guard_handle = guard_handles[audit_idx],
+    .root_handle = -1,
+    .matches = 0,
+  };
+  if (wyl_engine_snapshot (wyl_handle_get_read_engine (handle), "guard_row",
+          guard_wrapper_cb, &audit_wrapper) != WYRELOG_E_OK) {
+    rmdir_recursive (tmpdir);
+    return 187;
+  }
+  if (audit_wrapper.matches < 1 || audit_wrapper.root_handle <= 0) {
+    rmdir_recursive (tmpdir);
+    return 188;
+  }
+
+  GuardCmpExpect audit_cmp = {
+    .cmp_handle = audit_wrapper.root_handle,
+    .field_id = risk_id,
+    .op_id = lt_id,
+    .value_id = value_70_id,
+    .matches = 0,
+  };
+  if (wyl_engine_snapshot (wyl_handle_get_read_engine (handle),
+          "guard_cmp_row", guard_cmp_cb, &audit_cmp) != WYRELOG_E_OK) {
+    rmdir_recursive (tmpdir);
+    return 189;
+  }
+  if (audit_cmp.matches < 1) {
+    rmdir_recursive (tmpdir);
+    return 190;
+  }
+
+  GuardWrapperExpect admin_wrapper = {
+    .guard_handle = guard_handles[admin_idx],
+    .root_handle = -1,
+    .matches = 0,
+  };
+  if (wyl_engine_snapshot (wyl_handle_get_read_engine (handle), "guard_row",
+          guard_wrapper_cb, &admin_wrapper) != WYRELOG_E_OK) {
+    rmdir_recursive (tmpdir);
+    return 191;
+  }
+  if (admin_wrapper.matches < 1 || admin_wrapper.root_handle <= 0) {
+    rmdir_recursive (tmpdir);
+    return 192;
+  }
+
+  GuardAndExpect admin_and = {
+    .and_handle = admin_wrapper.root_handle,
+    .left_handle = -1,
+    .right_handle = -1,
+    .matches = 0,
+  };
+  if (wyl_engine_snapshot (wyl_handle_get_read_engine (handle),
+          "guard_and_row", guard_and_cb, &admin_and) != WYRELOG_E_OK) {
+    rmdir_recursive (tmpdir);
+    return 193;
+  }
+  if (admin_and.matches < 1 || admin_and.left_handle <= 0
+      || admin_and.right_handle <= 0) {
+    rmdir_recursive (tmpdir);
+    return 194;
+  }
+
+  GuardCmpExpect admin_risk = {
+    .cmp_handle = admin_and.left_handle,
+    .field_id = risk_id,
+    .op_id = lt_id,
+    .value_id = value_30_id,
+    .matches = 0,
+  };
+  if (wyl_engine_snapshot (wyl_handle_get_read_engine (handle),
+          "guard_cmp_row", guard_cmp_cb, &admin_risk) != WYRELOG_E_OK) {
+    rmdir_recursive (tmpdir);
+    return 195;
+  }
+  if (admin_risk.matches < 1) {
+    rmdir_recursive (tmpdir);
+    return 196;
+  }
+
+  GuardCmpExpect admin_loc = {
+    .cmp_handle = admin_and.right_handle,
+    .field_id = loc_class_id,
+    .op_id = eq_id,
+    .value_id = trusted_id,
+    .matches = 0,
+  };
+  if (wyl_engine_snapshot (wyl_handle_get_read_engine (handle),
+          "guard_cmp_row", guard_cmp_cb, &admin_loc) != WYRELOG_E_OK) {
+    rmdir_recursive (tmpdir);
+    return 197;
+  }
+  if (admin_loc.matches < 1) {
+    rmdir_recursive (tmpdir);
+    return 198;
+  }
+
+  rmdir_recursive (tmpdir);
+  return 0;
 }
 
 static gint
@@ -3241,9 +3574,11 @@ main (void)
     return rc;
   if ((rc = check_guard_context_compound_carries_request_payload ()) != 0)
     return rc;
-  if ((rc = check_perm_arm_rule_placeholder_contract ()) != 0)
+  if ((rc = check_perm_arm_rule_guard_payload_contract ()) != 0)
     return rc;
-  if ((rc = check_perm_arm_rule_placeholder_contract_after_reload ()) != 0)
+  if ((rc = check_perm_arm_rule_guard_payload_contract_after_reload ()) != 0)
+    return rc;
+  if ((rc = check_perm_arm_rule_guard_payload_projection ()) != 0)
     return rc;
   if ((rc = check_insert_fanout_reaches_read_engine ()) != 0)
     return rc;

--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -64,6 +64,23 @@ typedef struct
   guint matches;
 } SeenExpect;
 
+typedef struct
+{
+  gint64 context_id;
+  gint64 expected_scope_id;
+  gint64 metadata_id;
+  guint matches;
+} GuardScopeCompoundExpect;
+
+typedef struct
+{
+  gint64 metadata_id;
+  gint64 expected_timestamp;
+  gint64 expected_loc_class_id;
+  gint64 expected_risk;
+  guint matches;
+} GuardMetadataCompoundExpect;
+
 static gchar *
 make_tmpdir (void)
 {
@@ -118,6 +135,36 @@ write_compound_templates (const gchar *dir)
   return write_file_in_dir (dir, "bootstrap.dl",
       ".decl event(id: int64, payload: scope/1 side)\n"
       ".decl seen(id: int64)\n" "seen(ID) :- event(ID, scope(_)).\n")
+      && write_file_in_dir (dir, "fsm/principal.dl",
+      ".decl principal_transition(from_state: symbol, event: symbol,"
+      " to_state: symbol)\n")
+      && write_file_in_dir (dir, "fsm/session.dl",
+      ".decl session_active(state: symbol)\n"
+      ".decl session_transition(from_state: symbol, event: symbol,"
+      " to_state: symbol)\n")
+      && write_file_in_dir (dir, "fsm/permission_scope.dl",
+      ".decl perm_arm_rule(perm: symbol, guard_handle: symbol)\n")
+      && write_file_in_dir (dir, "lobac/decision.dl", "// decision stub\n");
+}
+
+static gboolean
+write_guard_context_compound_templates (const gchar *dir)
+{
+  g_autofree gchar *fsm_dir = g_build_filename (dir, "fsm", NULL);
+  if (g_mkdir (fsm_dir, 0755) != 0)
+    return FALSE;
+  g_autofree gchar *lobac_dir = g_build_filename (dir, "lobac", NULL);
+  if (g_mkdir (lobac_dir, 0755) != 0)
+    return FALSE;
+
+  return write_file_in_dir (dir, "bootstrap.dl",
+      ".decl compound_scope_row(handle: int64, metadata: int64,"
+      " scope: symbol)\n"
+      ".decl compound_metadata_row(handle: int64, timestamp: int64,"
+      " loc_class: symbol, risk: int64)\n"
+      "compound_scope_row(H, M, S) :- __compound_scope_2(H, M, S).\n"
+      "compound_metadata_row(H, T, L, R) :- __compound_metadata_3(H, T, L,"
+      " R).\n")
       && write_file_in_dir (dir, "fsm/principal.dl",
       ".decl principal_transition(from_state: symbol, event: symbol,"
       " to_state: symbol)\n")
@@ -246,6 +293,39 @@ seen_expect_cb (const gchar *relation, const gint64 *row, guint ncols,
     return;
   if (row[0] == expect->expected_id)
     expect->matches++;
+}
+
+static void
+guard_scope_compound_cb (const gchar *relation, const gint64 *row, guint ncols,
+    gpointer user_data)
+{
+  GuardScopeCompoundExpect *expect = user_data;
+
+  if (g_strcmp0 (relation, "compound_scope_row") != 0 || ncols != 3)
+    return;
+  if (row[0] != expect->context_id || row[2] != expect->expected_scope_id)
+    return;
+
+  expect->metadata_id = row[1];
+  expect->matches++;
+}
+
+static void
+guard_metadata_compound_cb (const gchar *relation, const gint64 *row,
+    guint ncols, gpointer user_data)
+{
+  GuardMetadataCompoundExpect *expect = user_data;
+
+  if (g_strcmp0 (relation, "compound_metadata_row") != 0 || ncols != 4)
+    return;
+  if (row[0] != expect->metadata_id)
+    return;
+  if (row[1] != expect->expected_timestamp
+      || row[2] != expect->expected_loc_class_id
+      || row[3] != expect->expected_risk)
+    return;
+
+  expect->matches++;
 }
 
 static void
@@ -926,6 +1006,148 @@ check_compound_make_result_is_insertable (void)
   rmdir_recursive (tmpdir);
   if (expect.matches != 1)
     return 111;
+  return 0;
+}
+
+static gint
+check_guard_context_compound_carries_request_payload (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  g_autofree gchar *tmpdir = NULL;
+  gint64 trusted_id = -1;
+  gint64 public_id = -1;
+  gint64 alpha_scope_id = -1;
+  gint64 beta_scope_id = -1;
+  gint64 first_context_id = -1;
+  gint64 second_context_id = -1;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 112;
+  tmpdir = make_tmpdir ();
+  if (tmpdir == NULL)
+    return 113;
+  if (!write_guard_context_compound_templates (tmpdir)) {
+    rmdir_recursive (tmpdir);
+    return 114;
+  }
+  if (wyl_handle_open_engine_pair (handle, tmpdir) != WYRELOG_E_OK) {
+    rmdir_recursive (tmpdir);
+    return 115;
+  }
+  if (wyl_handle_intern_engine_symbol (handle, "trusted", &trusted_id)
+      != WYRELOG_E_OK) {
+    rmdir_recursive (tmpdir);
+    return 116;
+  }
+  if (wyl_handle_intern_engine_symbol (handle, "public", &public_id)
+      != WYRELOG_E_OK) {
+    rmdir_recursive (tmpdir);
+    return 117;
+  }
+  if (wyl_handle_intern_engine_symbol (handle, "scope-alpha", &alpha_scope_id)
+      != WYRELOG_E_OK) {
+    rmdir_recursive (tmpdir);
+    return 118;
+  }
+  if (wyl_handle_intern_engine_symbol (handle, "scope-beta", &beta_scope_id)
+      != WYRELOG_E_OK) {
+    rmdir_recursive (tmpdir);
+    return 119;
+  }
+
+  if (wyl_handle_make_guard_context_compound (handle, 1700000001, trusted_id,
+          25, alpha_scope_id, &first_context_id) != WYRELOG_E_OK) {
+    rmdir_recursive (tmpdir);
+    return 120;
+  }
+  if (wyl_handle_make_guard_context_compound (handle, 1700000002, public_id,
+          80, beta_scope_id, &second_context_id) != WYRELOG_E_OK) {
+    rmdir_recursive (tmpdir);
+    return 121;
+  }
+  if (first_context_id <= 0 || second_context_id <= 0) {
+    rmdir_recursive (tmpdir);
+    return 122;
+  }
+  if (first_context_id == second_context_id) {
+    rmdir_recursive (tmpdir);
+    return 123;
+  }
+  GuardScopeCompoundExpect first_scope = {
+    .context_id = first_context_id,
+    .expected_scope_id = alpha_scope_id,
+    .metadata_id = -1,
+    .matches = 0,
+  };
+  if (wyl_engine_snapshot (wyl_handle_get_read_engine (handle),
+          "compound_scope_row", guard_scope_compound_cb, &first_scope)
+      != WYRELOG_E_OK) {
+    rmdir_recursive (tmpdir);
+    return 124;
+  }
+  if (first_scope.matches < 1 || first_scope.metadata_id <= 0) {
+    rmdir_recursive (tmpdir);
+    return 125;
+  }
+
+  GuardScopeCompoundExpect second_scope = {
+    .context_id = second_context_id,
+    .expected_scope_id = beta_scope_id,
+    .metadata_id = -1,
+    .matches = 0,
+  };
+  if (wyl_engine_snapshot (wyl_handle_get_read_engine (handle),
+          "compound_scope_row", guard_scope_compound_cb, &second_scope)
+      != WYRELOG_E_OK) {
+    rmdir_recursive (tmpdir);
+    return 126;
+  }
+  if (second_scope.matches < 1 || second_scope.metadata_id <= 0) {
+    rmdir_recursive (tmpdir);
+    return 127;
+  }
+  if (first_scope.metadata_id == second_scope.metadata_id) {
+    rmdir_recursive (tmpdir);
+    return 128;
+  }
+
+  GuardMetadataCompoundExpect first_metadata = {
+    .metadata_id = first_scope.metadata_id,
+    .expected_timestamp = 1700000001,
+    .expected_loc_class_id = trusted_id,
+    .expected_risk = 25,
+    .matches = 0,
+  };
+  if (wyl_engine_snapshot (wyl_handle_get_read_engine (handle),
+          "compound_metadata_row", guard_metadata_compound_cb,
+          &first_metadata) != WYRELOG_E_OK) {
+    rmdir_recursive (tmpdir);
+    return 129;
+  }
+  if (first_metadata.matches < 1) {
+    rmdir_recursive (tmpdir);
+    return 130;
+  }
+
+  GuardMetadataCompoundExpect second_metadata = {
+    .metadata_id = second_scope.metadata_id,
+    .expected_timestamp = 1700000002,
+    .expected_loc_class_id = public_id,
+    .expected_risk = 80,
+    .matches = 0,
+  };
+  if (wyl_engine_snapshot (wyl_handle_get_read_engine (handle),
+          "compound_metadata_row", guard_metadata_compound_cb,
+          &second_metadata) != WYRELOG_E_OK) {
+    rmdir_recursive (tmpdir);
+    return 131;
+  }
+  if (second_metadata.matches < 1) {
+    rmdir_recursive (tmpdir);
+    return 132;
+  }
+
+  rmdir_recursive (tmpdir);
   return 0;
 }
 
@@ -2914,6 +3136,8 @@ main (void)
   if ((rc = check_compound_make_reaches_engine_pair ()) != 0)
     return rc;
   if ((rc = check_compound_make_result_is_insertable ()) != 0)
+    return rc;
+  if ((rc = check_guard_context_compound_carries_request_payload ()) != 0)
     return rc;
   if ((rc = check_insert_fanout_reaches_read_engine ()) != 0)
     return rc;

--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -6,6 +6,7 @@
 #include "wyrelog/policy/store-private.h"
 #include "wyrelog/wyl-handle-compound-private.h"
 #include "wyrelog/wyl-handle-private.h"
+#include "wyrelog/wyl-permission-scope-private.h"
 
 #ifndef WYL_TEST_TEMPLATE_DIR
 #error "WYL_TEST_TEMPLATE_DIR must be defined by the build."
@@ -80,6 +81,16 @@ typedef struct
   gint64 expected_risk;
   guint matches;
 } GuardMetadataCompoundExpect;
+
+typedef struct
+{
+  const gint64 *perm_ids;
+  guint *seen_counts;
+  gsize nperms;
+  gint64 placeholder_id;
+  guint total;
+  guint unexpected_guard_handle;
+} PermArmRuleSnapshotExpect;
 
 static gchar *
 make_tmpdir (void)
@@ -326,6 +337,27 @@ guard_metadata_compound_cb (const gchar *relation, const gint64 *row,
     return;
 
   expect->matches++;
+}
+
+static void
+perm_arm_rule_snapshot_cb (const gchar *relation, const gint64 *row,
+    guint ncols, gpointer user_data)
+{
+  PermArmRuleSnapshotExpect *expect = user_data;
+
+  if (g_strcmp0 (relation, "perm_arm_rule_observed") != 0 || ncols != 2)
+    return;
+
+  expect->total++;
+  if (row[1] != expect->placeholder_id)
+    expect->unexpected_guard_handle++;
+
+  for (gsize i = 0; i < expect->nperms; i++) {
+    if (row[0] == expect->perm_ids[i]) {
+      expect->seen_counts[i]++;
+      return;
+    }
+  }
 }
 
 static void
@@ -1149,6 +1181,76 @@ check_guard_context_compound_carries_request_payload (void)
 
   rmdir_recursive (tmpdir);
   return 0;
+}
+
+static gint
+assert_perm_arm_rule_placeholder_snapshot (WylHandle *handle, gint base_code)
+{
+  gsize nperms = wyl_perm_arm_rule_count ();
+  g_autofree gint64 *perm_ids = g_new0 (gint64, nperms);
+  g_autofree guint *seen_counts = g_new0 (guint, nperms);
+
+  for (gsize i = 0; i < nperms; i++) {
+    if (wyl_handle_intern_engine_symbol (handle, wyl_perm_arm_rule_perm_id (i),
+            &perm_ids[i]) != WYRELOG_E_OK)
+      return base_code;
+  }
+
+  gint64 placeholder_id = -1;
+  if (wyl_handle_intern_engine_symbol (handle, "_v0_deferred",
+          &placeholder_id) != WYRELOG_E_OK)
+    return base_code + 1;
+
+  PermArmRuleSnapshotExpect expect = {
+    .perm_ids = perm_ids,
+    .seen_counts = seen_counts,
+    .nperms = nperms,
+    .placeholder_id = placeholder_id,
+    .total = 0,
+    .unexpected_guard_handle = 0,
+  };
+  if (wyl_engine_snapshot (wyl_handle_get_read_engine (handle),
+          "perm_arm_rule_observed", perm_arm_rule_snapshot_cb, &expect)
+      != WYRELOG_E_OK)
+    return base_code + 2;
+
+  if (expect.unexpected_guard_handle != 0)
+    return base_code + 3;
+  if (expect.total != nperms)
+    return base_code + 4;
+  for (gsize i = 0; i < nperms; i++) {
+    if (seen_counts[i] != 1)
+      return base_code + 5 + (gint) i;
+  }
+  return 0;
+}
+
+static gint
+check_perm_arm_rule_placeholder_contract (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 133;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 134;
+  return assert_perm_arm_rule_placeholder_snapshot (handle, 135);
+}
+
+static gint
+check_perm_arm_rule_placeholder_contract_after_reload (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 151;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 152;
+  if (wyl_handle_reload_engine_pair (handle) != WYRELOG_E_OK)
+    return 153;
+  return assert_perm_arm_rule_placeholder_snapshot (handle, 154);
 }
 
 static gint
@@ -3138,6 +3240,10 @@ main (void)
   if ((rc = check_compound_make_result_is_insertable ()) != 0)
     return rc;
   if ((rc = check_guard_context_compound_carries_request_payload ()) != 0)
+    return rc;
+  if ((rc = check_perm_arm_rule_placeholder_contract ()) != 0)
+    return rc;
+  if ((rc = check_perm_arm_rule_placeholder_contract_after_reload ()) != 0)
     return rc;
   if ((rc = check_insert_fanout_reaches_read_engine ()) != 0)
     return rc;

--- a/wyrelog/wyl-decide.c
+++ b/wyrelog/wyl-decide.c
@@ -299,7 +299,8 @@ insert_guard_eval_facts (WylHandle *handle, const gint64 row[3],
     return rc;
 
   gint64 context_id = 0;
-  rc = wyl_handle_get_guard_context_compound (handle, &context_id);
+  rc = wyl_handle_make_guard_context_compound (handle, req->guard_timestamp,
+      loc_class_id, req->guard_risk, row[2], &context_id);
   if (rc != WYRELOG_E_OK)
     return rc;
 

--- a/wyrelog/wyl-handle-compound-private.h
+++ b/wyrelog/wyl-handle-compound-private.h
@@ -28,11 +28,14 @@ wyrelog_error_t wyl_handle_make_read_engine_compound (WylHandle * self,
     gint64 * out_id);
 
 /*
- * Returns the cached read-engine guard context compound used as the
- * request-local bridge key for context_now/guard_context/eval_guard facts.
- * The cache is invalidated with the handle-owned engine pair lifecycle.
+ * Allocates the request-local guard context compound used as the bridge key
+ * for context_now/guard_context/eval_guard facts. The returned side-tier
+ * handle is read-engine-local scratch state and encodes:
+ *
+ *   scope(metadata(timestamp, loc_class, risk), scope)
  */
-wyrelog_error_t wyl_handle_get_guard_context_compound (WylHandle * self,
+wyrelog_error_t wyl_handle_make_guard_context_compound (WylHandle * self,
+    gint64 timestamp, gint64 loc_class_id, gint64 risk, gint64 scope_id,
     gint64 * out_id);
 
 G_END_DECLS;

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -84,6 +84,9 @@ wyl_handle_init (WylHandle *self)
 static wyrelog_error_t
 wyl_handle_seed_perm_arm_rules (WylHandle *self)
 {
+  /* Compatibility seed: keep the guard-handle column on the
+   * template-documented placeholder until runtime guard AST
+   * compounds become the sole perm_arm_rule source. */
   for (gsize i = 0; i < wyl_perm_arm_rule_count (); i++) {
     gint64 row[2];
     wyrelog_error_t rc = wyl_handle_intern_engine_symbol (self,

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -24,8 +24,6 @@ struct _WylHandle
   gint64 created_at_us;
   WylEngine *read_engine;
   WylEngine *delta_engine;
-  WylEngine *guard_context_compound_engine;
-  gint64 guard_context_compound_id;
   GHashTable *engine_symbols_by_id;
   gchar *template_dir;
   WylDeltaCallback delta_callback;
@@ -274,8 +272,6 @@ wyl_shutdown (WylHandle *handle)
   g_clear_pointer (&handle->policy_store, wyl_policy_store_close);
   g_clear_object (&handle->read_engine);
   g_clear_object (&handle->delta_engine);
-  handle->guard_context_compound_engine = NULL;
-  handle->guard_context_compound_id = 0;
   g_clear_pointer (&handle->template_dir, g_free);
   g_object_set_qdata (G_OBJECT (handle),
       wyl_handle_engine_remove_fault_once_quark (), NULL);
@@ -443,9 +439,6 @@ replace_engine_pair (WylHandle *self, const gchar *template_dir)
 
   WylEngine *old_read_engine = self->read_engine;
   WylEngine *old_delta_engine = self->delta_engine;
-  WylEngine *old_guard_context_compound_engine =
-      self->guard_context_compound_engine;
-  gint64 old_guard_context_compound_id = self->guard_context_compound_id;
   GHashTable *old_symbols = self->engine_symbols_by_id;
   gchar *old_template_dir = self->template_dir;
 
@@ -463,8 +456,6 @@ replace_engine_pair (WylHandle *self, const gchar *template_dir)
 
   self->read_engine = new_read_engine;
   self->delta_engine = new_delta_engine;
-  self->guard_context_compound_engine = NULL;
-  self->guard_context_compound_id = 0;
   self->engine_symbols_by_id = new_engine_symbol_map ();
   self->template_dir = g_strdup (template_dir);
 
@@ -476,8 +467,6 @@ replace_engine_pair (WylHandle *self, const gchar *template_dir)
     g_clear_pointer (&self->template_dir, g_free);
     self->read_engine = old_read_engine;
     self->delta_engine = old_delta_engine;
-    self->guard_context_compound_engine = old_guard_context_compound_engine;
-    self->guard_context_compound_id = old_guard_context_compound_id;
     self->engine_symbols_by_id = old_symbols;
     self->template_dir = old_template_dir;
     return rc;
@@ -492,8 +481,6 @@ replace_engine_pair (WylHandle *self, const gchar *template_dir)
       g_clear_pointer (&self->template_dir, g_free);
       self->read_engine = old_read_engine;
       self->delta_engine = old_delta_engine;
-      self->guard_context_compound_engine = old_guard_context_compound_engine;
-      self->guard_context_compound_id = old_guard_context_compound_id;
       self->engine_symbols_by_id = old_symbols;
       self->template_dir = old_template_dir;
       return rc;
@@ -635,7 +622,8 @@ wyl_handle_make_read_engine_compound (WylHandle *self, const gchar *functor,
 }
 
 wyrelog_error_t
-wyl_handle_get_guard_context_compound (WylHandle *self, gint64 *out_id)
+wyl_handle_make_guard_context_compound (WylHandle *self, gint64 timestamp,
+    gint64 loc_class_id, gint64 risk, gint64 scope_id, gint64 *out_id)
 {
   if (out_id != NULL)
     *out_id = (gint64) WIRELOG_COMPOUND_HANDLE_NULL;
@@ -645,43 +633,23 @@ wyl_handle_get_guard_context_compound (WylHandle *self, gint64 *out_id)
   if (self->read_engine == NULL || self->delta_engine == NULL)
     return WYRELOG_E_INVALID;
 
-  if (self->guard_context_compound_engine == self->read_engine
-      && self->guard_context_compound_id != 0) {
-    *out_id = self->guard_context_compound_id;
-    return WYRELOG_E_OK;
-  }
-
-  gint64 context_symbol = 0;
-  wyrelog_error_t rc = wyl_handle_intern_engine_symbol (self,
-      "_request_context", &context_symbol);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-
   wirelog_compound_arg_t metadata_args[3] = {
-    {WIRELOG_TYPE_INT64, 0},
-    {WIRELOG_TYPE_STRING, context_symbol},
-    {WIRELOG_TYPE_INT64, 0},
+    {WIRELOG_TYPE_INT64, timestamp},
+    {WIRELOG_TYPE_STRING, loc_class_id},
+    {WIRELOG_TYPE_INT64, risk},
   };
   gint64 metadata_id = 0;
-  rc = wyl_handle_make_read_engine_compound (self, "metadata", metadata_args,
-      G_N_ELEMENTS (metadata_args), &metadata_id);
+  wyrelog_error_t rc = wyl_handle_make_read_engine_compound (self,
+      "metadata", metadata_args, G_N_ELEMENTS (metadata_args), &metadata_id);
   if (rc != WYRELOG_E_OK)
     return rc;
 
   wirelog_compound_arg_t scope_args[2] = {
     {WIRELOG_TYPE_INT64, metadata_id},
-    {WIRELOG_TYPE_INT64, 0},
+    {WIRELOG_TYPE_STRING, scope_id},
   };
-  gint64 context_id = 0;
-  rc = wyl_handle_make_read_engine_compound (self, "scope", scope_args,
-      G_N_ELEMENTS (scope_args), &context_id);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-
-  self->guard_context_compound_engine = self->read_engine;
-  self->guard_context_compound_id = context_id;
-  *out_id = context_id;
-  return WYRELOG_E_OK;
+  return wyl_handle_make_read_engine_compound (self, "scope", scope_args,
+      G_N_ELEMENTS (scope_args), out_id);
 }
 
 static gboolean

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -81,19 +81,162 @@ wyl_handle_init (WylHandle *self)
       g_hash_table_new_full (g_int64_hash, g_int64_equal, g_free, g_free);
 }
 
+static wyrelog_error_t wyl_handle_make_guard_expr_node_compound (WylHandle *
+    self, const wyl_guard_expr_t * expr, gint64 * out_id);
+
+static wyrelog_error_t
+wyl_handle_intern_guard_symbol (WylHandle *self, const gchar *symbol,
+    gint64 *out_id)
+{
+  if (symbol == NULL)
+    return WYRELOG_E_INVALID;
+  return wyl_handle_intern_engine_symbol (self, symbol, out_id);
+}
+
+static wyrelog_error_t
+wyl_handle_make_guard_cmp_compound (WylHandle *self,
+    const wyl_guard_expr_t *expr, gint64 *out_id)
+{
+  gint64 field_id = 0;
+  wyrelog_error_t rc = wyl_handle_intern_guard_symbol (self,
+      wyl_guard_field_name (expr->u.cmp.field), &field_id);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  gint64 op_id = 0;
+  rc = wyl_handle_intern_guard_symbol (self,
+      wyl_guard_op_name (expr->u.cmp.op), &op_id);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  gint64 value_id = 0;
+  rc = wyl_handle_intern_guard_symbol (self, expr->u.cmp.value, &value_id);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  wirelog_compound_arg_t args[3] = {
+    {WIRELOG_TYPE_STRING, field_id},
+    {WIRELOG_TYPE_STRING, op_id},
+    {WIRELOG_TYPE_STRING, value_id},
+  };
+  return wyl_handle_make_engine_compound (self, "guard_cmp", args,
+      G_N_ELEMENTS (args), out_id);
+}
+
+static wyrelog_error_t
+wyl_handle_make_guard_tag_compound (WylHandle *self,
+    const wyl_guard_expr_t *expr, gint64 *out_id)
+{
+  gint64 atom_id = 0;
+  wyrelog_error_t rc =
+      wyl_handle_intern_guard_symbol (self, expr->u.tag.atom, &atom_id);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  wirelog_compound_arg_t args[1] = {
+    {WIRELOG_TYPE_STRING, atom_id},
+  };
+  return wyl_handle_make_engine_compound (self, "guard_tag", args,
+      G_N_ELEMENTS (args), out_id);
+}
+
+static wyrelog_error_t
+wyl_handle_make_guard_unary_compound (WylHandle *self, const gchar *functor,
+    const wyl_guard_expr_t *child, gint64 *out_id)
+{
+  gint64 child_id = 0;
+  wyrelog_error_t rc =
+      wyl_handle_make_guard_expr_node_compound (self, child, &child_id);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  wirelog_compound_arg_t args[1] = {
+    {WIRELOG_TYPE_INT64, child_id},
+  };
+  return wyl_handle_make_engine_compound (self, functor, args,
+      G_N_ELEMENTS (args), out_id);
+}
+
+static wyrelog_error_t
+wyl_handle_make_guard_binary_compound (WylHandle *self, const gchar *functor,
+    const wyl_guard_expr_t *left, const wyl_guard_expr_t *right, gint64 *out_id)
+{
+  gint64 left_id = 0;
+  wyrelog_error_t rc =
+      wyl_handle_make_guard_expr_node_compound (self, left, &left_id);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  gint64 right_id = 0;
+  rc = wyl_handle_make_guard_expr_node_compound (self, right, &right_id);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  wirelog_compound_arg_t args[2] = {
+    {WIRELOG_TYPE_INT64, left_id},
+    {WIRELOG_TYPE_INT64, right_id},
+  };
+  return wyl_handle_make_engine_compound (self, functor, args,
+      G_N_ELEMENTS (args), out_id);
+}
+
+static wyrelog_error_t
+wyl_handle_make_guard_expr_node_compound (WylHandle *self,
+    const wyl_guard_expr_t *expr, gint64 *out_id)
+{
+  if (out_id != NULL)
+    *out_id = (gint64) WIRELOG_COMPOUND_HANDLE_NULL;
+  if (expr == NULL || out_id == NULL)
+    return WYRELOG_E_INVALID;
+
+  switch (expr->kind) {
+    case WYL_GUARD_KIND_CMP:
+      return wyl_handle_make_guard_cmp_compound (self, expr, out_id);
+    case WYL_GUARD_KIND_TAG:
+      return wyl_handle_make_guard_tag_compound (self, expr, out_id);
+    case WYL_GUARD_KIND_NOT:
+      return wyl_handle_make_guard_unary_compound (self, "guard_not",
+          expr->u.unary.child, out_id);
+    case WYL_GUARD_KIND_AND:
+      return wyl_handle_make_guard_binary_compound (self, "guard_and",
+          expr->u.binop.left, expr->u.binop.right, out_id);
+    case WYL_GUARD_KIND_OR:
+      return wyl_handle_make_guard_binary_compound (self, "guard_or",
+          expr->u.binop.left, expr->u.binop.right, out_id);
+    case WYL_GUARD_KIND_LAST_:
+    default:
+      return WYRELOG_E_INVALID;
+  }
+}
+
+static wyrelog_error_t
+wyl_handle_make_guard_expr_compound (WylHandle *self,
+    const wyl_guard_expr_t *expr, gint64 *out_id)
+{
+  gint64 root_id = 0;
+  wyrelog_error_t rc =
+      wyl_handle_make_guard_expr_node_compound (self, expr, &root_id);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  wirelog_compound_arg_t args[1] = {
+    {WIRELOG_TYPE_INT64, root_id},
+  };
+  return wyl_handle_make_engine_compound (self, "guard", args,
+      G_N_ELEMENTS (args), out_id);
+}
+
 static wyrelog_error_t
 wyl_handle_seed_perm_arm_rules (WylHandle *self)
 {
-  /* Compatibility seed: keep the guard-handle column on the
-   * template-documented placeholder until runtime guard AST
-   * compounds become the sole perm_arm_rule source. */
   for (gsize i = 0; i < wyl_perm_arm_rule_count (); i++) {
     gint64 row[2];
     wyrelog_error_t rc = wyl_handle_intern_engine_symbol (self,
         wyl_perm_arm_rule_perm_id (i), &row[0]);
     if (rc != WYRELOG_E_OK)
       return rc;
-    rc = wyl_handle_intern_engine_symbol (self, "_v0_deferred", &row[1]);
+    rc = wyl_handle_make_guard_expr_compound (self,
+        wyl_perm_arm_rule_expr (i), &row[1]);
     if (rc != WYRELOG_E_OK)
       return rc;
     rc = wyl_handle_engine_insert (self, "perm_arm_rule", row, 2);

--- a/wyrelog/wyl-permission-scope-private.h
+++ b/wyrelog/wyl-permission-scope-private.h
@@ -18,11 +18,11 @@ G_BEGIN_DECLS;
  * request-local eval_guard/4 bridge fact to wirelog.
  *
  * The version-0 Datalog bridge carries a request-local context
- * handle: context_now(user, scope, ctx), guard_context(ctx, user,
- * scope, timestamp, loc_class, risk), and eval_guard(user, perm,
- * scope, ctx). The guard expression payload remains in the C
- * catalogue until wirelog compound declarations can carry it
- * directly.
+ * compound: context_now(user, scope, scope(metadata(timestamp,
+ * loc_class, risk), scope)), guard_context(ctx, user, scope,
+ * timestamp, loc_class, risk), and eval_guard(user, perm, scope,
+ * ctx). The guard expression payload remains in the C catalogue
+ * until wirelog compound declarations can carry it directly.
  *
  * Evaluation contract: every uncertain or undefined branch
  * returns FALSE (fail-closed). This includes a NULL expression, a


### PR DESCRIPTION
## Summary

- build request-local guard context compounds from timestamp, location class,
  risk, and scope
- make guard arm rules runtime-seeded from the C catalogue instead of static
  template facts
- seed guard arm rows with side-tier guard AST payload handles while keeping
  Datalog guard evaluation unchanged

## Tests

- `meson test -C builddir handle-engine-pair fsm-permission-scope access-decision decide daemon-http-decide wyrelogd-startup-readiness --print-errorlogs`
- `meson test -C builddir-audit handle-engine-pair fsm-permission-scope access-decision decide daemon-http-decide client-audit-daemon wyrelogd-startup-readiness --print-errorlogs`
- `git diff --check`
