### PR TITLE
Add guarded bearer credential flow

### DIFF
--- a/tests/test-client-smoke.c
+++ b/tests/test-client-smoke.c
@@ -21,6 +21,7 @@ typedef struct
   gchar *last_role;
   gchar *last_scope;
   gchar *last_session_token;
+  gchar *last_authorization;
   gchar *last_password;
   gchar *last_skip_mfa;
   gchar *last_guard_timestamp;
@@ -69,6 +70,7 @@ test_http_server_handler (SoupServer *server, SoupServerMessage *msg,
   g_free (http->last_role);
   g_free (http->last_scope);
   g_free (http->last_session_token);
+  g_free (http->last_authorization);
   g_free (http->last_password);
   g_free (http->last_skip_mfa);
   g_free (http->last_guard_timestamp);
@@ -95,6 +97,8 @@ test_http_server_handler (SoupServer *server, SoupServerMessage *msg,
   http->last_session_token =
       query != NULL ? g_strdup (g_hash_table_lookup (query,
           "session_token")) : NULL;
+  http->last_authorization = g_strdup (soup_message_headers_get_one
+      (soup_server_message_get_request_headers (msg), "Authorization"));
   http->last_password =
       query != NULL ? g_strdup (g_hash_table_lookup (query, "password")) : NULL;
   http->last_skip_mfa =
@@ -261,6 +265,27 @@ main (void)
       g_strcmp0 (client_principal_state, "mfa_required") != 0 ||
       g_strcmp0 (client_session_state, "active") != 0)
     return 138;
+  http.body = "{\"ok\":true}";
+  if (wyl_client_policy_permission_grant (local_client, "fallback target",
+          "site.policy.read", "tenant/fallback", 123, "public", 49)
+      != WYRELOG_E_OK)
+    return 170;
+  if (g_strcmp0 (http.last_session_token, "session-1") != 0 ||
+      http.last_authorization != NULL)
+    return 171;
+  g_autoptr (WylAuditIter) fallback_guarded_audit_iter = NULL;
+  if (wyl_client_audit_query_with_guard_context (local_client, NULL, 123,
+          "public", 69, &fallback_guarded_audit_iter) != WYRELOG_E_OK)
+    return 173;
+  g_autofree gchar *fallback_guarded_audit_uri =
+      wyl_audit_iter_dup_request_uri (fallback_guarded_audit_iter);
+  if (strstr (fallback_guarded_audit_uri, "session_token=session-1") == NULL)
+    return 174;
+  g_autoptr (SoupMessage) fallback_guarded_audit_message =
+      wyl_audit_iter_new_request_message (fallback_guarded_audit_iter);
+  if (soup_message_headers_get_one (soup_message_get_request_headers
+          (fallback_guarded_audit_message), "Authorization") != NULL)
+    return 175;
 
   http.body = "{\"session_token\":\"session-2\",\"username\":\"alice\","
       "\"principal_state\":\"authenticated\",\"session_state\":\"active\","
@@ -320,7 +345,8 @@ main (void)
       g_strcmp0 (http.last_subject, "target user") != 0 ||
       g_strcmp0 (http.last_perm, "site.policy.read") != 0 ||
       g_strcmp0 (http.last_scope, "tenant/a") != 0 ||
-      g_strcmp0 (http.last_session_token, "session-2") != 0 ||
+      http.last_session_token != NULL ||
+      g_strcmp0 (http.last_authorization, "Bearer access-2") != 0 ||
       g_strcmp0 (http.last_guard_timestamp, "123") != 0 ||
       g_strcmp0 (http.last_guard_loc_class, "public") != 0 ||
       g_strcmp0 (http.last_guard_risk, "49") != 0)
@@ -328,7 +354,9 @@ main (void)
   if (wyl_client_policy_permission_revoke (local_client, "target user",
           "site.policy.read", "tenant/a", 123, "public", 49) != WYRELOG_E_OK)
     return 519;
-  if (g_strcmp0 (http.last_path, "/policy/permissions/revoke") != 0)
+  if (g_strcmp0 (http.last_path, "/policy/permissions/revoke") != 0 ||
+      http.last_session_token != NULL ||
+      g_strcmp0 (http.last_authorization, "Bearer access-2") != 0)
     return 520;
   if (wyl_client_policy_role_grant (local_client, "target user",
           "site.reader", "tenant/b", 123, "public", 29) != WYRELOG_E_OK)
@@ -336,12 +364,16 @@ main (void)
   if (g_strcmp0 (http.last_path, "/policy/roles/grant") != 0 ||
       g_strcmp0 (http.last_role, "site.reader") != 0 ||
       g_strcmp0 (http.last_scope, "tenant/b") != 0 ||
+      http.last_session_token != NULL ||
+      g_strcmp0 (http.last_authorization, "Bearer access-2") != 0 ||
       g_strcmp0 (http.last_guard_risk, "29") != 0)
     return 522;
   if (wyl_client_policy_role_revoke (local_client, "target user",
           "site.reader", "tenant/b", 123, "public", 29) != WYRELOG_E_OK)
     return 523;
-  if (g_strcmp0 (http.last_path, "/policy/roles/revoke") != 0)
+  if (g_strcmp0 (http.last_path, "/policy/roles/revoke") != 0 ||
+      http.last_session_token != NULL ||
+      g_strcmp0 (http.last_authorization, "Bearer access-2") != 0)
     return 524;
   http.status = 400;
   if (wyl_client_policy_permission_grant (local_client, "target", "read",
@@ -380,7 +412,7 @@ main (void)
   g_autofree gchar *guarded_audit_uri =
       wyl_audit_iter_dup_request_uri (guarded_audit_iter);
   if (strstr (guarded_audit_uri, "/audit/events?") == NULL ||
-      strstr (guarded_audit_uri, "session_token=session-2") == NULL ||
+      strstr (guarded_audit_uri, "session_token=") != NULL ||
       strstr (guarded_audit_uri, "guard_timestamp=123") == NULL ||
       strstr (guarded_audit_uri, "guard_loc_class=public") == NULL ||
       strstr (guarded_audit_uri, "guard_risk=69") == NULL ||
@@ -392,8 +424,10 @@ main (void)
   if (wyl_client_send_message (local_client, guarded_audit_message, &body) !=
       WYRELOG_E_OK)
     return 156;
-  if (g_strcmp0 (http.last_session_token, "session-2") != 0)
+  if (http.last_session_token != NULL)
     return 157;
+  if (g_strcmp0 (http.last_authorization, "Bearer access-2") != 0)
+    return 172;
   if (g_strcmp0 (http.last_guard_timestamp, "123") != 0)
     return 158;
   if (g_strcmp0 (http.last_guard_loc_class, "public") != 0)
@@ -462,6 +496,8 @@ main (void)
     return 59;
   if (g_strcmp0 (http.last_session_token, "doc/42") != 0)
     return 60;
+  if (http.last_authorization != NULL)
+    return 176;
   if (http.last_guard_timestamp != NULL || http.last_guard_loc_class != NULL ||
       http.last_guard_risk != NULL)
     return 69;
@@ -621,6 +657,7 @@ main (void)
   g_clear_pointer (&http.last_role, g_free);
   g_clear_pointer (&http.last_scope, g_free);
   g_clear_pointer (&http.last_session_token, g_free);
+  g_clear_pointer (&http.last_authorization, g_free);
   g_clear_pointer (&http.last_password, g_free);
   g_clear_pointer (&http.last_skip_mfa, g_free);
   g_clear_pointer (&http.last_guard_timestamp, g_free);

--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -418,6 +418,39 @@ verify_login_access_token (const gchar *body, const gchar *session_token,
   return 0;
 }
 
+#ifdef WYL_HAS_AUDIT
+static wyrelog_error_t
+sign_test_access_token (SoupServer *server, const gchar *session_id,
+    const gchar *subject, const gchar *principal_state, const gchar *issuer,
+    const gchar *audience, gint64 issued_at, gchar **out_token)
+{
+  if (out_token == NULL)
+    return WYRELOG_E_INVALID;
+  *out_token = NULL;
+
+  guint8 secret[32];
+  wyrelog_error_t rc =
+      wyl_daemon_http_copy_access_token_secret (server, secret, sizeof secret);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  wyl_jwt_issue_input_t input = {
+    .jti = "test-access-token",
+    .subject = subject,
+    .issuer = issuer,
+    .audience = audience,
+    .tenant = "__wr_default",
+    .principal_state_at_issue = principal_state,
+    .session_id = session_id,
+    .issued_at = issued_at,
+    .ttl_seconds = WYL_JWT_ACCESS_TTL_SECONDS,
+  };
+  rc = wyl_jwt_sign_hs256 (&input, secret, sizeof secret, out_token);
+  memset (secret, 0, sizeof secret);
+  return rc;
+}
+#endif
+
 static gint
 check_raw_login_contract (SoupServer *server, WylHandle *handle,
     const gchar *base_url)
@@ -600,6 +633,39 @@ send_raw_policy_mutation (SoupSession *session, const gchar *method,
   return 0;
 }
 
+static gint
+send_raw_policy_mutation_bearer (SoupSession *session, const gchar *method,
+    const gchar *base_url, const gchar *path, const gchar *query,
+    const gchar *access_token, guint *out_status, gchar **out_body)
+{
+  if (access_token == NULL)
+    return 164;
+  if (out_status == NULL || out_body == NULL)
+    return 120;
+  *out_status = 0;
+  *out_body = NULL;
+
+  g_autofree gchar *uri = build_policy_mutation_uri (base_url, path, query);
+  g_autoptr (SoupMessage) msg = soup_message_new (method, uri);
+  if (msg == NULL)
+    return 121;
+  g_autofree gchar *authorization = g_strdup_printf ("Bearer %s",
+      access_token);
+  soup_message_headers_replace (soup_message_get_request_headers (msg),
+      "Authorization", authorization);
+
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GBytes) bytes = soup_session_send_and_read (session, msg, NULL,
+      &error);
+  if (bytes == NULL)
+    return 122;
+  gsize size = 0;
+  const gchar *data = g_bytes_get_data (bytes, &size);
+  *out_status = soup_message_get_status (msg);
+  *out_body = g_strndup (data, size);
+  return 0;
+}
+
 static wyrelog_error_t
 grant_policy_write_authority (WylHandle *handle, const gchar *subject,
     const gchar *scope)
@@ -664,8 +730,11 @@ check_policy_permission_mutation_contract (WylHandle *handle,
   wyl_handle_set_login_skip_mfa_allowed (handle, FALSE);
 
   g_autofree gchar *session_token = wyl_client_dup_session_token (client);
+  g_autofree gchar *access_token = wyl_client_dup_access_token (client);
   if (session_token == NULL)
     return 124;
+  if (access_token == NULL)
+    return 164;
 
   wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
   if (wyl_policy_store_upsert_permission (store, "site.policy.read",
@@ -791,6 +860,20 @@ check_policy_permission_mutation_contract (WylHandle *handle,
   if (!direct_permission_exists (handle, "target", "site.policy.read",
           "tenant-a"))
     return 136;
+  g_clear_pointer (&body, g_free);
+
+  rc = send_raw_policy_mutation_bearer (session, "POST", base_url,
+      "/policy/permissions/grant",
+      "subject=bearer-target&perm=site.policy.read&scope=tenant-a"
+      "&guard_timestamp=123&guard_loc_class=public&guard_risk=49",
+      access_token, &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 200 || strstr (body, "\"ok\":true") == NULL)
+    return 165;
+  if (!direct_permission_exists (handle, "bearer-target", "site.policy.read",
+          "tenant-a"))
+    return 166;
   g_clear_pointer (&body, g_free);
 
   g_autofree gchar *builtin_grant_query =
@@ -1024,6 +1107,35 @@ send_raw_audit (SoupSession *session, const gchar *base_url,
 }
 
 static gint
+send_raw_audit_bearer (SoupSession *session, const gchar *base_url,
+    const gchar *query, const gchar *access_token, guint *out_status,
+    gchar **out_body)
+{
+  if (access_token == NULL)
+    return 89;
+
+  g_autofree gchar *uri = build_audit_uri (base_url, query);
+  g_autoptr (SoupMessage) msg = soup_message_new ("GET", uri);
+  if (msg == NULL)
+    return 91;
+  g_autofree gchar *authorization = g_strdup_printf ("Bearer %s",
+      access_token);
+  soup_message_headers_replace (soup_message_get_request_headers (msg),
+      "Authorization", authorization);
+
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GBytes) bytes = soup_session_send_and_read (session, msg, NULL,
+      &error);
+  if (bytes == NULL)
+    return 92;
+  gsize size = 0;
+  const gchar *data = g_bytes_get_data (bytes, &size);
+  *out_status = soup_message_get_status (msg);
+  *out_body = g_strndup (data, size);
+  return 0;
+}
+
+static gint
 runtime_audit_events_table_exists (WylHandle *handle, gboolean *out_exists)
 {
   if (handle == NULL || out_exists == NULL)
@@ -1041,8 +1153,9 @@ runtime_audit_events_table_exists (WylHandle *handle, gboolean *out_exists)
 }
 
 static gint
-check_raw_audit_contract (WylHandle *handle, WylClient *client,
-    const gchar *base_url, const gchar *session_token)
+check_raw_audit_contract (SoupServer *server, WylHandle *handle,
+    WylClient *client, const gchar *base_url, const gchar *session_token,
+    const gchar *access_token)
 {
   g_autoptr (SoupSession) session = soup_session_new ();
   guint status = 0;
@@ -1098,6 +1211,91 @@ check_raw_audit_contract (WylHandle *handle, WylClient *client,
     return rc;
   if (status != 403 || strstr (body, "\"audit_denied\"") == NULL)
     return 98;
+
+  g_clear_pointer (&body, g_free);
+  g_autofree gchar *bearer_allowed =
+      g_strdup_printf ("guard_timestamp=123&guard_loc_class=public"
+      "&guard_risk=69");
+  rc = send_raw_audit_bearer (session, base_url, bearer_allowed, access_token,
+      &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 200 || strstr (body, "[") == NULL)
+    return 106;
+
+  g_clear_pointer (&body, g_free);
+  g_autofree gchar *mixed =
+      g_strdup_printf ("session_token=%s&guard_timestamp=123"
+      "&guard_loc_class=public&guard_risk=69", session_token);
+  rc = send_raw_audit_bearer (session, base_url, mixed, access_token,
+      &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 400 || strstr (body, "\"invalid_audit_auth\"") == NULL)
+    return 107;
+
+  g_clear_pointer (&body, g_free);
+  rc = send_raw_audit_bearer (session, base_url,
+      "guard_timestamp=abc&guard_loc_class=public&guard_risk=69",
+      "malformed.jwt", &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 400 || strstr (body, "\"invalid_audit_auth\"") == NULL)
+    return 108;
+
+  g_clear_pointer (&body, g_free);
+  rc = send_raw_audit_bearer (session, base_url,
+      "guard_timestamp=123&guard_loc_class=public&guard_risk=69",
+      "malformed.jwt", &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 401 || strstr (body, "\"audit_auth_required\"") == NULL)
+    return 109;
+
+  gint64 now = g_get_real_time () / G_USEC_PER_SEC;
+  const struct
+  {
+    const gchar *session_id;
+    const gchar *subject;
+    const gchar *principal_state;
+    const gchar *issuer;
+    const gchar *audience;
+    gint64 issued_at_delta;
+    gint failure_code;
+  } invalid_tokens[] = {
+    {"unknown-session", "http-audit-user", "authenticated", "wyrelogd",
+        "wyrelog-client", 0, 110},
+    {session_token, "other-user", "authenticated", "wyrelogd",
+        "wyrelog-client", 0, 111},
+    {session_token, "http-audit-user", "mfa_required", "wyrelogd",
+        "wyrelog-client", 0, 112},
+    {session_token, "http-audit-user", "authenticated", "wyrelogd",
+        "other-audience", 0, 113},
+    {session_token, "http-audit-user", "authenticated", "other-issuer",
+        "wyrelog-client", 0, 116},
+    {session_token, "http-audit-user", "authenticated", "wyrelogd",
+        "wyrelog-client", -1000, 114},
+    {session_token, "http-audit-user", "authenticated", "wyrelogd",
+        "wyrelog-client", 60, 115},
+  };
+  for (gsize i = 0; i < G_N_ELEMENTS (invalid_tokens); i++) {
+    g_autofree gchar *bad_token = NULL;
+    if (sign_test_access_token (server, invalid_tokens[i].session_id,
+            invalid_tokens[i].subject, invalid_tokens[i].principal_state,
+            invalid_tokens[i].issuer, invalid_tokens[i].audience,
+            now + invalid_tokens[i].issued_at_delta, &bad_token)
+        != WYRELOG_E_OK)
+      return invalid_tokens[i].failure_code + 40;
+
+    g_clear_pointer (&body, g_free);
+    rc = send_raw_audit_bearer (session, base_url,
+        "guard_timestamp=123&guard_loc_class=public&guard_risk=69",
+        bad_token, &status, &body);
+    if (rc != 0)
+      return rc;
+    if (status != 401 || strstr (body, "\"audit_auth_required\"") == NULL)
+      return invalid_tokens[i].failure_code;
+  }
 
   g_autoptr (WylAuditIter) invalid_filter = NULL;
   if (wyl_client_audit_query_with_guard_context (client, "action()", 123,
@@ -1225,8 +1423,11 @@ main (void)
   if (wyl_client_login_skip_mfa (client, "http-audit-user") != WYRELOG_E_OK)
     return 84;
   g_autofree gchar *audit_session_token = wyl_client_dup_session_token (client);
+  g_autofree gchar *audit_access_token = wyl_client_dup_access_token (client);
   if (audit_session_token == NULL)
     return 85;
+  if (audit_access_token == NULL)
+    return 89;
   if (grant_audit_read (handle, "http-audit-user", audit_session_token) !=
       WYRELOG_E_OK)
     return 86;
@@ -1235,8 +1436,8 @@ main (void)
   if (drop_runtime_audit_events_table (handle) != WYRELOG_E_OK)
     return 87;
 
-  gint audit_auth_rc = check_raw_audit_contract (handle, client, base_url,
-      audit_session_token);
+  gint audit_auth_rc = check_raw_audit_contract (http.server, handle, client,
+      base_url, audit_session_token, audit_access_token);
   if (audit_auth_rc != 0)
     return audit_auth_rc;
 

--- a/wyrelog/audit/iter.c
+++ b/wyrelog/audit/iter.c
@@ -14,6 +14,7 @@ struct _WylAuditIter
   WylClient *client;
   gchar *query_filter;
   gchar *session_token;
+  gchar *access_token;
   gboolean has_guard_context;
   gint64 guard_timestamp;
   gchar *guard_loc_class;
@@ -36,6 +37,7 @@ wyl_audit_iter_finalize (GObject *object)
   g_clear_object (&self->current_event);
   g_free (self->query_filter);
   g_free (self->session_token);
+  g_free (self->access_token);
   g_free (self->guard_loc_class);
 
   G_OBJECT_CLASS (wyl_audit_iter_parent_class)->finalize (object);
@@ -89,11 +91,13 @@ wyl_client_audit_query_with_guard_context (WylClient *client,
   g_autofree gchar *session_token = wyl_client_dup_session_token (client);
   if (session_token == NULL || session_token[0] == '\0')
     return WYRELOG_E_INVALID;
+  g_autofree gchar *access_token = wyl_client_dup_access_token (client);
 
   WylAuditIter *iter = g_object_new (WYL_TYPE_AUDIT_ITER, NULL);
   iter->client = g_object_ref (client);
   iter->query_filter = g_strdup (query_filter);
   iter->session_token = g_steal_pointer (&session_token);
+  iter->access_token = g_steal_pointer (&access_token);
   iter->has_guard_context = TRUE;
   iter->guard_timestamp = guard_timestamp;
   iter->guard_loc_class = g_strdup (guard_loc_class);
@@ -121,14 +125,22 @@ wyl_audit_iter_dup_request_uri (const WylAuditIter *iter)
   g_autoptr (GString) query = g_string_new (NULL);
 
   if (iter->has_guard_context) {
-    g_autofree gchar *escaped_session =
-        g_uri_escape_string (iter->session_token, NULL, TRUE);
     g_autofree gchar *escaped_loc =
         g_uri_escape_string (iter->guard_loc_class, NULL, TRUE);
-    g_string_append_printf (query,
-        "session_token=%s&guard_timestamp=%" G_GINT64_FORMAT
-        "&guard_loc_class=%s&guard_risk=%" G_GINT64_FORMAT,
-        escaped_session, iter->guard_timestamp, escaped_loc, iter->guard_risk);
+    if (iter->access_token == NULL) {
+      g_autofree gchar *escaped_session =
+          g_uri_escape_string (iter->session_token, NULL, TRUE);
+      g_string_append_printf (query,
+          "session_token=%s&guard_timestamp=%" G_GINT64_FORMAT
+          "&guard_loc_class=%s&guard_risk=%" G_GINT64_FORMAT,
+          escaped_session, iter->guard_timestamp, escaped_loc,
+          iter->guard_risk);
+    } else {
+      g_string_append_printf (query,
+          "guard_timestamp=%" G_GINT64_FORMAT
+          "&guard_loc_class=%s&guard_risk=%" G_GINT64_FORMAT,
+          iter->guard_timestamp, escaped_loc, iter->guard_risk);
+    }
   }
 
   if (iter->query_filter == NULL || iter->query_filter[0] == '\0') {
@@ -152,7 +164,14 @@ wyl_audit_iter_new_request_message (WylAuditIter *iter)
   g_return_val_if_fail (WYL_IS_AUDIT_ITER (iter), NULL);
 
   g_autofree gchar *request_uri = wyl_audit_iter_dup_request_uri (iter);
-  return soup_message_new ("GET", request_uri);
+  SoupMessage *message = soup_message_new ("GET", request_uri);
+  if (message != NULL && iter->access_token != NULL) {
+    g_autofree gchar *authorization = g_strdup_printf ("Bearer %s",
+        iter->access_token);
+    soup_message_headers_replace (soup_message_get_request_headers (message),
+        "Authorization", authorization);
+  }
+  return message;
 }
 
 WylAuditEvent *

--- a/wyrelog/auth/jwt-private.h
+++ b/wyrelog/auth/jwt-private.h
@@ -22,6 +22,18 @@ typedef struct
   gint64 ttl_seconds;
 } wyl_jwt_issue_input_t;
 
+typedef struct
+{
+  gchar *subject;
+  gchar *issuer;
+  gchar *audience;
+  gchar *principal_state_at_issue;
+  gchar *session_id;
+  gint64 not_before;
+  gint64 expires_at;
+} wyl_jwt_access_claims_t;
+
+void wyl_jwt_access_claims_clear (wyl_jwt_access_claims_t * claims);
 wyrelog_error_t wyl_jwt_base64url_encode (const guint8 * data, gsize len,
     gchar ** out_text);
 wyrelog_error_t wyl_jwt_base64url_decode (const gchar * text,
@@ -35,6 +47,8 @@ wyrelog_error_t wyl_jwt_sign_hs256 (const wyl_jwt_issue_input_t * input,
     const guint8 * secret, gsize secret_len, gchar ** out_token);
 wyrelog_error_t wyl_jwt_verify_hs256_signature (const gchar * token,
     const guint8 * secret, gsize secret_len, GBytes ** out_payload_json);
+wyrelog_error_t wyl_jwt_parse_access_claims_json (GBytes * payload_json,
+    wyl_jwt_access_claims_t * out_claims);
 wyrelog_error_t wyl_jwt_verify_hs256_access_token (const gchar * token,
     const guint8 * secret, gsize secret_len, const gchar * expected_issuer,
     const gchar * expected_audience, gint64 now, GBytes ** out_payload_json);

--- a/wyrelog/auth/jwt.c
+++ b/wyrelog/auth/jwt.c
@@ -437,10 +437,7 @@ skip_json_ws (const gchar **cursor)
 
 typedef struct
 {
-  gchar *issuer;
-  gchar *audience;
-  gint64 not_before;
-  gint64 expires_at;
+  wyl_jwt_access_claims_t claims;
   guint seen_mask;
 } ParsedJwtClaims;
 
@@ -462,8 +459,20 @@ enum
 static void
 parsed_jwt_claims_clear (ParsedJwtClaims *claims)
 {
+  wyl_jwt_access_claims_clear (&claims->claims);
+  memset (claims, 0, sizeof *claims);
+}
+
+void
+wyl_jwt_access_claims_clear (wyl_jwt_access_claims_t *claims)
+{
+  if (claims == NULL)
+    return;
+  g_free (claims->subject);
   g_free (claims->issuer);
   g_free (claims->audience);
+  g_free (claims->principal_state_at_issue);
+  g_free (claims->session_id);
   memset (claims, 0, sizeof *claims);
 }
 
@@ -530,24 +539,31 @@ parse_jwt_payload_claims (const gchar *payload, ParsedJwtClaims *claims)
     if (g_strcmp0 (key, "jti") == 0)
       rc = parse_string_claim_value (&p, claims, CLAIM_JTI, NULL);
     else if (g_strcmp0 (key, "sub") == 0)
-      rc = parse_string_claim_value (&p, claims, CLAIM_SUB, NULL);
+      rc = parse_string_claim_value (&p, claims, CLAIM_SUB,
+          &claims->claims.subject);
     else if (g_strcmp0 (key, "iss") == 0)
-      rc = parse_string_claim_value (&p, claims, CLAIM_ISS, &claims->issuer);
+      rc = parse_string_claim_value (&p, claims, CLAIM_ISS,
+          &claims->claims.issuer);
     else if (g_strcmp0 (key, "aud") == 0)
-      rc = parse_string_claim_value (&p, claims, CLAIM_AUD, &claims->audience);
+      rc = parse_string_claim_value (&p, claims, CLAIM_AUD,
+          &claims->claims.audience);
     else if (g_strcmp0 (key, "iat") == 0) {
       gint64 ignored = 0;
       rc = parse_int_claim_value (&p, claims, CLAIM_IAT, &ignored);
     } else if (g_strcmp0 (key, "nbf") == 0)
-      rc = parse_int_claim_value (&p, claims, CLAIM_NBF, &claims->not_before);
+      rc = parse_int_claim_value (&p, claims, CLAIM_NBF,
+          &claims->claims.not_before);
     else if (g_strcmp0 (key, "exp") == 0)
-      rc = parse_int_claim_value (&p, claims, CLAIM_EXP, &claims->expires_at);
+      rc = parse_int_claim_value (&p, claims, CLAIM_EXP,
+          &claims->claims.expires_at);
     else if (g_strcmp0 (key, "tenant") == 0)
       rc = parse_string_claim_value (&p, claims, CLAIM_TENANT, NULL);
     else if (g_strcmp0 (key, "principal_state_at_issue") == 0)
-      rc = parse_string_claim_value (&p, claims, CLAIM_PRINCIPAL_STATE, NULL);
+      rc = parse_string_claim_value (&p, claims, CLAIM_PRINCIPAL_STATE,
+          &claims->claims.principal_state_at_issue);
     else if (g_strcmp0 (key, "session_id") == 0)
-      rc = parse_string_claim_value (&p, claims, CLAIM_SESSION_ID, NULL);
+      rc = parse_string_claim_value (&p, claims, CLAIM_SESSION_ID,
+          &claims->claims.session_id);
     else
       return WYRELOG_E_POLICY;
     if (rc != WYRELOG_E_OK)
@@ -573,6 +589,31 @@ parse_jwt_payload_claims (const gchar *payload, ParsedJwtClaims *claims)
 }
 
 wyrelog_error_t
+wyl_jwt_parse_access_claims_json (GBytes *payload_json,
+    wyl_jwt_access_claims_t *out_claims)
+{
+  if (payload_json == NULL || out_claims == NULL)
+    return WYRELOG_E_INVALID;
+  memset (out_claims, 0, sizeof *out_claims);
+
+  gsize payload_len = 0;
+  const gchar *payload_data = g_bytes_get_data (payload_json, &payload_len);
+  if (memchr (payload_data, '\0', payload_len) != NULL)
+    return WYRELOG_E_POLICY;
+  g_autofree gchar *payload_text = g_strndup (payload_data, payload_len);
+  ParsedJwtClaims claims = { 0 };
+  wyrelog_error_t rc = parse_jwt_payload_claims (payload_text, &claims);
+  if (rc != WYRELOG_E_OK) {
+    parsed_jwt_claims_clear (&claims);
+    return rc;
+  }
+
+  *out_claims = claims.claims;
+  memset (&claims, 0, sizeof claims);
+  return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
 wyl_jwt_verify_hs256_access_token (const gchar *token, const guint8 *secret,
     gsize secret_len, const gchar *expected_issuer,
     const gchar *expected_audience, gint64 now, GBytes **out_payload_json)
@@ -588,21 +629,14 @@ wyl_jwt_verify_hs256_access_token (const gchar *token, const guint8 *secret,
   if (rc != WYRELOG_E_OK)
     return rc;
 
-  gsize payload_len = 0;
-  const gchar *payload_data = g_bytes_get_data (payload, &payload_len);
-  if (memchr (payload_data, '\0', payload_len) != NULL)
-    return WYRELOG_E_POLICY;
-  g_autofree gchar *payload_text = g_strndup (payload_data, payload_len);
-  ParsedJwtClaims claims = { 0 };
-  rc = parse_jwt_payload_claims (payload_text, &claims);
-  if (rc != WYRELOG_E_OK) {
-    parsed_jwt_claims_clear (&claims);
+  wyl_jwt_access_claims_t claims = { 0 };
+  rc = wyl_jwt_parse_access_claims_json (payload, &claims);
+  if (rc != WYRELOG_E_OK)
     return rc;
-  }
   gboolean claims_valid = g_strcmp0 (claims.issuer, expected_issuer) == 0
       && g_strcmp0 (claims.audience, expected_audience) == 0
       && now >= claims.not_before && now < claims.expires_at;
-  parsed_jwt_claims_clear (&claims);
+  wyl_jwt_access_claims_clear (&claims);
   if (!claims_valid)
     return WYRELOG_E_POLICY;
 

--- a/wyrelog/client.h
+++ b/wyrelog/client.h
@@ -66,9 +66,9 @@ wyrelog_error_t wyl_client_decide_with_guard_context (WylClient * client,
 wyrelog_error_t wyl_client_audit_query (WylClient * client,
     const gchar * query_filter, WylAuditIter ** out_iter);
 /*
- * Builds an audit query that carries the current login session token and a
- * request guard context. Daemons may require this form for guarded audit read
- * authorization.
+ * Builds an audit query that carries the current guarded credential and a
+ * request guard context. The client prefers bearer access-token auth when
+ * available and falls back to the current login session token.
  */
 wyrelog_error_t wyl_client_audit_query_with_guard_context (WylClient * client,
     const gchar * query_filter,

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -266,6 +266,72 @@ issue_login_access_token (WylDaemonHttpContext *ctx, const gchar *session_token,
   return rc;
 }
 
+static const gchar *
+lookup_bearer_token (SoupServerMessage *msg)
+{
+  SoupMessageHeaders *headers = soup_server_message_get_request_headers (msg);
+  const gchar *authorization = soup_message_headers_get_one (headers,
+      "Authorization");
+  if (authorization == NULL)
+    return NULL;
+  if (!g_str_has_prefix (authorization, "Bearer "))
+    return "";
+  const gchar *token = authorization + strlen ("Bearer ");
+  if (token[0] == '\0')
+    return "";
+  return token;
+}
+
+static wyrelog_error_t
+resolve_bearer_session (SoupServer *server, WylDaemonHttpContext *ctx,
+    const gchar *token, gchar **out_session_id, gchar **out_actor)
+{
+  if (ctx == NULL || token == NULL || out_session_id == NULL ||
+      out_actor == NULL)
+    return WYRELOG_E_INVALID;
+  *out_session_id = NULL;
+  *out_actor = NULL;
+
+  guint8 secret[WYL_DAEMON_JWT_KEY_LEN];
+  wyrelog_error_t rc = copy_access_token_secret (ctx, secret);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  g_autoptr (GBytes) payload = NULL;
+  gint64 now = g_get_real_time () / G_USEC_PER_SEC;
+  rc = wyl_jwt_verify_hs256_access_token (token, secret, sizeof secret,
+      WYL_DAEMON_JWT_ISSUER, WYL_DAEMON_JWT_AUDIENCE, now, &payload);
+  sodium_memzero (secret, sizeof secret);
+  if (rc != WYRELOG_E_OK)
+    return WYRELOG_E_POLICY;
+
+  wyl_jwt_access_claims_t claims = { 0 };
+  rc = wyl_jwt_parse_access_claims_json (payload, &claims);
+  if (rc != WYRELOG_E_OK)
+    return WYRELOG_E_POLICY;
+  if (g_strcmp0 (claims.principal_state_at_issue, "authenticated") != 0) {
+    wyl_jwt_access_claims_clear (&claims);
+    return WYRELOG_E_POLICY;
+  }
+
+  g_autoptr (WylSession) session =
+      wyl_daemon_http_ref_session (server, claims.session_id);
+  if (session == NULL) {
+    wyl_jwt_access_claims_clear (&claims);
+    return WYRELOG_E_POLICY;
+  }
+  g_autofree gchar *live_username = wyl_session_dup_username (session);
+  if (g_strcmp0 (live_username, claims.subject) != 0) {
+    wyl_jwt_access_claims_clear (&claims);
+    return WYRELOG_E_POLICY;
+  }
+
+  *out_session_id = g_steal_pointer (&claims.session_id);
+  *out_actor = g_steal_pointer (&claims.subject);
+  wyl_jwt_access_claims_clear (&claims);
+  return WYRELOG_E_OK;
+}
+
 static void
 set_json_error (SoupServerMessage *msg, guint status, const gchar *code)
 {
@@ -325,7 +391,19 @@ authorize_guarded_session_action (SoupServer *server, SoupServerMessage *msg,
     guard_loc_class = g_hash_table_lookup (query, "guard_loc_class");
     guard_risk = g_hash_table_lookup (query, "guard_risk");
   }
-  if (session_token == NULL || session_token[0] == '\0') {
+  const gchar *bearer_token = lookup_bearer_token (msg);
+  gboolean has_session_token = session_token != NULL
+      && session_token[0] != '\0';
+  gboolean has_bearer_token = bearer_token != NULL && bearer_token[0] != '\0';
+  if (!has_session_token && !has_bearer_token) {
+    set_json_error (msg, 401, auth_required_code);
+    return FALSE;
+  }
+  if (has_session_token && bearer_token != NULL) {
+    set_json_error (msg, 400, invalid_code);
+    return FALSE;
+  }
+  if (bearer_token != NULL && !has_bearer_token) {
     set_json_error (msg, 401, auth_required_code);
     return FALSE;
   }
@@ -344,17 +422,28 @@ authorize_guarded_session_action (SoupServer *server, SoupServerMessage *msg,
     return FALSE;
   }
 
-  g_autoptr (WylSession) session =
-      wyl_daemon_http_ref_session (server, session_token);
-  if (session == NULL) {
-    set_json_error (msg, 401, auth_required_code);
-    return FALSE;
-  }
-
-  g_autofree gchar *username = wyl_session_dup_username (session);
-  if (username == NULL || username[0] == '\0') {
-    set_json_error (msg, 401, auth_required_code);
-    return FALSE;
+  g_autofree gchar *auth_session_id = NULL;
+  g_autofree gchar *username = NULL;
+  if (has_session_token) {
+    g_autoptr (WylSession) session =
+        wyl_daemon_http_ref_session (server, session_token);
+    if (session == NULL) {
+      set_json_error (msg, 401, auth_required_code);
+      return FALSE;
+    }
+    username = wyl_session_dup_username (session);
+    auth_session_id = g_strdup (session_token);
+    if (username == NULL || username[0] == '\0') {
+      set_json_error (msg, 401, auth_required_code);
+      return FALSE;
+    }
+  } else {
+    wyrelog_error_t auth_rc = resolve_bearer_session (server, ctx,
+        bearer_token, &auth_session_id, &username);
+    if (auth_rc != WYRELOG_E_OK) {
+      set_json_error (msg, 401, auth_required_code);
+      return FALSE;
+    }
   }
 
   g_autoptr (wyl_decide_req_t) req = wyl_decide_req_new ();
@@ -362,7 +451,7 @@ authorize_guarded_session_action (SoupServer *server, SoupServerMessage *msg,
   wyl_decide_req_set_subject_id (req, username);
   wyl_decide_req_set_action (req, action);
   wyl_decide_req_set_resource_id (req,
-      resource != NULL ? resource : session_token);
+      resource != NULL ? resource : auth_session_id);
   wyl_decide_req_set_guard_context (req, timestamp, guard_loc_class, risk);
 
   wyrelog_error_t rc = wyl_decide (ctx->handle, req, resp);

--- a/wyrelog/wyl-client.c
+++ b/wyrelog/wyl-client.c
@@ -264,6 +264,8 @@ client_policy_mutation_request (WylClient *client, const gchar *path,
   g_autofree gchar *session_token = wyl_client_dup_session_token (client);
   if (session_token == NULL || session_token[0] == '\0')
     return WYRELOG_E_INVALID;
+  g_autofree gchar *access_token = wyl_client_dup_access_token (client);
+  gboolean use_access_token = access_token != NULL && access_token[0] != '\0';
 
   g_autofree gchar *base_url = wyl_client_dup_base_url (client);
   if (base_url == NULL)
@@ -275,21 +277,35 @@ client_policy_mutation_request (WylClient *client, const gchar *path,
   g_autofree gchar *escaped_target =
       g_uri_escape_string (target_value, NULL, TRUE);
   g_autofree gchar *escaped_scope = g_uri_escape_string (scope, NULL, TRUE);
-  g_autofree gchar *escaped_session =
-      g_uri_escape_string (session_token, NULL, TRUE);
   g_autofree gchar *escaped_loc =
       g_uri_escape_string (guard_loc_class, NULL, TRUE);
-  g_autofree gchar *uri =
-      g_strdup_printf ("%s/%s?subject=%s&%s=%s&scope=%s&session_token=%s"
-      "&guard_timestamp=%" G_GINT64_FORMAT
-      "&guard_loc_class=%s&guard_risk=%" G_GINT64_FORMAT,
-      base_url, path, escaped_subject, target_name, escaped_target,
-      escaped_scope, escaped_session, guard_timestamp, escaped_loc,
-      guard_risk);
+  g_autofree gchar *uri = NULL;
+  if (use_access_token) {
+    uri = g_strdup_printf ("%s/%s?subject=%s&%s=%s&scope=%s"
+        "&guard_timestamp=%" G_GINT64_FORMAT
+        "&guard_loc_class=%s&guard_risk=%" G_GINT64_FORMAT,
+        base_url, path, escaped_subject, target_name, escaped_target,
+        escaped_scope, guard_timestamp, escaped_loc, guard_risk);
+  } else {
+    g_autofree gchar *escaped_session =
+        g_uri_escape_string (session_token, NULL, TRUE);
+    uri = g_strdup_printf ("%s/%s?subject=%s&%s=%s&scope=%s&session_token=%s"
+        "&guard_timestamp=%" G_GINT64_FORMAT
+        "&guard_loc_class=%s&guard_risk=%" G_GINT64_FORMAT,
+        base_url, path, escaped_subject, target_name, escaped_target,
+        escaped_scope, escaped_session, guard_timestamp, escaped_loc,
+        guard_risk);
+  }
 
   g_autoptr (SoupMessage) message = soup_message_new ("POST", uri);
   if (message == NULL)
     return WYRELOG_E_INVALID;
+  if (use_access_token) {
+    g_autofree gchar *authorization = g_strdup_printf ("Bearer %s",
+        access_token);
+    soup_message_headers_replace (soup_message_get_request_headers (message),
+        "Authorization", authorization);
+  }
 
   g_autoptr (GError) error = NULL;
   g_autoptr (GBytes) body =


### PR DESCRIPTION
## Summary

- accept verified bearer access tokens for guarded daemon authorization
- bind bearer claims to the live daemon session before LoBAC decisions
- prefer bearer credentials in guarded client audit and policy requests
- keep session-token fallback and existing decide request behavior

## Tests

- meson test -C builddir jwt daemon-http-decide client-smoke --print-errorlogs
- meson test -C builddir-audit jwt daemon-http-decide client-smoke --print-errorlogs
- git diff --check
