### PR TITLE
Authorize login skip-MFA through policy

### DIFF
--- a/templates/access/bootstrap.dl
+++ b/templates/access/bootstrap.dl
@@ -96,6 +96,9 @@ permission("wr.policy.read").
 permission("wr.policy.write").
 permission("wr.policy.grant_role").
 
+// login family
+permission("wr.login.skip_mfa").
+
 // stream family
 permission("wr.stream.read").
 permission("wr.stream.write_reserved").    // only system_agent

--- a/tests/test-daemon-checks.c
+++ b/tests/test-daemon-checks.c
@@ -5,6 +5,7 @@
 #include "wyrelog/wyrelog.h"
 #include "wyrelog/audit/conn-private.h"
 #include "wyrelog/engine.h"
+#include "wyrelog/policy/store-private.h"
 #include "wyrelog/wyl-handle-private.h"
 #include "daemon/checks.h"
 
@@ -112,6 +113,35 @@ check_login_skip_mfa_ready_allows_development_path (void)
 }
 
 static gint
+check_login_skip_mfa_ready_allows_policy_path (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  gint64 count = 0;
+
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 40;
+  if (wyl_policy_store_grant_direct_permission (wyl_handle_get_policy_store
+          (handle), "wyrelogd-skip-mfa-user", "wr.login.skip_mfa", "login")
+      != WYRELOG_E_OK)
+    return 41;
+  if (wyl_daemon_check_login_skip_mfa_ready (handle) != WYRELOG_E_OK)
+    return 42;
+
+  duckdb_connection conn =
+      wyl_audit_conn_get_connection (wyl_handle_get_audit_conn (handle));
+  if (!count_duckdb_rows (conn,
+          "SELECT COUNT(*) FROM audit_events "
+          "WHERE action = 'principal_state' "
+          "AND subject_id = 'wyrelogd-skip-mfa-user' "
+          "AND deny_reason = 'login_skip_mfa' "
+          "AND resource_id = 'authenticated' AND decision = 1;", &count))
+    return 43;
+  if (count != 1)
+    return 44;
+  return 0;
+}
+
+static gint
 check_policy_audit_facts_ready_loads_read_engine (void)
 {
   g_autoptr (WylHandle) handle = NULL;
@@ -180,6 +210,8 @@ main (void)
   if ((rc = check_login_skip_mfa_ready_rejects_production_path ()) != 0)
     return rc;
   if ((rc = check_login_skip_mfa_ready_allows_development_path ()) != 0)
+    return rc;
+  if ((rc = check_login_skip_mfa_ready_allows_policy_path ()) != 0)
     return rc;
   return 0;
 }

--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -414,6 +414,21 @@ check_raw_login_contract (SoupServer *server, WylHandle *handle,
     return 473;
   g_clear_pointer (&body, g_free);
 
+  if (wyl_policy_store_grant_direct_permission (wyl_handle_get_policy_store
+          (handle), "login-user", "wr.login.skip_mfa", "login")
+      != WYRELOG_E_OK)
+    return 484;
+
+  rc = send_raw_login (session, "POST", base_url,
+      "username=login-user&skip_mfa=true", &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 200 ||
+      strstr (body, "\"session_token\":\"") == NULL ||
+      strstr (body, "\"principal_state\":\"authenticated\"") == NULL)
+    return 485;
+  g_clear_pointer (&body, g_free);
+
   rc = send_raw_login (session, "POST", base_url,
       "username=login-user&skip_mfa=false", &status, &body);
   if (rc != 0)

--- a/tests/test-policy-store.c
+++ b/tests/test-policy-store.c
@@ -887,6 +887,62 @@ check_store_grants_direct_permission (void)
 }
 
 static gint
+check_store_checks_effective_subject_permission (void)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 233;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 234;
+  if (wyl_policy_store_upsert_permission (store, "site.effective.read",
+          "effective read", "basic") != WYRELOG_E_OK)
+    return 235;
+  if (wyl_policy_store_grant_direct_permission (store, "direct-effective-user",
+          "site.effective.read", "effective-scope") != WYRELOG_E_OK)
+    return 236;
+
+  gboolean has_permission = FALSE;
+  if (wyl_policy_store_subject_has_permission (store, "direct-effective-user",
+          "site.effective.read", "effective-scope", &has_permission)
+      != WYRELOG_E_OK)
+    return 237;
+  if (!has_permission)
+    return 238;
+
+  if (wyl_policy_store_upsert_role (store, "site.effective-role",
+          "effective role") != WYRELOG_E_OK)
+    return 239;
+  if (wyl_policy_store_grant_role_permission (store, "site.effective-role",
+          "site.effective.read") != WYRELOG_E_OK)
+    return 240;
+  if (wyl_policy_store_grant_role_membership (store, "role-effective-user",
+          "site.effective-role", "effective-scope") != WYRELOG_E_OK)
+    return 241;
+
+  has_permission = FALSE;
+  if (wyl_policy_store_subject_has_permission (store, "role-effective-user",
+          "site.effective.read", "effective-scope", &has_permission)
+      != WYRELOG_E_OK)
+    return 242;
+  if (!has_permission)
+    return 243;
+
+  has_permission = TRUE;
+  if (wyl_policy_store_subject_has_permission (store, "role-effective-user",
+          "site.effective.read", "other-scope", &has_permission)
+      != WYRELOG_E_OK)
+    return 244;
+  if (has_permission)
+    return 245;
+  if (wyl_policy_store_subject_has_permission (store, "role-effective-user",
+          "site.effective.read", "effective-scope", NULL)
+      != WYRELOG_E_INVALID)
+    return 246;
+  return 0;
+}
+
+static gint
 check_role_membership_mutation_rolls_back_on_event_failure (void)
 {
   g_autoptr (wyl_policy_store_t) store = NULL;
@@ -1602,6 +1658,8 @@ main (void)
   if ((rc = check_store_grants_role_membership ()) != 0)
     return rc;
   if ((rc = check_store_grants_direct_permission ()) != 0)
+    return rc;
+  if ((rc = check_store_checks_effective_subject_permission ()) != 0)
     return rc;
   if ((rc = check_role_membership_mutation_rolls_back_on_event_failure ())
       != 0)

--- a/tests/test-policy-store.c
+++ b/tests/test-policy-store.c
@@ -267,23 +267,29 @@ check_store_seeds_builtin_catalog (void)
     return 208;
   if (matches != 1)
     return 209;
+  if (count_rows (store, "SELECT COUNT(*) FROM permissions "
+          "WHERE perm_id = 'wr.login.skip_mfa' "
+          "AND class = 'critical';", &matches) != 0)
+    return 210;
+  if (matches != 1)
+    return 211;
 
   if (wyl_policy_store_upsert_role (store, "site.local-admin",
           "local admin") != WYRELOG_E_OK)
-    return 210;
+    return 212;
   if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
-    return 211;
+    return 213;
   if (wyl_policy_store_role_exists (store, "site.local-admin", &exists)
       != WYRELOG_E_OK)
-    return 212;
+    return 214;
   if (!exists)
-    return 213;
+    return 215;
 
   if (count_rows (store, "SELECT COUNT(*) FROM roles "
           "WHERE role_id = 'wr.auditor';", &matches) != 0)
-    return 214;
+    return 216;
   if (matches != 1)
-    return 215;
+    return 217;
 
   return 0;
 }
@@ -368,6 +374,12 @@ check_store_rejects_builtin_catalog_upsert_drift (void)
   if (wyl_policy_store_upsert_permission (store, "wr.audit.read",
           "changed audit read", "sensitive") != WYRELOG_E_POLICY)
     return 237;
+  if (wyl_policy_store_upsert_permission (store, "wr.login.skip_mfa",
+          "login skip mfa", "critical") != WYRELOG_E_OK)
+    return 242;
+  if (wyl_policy_store_upsert_permission (store, "wr.login.skip_mfa",
+          "login skip mfa", "sensitive") != WYRELOG_E_POLICY)
+    return 243;
   if (wyl_policy_store_upsert_permission (store, "wr.audit.read",
           "audit read", "basic") != WYRELOG_E_POLICY)
     return 238;

--- a/tests/test-session-username.c
+++ b/tests/test-session-username.c
@@ -976,6 +976,54 @@ check_login_skip_mfa_uses_deployment_mode (void)
 }
 
 static gint
+check_login_skip_mfa_uses_policy_permission (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 173;
+
+  if (grant_direct (handle, "skip-mfa-policy-user", "wr.login.skip_mfa",
+          "login") != WYRELOG_E_OK)
+    return 174;
+
+  g_autoptr (WylSession) policy_session = NULL;
+  if (login_skip_mfa_user (handle, "skip-mfa-policy-user", &policy_session)
+      != WYRELOG_E_OK)
+    return 175;
+  if (policy_session == NULL)
+    return 176;
+
+  PrincipalStateExpect expect = {
+    .subject_id = "skip-mfa-policy-user",
+    .state = "authenticated",
+  };
+  if (wyl_policy_store_foreach_principal_state (wyl_handle_get_policy_store
+          (handle), principal_state_expect_cb, &expect) != WYRELOG_E_OK)
+    return 177;
+  if (expect.matches != 1)
+    return 178;
+
+  g_autoptr (WylSession) other_session = NULL;
+  if (login_skip_mfa_user (handle, "skip-mfa-other-user", &other_session)
+      != WYRELOG_E_POLICY)
+    return 179;
+  if (other_session != NULL)
+    return 180;
+
+  if (grant_direct (handle, "skip-mfa-wrong-scope-user", "wr.login.skip_mfa",
+          "not-login") != WYRELOG_E_OK)
+    return 181;
+  g_autoptr (WylSession) wrong_scope_session = NULL;
+  if (login_skip_mfa_user (handle, "skip-mfa-wrong-scope-user",
+          &wrong_scope_session) != WYRELOG_E_POLICY)
+    return 182;
+  if (wrong_scope_session != NULL)
+    return 183;
+
+  return 0;
+}
+
+static gint
 check_login_skip_mfa_inserts_wirelog_principal_fired (void)
 {
   g_autoptr (WylHandle) handle = NULL;
@@ -1681,6 +1729,8 @@ main (void)
   if ((rc = check_login_skip_mfa_authenticates_principal ()) != 0)
     return rc;
   if ((rc = check_login_skip_mfa_uses_deployment_mode ()) != 0)
+    return rc;
+  if ((rc = check_login_skip_mfa_uses_policy_permission ()) != 0)
     return rc;
   if ((rc = check_login_skip_mfa_inserts_wirelog_principal_fired ()) != 0)
     return rc;

--- a/tests/test-session-username.c
+++ b/tests/test-session-username.c
@@ -1020,6 +1020,16 @@ check_login_skip_mfa_uses_policy_permission (void)
   if (wrong_scope_session != NULL)
     return 183;
 
+  if (grant_role_permission (handle, "skip-mfa-role-user",
+          "site.skip-mfa-role", "wr.login.skip_mfa", "login") != WYRELOG_E_OK)
+    return 184;
+  g_autoptr (WylSession) role_session = NULL;
+  if (login_skip_mfa_user (handle, "skip-mfa-role-user", &role_session)
+      != WYRELOG_E_OK)
+    return 185;
+  if (role_session == NULL)
+    return 186;
+
   return 0;
 }
 

--- a/tests/test-template-tree.c
+++ b/tests/test-template-tree.c
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #include <glib.h>
+#include <string.h>
 
 #include "wyrelog/policy/store-private.h"
 
@@ -53,6 +54,19 @@ collect_template_facts (const gchar *contents, const gchar *prefix,
   return 0;
 }
 
+static guint
+count_substring (const gchar *haystack, const gchar *needle)
+{
+  guint count = 0;
+  const gchar *p = haystack;
+
+  while ((p = strstr (p, needle)) != NULL) {
+    count++;
+    p += strlen (needle);
+  }
+  return count;
+}
+
 static gint
 check_seed_list (GHashTable *template_ids, gsize count,
     const gchar *(*id_at) (gsize))
@@ -82,6 +96,8 @@ check_bootstrap_seed_consistency (void)
 
   if (!g_file_get_contents (path, &contents, &len, &error))
     return 30;
+  if (count_substring (contents, "\"wr.login.skip_mfa\"") != 1)
+    return 33;
 
   g_autoptr (GHashTable) roles = g_hash_table_new_full (g_str_hash,
       g_str_equal, g_free, NULL);

--- a/wyrelog/daemon/checks.c
+++ b/wyrelog/daemon/checks.c
@@ -173,7 +173,7 @@ wyl_daemon_check_login_skip_mfa_ready (WylHandle *handle)
     return WYRELOG_E_OK;
   if (rc != WYRELOG_E_OK)
     return rc;
-  if (!allowed || session == NULL)
+  if (session == NULL)
     return WYRELOG_E_POLICY;
 
   g_autofree gchar *session_id = wyl_session_dup_id_string (session);

--- a/wyrelog/policy/store-private.h
+++ b/wyrelog/policy/store-private.h
@@ -138,6 +138,9 @@ wyrelog_error_t
 wyrelog_error_t wyl_policy_store_direct_permission_exists (wyl_policy_store_t *
     store, const gchar * subject_id, const gchar * perm_id, const gchar * scope,
     gboolean * out_exists);
+wyrelog_error_t wyl_policy_store_subject_has_permission (wyl_policy_store_t *
+    store, const gchar * subject_id, const gchar * perm_id, const gchar * scope,
+    gboolean * out_has_permission);
 wyrelog_error_t wyl_policy_store_foreach_direct_permission (wyl_policy_store_t *
     store, wyl_policy_direct_permission_cb cb, gpointer user_data);
 wyrelog_error_t

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -1139,6 +1139,60 @@ wyl_policy_store_direct_permission_exists (wyl_policy_store_t *store,
 }
 
 wyrelog_error_t
+wyl_policy_store_subject_has_permission (wyl_policy_store_t *store,
+    const gchar *subject_id, const gchar *perm_id, const gchar *scope,
+    gboolean *out_has_permission)
+{
+  sqlite3_stmt *stmt = NULL;
+
+  if (store == NULL || store->db == NULL || subject_id == NULL
+      || perm_id == NULL || scope == NULL || out_has_permission == NULL)
+    return WYRELOG_E_INVALID;
+
+  *out_has_permission = FALSE;
+  static const gchar *sql =
+      "WITH RECURSIVE role_closure(role_id, effective_role_id) AS ("
+      "  SELECT role_id, role_id FROM roles"
+      "  UNION"
+      "  SELECT role_closure.role_id, ri.parent_role_id"
+      "  FROM role_closure"
+      "  JOIN role_inheritances ri"
+      "    ON ri.child_role_id = role_closure.effective_role_id"
+      "), role_subject_permission(subject_id, scope, perm_id) AS ("
+      "  SELECT rm.subject_id, rm.scope, rp.perm_id"
+      "  FROM role_memberships rm"
+      "  JOIN role_closure rc ON rc.role_id = rm.role_id"
+      "  JOIN role_permissions rp ON rp.role_id = rc.effective_role_id"
+      "), subject_permission(subject_id, scope, perm_id) AS ("
+      "  SELECT subject_id, scope, perm_id FROM direct_permissions"
+      "  UNION"
+      "  SELECT subject_id, scope, perm_id FROM role_subject_permission"
+      ") "
+      "SELECT 1 FROM subject_permission "
+      "WHERE subject_id = ? AND perm_id = ? AND scope = ? LIMIT 1;";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if ((rc = bind_text (stmt, 1, subject_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 2, perm_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 3, scope)) != WYRELOG_E_OK) {
+    sqlite3_finalize (stmt);
+    return rc;
+  }
+
+  int step_rc = sqlite3_step (stmt);
+  if (step_rc == SQLITE_ROW)
+    *out_has_permission = TRUE;
+  else if (step_rc != SQLITE_DONE) {
+    sqlite3_finalize (stmt);
+    return WYRELOG_E_IO;
+  }
+
+  sqlite3_finalize (stmt);
+  return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
 wyl_policy_store_foreach_direct_permission (wyl_policy_store_t *store,
     wyl_policy_direct_permission_cb cb, gpointer user_data)
 {

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -42,6 +42,7 @@ static const BuiltinPermission builtin_permissions[] = {
   {"wr.policy.read", "policy read", "sensitive"},
   {"wr.policy.write", "policy write", "critical"},
   {"wr.policy.grant_role", "policy role grant", "critical"},
+  {"wr.login.skip_mfa", "login skip mfa", "critical"},
   {"wr.stream.read", "stream read", "basic"},
   {"wr.stream.write_reserved", "reserved stream write", "critical"},
   {"wr.stream.list", "stream list", "basic"},

--- a/wyrelog/wyl-session.c
+++ b/wyrelog/wyl-session.c
@@ -8,6 +8,9 @@
 #include "wyl-id-private.h"
 #include "policy/store-private.h"
 
+#define WYL_LOGIN_SKIP_MFA_PERMISSION "wr.login.skip_mfa"
+#define WYL_LOGIN_SKIP_MFA_SCOPE "login"
+
 struct _WylSession
 {
   GObject parent_instance;
@@ -60,6 +63,28 @@ reload_session_snapshot (WylHandle *handle)
   if (wyl_handle_get_read_engine (handle) == NULL)
     return WYRELOG_E_OK;
   return wyl_handle_reload_engine_pair (handle);
+}
+
+static wyrelog_error_t
+login_skip_mfa_allowed (WylHandle *handle, const wyl_login_req_t *req,
+    gboolean *out_allowed)
+{
+  if (handle == NULL || req == NULL || out_allowed == NULL)
+    return WYRELOG_E_INVALID;
+
+  *out_allowed = FALSE;
+  if (wyl_handle_get_login_skip_mfa_allowed (handle)) {
+    *out_allowed = TRUE;
+    return WYRELOG_E_OK;
+  }
+
+  const gchar *username = wyl_login_req_get_username (req);
+  if (username == NULL || username[0] == '\0')
+    return WYRELOG_E_OK;
+
+  return wyl_policy_store_subject_has_permission (wyl_handle_get_policy_store
+      (handle), username, WYL_LOGIN_SKIP_MFA_PERMISSION,
+      WYL_LOGIN_SKIP_MFA_SCOPE, out_allowed);
 }
 
 #ifdef WYL_HAS_AUDIT
@@ -514,15 +539,21 @@ wyl_session_login (WylHandle *handle, const wyl_login_req_t *req,
   if (handle == NULL)
     return WYRELOG_E_INVALID;
 
-  if (req != NULL && wyl_login_req_get_skip_mfa (req) &&
-      !wyl_handle_get_login_skip_mfa_allowed (handle)) {
+  if (req != NULL && wyl_login_req_get_skip_mfa (req)) {
+    gboolean skip_mfa_allowed = FALSE;
+    wyrelog_error_t rc = login_skip_mfa_allowed (handle, req,
+        &skip_mfa_allowed);
+    if (rc != WYRELOG_E_OK)
+      return rc;
+    if (!skip_mfa_allowed) {
 #ifdef WYL_HAS_AUDIT
-    wyrelog_error_t audit_rc = emit_login_skip_mfa_denied_audit (handle,
-        wyl_login_req_get_username (req));
-    if (audit_rc != WYRELOG_E_OK)
-      return audit_rc;
+      wyrelog_error_t audit_rc = emit_login_skip_mfa_denied_audit (handle,
+          wyl_login_req_get_username (req));
+      if (audit_rc != WYRELOG_E_OK)
+        return audit_rc;
 #endif
-    return WYRELOG_E_POLICY;
+      return WYRELOG_E_POLICY;
+    }
   }
 
   WylSession *session = g_object_new (WYL_TYPE_SESSION, NULL);


### PR DESCRIPTION
## Summary
- reserve the built-in login skip-MFA permission without default grants
- authorize production skip-MFA through effective Policy DB permission lookup
- update daemon readiness and ingress tests for policy-authorized skip-MFA

## Tests
- meson test -C builddir template-tree policy-store session-username daemon-http-decide --print-errorlogs
- meson test -C builddir-audit template-tree policy-store session-username daemon-checks daemon-http-decide --print-errorlogs
