### PR TITLE
Expose request guard context predicates for guarded decisions

### DIFF
--- a/templates/access/fsm/permission_scope.dl
+++ b/templates/access/fsm/permission_scope.dl
@@ -18,6 +18,9 @@
 //                                                   bootstrap.dl
 //   perm_arm_rule(perm, guard_handle)            -- guard(root) side
 //                                                   payload handle
+//   perm_window_guard(perm, window)              -- guarded permission
+//                                                   requires a named
+//                                                   timestamp window
 //   context_now(user, scope, ctx)                -- scope(metadata(ts,
 //                                                   loc_class, risk),
 //                                                   scope) activation
@@ -26,6 +29,8 @@
 //   guard_context_timestamp(user, scope, ts)     -- context field views
 //   guard_context_loc_class(user, scope, loc)
 //   guard_context_risk(user, scope, risk)
+//   guard_context_in_window(user, scope, ts,     -- host-confirmed
+//       window)                                      timestamp window
 //   eval_guard(user, perm, scope, ctx)           -- host guard result
 //
 // perm_arm_rule rows are runtime-seeded from the C catalogue so the
@@ -35,14 +40,18 @@
 
 .decl perm_state(user: symbol, perm: symbol, scope: symbol, state: symbol)
 .decl perm_arm_rule(perm: symbol, guard_handle: int64)
+.decl perm_window_guard(perm: symbol, window: symbol)
 .decl context_now(user: symbol, scope: symbol, ctx: scope/2 side)
 .decl guard_context(ctx: scope/2 side, user: symbol, scope: symbol,
     timestamp: int64, loc_class: symbol, risk: int64)
 .decl guard_context_timestamp(user: symbol, scope: symbol, timestamp: int64)
 .decl guard_context_loc_class(user: symbol, scope: symbol, loc_class: symbol)
 .decl guard_context_risk(user: symbol, scope: symbol, risk: int64)
+.decl guard_context_in_window(user: symbol, scope: symbol, timestamp: int64,
+    window: symbol)
 .decl eval_guard(user: symbol, perm: symbol, scope: symbol, ctx: scope/2 side)
 .decl perm_arm_rule_observed(perm: symbol, guard_handle: int64)
+.decl perm_window_guard_observed(perm: symbol, window: symbol)
 .decl armed(user: symbol, perm: symbol, scope: symbol)
 
 // --- perm_arm_rule catalogue seed ------------------------------------
@@ -56,6 +65,7 @@
 // mirror, not an evaluator input yet.
 
 perm_arm_rule_observed(P, G) :- perm_arm_rule(P, G).
+perm_window_guard_observed(P, W) :- perm_window_guard(P, W).
 
 // --- guard context field views ---------------------------------------
 
@@ -84,4 +94,20 @@ armed(U, P, S) :-
     guard_context_loc_class(U, S, L),
     guard_context_risk(U, S, R),
     perm_arm_rule(P, _),
+    !perm_window_guard(P, _),
+    eval_guard(U, P, S, C).
+
+// rule-4: window-gated permission. The C evaluator still decides
+// the guard; this rule only requires the request-local evidence for
+// the same named timestamp window before arming the permission.
+armed(U, P, S) :-
+    has_permission(U, P, S),
+    context_now(U, S, C),
+    guard_context(C, U, S, T, L, R),
+    guard_context_timestamp(U, S, T),
+    guard_context_loc_class(U, S, L),
+    guard_context_risk(U, S, R),
+    perm_arm_rule(P, _),
+    perm_window_guard(P, W),
+    guard_context_in_window(U, S, T, W),
     eval_guard(U, P, S, C).

--- a/templates/access/fsm/permission_scope.dl
+++ b/templates/access/fsm/permission_scope.dl
@@ -23,6 +23,9 @@
 //                                                   scope) activation
 //   guard_context(ctx, user, scope, timestamp,   -- structured request
 //                 loc_class, risk)                  context payload
+//   guard_context_timestamp(user, scope, ts)     -- context field views
+//   guard_context_loc_class(user, scope, loc)
+//   guard_context_risk(user, scope, risk)
 //   eval_guard(user, perm, scope, ctx)           -- host guard result
 //
 // perm_arm_rule rows are runtime-seeded from the C catalogue so the
@@ -35,6 +38,9 @@
 .decl context_now(user: symbol, scope: symbol, ctx: scope/2 side)
 .decl guard_context(ctx: scope/2 side, user: symbol, scope: symbol,
     timestamp: int64, loc_class: symbol, risk: int64)
+.decl guard_context_timestamp(user: symbol, scope: symbol, timestamp: int64)
+.decl guard_context_loc_class(user: symbol, scope: symbol, loc_class: symbol)
+.decl guard_context_risk(user: symbol, scope: symbol, risk: int64)
 .decl eval_guard(user: symbol, perm: symbol, scope: symbol, ctx: scope/2 side)
 .decl perm_arm_rule_observed(perm: symbol, guard_handle: int64)
 .decl armed(user: symbol, perm: symbol, scope: symbol)
@@ -50,6 +56,12 @@
 // mirror, not an evaluator input yet.
 
 perm_arm_rule_observed(P, G) :- perm_arm_rule(P, G).
+
+// --- guard context field views ---------------------------------------
+
+// The host inserts and removes these request-local rows alongside
+// guard_context/6. Keeping them EDB-only preserves cleanup semantics
+// for the embedded incremental evaluator.
 
 // --- armed/3 derivation ----------------------------------------------
 
@@ -67,6 +79,9 @@ armed(U, P, S) :-
 armed(U, P, S) :-
     has_permission(U, P, S),
     context_now(U, S, C),
-    guard_context(C, U, S, _, _, _),
+    guard_context(C, U, S, T, L, R),
+    guard_context_timestamp(U, S, T),
+    guard_context_loc_class(U, S, L),
+    guard_context_risk(U, S, R),
     perm_arm_rule(P, _),
     eval_guard(U, P, S, C).

--- a/tests/test-decide.c
+++ b/tests/test-decide.c
@@ -272,6 +272,10 @@ check_guard_bridge_facts_absent (WylHandle *handle, const gchar *subject,
       base_code + 13);
   if (rc != 0)
     return rc;
+  rc = check_guard_context_field_absent (handle, "guard_context_in_window",
+      base_code + 15);
+  if (rc != 0)
+    return rc;
 
   return 0;
 }
@@ -352,6 +356,10 @@ check_guard_cleanup_fault_residue (WylHandle *handle, gint base_code)
     return field_check;
   field_check = check_guard_context_field_absent (handle,
       "guard_context_risk", base_code + 11);
+  if (field_check != 0)
+    return field_check;
+  field_check = check_guard_context_field_absent (handle,
+      "guard_context_in_window", base_code + 13);
   if (field_check != 0)
     return field_check;
 
@@ -874,6 +882,50 @@ check_decide_fail_closes_on_guard_cleanup_faults (void)
 }
 
 static gint
+check_window_guard_cleanup_fault (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 310;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 311;
+  if (insert_allow_fixture_state (handle, "cleanup-window-user",
+          "wr.stream.write_reserved", "cleanup-window-resource", FALSE)
+      != WYRELOG_E_OK)
+    return 312;
+
+  WindowExpect expect = {
+    .expected_window = "off_hours",
+    .expected_timestamp = 4242,
+    .answer = TRUE,
+    .calls = 0,
+  };
+  g_autoptr (wyl_decide_req_t) req = wyl_decide_req_new ();
+  wyl_decide_req_set_subject_id (req, "cleanup-window-user");
+  wyl_decide_req_set_action (req, "wr.stream.write_reserved");
+  wyl_decide_req_set_resource_id (req, "cleanup-window-resource");
+  wyl_decide_req_set_guard_context (req, 4242, "trusted", 1);
+  wyl_decide_req_set_guard_window_matcher (req, window_expect_cb, &expect);
+
+  g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
+  wyl_handle_set_engine_remove_fault_once (handle, "guard_context_in_window",
+      WYRELOG_E_INTERNAL);
+  if (wyl_decide (handle, req, resp) != WYRELOG_E_INTERNAL)
+    return 313;
+  if (expect.calls != 1)
+    return 314;
+  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_DENY)
+    return 315;
+  if (g_strcmp0 (wyl_decide_resp_get_deny_reason (resp),
+          "guard_cleanup_failed") != 0)
+    return 316;
+
+  return check_guard_bridge_facts_absent (handle, "cleanup-window-user",
+      "wr.stream.write_reserved", "cleanup-window-resource", 317);
+}
+
+static gint
 check_decide_evaluates_window_guard (void)
 {
   g_autoptr (WylHandle) handle = NULL;
@@ -948,6 +1000,8 @@ main (void)
   if ((rc = check_decide_prioritizes_guarded_blockers ()) != 0)
     return rc;
   if ((rc = check_decide_fail_closes_on_guard_cleanup_faults ()) != 0)
+    return rc;
+  if ((rc = check_window_guard_cleanup_fault ()) != 0)
     return rc;
   if ((rc = check_decide_evaluates_window_guard ()) != 0)
     return rc;

--- a/tests/test-decide.c
+++ b/tests/test-decide.c
@@ -194,6 +194,33 @@ count_guard_context_cb (const gchar *relation, const gint64 *row, guint ncols,
     expect->matches++;
 }
 
+static void
+count_any_guard_context_field_cb (const gchar *relation, const gint64 *row,
+    guint ncols, gpointer user_data)
+{
+  guint *seen = user_data;
+
+  (void) relation;
+  (void) row;
+  (void) ncols;
+
+  (*seen)++;
+}
+
+static gint
+check_guard_context_field_absent (WylHandle *handle, const gchar *relation,
+    gint base_code)
+{
+  guint seen = 0;
+  wyrelog_error_t rc = wyl_engine_snapshot (wyl_handle_get_read_engine (handle),
+      relation, count_any_guard_context_field_cb, &seen);
+  if (rc != WYRELOG_E_OK)
+    return base_code;
+  if (seen != 0)
+    return base_code + 1;
+  return 0;
+}
+
 static gint
 check_guard_bridge_facts_absent (WylHandle *handle, const gchar *subject,
     const gchar *action, const gchar *resource, gint base_code)
@@ -232,6 +259,19 @@ check_guard_bridge_facts_absent (WylHandle *handle, const gchar *subject,
     return base_code + 7;
   if (expect.matches != 0)
     return base_code + 8;
+
+  rc = check_guard_context_field_absent (handle, "guard_context_timestamp",
+      base_code + 9);
+  if (rc != 0)
+    return rc;
+  rc = check_guard_context_field_absent (handle, "guard_context_loc_class",
+      base_code + 11);
+  if (rc != 0)
+    return rc;
+  rc = check_guard_context_field_absent (handle, "guard_context_risk",
+      base_code + 13);
+  if (rc != 0)
+    return rc;
 
   return 0;
 }
@@ -301,6 +341,19 @@ check_guard_cleanup_fault_residue (WylHandle *handle, gint base_code)
 
   if (eval_guard != 0 || context_now != 0 || guard_context != 0)
     return base_code + 6;
+
+  gint field_check = check_guard_context_field_absent (handle,
+      "guard_context_timestamp", base_code + 7);
+  if (field_check != 0)
+    return field_check;
+  field_check = check_guard_context_field_absent (handle,
+      "guard_context_loc_class", base_code + 9);
+  if (field_check != 0)
+    return field_check;
+  field_check = check_guard_context_field_absent (handle,
+      "guard_context_risk", base_code + 11);
+  if (field_check != 0)
+    return field_check;
 
   return 0;
 }
@@ -808,7 +861,16 @@ check_decide_fail_closes_on_guard_cleanup_faults (void)
   rc = check_guard_cleanup_fault ("context_now", 160);
   if (rc != 0)
     return rc;
-  return check_guard_cleanup_fault ("guard_context", 190);
+  rc = check_guard_cleanup_fault ("guard_context_timestamp", 190);
+  if (rc != 0)
+    return rc;
+  rc = check_guard_cleanup_fault ("guard_context_loc_class", 220);
+  if (rc != 0)
+    return rc;
+  rc = check_guard_cleanup_fault ("guard_context_risk", 250);
+  if (rc != 0)
+    return rc;
+  return check_guard_cleanup_fault ("guard_context", 280);
 }
 
 static gint

--- a/tests/test-fsm-permission-scope.c
+++ b/tests/test-fsm-permission-scope.c
@@ -21,8 +21,8 @@
  * context_now / guard_context. No edge can close a cycle because
  * perm_arm_rule, perm_state, has_permission, context_now,
  * guard_context, guard_context_timestamp,
- * guard_context_loc_class, guard_context_risk and eval_guard are
- * EDB-only.
+ * guard_context_loc_class, guard_context_risk,
+ * guard_context_in_window and eval_guard are EDB-only.
  */
 static gint
 check_stratification (void)
@@ -39,11 +39,25 @@ check_stratification (void)
     {.predicate = "guard_context_loc_class",.negated = FALSE},
     {.predicate = "guard_context_risk",.negated = FALSE},
     {.predicate = "perm_arm_rule",.negated = FALSE},
+    {.predicate = "perm_window_guard",.negated = TRUE},
+    {.predicate = "eval_guard",.negated = FALSE},
+  };
+  static const wyl_dl_body_atom_t rule4_body[] = {
+    {.predicate = "has_permission",.negated = FALSE},
+    {.predicate = "context_now",.negated = FALSE},
+    {.predicate = "guard_context",.negated = FALSE},
+    {.predicate = "guard_context_timestamp",.negated = FALSE},
+    {.predicate = "guard_context_loc_class",.negated = FALSE},
+    {.predicate = "guard_context_risk",.negated = FALSE},
+    {.predicate = "perm_arm_rule",.negated = FALSE},
+    {.predicate = "perm_window_guard",.negated = FALSE},
+    {.predicate = "guard_context_in_window",.negated = FALSE},
     {.predicate = "eval_guard",.negated = FALSE},
   };
   wyl_dl_rule_t rules[] = {
     {.head = "armed",.body = rule1_body,.body_len = G_N_ELEMENTS (rule1_body)},
     {.head = "armed",.body = rule3_body,.body_len = G_N_ELEMENTS (rule3_body)},
+    {.head = "armed",.body = rule4_body,.body_len = G_N_ELEMENTS (rule4_body)},
   };
 
   if (wyl_dl_static_check (rules, G_N_ELEMENTS (rules)) != WYRELOG_E_OK)
@@ -64,6 +78,12 @@ check_catalogue_invariants (void)
     return 13;
   if (wyl_perm_arm_rule_lookup ("wr.sys.admin") == NULL)
     return 14;
+  if (g_strcmp0 (wyl_guard_expr_timestamp_window (wyl_perm_arm_rule_lookup
+              ("wr.stream.write_reserved")), "off_hours") != 0)
+    return 15;
+  if (wyl_guard_expr_timestamp_window (wyl_perm_arm_rule_lookup
+          ("wr.audit.read")) != NULL)
+    return 16;
   /* The accessor view of the catalogue must agree with the lookup
    * view on every row. */
   for (gsize i = 0; i < wyl_perm_arm_rule_count (); i++) {

--- a/tests/test-fsm-permission-scope.c
+++ b/tests/test-fsm-permission-scope.c
@@ -20,9 +20,9 @@
  * \+ perm_arm_rule, and the guarded rule goes through eval_guard /
  * context_now / guard_context. No edge can close a cycle because
  * perm_arm_rule, perm_state, has_permission, context_now,
- * guard_context and eval_guard are
- * EDB-only — none of them appears as a head predicate in the
- * lifted rule set.
+ * guard_context, guard_context_timestamp,
+ * guard_context_loc_class, guard_context_risk and eval_guard are
+ * EDB-only.
  */
 static gint
 check_stratification (void)
@@ -35,6 +35,9 @@ check_stratification (void)
     {.predicate = "has_permission",.negated = FALSE},
     {.predicate = "context_now",.negated = FALSE},
     {.predicate = "guard_context",.negated = FALSE},
+    {.predicate = "guard_context_timestamp",.negated = FALSE},
+    {.predicate = "guard_context_loc_class",.negated = FALSE},
+    {.predicate = "guard_context_risk",.negated = FALSE},
     {.predicate = "perm_arm_rule",.negated = FALSE},
     {.predicate = "eval_guard",.negated = FALSE},
   };

--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -96,6 +96,16 @@ typedef struct
 
 typedef struct
 {
+  gint64 stream_perm_id;
+  gint64 audit_perm_id;
+  gint64 window_id;
+  guint stream_window_matches;
+  guint audit_window_matches;
+  guint total;
+} PermWindowGuardSnapshotExpect;
+
+typedef struct
+{
   gint64 guard_handle;
   gint64 root_handle;
   guint matches;
@@ -180,7 +190,8 @@ write_compound_templates (const gchar *dir)
       ".decl session_transition(from_state: symbol, event: symbol,"
       " to_state: symbol)\n")
       && write_file_in_dir (dir, "fsm/permission_scope.dl",
-      ".decl perm_arm_rule(perm: symbol, guard_handle: int64)\n")
+      ".decl perm_arm_rule(perm: symbol, guard_handle: int64)\n"
+      ".decl perm_window_guard(perm: symbol, window: symbol)\n")
       && write_file_in_dir (dir, "lobac/decision.dl", "// decision stub\n");
 }
 
@@ -210,7 +221,8 @@ write_guard_context_compound_templates (const gchar *dir)
       ".decl session_transition(from_state: symbol, event: symbol,"
       " to_state: symbol)\n")
       && write_file_in_dir (dir, "fsm/permission_scope.dl",
-      ".decl perm_arm_rule(perm: symbol, guard_handle: int64)\n")
+      ".decl perm_arm_rule(perm: symbol, guard_handle: int64)\n"
+      ".decl perm_window_guard(perm: symbol, window: symbol)\n")
       && write_file_in_dir (dir, "lobac/decision.dl", "// decision stub\n");
 }
 
@@ -242,7 +254,8 @@ write_guard_payload_templates (const gchar *dir)
       ".decl session_transition(from_state: symbol, event: symbol,"
       " to_state: symbol)\n")
       && write_file_in_dir (dir, "fsm/permission_scope.dl",
-      ".decl perm_arm_rule(perm: symbol, guard_handle: int64)\n")
+      ".decl perm_arm_rule(perm: symbol, guard_handle: int64)\n"
+      ".decl perm_window_guard(perm: symbol, window: symbol)\n")
       && write_file_in_dir (dir, "lobac/decision.dl", "// decision stub\n");
 }
 
@@ -419,6 +432,22 @@ perm_arm_rule_snapshot_cb (const gchar *relation, const gint64 *row,
       return;
     }
   }
+}
+
+static void
+perm_window_guard_snapshot_cb (const gchar *relation, const gint64 *row,
+    guint ncols, gpointer user_data)
+{
+  PermWindowGuardSnapshotExpect *expect = user_data;
+
+  if (g_strcmp0 (relation, "perm_window_guard_observed") != 0 || ncols != 2)
+    return;
+
+  expect->total++;
+  if (row[0] == expect->stream_perm_id && row[1] == expect->window_id)
+    expect->stream_window_matches++;
+  if (row[0] == expect->audit_perm_id)
+    expect->audit_window_matches++;
 }
 
 static void
@@ -1365,6 +1394,50 @@ check_perm_arm_rule_guard_payload_contract_after_reload (void)
   if (wyl_handle_reload_engine_pair (handle) != WYRELOG_E_OK)
     return 153;
   return assert_perm_arm_rule_guard_payload_snapshot (handle, 154);
+}
+
+static gint
+check_perm_window_guard_seed_contract (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  gint64 stream_perm_id = -1;
+  gint64 audit_perm_id = -1;
+  gint64 window_id = -1;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 166;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 167;
+  if (wyl_handle_intern_engine_symbol (handle, "wr.stream.write_reserved",
+          &stream_perm_id) != WYRELOG_E_OK)
+    return 168;
+  if (wyl_handle_intern_engine_symbol (handle, "wr.audit.read",
+          &audit_perm_id) != WYRELOG_E_OK)
+    return 169;
+  if (wyl_handle_intern_engine_symbol (handle, "off_hours", &window_id)
+      != WYRELOG_E_OK)
+    return 170;
+
+  PermWindowGuardSnapshotExpect expect = {
+    .stream_perm_id = stream_perm_id,
+    .audit_perm_id = audit_perm_id,
+    .window_id = window_id,
+    .stream_window_matches = 0,
+    .audit_window_matches = 0,
+    .total = 0,
+  };
+  if (wyl_engine_snapshot (wyl_handle_get_read_engine (handle),
+          "perm_window_guard_observed", perm_window_guard_snapshot_cb, &expect)
+      != WYRELOG_E_OK)
+    return 171;
+  if (expect.stream_window_matches != 1)
+    return 172;
+  if (expect.audit_window_matches != 0)
+    return 173;
+  if (expect.total != 1)
+    return 174;
+  return 0;
 }
 
 static gint
@@ -3577,6 +3650,8 @@ main (void)
   if ((rc = check_perm_arm_rule_guard_payload_contract ()) != 0)
     return rc;
   if ((rc = check_perm_arm_rule_guard_payload_contract_after_reload ()) != 0)
+    return rc;
+  if ((rc = check_perm_window_guard_seed_contract ()) != 0)
     return rc;
   if ((rc = check_perm_arm_rule_guard_payload_projection ()) != 0)
     return rc;

--- a/wyrelog/wyl-decide.c
+++ b/wyrelog/wyl-decide.c
@@ -32,9 +32,15 @@ typedef struct guard_eval_facts_t
 {
   gint64 context_now[3];
   gint64 guard_context[6];
+  gint64 guard_context_timestamp[3];
+  gint64 guard_context_loc_class[3];
+  gint64 guard_context_risk[3];
   gint64 eval_guard[4];
   gboolean context_now_inserted;
   gboolean guard_context_inserted;
+  gboolean guard_context_timestamp_inserted;
+  gboolean guard_context_loc_class_inserted;
+  gboolean guard_context_risk_inserted;
   gboolean eval_guard_inserted;
 } guard_eval_facts_t;
 
@@ -276,6 +282,24 @@ remove_guard_eval_facts (WylHandle *handle, const guard_eval_facts_t *facts)
     if (first_rc == WYRELOG_E_OK)
       first_rc = rc;
   }
+  if (facts->guard_context_timestamp_inserted) {
+    wyrelog_error_t rc = wyl_handle_engine_remove (handle,
+        "guard_context_timestamp", facts->guard_context_timestamp, 3);
+    if (first_rc == WYRELOG_E_OK)
+      first_rc = rc;
+  }
+  if (facts->guard_context_loc_class_inserted) {
+    wyrelog_error_t rc = wyl_handle_engine_remove (handle,
+        "guard_context_loc_class", facts->guard_context_loc_class, 3);
+    if (first_rc == WYRELOG_E_OK)
+      first_rc = rc;
+  }
+  if (facts->guard_context_risk_inserted) {
+    wyrelog_error_t rc = wyl_handle_engine_remove (handle,
+        "guard_context_risk", facts->guard_context_risk, 3);
+    if (first_rc == WYRELOG_E_OK)
+      first_rc = rc;
+  }
   if (facts->guard_context_inserted) {
     wyrelog_error_t rc = wyl_handle_engine_remove (handle, "guard_context",
         facts->guard_context, 6);
@@ -311,6 +335,18 @@ insert_guard_eval_facts (WylHandle *handle, const gint64 row[3],
   facts->guard_context[4] = loc_class_id;
   facts->guard_context[5] = req->guard_risk;
 
+  facts->guard_context_timestamp[0] = row[0];
+  facts->guard_context_timestamp[1] = row[2];
+  facts->guard_context_timestamp[2] = req->guard_timestamp;
+
+  facts->guard_context_loc_class[0] = row[0];
+  facts->guard_context_loc_class[1] = row[2];
+  facts->guard_context_loc_class[2] = loc_class_id;
+
+  facts->guard_context_risk[0] = row[0];
+  facts->guard_context_risk[1] = row[2];
+  facts->guard_context_risk[2] = req->guard_risk;
+
   facts->context_now[0] = row[0];
   facts->context_now[1] = row[2];
   facts->context_now[2] = context_id;
@@ -325,6 +361,30 @@ insert_guard_eval_facts (WylHandle *handle, const gint64 row[3],
   if (rc != WYRELOG_E_OK)
     return rc;
   facts->guard_context_inserted = TRUE;
+
+  rc = wyl_handle_engine_insert (handle, "guard_context_timestamp",
+      facts->guard_context_timestamp, 3);
+  if (rc != WYRELOG_E_OK) {
+    (void) remove_guard_eval_facts (handle, facts);
+    return rc;
+  }
+  facts->guard_context_timestamp_inserted = TRUE;
+
+  rc = wyl_handle_engine_insert (handle, "guard_context_loc_class",
+      facts->guard_context_loc_class, 3);
+  if (rc != WYRELOG_E_OK) {
+    (void) remove_guard_eval_facts (handle, facts);
+    return rc;
+  }
+  facts->guard_context_loc_class_inserted = TRUE;
+
+  rc = wyl_handle_engine_insert (handle, "guard_context_risk",
+      facts->guard_context_risk, 3);
+  if (rc != WYRELOG_E_OK) {
+    (void) remove_guard_eval_facts (handle, facts);
+    return rc;
+  }
+  facts->guard_context_risk_inserted = TRUE;
 
   rc = wyl_handle_engine_insert (handle, "context_now", facts->context_now, 3);
   if (rc != WYRELOG_E_OK) {

--- a/wyrelog/wyl-decide.c
+++ b/wyrelog/wyl-decide.c
@@ -35,12 +35,14 @@ typedef struct guard_eval_facts_t
   gint64 guard_context_timestamp[3];
   gint64 guard_context_loc_class[3];
   gint64 guard_context_risk[3];
+  gint64 guard_context_in_window[4];
   gint64 eval_guard[4];
   gboolean context_now_inserted;
   gboolean guard_context_inserted;
   gboolean guard_context_timestamp_inserted;
   gboolean guard_context_loc_class_inserted;
   gboolean guard_context_risk_inserted;
+  gboolean guard_context_in_window_inserted;
   gboolean eval_guard_inserted;
 } guard_eval_facts_t;
 
@@ -300,6 +302,12 @@ remove_guard_eval_facts (WylHandle *handle, const guard_eval_facts_t *facts)
     if (first_rc == WYRELOG_E_OK)
       first_rc = rc;
   }
+  if (facts->guard_context_in_window_inserted) {
+    wyrelog_error_t rc = wyl_handle_engine_remove (handle,
+        "guard_context_in_window", facts->guard_context_in_window, 4);
+    if (first_rc == WYRELOG_E_OK)
+      first_rc = rc;
+  }
   if (facts->guard_context_inserted) {
     wyrelog_error_t rc = wyl_handle_engine_remove (handle, "guard_context",
         facts->guard_context, 6);
@@ -312,7 +320,8 @@ remove_guard_eval_facts (WylHandle *handle, const guard_eval_facts_t *facts)
 
 static wyrelog_error_t
 insert_guard_eval_facts (WylHandle *handle, const gint64 row[3],
-    const wyl_decide_req_t *req, guard_eval_facts_t *facts)
+    const wyl_guard_expr_t *guard, const wyl_decide_req_t *req,
+    guard_eval_facts_t *facts)
 {
   memset (facts, 0, sizeof (*facts));
 
@@ -346,6 +355,18 @@ insert_guard_eval_facts (WylHandle *handle, const gint64 row[3],
   facts->guard_context_risk[0] = row[0];
   facts->guard_context_risk[1] = row[2];
   facts->guard_context_risk[2] = req->guard_risk;
+
+  const gchar *window = wyl_guard_expr_timestamp_window (guard);
+  if (window != NULL) {
+    gint64 window_id = 0;
+    rc = wyl_handle_intern_engine_symbol (handle, window, &window_id);
+    if (rc != WYRELOG_E_OK)
+      return rc;
+    facts->guard_context_in_window[0] = row[0];
+    facts->guard_context_in_window[1] = row[2];
+    facts->guard_context_in_window[2] = req->guard_timestamp;
+    facts->guard_context_in_window[3] = window_id;
+  }
 
   facts->context_now[0] = row[0];
   facts->context_now[1] = row[2];
@@ -385,6 +406,16 @@ insert_guard_eval_facts (WylHandle *handle, const gint64 row[3],
     return rc;
   }
   facts->guard_context_risk_inserted = TRUE;
+
+  if (window != NULL) {
+    rc = wyl_handle_engine_insert (handle, "guard_context_in_window",
+        facts->guard_context_in_window, 4);
+    if (rc != WYRELOG_E_OK) {
+      (void) remove_guard_eval_facts (handle, facts);
+      return rc;
+    }
+    facts->guard_context_in_window_inserted = TRUE;
+  }
 
   rc = wyl_handle_engine_insert (handle, "context_now", facts->context_now, 3);
   if (rc != WYRELOG_E_OK) {
@@ -536,7 +567,7 @@ wyl_decide (WylHandle *handle, const wyl_decide_req_t *req,
         wyl_decide_resp_set_deny_tags (resp, deny_reason, deny_origin);
         goto emit_audit;
       }
-      rc = insert_guard_eval_facts (handle, row, req, &guard_facts);
+      rc = insert_guard_eval_facts (handle, row, guard, req, &guard_facts);
       if (rc != WYRELOG_E_OK)
         return rc;
     }

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -231,17 +231,28 @@ wyl_handle_seed_perm_arm_rules (WylHandle *self)
 {
   for (gsize i = 0; i < wyl_perm_arm_rule_count (); i++) {
     gint64 row[2];
+    const wyl_guard_expr_t *guard = wyl_perm_arm_rule_expr (i);
     wyrelog_error_t rc = wyl_handle_intern_engine_symbol (self,
         wyl_perm_arm_rule_perm_id (i), &row[0]);
     if (rc != WYRELOG_E_OK)
       return rc;
-    rc = wyl_handle_make_guard_expr_compound (self,
-        wyl_perm_arm_rule_expr (i), &row[1]);
+    rc = wyl_handle_make_guard_expr_compound (self, guard, &row[1]);
     if (rc != WYRELOG_E_OK)
       return rc;
     rc = wyl_handle_engine_insert (self, "perm_arm_rule", row, 2);
     if (rc != WYRELOG_E_OK)
       return rc;
+
+    const gchar *window = wyl_guard_expr_timestamp_window (guard);
+    if (window != NULL) {
+      gint64 window_row[2] = { row[0], 0 };
+      rc = wyl_handle_intern_engine_symbol (self, window, &window_row[1]);
+      if (rc != WYRELOG_E_OK)
+        return rc;
+      rc = wyl_handle_engine_insert (self, "perm_window_guard", window_row, 2);
+      if (rc != WYRELOG_E_OK)
+        return rc;
+    }
   }
   return WYRELOG_E_OK;
 }

--- a/wyrelog/wyl-permission-scope-private.h
+++ b/wyrelog/wyl-permission-scope-private.h
@@ -97,6 +97,13 @@ const gchar *wyl_perm_arm_rule_perm_id (gsize idx);
 const wyl_guard_expr_t *wyl_perm_arm_rule_expr (gsize idx);
 
 /*
+ * Returns the single timestamp window name required by @e, or NULL
+ * when the guard has no simple timestamp-in window requirement.
+ * The returned string is borrowed from @e.
+ */
+const gchar *wyl_guard_expr_timestamp_window (const wyl_guard_expr_t * e);
+
+/*
  * Returns TRUE iff loc_class belongs to the v0 guard context
  * schema. This is private because the public API should continue
  * to expose loc_class as an opaque string carried by decide and

--- a/wyrelog/wyl-permission-scope.c
+++ b/wyrelog/wyl-permission-scope.c
@@ -164,6 +164,34 @@ wyl_perm_arm_rule_expr (gsize idx)
   return catalogue_trees[idx];
 }
 
+const gchar *
+wyl_guard_expr_timestamp_window (const wyl_guard_expr_t *e)
+{
+  if (e == NULL)
+    return NULL;
+
+  switch (e->kind) {
+    case WYL_GUARD_KIND_CMP:
+      if (e->u.cmp.field == WYL_GUARD_FIELD_TIMESTAMP
+          && e->u.cmp.op == WYL_GUARD_OP_IN)
+        return e->u.cmp.value;
+      return NULL;
+    case WYL_GUARD_KIND_AND:{
+      const gchar *left = wyl_guard_expr_timestamp_window (e->u.binop.left);
+      const gchar *right = wyl_guard_expr_timestamp_window (e->u.binop.right);
+      if (left != NULL && right != NULL)
+        return g_strcmp0 (left, right) == 0 ? left : NULL;
+      return left != NULL ? left : right;
+    }
+    case WYL_GUARD_KIND_OR:
+    case WYL_GUARD_KIND_NOT:
+    case WYL_GUARD_KIND_TAG:
+    case WYL_GUARD_KIND_LAST_:
+    default:
+      return NULL;
+  }
+}
+
 gboolean
 wyl_guard_loc_class_is_valid (const gchar *loc_class)
 {


### PR DESCRIPTION
## Summary

- add request-local guard context field predicates for timestamp,
  location class, and risk
- add host-confirmed request-local window facts for timestamp-window
  guarded permissions
- keep C guard evaluation authoritative while requiring matching wirelog
  evidence before guarded permissions arm
- extend cleanup, fault, stratification, and runtime seed coverage

## Verification

- meson test -C builddir fsm-permission-scope decide handle-engine-pair daemon-http-decide --print-errorlogs
- meson test -C builddir-audit fsm-permission-scope decide handle-engine-pair daemon-http-decide client-audit-daemon --print-errorlogs
- git diff --check
