### PR TITLE
Add daemon logout invalidation

### DIFF
--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -452,6 +452,99 @@ sign_test_access_token (SoupServer *server, const gchar *session_id,
 #endif
 
 static gint
+send_raw_logout (SoupSession *session, const gchar *method,
+    const gchar *base_url, const gchar *query, guint *out_status,
+    gchar **out_body)
+{
+  if (out_status == NULL || out_body == NULL)
+    return 484;
+  *out_status = 0;
+  *out_body = NULL;
+
+  g_autofree gchar *root = g_strdup (base_url);
+  while (root[0] != '\0' && g_str_has_suffix (root, "/"))
+    root[strlen (root) - 1] = '\0';
+
+  g_autofree gchar *uri = query != NULL ?
+      g_strdup_printf ("%s/auth/logout?%s", root, query) :
+      g_strdup_printf ("%s/auth/logout", root);
+  g_autoptr (SoupMessage) msg = soup_message_new (method, uri);
+  if (msg == NULL)
+    return 485;
+
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GBytes) bytes = soup_session_send_and_read (session, msg, NULL,
+      &error);
+  if (bytes == NULL)
+    return 486;
+  gsize size = 0;
+  const gchar *data = g_bytes_get_data (bytes, &size);
+  *out_status = soup_message_get_status (msg);
+  *out_body = g_strndup (data, size);
+  return 0;
+}
+
+static gint
+send_raw_logout_authorization (SoupSession *session, const gchar *method,
+    const gchar *base_url, const gchar *query, const gchar *authorization,
+    guint *out_status, gchar **out_body)
+{
+  if (out_status == NULL || out_body == NULL)
+    return 484;
+  *out_status = 0;
+  *out_body = NULL;
+
+  g_autofree gchar *root = g_strdup (base_url);
+  while (root[0] != '\0' && g_str_has_suffix (root, "/"))
+    root[strlen (root) - 1] = '\0';
+
+  g_autofree gchar *uri = query != NULL ?
+      g_strdup_printf ("%s/auth/logout?%s", root, query) :
+      g_strdup_printf ("%s/auth/logout", root);
+  g_autoptr (SoupMessage) msg = soup_message_new (method, uri);
+  if (msg == NULL)
+    return 485;
+  soup_message_headers_replace (soup_message_get_request_headers (msg),
+      "Authorization", authorization);
+
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GBytes) bytes = soup_session_send_and_read (session, msg, NULL,
+      &error);
+  if (bytes == NULL)
+    return 486;
+  gsize size = 0;
+  const gchar *data = g_bytes_get_data (bytes, &size);
+  *out_status = soup_message_get_status (msg);
+  *out_body = g_strndup (data, size);
+  return 0;
+}
+
+static gint send_raw_policy_mutation (SoupSession * session,
+    const gchar * method, const gchar * base_url, const gchar * path,
+    const gchar * query, guint * out_status, gchar ** out_body);
+static wyrelog_error_t grant_policy_write_authority (WylHandle * handle,
+    const gchar * subject, const gchar * scope);
+
+typedef struct
+{
+  const gchar *session_id;
+  const gchar *state;
+  guint matches;
+} SessionStateExpect;
+
+static wyrelog_error_t
+session_state_expect_cb (const gchar *session_id, const gchar *state,
+    gpointer user_data)
+{
+  SessionStateExpect *expect = user_data;
+
+  if (g_strcmp0 (session_id, expect->session_id) == 0 &&
+      g_strcmp0 (state, expect->state) == 0)
+    expect->matches++;
+  return WYRELOG_E_OK;
+}
+
+static gint
 check_raw_login_contract (SoupServer *server, WylHandle *handle,
     const gchar *base_url)
 {
@@ -597,6 +690,96 @@ check_raw_login_contract (SoupServer *server, WylHandle *handle,
       wyl_daemon_http_ref_session (server, "unknown-session");
   if (unknown_session != NULL)
     return 480;
+
+  rc = send_raw_logout (session, "GET", base_url, NULL, &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 405 || strstr (body, "\"method_not_allowed\"") == NULL)
+    return 487;
+  g_clear_pointer (&body, g_free);
+
+  rc = send_raw_logout (session, "POST", base_url, NULL, &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 401 || strstr (body, "\"logout_auth_required\"") == NULL)
+    return 488;
+  g_clear_pointer (&body, g_free);
+
+  rc = send_raw_logout (session, "POST", base_url, "session_token=unknown",
+      &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 401 || strstr (body, "\"logout_auth_required\"") == NULL)
+    return 489;
+  g_clear_pointer (&body, g_free);
+
+  rc = send_raw_login (session, "POST", base_url, "username=logout-user",
+      &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 200)
+    return 490;
+  g_autofree gchar *logout_session_token =
+      extract_json_string (body, "session_token");
+  if (logout_session_token == NULL)
+    return 491;
+  g_clear_pointer (&body, g_free);
+  if (grant_policy_write_authority (handle, "logout-user",
+          logout_session_token) != WYRELOG_E_OK)
+    return 492;
+  if (wyl_policy_store_upsert_permission (wyl_handle_get_policy_store (handle),
+          "site.policy.read", "site policy read", "basic") != WYRELOG_E_OK)
+    return 493;
+
+  g_autofree gchar *logout_query = g_strdup_printf ("session_token=%s",
+      logout_session_token);
+  rc = send_raw_logout_authorization (session, "POST", base_url, logout_query,
+      "Bearer ignored", &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 400 || strstr (body, "\"invalid_logout_auth\"") == NULL)
+    return 494;
+  g_clear_pointer (&body, g_free);
+
+  rc = send_raw_logout (session, "POST", base_url, logout_query, &status,
+      &body);
+  if (rc != 0)
+    return rc;
+  if (status != 200 || strstr (body, "\"ok\":true") == NULL)
+    return 495;
+  g_autoptr (WylSession) logged_out_session =
+      wyl_daemon_http_ref_session (server, logout_session_token);
+  if (logged_out_session != NULL)
+    return 496;
+  SessionStateExpect closed_expect = {
+    .session_id = logout_session_token,
+    .state = "closed",
+  };
+  if (wyl_policy_store_foreach_session_state (wyl_handle_get_policy_store
+          (handle), session_state_expect_cb, &closed_expect) != WYRELOG_E_OK)
+    return 497;
+  if (closed_expect.matches != 1)
+    return 498;
+  g_clear_pointer (&body, g_free);
+
+  g_autofree gchar *guarded_query = g_strdup_printf ("session_token=%s"
+      "&subject=after-logout&perm=site.policy.read&scope=after-logout"
+      "&guard_timestamp=123&guard_loc_class=public&guard_risk=69",
+      logout_session_token);
+  rc = send_raw_policy_mutation (session, "POST", base_url,
+      "/policy/permissions/grant", guarded_query, &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 401 || strstr (body, "\"policy_auth_required\"") == NULL)
+    return 499;
+  g_clear_pointer (&body, g_free);
+
+  rc = send_raw_logout (session, "POST", base_url, logout_query, &status,
+      &body);
+  if (rc != 0)
+    return rc;
+  if (status != 401 || strstr (body, "\"logout_auth_required\"") == NULL)
+    return 500;
 
   return 0;
 }

--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -583,6 +583,14 @@ check_raw_login_contract (SoupServer *server, WylHandle *handle,
   g_autofree gchar *stored_username = wyl_session_dup_username (stored_session);
   if (g_strcmp0 (stored_username, "login-user") != 0)
     return 479;
+  if (wyl_daemon_http_remove_session_for_test (server, "unknown-session"))
+    return 481;
+  if (!wyl_daemon_http_remove_session_for_test (server, session_token))
+    return 482;
+  g_autoptr (WylSession) removed_session =
+      wyl_daemon_http_ref_session (server, session_token);
+  if (removed_session != NULL)
+    return 483;
   g_clear_pointer (&body, g_free);
 
   g_autoptr (WylSession) unknown_session =

--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -522,6 +522,10 @@ send_raw_logout_authorization (SoupSession *session, const gchar *method,
 static gint send_raw_policy_mutation (SoupSession * session,
     const gchar * method, const gchar * base_url, const gchar * path,
     const gchar * query, guint * out_status, gchar ** out_body);
+static gint send_raw_policy_mutation_bearer (SoupSession * session,
+    const gchar * method, const gchar * base_url, const gchar * path,
+    const gchar * query, const gchar * access_token, guint * out_status,
+    gchar ** out_body);
 static wyrelog_error_t grant_policy_write_authority (WylHandle * handle,
     const gchar * subject, const gchar * scope);
 
@@ -780,6 +784,96 @@ check_raw_login_contract (SoupServer *server, WylHandle *handle,
     return rc;
   if (status != 401 || strstr (body, "\"logout_auth_required\"") == NULL)
     return 500;
+  g_clear_pointer (&body, g_free);
+
+  rc = send_raw_logout_authorization (session, "POST", base_url, NULL,
+      "Bearer malformed.jwt", &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 401 || strstr (body, "\"logout_auth_required\"") == NULL)
+    return 501;
+  g_clear_pointer (&body, g_free);
+
+  wyl_handle_set_login_skip_mfa_allowed (handle, TRUE);
+  rc = send_raw_login (session, "POST", base_url,
+      "username=bearer-logout-user&skip_mfa=true", &status, &body);
+  wyl_handle_set_login_skip_mfa_allowed (handle, FALSE);
+  if (rc != 0)
+    return rc;
+  if (status != 200)
+    return 502;
+  g_autofree gchar *bearer_logout_session_token =
+      extract_json_string (body, "session_token");
+  if (bearer_logout_session_token == NULL)
+    return 503;
+  g_autofree gchar *bearer_logout_access_token =
+      extract_json_string (body, "access_token");
+  if (bearer_logout_access_token == NULL)
+    return 504;
+  g_clear_pointer (&body, g_free);
+  if (grant_policy_write_authority (handle, "bearer-logout-user",
+          bearer_logout_session_token) != WYRELOG_E_OK)
+    return 505;
+
+  rc = send_raw_logout_authorization (session, "POST", base_url, NULL,
+      "Bearer", &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 401 || strstr (body, "\"logout_auth_required\"") == NULL)
+    return 506;
+  g_clear_pointer (&body, g_free);
+
+  g_autofree gchar *bearer_logout_query = g_strdup_printf ("session_token=%s",
+      bearer_logout_session_token);
+  g_autofree gchar *bearer_authorization = g_strdup_printf ("Bearer %s",
+      bearer_logout_access_token);
+  rc = send_raw_logout_authorization (session, "POST", base_url,
+      bearer_logout_query, bearer_authorization, &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 400 || strstr (body, "\"invalid_logout_auth\"") == NULL)
+    return 507;
+  g_clear_pointer (&body, g_free);
+
+  rc = send_raw_logout_authorization (session, "POST", base_url, NULL,
+      bearer_authorization, &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 200 || strstr (body, "\"ok\":true") == NULL)
+    return 508;
+  g_autoptr (WylSession) bearer_logged_out_session =
+      wyl_daemon_http_ref_session (server, bearer_logout_session_token);
+  if (bearer_logged_out_session != NULL)
+    return 509;
+  g_clear_pointer (&body, g_free);
+
+  g_autofree gchar *bearer_guarded_query =
+      g_strdup_printf ("subject=after-bearer-logout&perm=site.policy.read"
+      "&scope=after-bearer-logout&guard_timestamp=123"
+      "&guard_loc_class=public&guard_risk=69");
+  rc = send_raw_policy_mutation_bearer (session, "POST", base_url,
+      "/policy/permissions/grant", bearer_guarded_query,
+      bearer_logout_access_token, &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 401 || strstr (body, "\"policy_auth_required\"") == NULL)
+    return 510;
+  g_clear_pointer (&body, g_free);
+
+  rc = send_raw_logout_authorization (session, "POST", base_url, NULL,
+      bearer_authorization, &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 401 || strstr (body, "\"logout_auth_required\"") == NULL)
+    return 511;
+  g_clear_pointer (&body, g_free);
+
+  rc = send_raw_logout (session, "POST", base_url, bearer_logout_query,
+      &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 401 || strstr (body, "\"logout_auth_required\"") == NULL)
+    return 512;
 
   return 0;
 }

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -856,6 +856,55 @@ login_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
 }
 
 static void
+logout_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
+    GHashTable *query, gpointer user_data)
+{
+  (void) path;
+
+  if (g_strcmp0 (soup_server_message_get_method (msg), "POST") != 0) {
+    set_json_error (msg, 405, "method_not_allowed");
+    return;
+  }
+
+  if (lookup_bearer_token (msg) != NULL) {
+    set_json_error (msg, 400, "invalid_logout_auth");
+    return;
+  }
+
+  const gchar *session_token = NULL;
+  if (query != NULL)
+    session_token = g_hash_table_lookup (query, "session_token");
+  if (session_token == NULL || session_token[0] == '\0') {
+    set_json_error (msg, 401, "logout_auth_required");
+    return;
+  }
+
+  g_autoptr (WylSession) session =
+      wyl_daemon_http_ref_session (server, session_token);
+  if (session == NULL) {
+    set_json_error (msg, 401, "logout_auth_required");
+    return;
+  }
+
+  WylDaemonHttpContext *ctx = user_data;
+  wyrelog_error_t rc = wyl_session_close (ctx->handle, session);
+  if (rc != WYRELOG_E_OK) {
+    set_json_error (msg, 500, "logout_failed");
+    return;
+  }
+
+  if (!wyl_daemon_http_context_remove_session (ctx, session_token)) {
+    set_json_error (msg, 401, "logout_auth_required");
+    return;
+  }
+
+  const gchar *body = "{\"ok\":true}";
+  soup_server_message_set_status (msg, 200, NULL);
+  soup_server_message_set_response (msg, "application/json",
+      SOUP_MEMORY_COPY, body, strlen (body));
+}
+
+static void
 decide_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
     GHashTable *query, gpointer user_data)
 {
@@ -949,6 +998,7 @@ wyl_daemon_start_http_server (const WylDaemonOptions *opts, WylHandle *handle,
       wyl_daemon_http_context_free);
   soup_server_add_handler (server, "/healthz", healthz_handler, NULL, NULL);
   soup_server_add_handler (server, "/auth/login", login_handler, ctx, NULL);
+  soup_server_add_handler (server, "/auth/logout", logout_handler, ctx, NULL);
   soup_server_add_handler (server, "/decide", decide_handler, ctx, NULL);
   soup_server_add_handler (server, "/policy/permissions/grant",
       policy_permission_grant_handler, ctx, NULL);

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -866,17 +866,37 @@ logout_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
     return;
   }
 
-  if (lookup_bearer_token (msg) != NULL) {
-    set_json_error (msg, 400, "invalid_logout_auth");
-    return;
-  }
-
   const gchar *session_token = NULL;
   if (query != NULL)
     session_token = g_hash_table_lookup (query, "session_token");
-  if (session_token == NULL || session_token[0] == '\0') {
+  gboolean has_session_token = session_token != NULL
+      && session_token[0] != '\0';
+  const gchar *bearer_token = lookup_bearer_token (msg);
+  gboolean has_bearer_token = bearer_token != NULL && bearer_token[0] != '\0';
+  if (!has_session_token && !has_bearer_token) {
     set_json_error (msg, 401, "logout_auth_required");
     return;
+  }
+  if (has_session_token && bearer_token != NULL) {
+    set_json_error (msg, 400, "invalid_logout_auth");
+    return;
+  }
+  if (bearer_token != NULL && !has_bearer_token) {
+    set_json_error (msg, 401, "logout_auth_required");
+    return;
+  }
+
+  WylDaemonHttpContext *ctx = user_data;
+  g_autofree gchar *bearer_session_token = NULL;
+  g_autofree gchar *bearer_actor = NULL;
+  if (has_bearer_token) {
+    wyrelog_error_t auth_rc = resolve_bearer_session (server, ctx,
+        bearer_token, &bearer_session_token, &bearer_actor);
+    if (auth_rc != WYRELOG_E_OK) {
+      set_json_error (msg, 401, "logout_auth_required");
+      return;
+    }
+    session_token = bearer_session_token;
   }
 
   g_autoptr (WylSession) session =
@@ -886,7 +906,6 @@ logout_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
     return;
   }
 
-  WylDaemonHttpContext *ctx = user_data;
   wyrelog_error_t rc = wyl_session_close (ctx->handle, session);
   if (rc != WYRELOG_E_OK) {
     set_json_error (msg, 500, "logout_failed");

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -91,6 +91,20 @@ wyl_daemon_http_context_store_session (WylDaemonHttpContext *ctx,
   return TRUE;
 }
 
+static gboolean
+wyl_daemon_http_context_remove_session (WylDaemonHttpContext *ctx,
+    const gchar *session_token)
+{
+  if (ctx == NULL || session_token == NULL || session_token[0] == '\0')
+    return FALSE;
+
+  g_mutex_lock (&ctx->lock);
+  gboolean removed = g_hash_table_remove (ctx->sessions_by_token,
+      session_token);
+  g_mutex_unlock (&ctx->lock);
+  return removed;
+}
+
 static WylDaemonHttpContext *
 wyl_daemon_http_get_context (SoupServer *server)
 {
@@ -117,6 +131,16 @@ wyl_daemon_http_ref_session (SoupServer *server, const gchar *session_token)
   g_mutex_unlock (&ctx->lock);
   return session;
 }
+
+#ifdef WYL_TEST_DAEMON_HTTP
+gboolean
+wyl_daemon_http_remove_session_for_test (SoupServer *server,
+    const gchar *session_token)
+{
+  WylDaemonHttpContext *ctx = wyl_daemon_http_get_context (server);
+  return wyl_daemon_http_context_remove_session (ctx, session_token);
+}
+#endif
 
 static void
 append_json_string (GString *json, const gchar *value)

--- a/wyrelog/daemon/http.h
+++ b/wyrelog/daemon/http.h
@@ -16,5 +16,7 @@ WylSession *wyl_daemon_http_ref_session (SoupServer * server,
 #ifdef WYL_TEST_DAEMON_HTTP
 wyrelog_error_t wyl_daemon_http_copy_access_token_secret (SoupServer * server,
     guint8 * out_secret, gsize out_len);
+gboolean wyl_daemon_http_remove_session_for_test (SoupServer * server,
+    const gchar * session_token);
 #endif
 #endif

--- a/wyrelog/daemon/runtime.c
+++ b/wyrelog/daemon/runtime.c
@@ -36,6 +36,16 @@ open_readiness_handle (const WylDaemonOptions *opts, WylHandle **out_handle)
   return wyl_handle_open_with_options (&open_opts, out_handle);
 }
 
+static gboolean
+quit_loop_on_early_signal (gpointer user_data)
+{
+  if (!wyl_daemon_early_signal_received ())
+    return G_SOURCE_CONTINUE;
+
+  g_main_loop_quit (user_data);
+  return G_SOURCE_CONTINUE;
+}
+
 int
 wyl_daemon_run_runtime (const WylDaemonOptions *opts)
 {
@@ -108,6 +118,8 @@ wyl_daemon_run_runtime (const WylDaemonOptions *opts)
   guint sigint_id = 0;
   guint sigterm_id = 0;
   wyl_daemon_install_signal_handlers (loop, &sigint_id, &sigterm_id);
+  guint early_signal_poll_id =
+      g_timeout_add (100, quit_loop_on_early_signal, loop);
   /* If SIGTERM/SIGINT arrived during readiness or post-readiness setup,
    * the early handler captured it but the GMainLoop's signal source did
    * not. Quit the loop preemptively so we exit cleanly without serving
@@ -118,6 +130,7 @@ wyl_daemon_run_runtime (const WylDaemonOptions *opts)
 #ifdef WYL_HAS_DAEMON_HTTP
   soup_server_disconnect (server);
 #endif
+  wyl_daemon_remove_signal_handler (&early_signal_poll_id);
   wyl_daemon_remove_signal_handler (&sigterm_id);
   wyl_daemon_remove_signal_handler (&sigint_id);
   return 0;


### PR DESCRIPTION
## Summary
- add a live daemon session invalidation primitive for the HTTP credential map
- add POST /auth/logout for session-token logout
- support private bearer access tokens as the alternate logout credential

## Verification
- meson test -C builddir daemon-http-decide --print-errorlogs
- meson test -C builddir-audit daemon-http-decide --print-errorlogs
- git diff --check
