### PR TITLE
Issue login access tokens

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -76,12 +76,14 @@ test('client-smoke', test_client_smoke)
 if build_client
   test_daemon_http_decide_c_args = [
     '-DWYL_HAS_DAEMON_HTTP',
+    '-DWYL_TEST_DAEMON_HTTP',
     '-DWYL_TEST_TEMPLATE_DIR="' + meson.project_source_root() / 'templates' / 'access' + '"',
   ]
   test_daemon_http_decide_deps = [
     wyrelog_dep,
     wyrelog_client_dep,
     libsoup_dep,
+    sodium_dep,
   ]
   if get_option('enable_audit').allowed()
     test_daemon_http_decide_c_args += '-DWYL_HAS_AUDIT'

--- a/tests/test-client-smoke.c
+++ b/tests/test-client-smoke.c
@@ -248,19 +248,23 @@ main (void)
     return 146;
   g_autofree gchar *client_session_token =
       wyl_client_dup_session_token (local_client);
+  g_autofree gchar *client_access_token =
+      wyl_client_dup_access_token (local_client);
   g_autofree gchar *client_username = wyl_client_dup_username (local_client);
   g_autofree gchar *client_principal_state =
       wyl_client_dup_principal_state (local_client);
   g_autofree gchar *client_session_state =
       wyl_client_dup_session_state (local_client);
   if (g_strcmp0 (client_session_token, "session-1") != 0 ||
+      client_access_token != NULL ||
       g_strcmp0 (client_username, "alice") != 0 ||
       g_strcmp0 (client_principal_state, "mfa_required") != 0 ||
       g_strcmp0 (client_session_state, "active") != 0)
     return 138;
 
   http.body = "{\"session_token\":\"session-2\",\"username\":\"alice\","
-      "\"principal_state\":\"authenticated\",\"session_state\":\"active\"}";
+      "\"principal_state\":\"authenticated\",\"session_state\":\"active\","
+      "\"access_token\":\"access-2\"}";
   if (wyl_client_login_skip_mfa (local_client, "alice") != WYRELOG_E_OK)
     return 147;
   if (g_strcmp0 (http.last_method, "POST") != 0)
@@ -272,14 +276,17 @@ main (void)
   if (g_strcmp0 (http.last_skip_mfa, "true") != 0)
     return 151;
   g_clear_pointer (&client_session_token, g_free);
+  g_clear_pointer (&client_access_token, g_free);
   g_clear_pointer (&client_username, g_free);
   g_clear_pointer (&client_principal_state, g_free);
   g_clear_pointer (&client_session_state, g_free);
   client_session_token = wyl_client_dup_session_token (local_client);
+  client_access_token = wyl_client_dup_access_token (local_client);
   client_username = wyl_client_dup_username (local_client);
   client_principal_state = wyl_client_dup_principal_state (local_client);
   client_session_state = wyl_client_dup_session_state (local_client);
   if (g_strcmp0 (client_session_token, "session-2") != 0 ||
+      g_strcmp0 (client_access_token, "access-2") != 0 ||
       g_strcmp0 (client_username, "alice") != 0 ||
       g_strcmp0 (client_principal_state, "authenticated") != 0 ||
       g_strcmp0 (client_session_state, "active") != 0)
@@ -365,7 +372,8 @@ main (void)
     return 161;
 
   http.body = "{\"session_token\":\"session-3\",\"username\":\"alice\","
-      "\"principal_state\":\"authenticated\",\"session_state\":\"active\"}";
+      "\"principal_state\":\"authenticated\",\"session_state\":\"active\","
+      "\"access_token\":\"access-3\"}";
   if (wyl_client_login_skip_mfa (local_client, "alice") != WYRELOG_E_OK)
     return 162;
 
@@ -399,6 +407,24 @@ main (void)
     return 141;
   if (wyl_client_mfa_verify (local_client, "123456") == WYRELOG_E_OK)
     return 142;
+
+  http.body = "{\"session_token\":\"session-bad\",\"username\":\"alice\","
+      "\"principal_state\":\"authenticated\",\"session_state\":\"active\","
+      "\"access_token\":\"\"}";
+  if (wyl_client_login_skip_mfa (local_client, "alice") != WYRELOG_E_IO)
+    return 163;
+
+  http.body = "{\"session_token\":\"session-bad\",\"username\":\"alice\","
+      "\"principal_state\":\"authenticated\",\"session_state\":\"active\","
+      "\"access_token\":null}";
+  if (wyl_client_login_skip_mfa (local_client, "alice") != WYRELOG_E_IO)
+    return 165;
+
+  http.body = "{\"session_token\":\"session-bad\",\"username\":\"alice\","
+      "\"principal_state\":\"authenticated\",\"session_state\":\"active\","
+      "\"access_token\":\"access-a\",\"access_token\":\"access-b\"}";
+  if (wyl_client_login_skip_mfa (local_client, "alice") != WYRELOG_E_IO)
+    return 164;
 
   http.body = "{\"session_token\":\"session-1\"}";
   if (wyl_client_login (local_client, "alice", NULL) != WYRELOG_E_IO)

--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -7,6 +7,7 @@
 #endif
 
 #include "daemon/http.h"
+#include "wyrelog/auth/jwt-private.h"
 #include "wyrelog/client.h"
 #include "wyrelog/policy/store-private.h"
 #include "wyrelog/wyl-handle-private.h"
@@ -377,6 +378,47 @@ extract_json_string (const gchar *body, const gchar *name)
 }
 
 static gint
+verify_login_access_token (const gchar *body, const gchar *session_token,
+    const gchar *username, const gchar *principal_state, SoupServer *server)
+{
+  g_autofree gchar *access_token = extract_json_string (body, "access_token");
+  if (access_token == NULL)
+    return 530;
+
+  guint8 secret[32];
+  if (wyl_daemon_http_copy_access_token_secret (server, secret, sizeof secret)
+      != WYRELOG_E_OK)
+    return 531;
+
+  g_autoptr (GBytes) payload = NULL;
+  gint64 now = g_get_real_time () / G_USEC_PER_SEC;
+  wyrelog_error_t rc = wyl_jwt_verify_hs256_access_token (access_token, secret,
+      sizeof secret, "wyrelogd", "wyrelog-client", now, &payload);
+  memset (secret, 0, sizeof secret);
+  if (rc != WYRELOG_E_OK)
+    return 532;
+
+  gsize payload_len = 0;
+  const gchar *payload_data = g_bytes_get_data (payload, &payload_len);
+  g_autofree gchar *payload_text = g_strndup (payload_data, payload_len);
+  g_autofree gchar *expected_sub = g_strdup_printf ("\"sub\":\"%s\"",
+      username);
+  g_autofree gchar *expected_state =
+      g_strdup_printf ("\"principal_state_at_issue\":\"%s\"",
+      principal_state);
+  g_autofree gchar *expected_session =
+      g_strdup_printf ("\"session_id\":\"%s\"", session_token);
+  if (strstr (payload_text, expected_sub) == NULL ||
+      strstr (payload_text, expected_state) == NULL ||
+      strstr (payload_text, expected_session) == NULL)
+    return 533;
+  g_autofree gchar *jti = extract_json_string (payload_text, "jti");
+  if (jti == NULL || g_strcmp0 (jti, session_token) == 0)
+    return 534;
+  return 0;
+}
+
+static gint
 check_raw_login_contract (SoupServer *server, WylHandle *handle,
     const gchar *base_url)
 {
@@ -427,6 +469,14 @@ check_raw_login_contract (SoupServer *server, WylHandle *handle,
       strstr (body, "\"session_token\":\"") == NULL ||
       strstr (body, "\"principal_state\":\"authenticated\"") == NULL)
     return 485;
+  g_autofree gchar *authenticated_session_token =
+      extract_json_string (body, "session_token");
+  if (authenticated_session_token == NULL)
+    return 486;
+  rc = verify_login_access_token (body, authenticated_session_token,
+      "login-user", "authenticated", server);
+  if (rc != 0)
+    return rc;
   g_clear_pointer (&body, g_free);
 
   rc = send_raw_login (session, "POST", base_url,
@@ -435,7 +485,8 @@ check_raw_login_contract (SoupServer *server, WylHandle *handle,
     return rc;
   if (status != 200 ||
       strstr (body, "\"session_token\":\"") == NULL ||
-      strstr (body, "\"principal_state\":\"mfa_required\"") == NULL)
+      strstr (body, "\"principal_state\":\"mfa_required\"") == NULL ||
+      strstr (body, "\"access_token\"") != NULL)
     return 474;
   g_clear_pointer (&body, g_free);
 

--- a/wyrelog/client.h
+++ b/wyrelog/client.h
@@ -44,6 +44,7 @@ wyrelog_error_t wyl_client_login (WylClient * client,
 wyrelog_error_t wyl_client_login_skip_mfa (WylClient * client,
     const gchar * username);
 gchar *wyl_client_dup_session_token (const WylClient * client);
+gchar *wyl_client_dup_access_token (const WylClient * client);
 gchar *wyl_client_dup_username (const WylClient * client);
 gchar *wyl_client_dup_principal_state (const WylClient * client);
 gchar *wyl_client_dup_session_state (const WylClient * client);

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -3,18 +3,29 @@
 
 #ifdef WYL_HAS_DAEMON_HTTP
 #include <errno.h>
+#include <sodium.h>
 #include <string.h>
 
 #include "wyrelog/wyrelog.h"
+#include "wyrelog/auth/jwt-private.h"
 #include "wyrelog/wyl-handle-private.h"
+#include "wyrelog/wyl-id-private.h"
 #include "wyrelog/wyl-permission-scope-private.h"
+
+#define WYL_DAEMON_JWT_ISSUER "wyrelogd"
+#define WYL_DAEMON_JWT_AUDIENCE "wyrelog-client"
+#define WYL_DAEMON_JWT_KEY_LEN 32
 
 typedef struct
 {
   WylHandle *handle;
+  guint8 access_token_secret[WYL_DAEMON_JWT_KEY_LEN];
+  gboolean access_token_secret_ready;
   GHashTable *sessions_by_token;
   GMutex lock;
 } WylDaemonHttpContext;
+
+static WylDaemonHttpContext *wyl_daemon_http_get_context (SoupServer * server);
 
 static void
 wyl_daemon_http_context_free (gpointer data)
@@ -24,6 +35,7 @@ wyl_daemon_http_context_free (gpointer data)
   if (ctx == NULL)
     return;
 
+  sodium_memzero (ctx->access_token_secret, sizeof ctx->access_token_secret);
   g_hash_table_unref (ctx->sessions_by_token);
   g_mutex_clear (&ctx->lock);
   g_free (ctx);
@@ -35,11 +47,34 @@ wyl_daemon_http_context_new (WylHandle *handle)
   WylDaemonHttpContext *ctx = g_new0 (WylDaemonHttpContext, 1);
 
   ctx->handle = handle;
+  if (sodium_init () >= 0) {
+    randombytes_buf (ctx->access_token_secret, sizeof ctx->access_token_secret);
+    ctx->access_token_secret_ready = TRUE;
+  }
   ctx->sessions_by_token =
       g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_object_unref);
   g_mutex_init (&ctx->lock);
   return ctx;
 }
+
+#ifdef WYL_TEST_DAEMON_HTTP
+wyrelog_error_t
+wyl_daemon_http_copy_access_token_secret (SoupServer *server,
+    guint8 *out_secret, gsize out_len)
+{
+  if (out_secret == NULL || out_len != WYL_DAEMON_JWT_KEY_LEN)
+    return WYRELOG_E_INVALID;
+
+  WylDaemonHttpContext *ctx = wyl_daemon_http_get_context (server);
+  if (ctx == NULL)
+    return WYRELOG_E_INVALID;
+  if (!ctx->access_token_secret_ready)
+    return WYRELOG_E_INTERNAL;
+
+  memcpy (out_secret, ctx->access_token_secret, WYL_DAEMON_JWT_KEY_LEN);
+  return WYRELOG_E_OK;
+}
+#endif
 
 static gboolean
 wyl_daemon_http_context_store_session (WylDaemonHttpContext *ctx,
@@ -153,7 +188,7 @@ build_decide_json (const wyl_decide_resp_t *resp)
 
 static gchar *
 build_login_json (const gchar *session_token, const gchar *username,
-    const gchar *principal_state)
+    const gchar *principal_state, const gchar *access_token)
 {
   g_autoptr (GString) json = g_string_new ("{");
 
@@ -163,8 +198,72 @@ build_login_json (const gchar *session_token, const gchar *username,
   append_json_string (json, username);
   g_string_append (json, ",\"principal_state\":");
   append_json_string (json, principal_state);
-  g_string_append (json, ",\"session_state\":\"active\"}");
+  g_string_append (json, ",\"session_state\":\"active\"");
+  if (access_token != NULL) {
+    g_string_append (json, ",\"access_token\":");
+    append_json_string (json, access_token);
+  }
+  g_string_append_c (json, '}');
   return g_string_free (g_steal_pointer (&json), FALSE);
+}
+
+static wyrelog_error_t
+copy_access_token_secret (WylDaemonHttpContext *ctx,
+    guint8 out_secret[WYL_DAEMON_JWT_KEY_LEN])
+{
+  if (ctx == NULL || out_secret == NULL)
+    return WYRELOG_E_INVALID;
+  if (!ctx->access_token_secret_ready)
+    return WYRELOG_E_INTERNAL;
+  memcpy (out_secret, ctx->access_token_secret, WYL_DAEMON_JWT_KEY_LEN);
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+issue_login_access_token (WylDaemonHttpContext *ctx, const gchar *session_token,
+    const gchar *username, const gchar *principal_state, WylSession *session,
+    gchar **out_token)
+{
+  if (out_token == NULL)
+    return WYRELOG_E_INVALID;
+  *out_token = NULL;
+  if (session_token == NULL || username == NULL || principal_state == NULL ||
+      session == NULL)
+    return WYRELOG_E_INVALID;
+
+  guint8 secret[WYL_DAEMON_JWT_KEY_LEN];
+  wyrelog_error_t rc = copy_access_token_secret (ctx, secret);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  wyl_id_t token_id;
+  rc = wyl_id_new (&token_id);
+  if (rc != WYRELOG_E_OK) {
+    sodium_memzero (secret, sizeof secret);
+    return rc;
+  }
+  gchar token_id_buf[WYL_ID_STRING_BUF];
+  rc = wyl_id_format (&token_id, token_id_buf, sizeof token_id_buf);
+  if (rc != WYRELOG_E_OK) {
+    sodium_memzero (secret, sizeof secret);
+    return rc;
+  }
+
+  gint64 issued_at = wyl_session_get_created_at_us (session) / G_USEC_PER_SEC;
+  wyl_jwt_issue_input_t input = {
+    .jti = token_id_buf,
+    .subject = username,
+    .issuer = WYL_DAEMON_JWT_ISSUER,
+    .audience = WYL_DAEMON_JWT_AUDIENCE,
+    .tenant = "__wr_default",
+    .principal_state_at_issue = principal_state,
+    .session_id = session_token,
+    .issued_at = issued_at,
+    .ttl_seconds = WYL_JWT_ACCESS_TTL_SECONDS,
+  };
+  rc = wyl_jwt_sign_hs256 (&input, secret, sizeof secret, out_token);
+  sodium_memzero (secret, sizeof secret);
+  return rc;
 }
 
 static void
@@ -619,13 +718,25 @@ login_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
     set_json_error (msg, 500, "login_failed");
     return;
   }
+  const gchar *principal_state =
+      skip_mfa_requested ? "authenticated" : "mfa_required";
+  g_autofree gchar *access_token = NULL;
+  if (skip_mfa_requested) {
+    rc = issue_login_access_token (ctx, session_token, username,
+        principal_state, session, &access_token);
+    if (rc != WYRELOG_E_OK) {
+      set_json_error (msg, 500, "login_failed");
+      return;
+    }
+  }
+
   if (!wyl_daemon_http_context_store_session (ctx, session_token, session)) {
     set_json_error (msg, 500, "login_failed");
     return;
   }
 
   g_autofree gchar *body = build_login_json (session_token, username,
-      skip_mfa_requested ? "authenticated" : "mfa_required");
+      principal_state, access_token);
   soup_server_message_set_status (msg, 200, NULL);
   soup_server_message_set_response (msg, "application/json",
       SOUP_MEMORY_COPY, body, strlen (body));

--- a/wyrelog/daemon/http.h
+++ b/wyrelog/daemon/http.h
@@ -13,4 +13,8 @@ SoupServer *wyl_daemon_start_http_server (const WylDaemonOptions * opts,
     WylHandle * handle, GError ** error);
 WylSession *wyl_daemon_http_ref_session (SoupServer * server,
     const gchar * session_token);
+#ifdef WYL_TEST_DAEMON_HTTP
+wyrelog_error_t wyl_daemon_http_copy_access_token_secret (SoupServer * server,
+    guint8 * out_secret, gsize out_len);
+#endif
 #endif

--- a/wyrelog/meson.build
+++ b/wyrelog/meson.build
@@ -119,7 +119,7 @@ wyrelogd_c_args = [
   '-DWYL_DEFAULT_TEMPLATE_DIR="' + get_option('datadir') / 'wyrelog' / 'access' + '"',
 ]
 if libsoup_dep.found()
-  wyrelogd_deps += libsoup_dep
+  wyrelogd_deps += [libsoup_dep, sodium_dep]
   wyrelogd_c_args += '-DWYL_HAS_DAEMON_HTTP'
 endif
 if get_option('enable_audit').allowed()

--- a/wyrelog/wyl-client.c
+++ b/wyrelog/wyl-client.c
@@ -7,6 +7,7 @@ struct _WylClient
   GObject parent_instance;
   gchar *base_url;
   gchar *session_token;
+  gchar *access_token;
   gchar *username;
   gchar *principal_state;
   gchar *session_state;
@@ -17,13 +18,14 @@ G_DEFINE_FINAL_TYPE (WylClient, wyl_client, G_TYPE_OBJECT);
 
 static gboolean parse_login_response_json (const gchar * data, gsize size,
     gchar ** out_session_token,
-    gchar ** out_username,
+    gchar ** out_access_token, gchar ** out_username,
     gchar ** out_principal_state, gchar ** out_session_state);
 
 static void
 wyl_client_clear_login_state (WylClient *self)
 {
   g_clear_pointer (&self->session_token, g_free);
+  g_clear_pointer (&self->access_token, g_free);
   g_clear_pointer (&self->username, g_free);
   g_clear_pointer (&self->principal_state, g_free);
   g_clear_pointer (&self->session_state, g_free);
@@ -92,6 +94,13 @@ wyl_client_dup_session_token (const WylClient *client)
 {
   g_return_val_if_fail (WYL_IS_CLIENT ((WylClient *) client), NULL);
   return g_strdup (client->session_token);
+}
+
+gchar *
+wyl_client_dup_access_token (const WylClient *client)
+{
+  g_return_val_if_fail (WYL_IS_CLIENT ((WylClient *) client), NULL);
+  return g_strdup (client->access_token);
 }
 
 gchar *
@@ -190,17 +199,19 @@ client_login_internal (WylClient *client, const gchar *username,
   gsize body_size = 0;
   const gchar *body_data = g_bytes_get_data (body, &body_size);
   g_autofree gchar *session_token = NULL;
+  g_autofree gchar *access_token = NULL;
   g_autofree gchar *parsed_username = NULL;
   g_autofree gchar *principal_state = NULL;
   g_autofree gchar *session_state = NULL;
   if (!parse_login_response_json (body_data, body_size, &session_token,
-          &parsed_username, &principal_state, &session_state)) {
+          &access_token, &parsed_username, &principal_state, &session_state)) {
     wyl_client_clear_login_state (client);
     return WYRELOG_E_IO;
   }
 
   wyl_client_clear_login_state (client);
   client->session_token = g_steal_pointer (&session_token);
+  client->access_token = g_steal_pointer (&access_token);
   client->username = g_steal_pointer (&parsed_username);
   client->principal_state = g_steal_pointer (&principal_state);
   client->session_state = g_steal_pointer (&session_state);
@@ -524,13 +535,15 @@ parse_decide_response_json (const gchar *data, gsize size, gint *out_decision)
 
 static gboolean
 parse_login_response_json (const gchar *data, gsize size,
-    gchar **out_session_token, gchar **out_username,
+    gchar **out_session_token, gchar **out_access_token, gchar **out_username,
     gchar **out_principal_state, gchar **out_session_state)
 {
   if (data == NULL || out_session_token == NULL || out_username == NULL ||
-      out_principal_state == NULL || out_session_state == NULL)
+      out_access_token == NULL || out_principal_state == NULL ||
+      out_session_state == NULL)
     return FALSE;
   *out_session_token = NULL;
+  *out_access_token = NULL;
   *out_username = NULL;
   *out_principal_state = NULL;
   *out_session_state = NULL;
@@ -540,6 +553,7 @@ parse_login_response_json (const gchar *data, gsize size,
     return FALSE;
 
   gboolean have_session_token = FALSE;
+  gboolean have_access_token = FALSE;
   gboolean have_username = FALSE;
   gboolean have_principal_state = FALSE;
   gboolean have_session_state = FALSE;
@@ -549,22 +563,37 @@ parse_login_response_json (const gchar *data, gsize size,
 
   while (TRUE) {
     g_autofree gchar *key = NULL;
-    g_autofree gchar *value = NULL;
-    if (!json_parse_string (&cursor, &key) || !json_consume (&cursor, ':') ||
-        !json_parse_string (&cursor, &value))
+    if (!json_parse_string (&cursor, &key) || !json_consume (&cursor, ':'))
       return FALSE;
 
     if (g_strcmp0 (key, "session_token") == 0) {
+      g_autofree gchar *value = NULL;
+      if (!json_parse_string (&cursor, &value))
+        return FALSE;
       if (have_session_token || value[0] == '\0')
         return FALSE;
       have_session_token = TRUE;
       *out_session_token = g_steal_pointer (&value);
+    } else if (g_strcmp0 (key, "access_token") == 0) {
+      g_autofree gchar *value = NULL;
+      if (!json_parse_string (&cursor, &value))
+        return FALSE;
+      if (have_access_token || value[0] == '\0')
+        return FALSE;
+      have_access_token = TRUE;
+      *out_access_token = g_steal_pointer (&value);
     } else if (g_strcmp0 (key, "username") == 0) {
+      g_autofree gchar *value = NULL;
+      if (!json_parse_string (&cursor, &value))
+        return FALSE;
       if (have_username || value[0] == '\0')
         return FALSE;
       have_username = TRUE;
       *out_username = g_steal_pointer (&value);
     } else if (g_strcmp0 (key, "principal_state") == 0) {
+      g_autofree gchar *value = NULL;
+      if (!json_parse_string (&cursor, &value))
+        return FALSE;
       if (have_principal_state ||
           (g_strcmp0 (value, "mfa_required") != 0 &&
               g_strcmp0 (value, "authenticated") != 0))
@@ -572,6 +601,9 @@ parse_login_response_json (const gchar *data, gsize size,
       have_principal_state = TRUE;
       *out_principal_state = g_steal_pointer (&value);
     } else if (g_strcmp0 (key, "session_state") == 0) {
+      g_autofree gchar *value = NULL;
+      if (!json_parse_string (&cursor, &value))
+        return FALSE;
       if (have_session_state || g_strcmp0 (value, "active") != 0)
         return FALSE;
       have_session_state = TRUE;
@@ -596,6 +628,7 @@ parse_login_response_json (const gchar *data, gsize size,
   if (!have_session_token || !have_username || !have_principal_state ||
       !have_session_state || cursor.pos != cursor.size) {
     g_clear_pointer (out_session_token, g_free);
+    g_clear_pointer (out_access_token, g_free);
     g_clear_pointer (out_username, g_free);
     g_clear_pointer (out_principal_state, g_free);
     g_clear_pointer (out_session_state, g_free);


### PR DESCRIPTION
## Summary
- accept and store optional login access tokens in the client
- create a process-local daemon signing key for login access tokens
- emit a signed access token on authenticated login responses
- keep MFA-required login responses token-free and preserve session-token auth

## Tests
- git diff --check origin/main..HEAD
- meson test -C builddir jwt client-smoke daemon-http-decide session-username --print-errorlogs
- meson test -C builddir-audit jwt client-smoke daemon-http-decide session-username --print-errorlogs
