### PR TITLE
Add private JWT issuer core

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -284,6 +284,14 @@ test_audit_event = executable('test-audit-event',
 
 test('audit-event', test_audit_event)
 
+test_jwt = executable('test-jwt',
+  'test-jwt.c',
+  include_directories : [wyrelog_inc, include_directories('../wyrelog')],
+  dependencies : [wyrelog_dep],
+)
+
+test('jwt', test_jwt)
+
 test_handle_id = executable('test-handle-id',
   'test-handle-id.c',
   dependencies : [wyrelog_dep],

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -287,7 +287,7 @@ test('audit-event', test_audit_event)
 test_jwt = executable('test-jwt',
   'test-jwt.c',
   include_directories : [wyrelog_inc, include_directories('../wyrelog')],
-  dependencies : [wyrelog_dep],
+  dependencies : [wyrelog_dep, sodium_dep],
 )
 
 test('jwt', test_jwt)

--- a/tests/test-jwt.c
+++ b/tests/test-jwt.c
@@ -150,6 +150,82 @@ check_unsigned_segments_are_base64url (void)
   return 0;
 }
 
+static gint
+check_hs256_token_signature_round_trip (void)
+{
+  static const guint8 secret[] = "test-secret";
+  g_autofree gchar *token = NULL;
+  if (wyl_jwt_sign_hs256 (&valid_input, secret, strlen ((const gchar *) secret),
+          &token) != WYRELOG_E_OK)
+    return 70;
+
+  g_auto (GStrv) parts = g_strsplit (token, ".", 0);
+  if (parts[0] == NULL || parts[1] == NULL || parts[2] == NULL ||
+      parts[3] != NULL)
+    return 71;
+  if (!is_base64url_text (parts[0]) || !is_base64url_text (parts[1]) ||
+      !is_base64url_text (parts[2]))
+    return 72;
+
+  g_autoptr (GBytes) payload = NULL;
+  if (wyl_jwt_verify_hs256_signature (token, secret,
+          strlen ((const gchar *) secret), &payload) != WYRELOG_E_OK)
+    return 73;
+  gsize payload_len = 0;
+  const gchar *payload_data = g_bytes_get_data (payload, &payload_len);
+  g_autofree gchar *payload_text = g_strndup (payload_data, payload_len);
+  if (strstr (payload_text, "\"sub\":\"alice\"") == NULL)
+    return 74;
+  return 0;
+}
+
+static gint
+check_hs256_signature_fails_closed (void)
+{
+  static const guint8 secret[] = "test-secret";
+  static const guint8 wrong_secret[] = "wrong-secret";
+  g_autofree gchar *token = NULL;
+  if (wyl_jwt_sign_hs256 (&valid_input, secret, strlen ((const gchar *) secret),
+          &token) != WYRELOG_E_OK)
+    return 80;
+
+  g_autoptr (GBytes) payload = NULL;
+  if (wyl_jwt_verify_hs256_signature (token, wrong_secret,
+          strlen ((const gchar *) wrong_secret), &payload) != WYRELOG_E_POLICY)
+    return 81;
+  if (wyl_jwt_verify_hs256_signature ("a.b", secret,
+          strlen ((const gchar *) secret), &payload) != WYRELOG_E_INVALID)
+    return 82;
+  if (wyl_jwt_sign_hs256 (&valid_input, NULL, 0, &token)
+      != WYRELOG_E_INVALID)
+    return 83;
+
+  g_auto (GStrv) parts = g_strsplit (token, ".", 0);
+  g_autofree gchar *tampered_payload = g_strdup_printf ("%s.%sA.%s",
+      parts[0], parts[1], parts[2]);
+  if (wyl_jwt_verify_hs256_signature (tampered_payload, secret,
+          strlen ((const gchar *) secret), &payload) != WYRELOG_E_POLICY)
+    return 84;
+
+  g_autofree gchar *tampered_signature = g_strdup_printf ("%s.%s.%sA",
+      parts[0], parts[1], parts[2]);
+  if (wyl_jwt_verify_hs256_signature (tampered_signature, secret,
+          strlen ((const gchar *) secret), &payload) != WYRELOG_E_POLICY)
+    return 85;
+
+  const gchar *none_header = "{\"alg\":\"none\",\"typ\":\"JWT\"}";
+  g_autofree gchar *none_header_segment = NULL;
+  if (wyl_jwt_base64url_encode ((const guint8 *) none_header,
+          strlen (none_header), &none_header_segment) != WYRELOG_E_OK)
+    return 86;
+  g_autofree gchar *none_token = g_strdup_printf ("%s.%s.%s",
+      none_header_segment, parts[1], parts[2]);
+  if (wyl_jwt_verify_hs256_signature (none_token, secret,
+          strlen ((const gchar *) secret), &payload) != WYRELOG_E_POLICY)
+    return 87;
+  return 0;
+}
+
 int
 main (void)
 {
@@ -166,6 +242,10 @@ main (void)
   if ((rc = check_payload_rejects_missing_claims ()) != 0)
     return rc;
   if ((rc = check_unsigned_segments_are_base64url ()) != 0)
+    return rc;
+  if ((rc = check_hs256_token_signature_round_trip ()) != 0)
+    return rc;
+  if ((rc = check_hs256_signature_fails_closed ()) != 0)
     return rc;
   return 0;
 }

--- a/tests/test-jwt.c
+++ b/tests/test-jwt.c
@@ -1,0 +1,171 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <glib.h>
+#include <string.h>
+
+#include "wyrelog/auth/jwt-private.h"
+
+static const wyl_jwt_issue_input_t valid_input = {
+  .jti = "01890c10-2e3f-7000-8000-000000000101",
+  .subject = "alice",
+  .issuer = "wyrelogd",
+  .audience = "wyrelog-client",
+  .tenant = "__wr_default",
+  .principal_state_at_issue = "authenticated",
+  .session_id = "01890c10-2e3f-7000-8000-000000000102",
+  .issued_at = 1000,
+  .ttl_seconds = 0,
+};
+
+static gboolean
+is_base64url_text (const gchar *text)
+{
+  return text != NULL && strchr (text, '=') == NULL
+      && strchr (text, '+') == NULL && strchr (text, '/') == NULL;
+}
+
+static gint
+check_base64url_round_trip (void)
+{
+  static const guint8 data[] = { 'w', 'y', 'r', 'e', 0, 0xff };
+  g_autofree gchar *encoded = NULL;
+  if (wyl_jwt_base64url_encode (data, sizeof data, &encoded) != WYRELOG_E_OK)
+    return 10;
+  if (!is_base64url_text (encoded))
+    return 11;
+
+  g_autoptr (GBytes) decoded = NULL;
+  if (wyl_jwt_base64url_decode (encoded, &decoded) != WYRELOG_E_OK)
+    return 12;
+  gsize decoded_len = 0;
+  const guint8 *decoded_data = g_bytes_get_data (decoded, &decoded_len);
+  if (decoded_len != sizeof data || memcmp (decoded_data, data, sizeof data)
+      != 0)
+    return 13;
+
+  if (wyl_jwt_base64url_decode ("abc=", &decoded) != WYRELOG_E_INVALID)
+    return 14;
+  if (wyl_jwt_base64url_decode ("a", &decoded) != WYRELOG_E_INVALID)
+    return 15;
+  if (wyl_jwt_base64url_encode (NULL, 1, &encoded) != WYRELOG_E_INVALID)
+    return 16;
+  return 0;
+}
+
+static gint
+check_header_json_is_fixed (void)
+{
+  g_autofree gchar *header = NULL;
+  if (wyl_jwt_build_header_json (&header) != WYRELOG_E_OK)
+    return 20;
+  if (g_strcmp0 (header, "{\"alg\":\"HS256\",\"typ\":\"JWT\"}") != 0)
+    return 21;
+  return 0;
+}
+
+static gint
+check_payload_json_contains_required_claims (void)
+{
+  g_autofree gchar *payload = NULL;
+  if (wyl_jwt_build_payload_json (&valid_input, &payload) != WYRELOG_E_OK)
+    return 30;
+
+  const gchar *expected =
+      "{\"jti\":\"01890c10-2e3f-7000-8000-000000000101\","
+      "\"sub\":\"alice\",\"iss\":\"wyrelogd\","
+      "\"aud\":\"wyrelog-client\",\"iat\":1000,\"nbf\":1000,"
+      "\"exp\":1900,\"tenant\":\"__wr_default\","
+      "\"principal_state_at_issue\":\"authenticated\","
+      "\"session_id\":\"01890c10-2e3f-7000-8000-000000000102\"}";
+  if (g_strcmp0 (payload, expected) != 0)
+    return 31;
+  return 0;
+}
+
+static gint
+check_payload_json_escapes_strings (void)
+{
+  wyl_jwt_issue_input_t input = valid_input;
+  input.subject = "a\"b\\c\n";
+
+  g_autofree gchar *payload = NULL;
+  if (wyl_jwt_build_payload_json (&input, &payload) != WYRELOG_E_OK)
+    return 40;
+  if (strstr (payload, "\"sub\":\"a\\\"b\\\\c\\n\"") == NULL)
+    return 41;
+  return 0;
+}
+
+static gint
+check_payload_rejects_missing_claims (void)
+{
+  wyl_jwt_issue_input_t input = valid_input;
+  input.tenant = "";
+
+  g_autofree gchar *payload = NULL;
+  if (wyl_jwt_build_payload_json (&input, &payload) != WYRELOG_E_INVALID)
+    return 50;
+  input = valid_input;
+  input.issued_at = -1;
+  if (wyl_jwt_build_payload_json (&input, &payload) != WYRELOG_E_INVALID)
+    return 51;
+  input = valid_input;
+  input.issued_at = G_MAXINT64 - 10;
+  input.ttl_seconds = 11;
+  if (wyl_jwt_build_payload_json (&input, &payload) != WYRELOG_E_INVALID)
+    return 52;
+  return 0;
+}
+
+static gint
+check_unsigned_segments_are_base64url (void)
+{
+  g_autofree gchar *header_segment = NULL;
+  g_autofree gchar *payload_segment = NULL;
+  if (wyl_jwt_build_unsigned_segments (&valid_input, &header_segment,
+          &payload_segment) != WYRELOG_E_OK)
+    return 60;
+  if (!is_base64url_text (header_segment) ||
+      !is_base64url_text (payload_segment))
+    return 61;
+
+  g_autoptr (GBytes) header_bytes = NULL;
+  if (wyl_jwt_base64url_decode (header_segment, &header_bytes)
+      != WYRELOG_E_OK)
+    return 62;
+  gsize header_len = 0;
+  const gchar *header = g_bytes_get_data (header_bytes, &header_len);
+  if (header_len != strlen ("{\"alg\":\"HS256\",\"typ\":\"JWT\"}") ||
+      memcmp (header, "{\"alg\":\"HS256\",\"typ\":\"JWT\"}", header_len) != 0)
+    return 63;
+
+  g_autoptr (GBytes) payload_bytes = NULL;
+  if (wyl_jwt_base64url_decode (payload_segment, &payload_bytes)
+      != WYRELOG_E_OK)
+    return 64;
+  gsize payload_len = 0;
+  const gchar *payload = g_bytes_get_data (payload_bytes, &payload_len);
+  g_autofree gchar *payload_text = g_strndup (payload, payload_len);
+  if (payload_len == 0 || strstr (payload_text, "\"exp\":1900") == NULL)
+    return 65;
+  return 0;
+}
+
+int
+main (void)
+{
+  gint rc;
+
+  if ((rc = check_base64url_round_trip ()) != 0)
+    return rc;
+  if ((rc = check_header_json_is_fixed ()) != 0)
+    return rc;
+  if ((rc = check_payload_json_contains_required_claims ()) != 0)
+    return rc;
+  if ((rc = check_payload_json_escapes_strings ()) != 0)
+    return rc;
+  if ((rc = check_payload_rejects_missing_claims ()) != 0)
+    return rc;
+  if ((rc = check_unsigned_segments_are_base64url ()) != 0)
+    return rc;
+  return 0;
+}

--- a/tests/test-jwt.c
+++ b/tests/test-jwt.c
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #include <glib.h>
+#include <sodium.h>
 #include <string.h>
 
 #include "wyrelog/auth/jwt-private.h"
@@ -226,6 +227,183 @@ check_hs256_signature_fails_closed (void)
   return 0;
 }
 
+static gint
+check_hs256_access_token_claims_and_time (void)
+{
+  static const guint8 secret[] = "test-secret";
+  g_autofree gchar *token = NULL;
+  if (wyl_jwt_sign_hs256 (&valid_input, secret, strlen ((const gchar *) secret),
+          &token) != WYRELOG_E_OK)
+    return 90;
+
+  g_autoptr (GBytes) payload = NULL;
+  if (wyl_jwt_verify_hs256_access_token (token, secret,
+          strlen ((const gchar *) secret), "wyrelogd", "wyrelog-client", 1000,
+          &payload) != WYRELOG_E_OK)
+    return 91;
+  if (payload == NULL)
+    return 92;
+
+  g_clear_pointer (&payload, g_bytes_unref);
+  if (wyl_jwt_verify_hs256_access_token (token, secret,
+          strlen ((const gchar *) secret), "wyrelogd", "wyrelog-client", 1899,
+          &payload) != WYRELOG_E_OK)
+    return 93;
+  g_clear_pointer (&payload, g_bytes_unref);
+  if (wyl_jwt_verify_hs256_access_token (token, secret,
+          strlen ((const gchar *) secret), "other-issuer", "wyrelog-client",
+          1000, &payload) != WYRELOG_E_POLICY)
+    return 94;
+  if (wyl_jwt_verify_hs256_access_token (token, secret,
+          strlen ((const gchar *) secret), "wyrelogd", "other-audience", 1000,
+          &payload) != WYRELOG_E_POLICY)
+    return 95;
+  if (wyl_jwt_verify_hs256_access_token (token, secret,
+          strlen ((const gchar *) secret), "wyrelogd", "wyrelog-client", 999,
+          &payload) != WYRELOG_E_POLICY)
+    return 96;
+  if (wyl_jwt_verify_hs256_access_token (token, secret,
+          strlen ((const gchar *) secret), "wyrelogd", "wyrelog-client", 1900,
+          &payload) != WYRELOG_E_POLICY)
+    return 97;
+  if (wyl_jwt_verify_hs256_access_token (token, secret,
+          strlen ((const gchar *) secret), "", "wyrelog-client", 1000,
+          &payload) != WYRELOG_E_INVALID)
+    return 98;
+  return 0;
+}
+
+static wyrelog_error_t
+sign_custom_payload_bytes (const guint8 *payload, gsize payload_len,
+    const guint8 *secret, gsize secret_len, gchar **out_token)
+{
+  if (payload == NULL || secret == NULL || secret_len == 0 || out_token == NULL)
+    return WYRELOG_E_INVALID;
+  *out_token = NULL;
+  if (sodium_init () < 0)
+    return WYRELOG_E_INTERNAL;
+
+  const gchar *header = "{\"alg\":\"HS256\",\"typ\":\"JWT\"}";
+  g_autofree gchar *header_segment = NULL;
+  g_autofree gchar *payload_segment = NULL;
+  wyrelog_error_t rc = wyl_jwt_base64url_encode ((const guint8 *) header,
+      strlen (header), &header_segment);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_jwt_base64url_encode (payload, payload_len, &payload_segment);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  g_autofree gchar *signing_input = g_strdup_printf ("%s.%s", header_segment,
+      payload_segment);
+  guint8 signature[crypto_auth_hmacsha256_BYTES];
+  crypto_auth_hmacsha256_state state;
+  crypto_auth_hmacsha256_init (&state, secret, secret_len);
+  crypto_auth_hmacsha256_update (&state, (const guint8 *) signing_input,
+      strlen (signing_input));
+  crypto_auth_hmacsha256_final (&state, signature);
+
+  g_autofree gchar *signature_segment = NULL;
+  rc = wyl_jwt_base64url_encode (signature, sizeof signature,
+      &signature_segment);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  *out_token = g_strdup_printf ("%s.%s", signing_input, signature_segment);
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+sign_custom_payload (const gchar *payload, const guint8 *secret,
+    gsize secret_len, gchar **out_token)
+{
+  if (payload == NULL)
+    return WYRELOG_E_INVALID;
+  return sign_custom_payload_bytes ((const guint8 *) payload, strlen (payload),
+      secret, secret_len, out_token);
+}
+
+static gint
+check_hs256_access_token_rejects_ambiguous_claims (void)
+{
+  static const guint8 secret[] = "test-secret";
+  const gchar *duplicate_payload =
+      "{\"jti\":\"jti\",\"sub\":\"alice\",\"iss\":\"wyrelogd\","
+      "\"iss\":\"evil\",\"aud\":\"wyrelog-client\",\"iat\":1000,"
+      "\"nbf\":1000,\"exp\":1900,\"tenant\":\"__wr_default\","
+      "\"principal_state_at_issue\":\"authenticated\","
+      "\"session_id\":\"session\"}";
+  g_autofree gchar *duplicate_token = NULL;
+  if (sign_custom_payload (duplicate_payload, secret,
+          strlen ((const gchar *) secret), &duplicate_token) != WYRELOG_E_OK)
+    return 110;
+
+  g_autoptr (GBytes) payload = NULL;
+  if (wyl_jwt_verify_hs256_access_token (duplicate_token, secret,
+          strlen ((const gchar *) secret), "wyrelogd", "wyrelog-client", 1000,
+          &payload) != WYRELOG_E_POLICY)
+    return 111;
+
+  const gchar *nested_payload =
+      "{\"nested\":{\"iss\":\"wyrelogd\",\"aud\":\"wyrelog-client\","
+      "\"nbf\":1000,\"exp\":1900},\"jti\":\"jti\",\"sub\":\"alice\","
+      "\"iss\":\"evil\",\"aud\":\"evil\",\"iat\":1000,\"tenant\":\"t\","
+      "\"principal_state_at_issue\":\"authenticated\","
+      "\"session_id\":\"session\"}";
+  g_autofree gchar *nested_token = NULL;
+  if (sign_custom_payload (nested_payload, secret,
+          strlen ((const gchar *) secret), &nested_token) != WYRELOG_E_OK)
+    return 112;
+  if (wyl_jwt_verify_hs256_access_token (nested_token, secret,
+          strlen ((const gchar *) secret), "wyrelogd", "wyrelog-client", 1000,
+          &payload) != WYRELOG_E_POLICY)
+    return 113;
+
+  const gchar *nul_issuer_payload =
+      "{\"jti\":\"jti\",\"sub\":\"alice\",\"iss\":\"wyrelogd\\u0000evil\","
+      "\"aud\":\"wyrelog-client\",\"iat\":1000,\"nbf\":1000,\"exp\":1900,"
+      "\"tenant\":\"t\",\"principal_state_at_issue\":\"authenticated\","
+      "\"session_id\":\"session\"}";
+  g_autofree gchar *nul_issuer_token = NULL;
+  if (sign_custom_payload (nul_issuer_payload, secret,
+          strlen ((const gchar *) secret), &nul_issuer_token) != WYRELOG_E_OK)
+    return 114;
+  if (wyl_jwt_verify_hs256_access_token (nul_issuer_token, secret,
+          strlen ((const gchar *) secret), "wyrelogd", "wyrelog-client", 1000,
+          &payload) != WYRELOG_E_POLICY)
+    return 115;
+
+  const gchar *short_escape_payload =
+      "{\"jti\":\"jti\",\"sub\":\"alice\",\"iss\":\"wyrelogd\\u00\","
+      "\"aud\":\"wyrelog-client\",\"iat\":1000,\"nbf\":1000,\"exp\":1900,"
+      "\"tenant\":\"t\",\"principal_state_at_issue\":\"authenticated\","
+      "\"session_id\":\"session\"}";
+  g_autofree gchar *short_escape_token = NULL;
+  if (sign_custom_payload (short_escape_payload, secret,
+          strlen ((const gchar *) secret), &short_escape_token)
+      != WYRELOG_E_OK)
+    return 116;
+  if (wyl_jwt_verify_hs256_access_token (short_escape_token, secret,
+          strlen ((const gchar *) secret), "wyrelogd", "wyrelog-client", 1000,
+          &payload) != WYRELOG_E_POLICY)
+    return 117;
+
+  static const guint8 raw_nul_payload[] =
+      "{\"jti\":\"jti\",\"sub\":\"alice\",\"iss\":\"wyrelogd\","
+      "\"aud\":\"wyrelog-client\",\"iat\":1000,\"nbf\":1000,\"exp\":1900,"
+      "\"tenant\":\"t\",\"principal_state_at_issue\":\"authenticated\","
+      "\"session_id\":\"session\"}" "\0" "{\"trailing\":\"ignored\"}";
+  g_autofree gchar *raw_nul_token = NULL;
+  if (sign_custom_payload_bytes (raw_nul_payload, sizeof raw_nul_payload - 1,
+          secret, strlen ((const gchar *) secret), &raw_nul_token)
+      != WYRELOG_E_OK)
+    return 118;
+  if (wyl_jwt_verify_hs256_access_token (raw_nul_token, secret,
+          strlen ((const gchar *) secret), "wyrelogd", "wyrelog-client", 1000,
+          &payload) != WYRELOG_E_POLICY)
+    return 119;
+  return 0;
+}
+
 int
 main (void)
 {
@@ -246,6 +424,10 @@ main (void)
   if ((rc = check_hs256_token_signature_round_trip ()) != 0)
     return rc;
   if ((rc = check_hs256_signature_fails_closed ()) != 0)
+    return rc;
+  if ((rc = check_hs256_access_token_claims_and_time ()) != 0)
+    return rc;
+  if ((rc = check_hs256_access_token_rejects_ambiguous_claims ()) != 0)
     return rc;
   return 0;
 }

--- a/wyrelog/auth/jwt-private.h
+++ b/wyrelog/auth/jwt-private.h
@@ -35,5 +35,8 @@ wyrelog_error_t wyl_jwt_sign_hs256 (const wyl_jwt_issue_input_t * input,
     const guint8 * secret, gsize secret_len, gchar ** out_token);
 wyrelog_error_t wyl_jwt_verify_hs256_signature (const gchar * token,
     const guint8 * secret, gsize secret_len, GBytes ** out_payload_json);
+wyrelog_error_t wyl_jwt_verify_hs256_access_token (const gchar * token,
+    const guint8 * secret, gsize secret_len, const gchar * expected_issuer,
+    const gchar * expected_audience, gint64 now, GBytes ** out_payload_json);
 
 G_END_DECLS;

--- a/wyrelog/auth/jwt-private.h
+++ b/wyrelog/auth/jwt-private.h
@@ -31,5 +31,9 @@ wyrelog_error_t wyl_jwt_build_payload_json (const wyl_jwt_issue_input_t *
     input, gchar ** out_json);
 wyrelog_error_t wyl_jwt_build_unsigned_segments (const wyl_jwt_issue_input_t *
     input, gchar ** out_header_segment, gchar ** out_payload_segment);
+wyrelog_error_t wyl_jwt_sign_hs256 (const wyl_jwt_issue_input_t * input,
+    const guint8 * secret, gsize secret_len, gchar ** out_token);
+wyrelog_error_t wyl_jwt_verify_hs256_signature (const gchar * token,
+    const guint8 * secret, gsize secret_len, GBytes ** out_payload_json);
 
 G_END_DECLS;

--- a/wyrelog/auth/jwt-private.h
+++ b/wyrelog/auth/jwt-private.h
@@ -1,0 +1,35 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+
+#include <glib.h>
+
+#include "wyrelog/error.h"
+
+G_BEGIN_DECLS;
+
+#define WYL_JWT_ACCESS_TTL_SECONDS 900
+
+typedef struct
+{
+  const gchar *jti;
+  const gchar *subject;
+  const gchar *issuer;
+  const gchar *audience;
+  const gchar *tenant;
+  const gchar *principal_state_at_issue;
+  const gchar *session_id;
+  gint64 issued_at;
+  gint64 ttl_seconds;
+} wyl_jwt_issue_input_t;
+
+wyrelog_error_t wyl_jwt_base64url_encode (const guint8 * data, gsize len,
+    gchar ** out_text);
+wyrelog_error_t wyl_jwt_base64url_decode (const gchar * text,
+    GBytes ** out_bytes);
+wyrelog_error_t wyl_jwt_build_header_json (gchar ** out_json);
+wyrelog_error_t wyl_jwt_build_payload_json (const wyl_jwt_issue_input_t *
+    input, gchar ** out_json);
+wyrelog_error_t wyl_jwt_build_unsigned_segments (const wyl_jwt_issue_input_t *
+    input, gchar ** out_header_segment, gchar ** out_payload_segment);
+
+G_END_DECLS;

--- a/wyrelog/auth/jwt.c
+++ b/wyrelog/auth/jwt.c
@@ -1,0 +1,198 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "auth/jwt-private.h"
+
+#include <string.h>
+
+static gboolean
+non_empty (const gchar *value)
+{
+  return value != NULL && value[0] != '\0';
+}
+
+static wyrelog_error_t
+validate_issue_input (const wyl_jwt_issue_input_t *input)
+{
+  if (input == NULL || !non_empty (input->jti) || !non_empty (input->subject)
+      || !non_empty (input->issuer) || !non_empty (input->audience)
+      || !non_empty (input->tenant)
+      || !non_empty (input->principal_state_at_issue)
+      || !non_empty (input->session_id) || input->issued_at < 0
+      || input->ttl_seconds < 0)
+    return WYRELOG_E_INVALID;
+  return WYRELOG_E_OK;
+}
+
+static void
+append_json_string (GString *json, const gchar *value)
+{
+  g_string_append_c (json, '"');
+  for (const guchar * p = (const guchar *)value; *p != '\0'; p++) {
+    switch (*p) {
+      case '"':
+        g_string_append (json, "\\\"");
+        break;
+      case '\\':
+        g_string_append (json, "\\\\");
+        break;
+      case '\b':
+        g_string_append (json, "\\b");
+        break;
+      case '\f':
+        g_string_append (json, "\\f");
+        break;
+      case '\n':
+        g_string_append (json, "\\n");
+        break;
+      case '\r':
+        g_string_append (json, "\\r");
+        break;
+      case '\t':
+        g_string_append (json, "\\t");
+        break;
+      default:
+        if (*p < 0x20)
+          g_string_append_printf (json, "\\u%04x", (guint) * p);
+        else
+          g_string_append_c (json, (gchar) * p);
+        break;
+    }
+  }
+  g_string_append_c (json, '"');
+}
+
+wyrelog_error_t
+wyl_jwt_base64url_encode (const guint8 *data, gsize len, gchar **out_text)
+{
+  if ((data == NULL && len > 0) || out_text == NULL)
+    return WYRELOG_E_INVALID;
+
+  *out_text = NULL;
+  g_autofree gchar *encoded = g_base64_encode (data, len);
+  for (gchar * p = encoded; *p != '\0'; p++) {
+    if (*p == '+')
+      *p = '-';
+    else if (*p == '/')
+      *p = '_';
+    else if (*p == '=') {
+      *p = '\0';
+      break;
+    }
+  }
+  *out_text = g_steal_pointer (&encoded);
+  return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
+wyl_jwt_base64url_decode (const gchar *text, GBytes **out_bytes)
+{
+  if (text == NULL || out_bytes == NULL)
+    return WYRELOG_E_INVALID;
+
+  *out_bytes = NULL;
+  gsize len = strlen (text);
+  if (len % 4 == 1)
+    return WYRELOG_E_INVALID;
+  for (const gchar * p = text; *p != '\0'; p++) {
+    if (!(g_ascii_isalnum (*p) || *p == '-' || *p == '_'))
+      return WYRELOG_E_INVALID;
+  }
+
+  g_autofree gchar *padded = g_strdup (text);
+  for (gchar * p = padded; *p != '\0'; p++) {
+    if (*p == '-')
+      *p = '+';
+    else if (*p == '_')
+      *p = '/';
+  }
+  gsize pad = (4 - (len % 4)) % 4;
+  if (pad > 0) {
+    g_autofree gchar *padding = g_strnfill (pad, '=');
+    g_autofree gchar *tmp = g_strconcat (padded, padding, NULL);
+    g_free (g_steal_pointer (&padded));
+    padded = g_steal_pointer (&tmp);
+  }
+
+  gsize out_len = 0;
+  guchar *decoded = g_base64_decode (padded, &out_len);
+  *out_bytes = g_bytes_new_take (decoded, out_len);
+  return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
+wyl_jwt_build_header_json (gchar **out_json)
+{
+  if (out_json == NULL)
+    return WYRELOG_E_INVALID;
+  *out_json = g_strdup ("{\"alg\":\"HS256\",\"typ\":\"JWT\"}");
+  return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
+wyl_jwt_build_payload_json (const wyl_jwt_issue_input_t *input,
+    gchar **out_json)
+{
+  if (out_json == NULL)
+    return WYRELOG_E_INVALID;
+  *out_json = NULL;
+  wyrelog_error_t rc = validate_issue_input (input);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  gint64 ttl = input->ttl_seconds > 0 ? input->ttl_seconds :
+      WYL_JWT_ACCESS_TTL_SECONDS;
+  if (ttl > G_MAXINT64 - input->issued_at)
+    return WYRELOG_E_INVALID;
+  gint64 expires_at = input->issued_at + ttl;
+
+  GString *json = g_string_new ("{");
+  g_string_append (json, "\"jti\":");
+  append_json_string (json, input->jti);
+  g_string_append (json, ",\"sub\":");
+  append_json_string (json, input->subject);
+  g_string_append (json, ",\"iss\":");
+  append_json_string (json, input->issuer);
+  g_string_append (json, ",\"aud\":");
+  append_json_string (json, input->audience);
+  g_string_append_printf (json,
+      ",\"iat\":%" G_GINT64_FORMAT ",\"nbf\":%" G_GINT64_FORMAT
+      ",\"exp\":%" G_GINT64_FORMAT,
+      input->issued_at, input->issued_at, expires_at);
+  g_string_append (json, ",\"tenant\":");
+  append_json_string (json, input->tenant);
+  g_string_append (json, ",\"principal_state_at_issue\":");
+  append_json_string (json, input->principal_state_at_issue);
+  g_string_append (json, ",\"session_id\":");
+  append_json_string (json, input->session_id);
+  g_string_append_c (json, '}');
+
+  *out_json = g_string_free (json, FALSE);
+  return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
+wyl_jwt_build_unsigned_segments (const wyl_jwt_issue_input_t *input,
+    gchar **out_header_segment, gchar **out_payload_segment)
+{
+  if (out_header_segment == NULL || out_payload_segment == NULL)
+    return WYRELOG_E_INVALID;
+  *out_header_segment = NULL;
+  *out_payload_segment = NULL;
+
+  g_autofree gchar *header = NULL;
+  g_autofree gchar *payload = NULL;
+  wyrelog_error_t rc = wyl_jwt_build_header_json (&header);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_jwt_build_payload_json (input, &payload);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_jwt_base64url_encode ((const guint8 *) header, strlen (header),
+      out_header_segment);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_jwt_base64url_encode ((const guint8 *) payload, strlen (payload),
+      out_payload_segment);
+  if (rc != WYRELOG_E_OK)
+    g_clear_pointer (out_header_segment, g_free);
+  return rc;
+}

--- a/wyrelog/auth/jwt.c
+++ b/wyrelog/auth/jwt.c
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #include "auth/jwt-private.h"
 
+#include <sodium.h>
 #include <string.h>
 
 static gboolean
@@ -195,4 +196,115 @@ wyl_jwt_build_unsigned_segments (const wyl_jwt_issue_input_t *input,
   if (rc != WYRELOG_E_OK)
     g_clear_pointer (out_header_segment, g_free);
   return rc;
+}
+
+static wyrelog_error_t
+signing_secret_valid (const guint8 *secret, gsize secret_len)
+{
+  if (secret == NULL || secret_len == 0)
+    return WYRELOG_E_INVALID;
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+sign_hs256_input (const gchar *signing_input, const guint8 *secret,
+    gsize secret_len, guint8 out_signature[crypto_auth_hmacsha256_BYTES])
+{
+  if (signing_input == NULL || signing_secret_valid (secret, secret_len)
+      != WYRELOG_E_OK)
+    return WYRELOG_E_INVALID;
+  if (sodium_init () < 0)
+    return WYRELOG_E_INTERNAL;
+
+  crypto_auth_hmacsha256_state state;
+  crypto_auth_hmacsha256_init (&state, secret, secret_len);
+  crypto_auth_hmacsha256_update (&state, (const guint8 *) signing_input,
+      strlen (signing_input));
+  crypto_auth_hmacsha256_final (&state, out_signature);
+  return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
+wyl_jwt_sign_hs256 (const wyl_jwt_issue_input_t *input,
+    const guint8 *secret, gsize secret_len, gchar **out_token)
+{
+  if (out_token == NULL || signing_secret_valid (secret, secret_len)
+      != WYRELOG_E_OK)
+    return WYRELOG_E_INVALID;
+  *out_token = NULL;
+
+  g_autofree gchar *header_segment = NULL;
+  g_autofree gchar *payload_segment = NULL;
+  wyrelog_error_t rc = wyl_jwt_build_unsigned_segments (input,
+      &header_segment, &payload_segment);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  g_autofree gchar *signing_input = g_strdup_printf ("%s.%s",
+      header_segment, payload_segment);
+  guint8 signature[crypto_auth_hmacsha256_BYTES];
+  rc = sign_hs256_input (signing_input, secret, secret_len, signature);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  g_autofree gchar *signature_segment = NULL;
+  rc = wyl_jwt_base64url_encode (signature, sizeof signature,
+      &signature_segment);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  *out_token = g_strdup_printf ("%s.%s", signing_input, signature_segment);
+  return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
+wyl_jwt_verify_hs256_signature (const gchar *token, const guint8 *secret,
+    gsize secret_len, GBytes **out_payload_json)
+{
+  if (token == NULL || out_payload_json == NULL ||
+      signing_secret_valid (secret, secret_len) != WYRELOG_E_OK)
+    return WYRELOG_E_INVALID;
+  *out_payload_json = NULL;
+
+  g_auto (GStrv) parts = g_strsplit (token, ".", 0);
+  if (parts[0] == NULL || parts[1] == NULL || parts[2] == NULL ||
+      parts[3] != NULL || parts[0][0] == '\0' || parts[1][0] == '\0' ||
+      parts[2][0] == '\0')
+    return WYRELOG_E_INVALID;
+
+  g_autoptr (GBytes) header = NULL;
+  wyrelog_error_t rc = wyl_jwt_base64url_decode (parts[0], &header);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  gsize header_len = 0;
+  const gchar *header_data = g_bytes_get_data (header, &header_len);
+  if (header_len != strlen ("{\"alg\":\"HS256\",\"typ\":\"JWT\"}") ||
+      memcmp (header_data, "{\"alg\":\"HS256\",\"typ\":\"JWT\"}",
+          header_len) != 0)
+    return WYRELOG_E_POLICY;
+
+  g_autoptr (GBytes) signature = NULL;
+  rc = wyl_jwt_base64url_decode (parts[2], &signature);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  gsize signature_len = 0;
+  const guint8 *signature_data = g_bytes_get_data (signature, &signature_len);
+  if (signature_len != crypto_auth_hmacsha256_BYTES)
+    return WYRELOG_E_POLICY;
+
+  g_autofree gchar *signing_input = g_strdup_printf ("%s.%s",
+      parts[0], parts[1]);
+  guint8 expected[crypto_auth_hmacsha256_BYTES];
+  rc = sign_hs256_input (signing_input, secret, secret_len, expected);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if (sodium_memcmp (signature_data, expected, sizeof expected) != 0)
+    return WYRELOG_E_POLICY;
+
+  g_autoptr (GBytes) payload = NULL;
+  rc = wyl_jwt_base64url_decode (parts[1], &payload);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  *out_payload_json = g_steal_pointer (&payload);
+  return WYRELOG_E_OK;
 }

--- a/wyrelog/auth/jwt.c
+++ b/wyrelog/auth/jwt.c
@@ -308,3 +308,304 @@ wyl_jwt_verify_hs256_signature (const gchar *token, const guint8 *secret,
   *out_payload_json = g_steal_pointer (&payload);
   return WYRELOG_E_OK;
 }
+
+static gboolean
+hex_value (gchar c, guint *out)
+{
+  if (c >= '0' && c <= '9')
+    *out = (guint) (c - '0');
+  else if (c >= 'a' && c <= 'f')
+    *out = (guint) (c - 'a' + 10);
+  else if (c >= 'A' && c <= 'F')
+    *out = (guint) (c - 'A' + 10);
+  else
+    return FALSE;
+  return TRUE;
+}
+
+static wyrelog_error_t
+parse_json_string (const gchar **cursor, gchar **out_value)
+{
+  if (cursor == NULL || *cursor == NULL || out_value == NULL || **cursor != '"')
+    return WYRELOG_E_INVALID;
+  *out_value = NULL;
+
+  const gchar *p = *cursor + 1;
+  GString *value = g_string_new (NULL);
+  while (*p != '\0' && *p != '"') {
+    if ((guchar) * p < 0x20) {
+      g_string_free (value, TRUE);
+      return WYRELOG_E_POLICY;
+    }
+    if (*p != '\\') {
+      g_string_append_c (value, *p++);
+      continue;
+    }
+
+    p++;
+    switch (*p) {
+      case '"':
+      case '\\':
+      case '/':
+        g_string_append_c (value, *p++);
+        break;
+      case 'b':
+        g_string_append_c (value, '\b');
+        p++;
+        break;
+      case 'f':
+        g_string_append_c (value, '\f');
+        p++;
+        break;
+      case 'n':
+        g_string_append_c (value, '\n');
+        p++;
+        break;
+      case 'r':
+        g_string_append_c (value, '\r');
+        p++;
+        break;
+      case 't':
+        g_string_append_c (value, '\t');
+        p++;
+        break;
+      case 'u':{
+        guint h0, h1, h2, h3;
+        for (guint i = 1; i <= 4; i++) {
+          if (p[i] == '\0') {
+            g_string_free (value, TRUE);
+            return WYRELOG_E_POLICY;
+          }
+        }
+        if (!hex_value (p[1], &h0) || !hex_value (p[2], &h1) ||
+            !hex_value (p[3], &h2) || !hex_value (p[4], &h3)) {
+          g_string_free (value, TRUE);
+          return WYRELOG_E_POLICY;
+        }
+        guint codepoint = (h0 << 12) | (h1 << 8) | (h2 << 4) | h3;
+        if (codepoint < 0x20 || codepoint > 0x7f) {
+          g_string_free (value, TRUE);
+          return WYRELOG_E_POLICY;
+        }
+        g_string_append_c (value, (gchar) codepoint);
+        p += 5;
+        break;
+      }
+      default:
+        g_string_free (value, TRUE);
+        return WYRELOG_E_POLICY;
+    }
+  }
+  if (*p != '"') {
+    g_string_free (value, TRUE);
+    return WYRELOG_E_POLICY;
+  }
+
+  *cursor = p + 1;
+  *out_value = g_string_free (value, FALSE);
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+parse_json_uint64 (const gchar **cursor, gint64 *out_value)
+{
+  if (cursor == NULL || *cursor == NULL || out_value == NULL ||
+      !g_ascii_isdigit (**cursor))
+    return WYRELOG_E_INVALID;
+
+  gint64 value = 0;
+  const gchar *p = *cursor;
+  while (g_ascii_isdigit (*p)) {
+    gint digit = *p - '0';
+    if (value > (G_MAXINT64 - digit) / 10)
+      return WYRELOG_E_POLICY;
+    value = value * 10 + digit;
+    p++;
+  }
+
+  *cursor = p;
+  *out_value = value;
+  return WYRELOG_E_OK;
+}
+
+static void
+skip_json_ws (const gchar **cursor)
+{
+  while (g_ascii_isspace (**cursor))
+    (*cursor)++;
+}
+
+typedef struct
+{
+  gchar *issuer;
+  gchar *audience;
+  gint64 not_before;
+  gint64 expires_at;
+  guint seen_mask;
+} ParsedJwtClaims;
+
+enum
+{
+  CLAIM_JTI = 1u << 0,
+  CLAIM_SUB = 1u << 1,
+  CLAIM_ISS = 1u << 2,
+  CLAIM_AUD = 1u << 3,
+  CLAIM_IAT = 1u << 4,
+  CLAIM_NBF = 1u << 5,
+  CLAIM_EXP = 1u << 6,
+  CLAIM_TENANT = 1u << 7,
+  CLAIM_PRINCIPAL_STATE = 1u << 8,
+  CLAIM_SESSION_ID = 1u << 9,
+  CLAIM_REQUIRED_MASK = (1u << 10) - 1,
+};
+
+static void
+parsed_jwt_claims_clear (ParsedJwtClaims *claims)
+{
+  g_free (claims->issuer);
+  g_free (claims->audience);
+  memset (claims, 0, sizeof *claims);
+}
+
+static wyrelog_error_t
+mark_claim_seen (ParsedJwtClaims *claims, guint bit)
+{
+  if ((claims->seen_mask & bit) != 0)
+    return WYRELOG_E_POLICY;
+  claims->seen_mask |= bit;
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+parse_string_claim_value (const gchar **cursor, ParsedJwtClaims *claims,
+    guint bit, gchar **out_value)
+{
+  wyrelog_error_t rc = mark_claim_seen (claims, bit);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  g_autofree gchar *value = NULL;
+  rc = parse_json_string (cursor, &value);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if (value[0] == '\0')
+    return WYRELOG_E_POLICY;
+  if (out_value != NULL)
+    *out_value = g_steal_pointer (&value);
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+parse_int_claim_value (const gchar **cursor, ParsedJwtClaims *claims,
+    guint bit, gint64 *out_value)
+{
+  wyrelog_error_t rc = mark_claim_seen (claims, bit);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return parse_json_uint64 (cursor, out_value);
+}
+
+static wyrelog_error_t
+parse_jwt_payload_claims (const gchar *payload, ParsedJwtClaims *claims)
+{
+  if (payload == NULL || claims == NULL)
+    return WYRELOG_E_INVALID;
+  memset (claims, 0, sizeof *claims);
+
+  const gchar *p = payload;
+  skip_json_ws (&p);
+  if (*p++ != '{')
+    return WYRELOG_E_POLICY;
+  skip_json_ws (&p);
+  while (*p != '}') {
+    g_autofree gchar *key = NULL;
+    wyrelog_error_t rc = parse_json_string (&p, &key);
+    if (rc != WYRELOG_E_OK)
+      return rc;
+    skip_json_ws (&p);
+    if (*p++ != ':')
+      return WYRELOG_E_POLICY;
+    skip_json_ws (&p);
+
+    if (g_strcmp0 (key, "jti") == 0)
+      rc = parse_string_claim_value (&p, claims, CLAIM_JTI, NULL);
+    else if (g_strcmp0 (key, "sub") == 0)
+      rc = parse_string_claim_value (&p, claims, CLAIM_SUB, NULL);
+    else if (g_strcmp0 (key, "iss") == 0)
+      rc = parse_string_claim_value (&p, claims, CLAIM_ISS, &claims->issuer);
+    else if (g_strcmp0 (key, "aud") == 0)
+      rc = parse_string_claim_value (&p, claims, CLAIM_AUD, &claims->audience);
+    else if (g_strcmp0 (key, "iat") == 0) {
+      gint64 ignored = 0;
+      rc = parse_int_claim_value (&p, claims, CLAIM_IAT, &ignored);
+    } else if (g_strcmp0 (key, "nbf") == 0)
+      rc = parse_int_claim_value (&p, claims, CLAIM_NBF, &claims->not_before);
+    else if (g_strcmp0 (key, "exp") == 0)
+      rc = parse_int_claim_value (&p, claims, CLAIM_EXP, &claims->expires_at);
+    else if (g_strcmp0 (key, "tenant") == 0)
+      rc = parse_string_claim_value (&p, claims, CLAIM_TENANT, NULL);
+    else if (g_strcmp0 (key, "principal_state_at_issue") == 0)
+      rc = parse_string_claim_value (&p, claims, CLAIM_PRINCIPAL_STATE, NULL);
+    else if (g_strcmp0 (key, "session_id") == 0)
+      rc = parse_string_claim_value (&p, claims, CLAIM_SESSION_ID, NULL);
+    else
+      return WYRELOG_E_POLICY;
+    if (rc != WYRELOG_E_OK)
+      return rc;
+
+    skip_json_ws (&p);
+    if (*p == ',') {
+      p++;
+      skip_json_ws (&p);
+      if (*p == '}')
+        return WYRELOG_E_POLICY;
+    } else if (*p != '}') {
+      return WYRELOG_E_POLICY;
+    }
+  }
+  p++;
+  skip_json_ws (&p);
+  if (*p != '\0')
+    return WYRELOG_E_POLICY;
+  if ((claims->seen_mask & CLAIM_REQUIRED_MASK) != CLAIM_REQUIRED_MASK)
+    return WYRELOG_E_POLICY;
+  return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
+wyl_jwt_verify_hs256_access_token (const gchar *token, const guint8 *secret,
+    gsize secret_len, const gchar *expected_issuer,
+    const gchar *expected_audience, gint64 now, GBytes **out_payload_json)
+{
+  if (!non_empty (expected_issuer) || !non_empty (expected_audience) ||
+      now < 0 || out_payload_json == NULL)
+    return WYRELOG_E_INVALID;
+  *out_payload_json = NULL;
+
+  g_autoptr (GBytes) payload = NULL;
+  wyrelog_error_t rc = wyl_jwt_verify_hs256_signature (token, secret,
+      secret_len, &payload);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  gsize payload_len = 0;
+  const gchar *payload_data = g_bytes_get_data (payload, &payload_len);
+  if (memchr (payload_data, '\0', payload_len) != NULL)
+    return WYRELOG_E_POLICY;
+  g_autofree gchar *payload_text = g_strndup (payload_data, payload_len);
+  ParsedJwtClaims claims = { 0 };
+  rc = parse_jwt_payload_claims (payload_text, &claims);
+  if (rc != WYRELOG_E_OK) {
+    parsed_jwt_claims_clear (&claims);
+    return rc;
+  }
+  gboolean claims_valid = g_strcmp0 (claims.issuer, expected_issuer) == 0
+      && g_strcmp0 (claims.audience, expected_audience) == 0
+      && now >= claims.not_before && now < claims.expires_at;
+  parsed_jwt_claims_clear (&claims);
+  if (!claims_valid)
+    return WYRELOG_E_POLICY;
+
+  *out_payload_json = g_steal_pointer (&payload);
+  return WYRELOG_E_OK;
+}

--- a/wyrelog/meson.build
+++ b/wyrelog/meson.build
@@ -15,6 +15,7 @@ wyrelog_public_headers = files(
 
 wyrelog_sources = files(
   'access/decision.c',
+  'auth/jwt.c',
   'audit/event.c',
   'policy/store.c',
   'wyl-boot.c',

--- a/wyrelog/meson.build
+++ b/wyrelog/meson.build
@@ -37,7 +37,14 @@ wyrelog_sources = files(
   'wyl-version.c',
 )
 
-wyrelog_deps = [glib_dep, gio_dep, libchronoid_dep, sqlite_dep, wirelog_dep]
+wyrelog_deps = [
+  glib_dep,
+  gio_dep,
+  libchronoid_dep,
+  sodium_dep,
+  sqlite_dep,
+  wirelog_dep,
+]
 
 wyrelog_log_levels = {
   'none' : 0,


### PR DESCRIPTION
## Summary
- add private JWT claim payload and unsigned segment builders
- sign and verify fixed-header HS256 JWT segments with libsodium
- verify access-token issuer, audience, and validity time after signature checks
- reject ambiguous payloads such as duplicate, nested, malformed, or NUL-bearing claims

## Tests
- git diff --check origin/main..HEAD
- meson test -C builddir jwt session-username daemon-http-decide --print-errorlogs
- meson test -C builddir-audit jwt session-username daemon-http-decide --print-errorlogs
