### PR TITLE
Harden audit source of truth

### DIFF
--- a/tests/test-audit-emit.c
+++ b/tests/test-audit-emit.c
@@ -748,27 +748,22 @@ check_emit_replays_runtime_query_after_table_loss (void)
     g_object_unref (handle);
     return 435;
   }
-  if (wyl_audit_conn_create_schema (wyl_handle_get_audit_conn (handle))
-      != WYRELOG_E_OK) {
-    g_object_unref (handle);
-    return 436;
-  }
   if (wyl_handle_load_policy_store_audit_events (handle) != WYRELOG_E_OK) {
     g_object_unref (handle);
-    return 437;
+    return 436;
   }
 
   g_autofree gchar *json = NULL;
   if (wyl_audit_conn_query_events_json (wyl_handle_get_audit_conn (handle),
           "action(\"audit.runtime.replay\")", &json) != WYRELOG_E_OK) {
     g_object_unref (handle);
-    return 438;
+    return 437;
   }
   if (g_strstr_len (json, -1, id) == NULL ||
       g_strstr_len (json, -1, "\"subject_id\":\"runtime-replay-user\"")
       == NULL) {
     g_object_unref (handle);
-    return 439;
+    return 438;
   }
 
   g_object_unref (handle);

--- a/tests/test-audit-emit.c
+++ b/tests/test-audit-emit.c
@@ -1028,19 +1028,63 @@ check_decide_allows_when_runtime_audit_projection_fails (void)
     g_object_unref (handle);
     return 54;
   }
-  gint64 count = -1;
-  if (!policy_count_rows (wyl_handle_get_policy_store (handle),
-          "SELECT COUNT(*) FROM audit_events "
-          "WHERE subject_id = 'audit-allow-user' "
-          "AND action = 'wr.audit-allow' "
-          "AND resource_id = 'audit-allow-scope' "
-          "AND decision = 1;", &count)) {
+  static const gchar *audit_sql =
+      "SELECT id, created_at_us FROM audit_events "
+      "WHERE action = ? AND subject_id = ? "
+      "AND resource_id = ? AND decision = ?;";
+  sqlite3_stmt *stmt = NULL;
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (sqlite3_prepare_v2 (wyl_policy_store_get_db (store), audit_sql, -1,
+          &stmt, NULL) != SQLITE_OK) {
     g_object_unref (handle);
     return 55;
   }
-  if (count != 1) {
+  if (sqlite3_bind_text (stmt, 1, "wr.audit-allow", -1, SQLITE_TRANSIENT)
+      != SQLITE_OK
+      || sqlite3_bind_text (stmt, 2, "audit-allow-user", -1, SQLITE_TRANSIENT)
+      != SQLITE_OK
+      || sqlite3_bind_text (stmt, 3, "audit-allow-scope", -1,
+          SQLITE_TRANSIENT) != SQLITE_OK
+      || sqlite3_bind_int (stmt, 4, WYL_DECISION_ALLOW) != SQLITE_OK) {
+    sqlite3_finalize (stmt);
+    g_object_unref (handle);
+    return 304;
+  }
+  if (sqlite3_step (stmt) != SQLITE_ROW) {
+    sqlite3_finalize (stmt);
     g_object_unref (handle);
     return 56;
+  }
+  g_autofree gchar *id =
+      g_strdup ((const gchar *) sqlite3_column_text (stmt, 0));
+  gint64 created_at_us = sqlite3_column_int64 (stmt, 1);
+  if (sqlite3_step (stmt) != SQLITE_DONE) {
+    sqlite3_finalize (stmt);
+    g_object_unref (handle);
+    return 301;
+  }
+  sqlite3_finalize (stmt);
+
+  gboolean contains = FALSE;
+  if (contains_audit_event_fact (handle, id, created_at_us, "allow",
+          &contains) != WYRELOG_E_OK || !contains) {
+    g_object_unref (handle);
+    return 302;
+  }
+  if (contains_audit_event_attr_fact (handle, "audit_event_action", id,
+          "wr.audit-allow", &contains) != WYRELOG_E_OK || !contains) {
+    g_object_unref (handle);
+    return 303;
+  }
+  if (contains_audit_event_attr_fact (handle, "audit_event_subject", id,
+          "audit-allow-user", &contains) != WYRELOG_E_OK || !contains) {
+    g_object_unref (handle);
+    return 305;
+  }
+  if (contains_audit_event_attr_fact (handle, "audit_event_resource", id,
+          "audit-allow-scope", &contains) != WYRELOG_E_OK || !contains) {
+    g_object_unref (handle);
+    return 306;
   }
 
   g_object_unref (handle);

--- a/tests/test-audit-emit.c
+++ b/tests/test-audit-emit.c
@@ -714,6 +714,68 @@ check_policy_store_audit_replay_loads_runtime_query (void)
 }
 
 static gint
+check_emit_replays_runtime_query_after_table_loss (void)
+{
+  WylHandle *handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 432;
+
+  duckdb_connection conn =
+      wyl_audit_conn_get_connection (wyl_handle_get_audit_conn (handle));
+  duckdb_result result;
+  memset (&result, 0, sizeof (result));
+  if (duckdb_query (conn, "DROP TABLE audit_events;", &result)
+      != DuckDBSuccess) {
+    duckdb_destroy_result (&result);
+    g_object_unref (handle);
+    return 433;
+  }
+  duckdb_destroy_result (&result);
+
+  g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
+  wyl_audit_event_set_subject_id (ev, "runtime-replay-user");
+  wyl_audit_event_set_action (ev, "audit.runtime.replay");
+  wyl_audit_event_set_resource_id (ev, "runtime-replay-resource");
+  wyl_audit_event_set_decision (ev, WYL_DECISION_ALLOW);
+  g_autofree gchar *id = wyl_audit_event_dup_id_string (ev);
+  if (wyl_audit_emit (handle, ev) != WYRELOG_E_OK) {
+    g_object_unref (handle);
+    return 434;
+  }
+
+  gint64 count = -1;
+  if (!policy_count_audit_rows (handle, id, &count) || count != 1) {
+    g_object_unref (handle);
+    return 435;
+  }
+  if (wyl_audit_conn_create_schema (wyl_handle_get_audit_conn (handle))
+      != WYRELOG_E_OK) {
+    g_object_unref (handle);
+    return 436;
+  }
+  if (wyl_handle_load_policy_store_audit_events (handle) != WYRELOG_E_OK) {
+    g_object_unref (handle);
+    return 437;
+  }
+
+  g_autofree gchar *json = NULL;
+  if (wyl_audit_conn_query_events_json (wyl_handle_get_audit_conn (handle),
+          "action(\"audit.runtime.replay\")", &json) != WYRELOG_E_OK) {
+    g_object_unref (handle);
+    return 438;
+  }
+  if (g_strstr_len (json, -1, id) == NULL ||
+      g_strstr_len (json, -1, "\"subject_id\":\"runtime-replay-user\"")
+      == NULL) {
+    g_object_unref (handle);
+    return 439;
+  }
+
+  g_object_unref (handle);
+  return 0;
+}
+
+static gint
 check_audit_conn_insert_event_idempotence (void)
 {
   WylHandle *handle = NULL;
@@ -928,7 +990,7 @@ check_decide_persists_representative_deny_reason (void)
 }
 
 static gint
-check_decide_fail_closes_on_audit_append_failure (void)
+check_decide_allows_when_runtime_audit_projection_fails (void)
 {
   WylHandle *handle = NULL;
   if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
@@ -967,16 +1029,21 @@ check_decide_fail_closes_on_audit_append_failure (void)
     g_object_unref (handle);
     return 53;
   }
-  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_DENY) {
+  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_ALLOW) {
     g_object_unref (handle);
     return 54;
   }
-  if (g_strcmp0 (wyl_decide_resp_get_deny_reason (resp),
-          "audit_unavailable") != 0) {
+  gint64 count = -1;
+  if (!policy_count_rows (wyl_handle_get_policy_store (handle),
+          "SELECT COUNT(*) FROM audit_events "
+          "WHERE subject_id = 'audit-allow-user' "
+          "AND action = 'wr.audit-allow' "
+          "AND resource_id = 'audit-allow-scope' "
+          "AND decision = 1;", &count)) {
     g_object_unref (handle);
     return 55;
   }
-  if (g_strcmp0 (wyl_decide_resp_get_deny_origin (resp), "audit_events") != 0) {
+  if (count != 1) {
     g_object_unref (handle);
     return 56;
   }
@@ -2592,6 +2659,8 @@ main (void)
     return rc;
   if ((rc = check_policy_store_audit_replay_loads_runtime_query ()) != 0)
     return rc;
+  if ((rc = check_emit_replays_runtime_query_after_table_loss ()) != 0)
+    return rc;
   if ((rc = check_audit_conn_insert_event_idempotence ()) != 0)
     return rc;
   if ((rc = check_duplicate_emit_keeps_runtime_row ()) != 0)
@@ -2610,7 +2679,7 @@ main (void)
     return rc;
   if ((rc = check_decide_persists_representative_deny_reason ()) != 0)
     return rc;
-  if ((rc = check_decide_fail_closes_on_audit_append_failure ()) != 0)
+  if ((rc = check_decide_allows_when_runtime_audit_projection_fails ()) != 0)
     return rc;
   if ((rc = check_permission_grant_rolls_back_on_store_audit_failure ()) != 0)
     return rc;

--- a/tests/test-daemon-delta.c
+++ b/tests/test-daemon-delta.c
@@ -6,6 +6,7 @@
 
 #include "wyrelog/wyrelog.h"
 #include "wyrelog/audit/conn-private.h"
+#include "wyrelog/policy/store-private.h"
 #include "wyrelog/wyl-handle-private.h"
 #include "daemon/delta.h"
 
@@ -14,20 +15,117 @@
 #endif
 
 static wyrelog_error_t
-intern3 (WylHandle *handle, const gchar *a, const gchar *b, const gchar *c,
-    gint64 row[3])
+intern_symbol (WylHandle *handle, const gchar *symbol, gint64 *out_id)
 {
-  wyrelog_error_t rc = wyl_handle_intern_engine_symbol (handle, a, &row[0]);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  rc = wyl_handle_intern_engine_symbol (handle, b, &row[1]);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  return wyl_handle_intern_engine_symbol (handle, c, &row[2]);
+  return wyl_handle_intern_engine_symbol (handle, symbol, out_id);
 }
 
 static wyrelog_error_t
-break_audit_events_table (WylHandle *handle)
+intern3 (WylHandle *handle, const gchar *a, const gchar *b, const gchar *c,
+    gint64 row[3])
+{
+  wyrelog_error_t rc = intern_symbol (handle, a, &row[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = intern_symbol (handle, b, &row[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return intern_symbol (handle, c, &row[2]);
+}
+
+static wyrelog_error_t
+contains_audit_event_fact (WylHandle *handle, const gchar *id,
+    gint64 created_at_us, gboolean *out_contains)
+{
+  gint64 row[3];
+  wyrelog_error_t rc = intern_symbol (handle, id, &row[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  row[1] = created_at_us;
+  rc = intern_symbol (handle, "allow", &row[2]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_engine_contains (handle, "audit_event", row, 3,
+      out_contains);
+}
+
+static wyrelog_error_t
+contains_audit_event_attr_fact (WylHandle *handle, const gchar *relation,
+    const gchar *id, const gchar *value, gboolean *out_contains)
+{
+  gint64 row[2];
+  wyrelog_error_t rc = intern_symbol (handle, id, &row[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = intern_symbol (handle, value, &row[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_engine_contains (handle, relation, row, 2, out_contains);
+}
+
+typedef struct
+{
+  const gchar *action;
+  const gchar *subject;
+  const gchar *resource;
+  const gchar *reason;
+  const gchar *origin;
+  gchar *id;
+  gint64 created_at_us;
+  guint matches;
+} AuditRowLookup;
+
+static wyrelog_error_t
+lookup_audit_row_cb (const gchar *id, gint64 created_at_us,
+    const gchar *subject_id, const gchar *action, const gchar *resource_id,
+    const gchar *deny_reason, const gchar *deny_origin,
+    wyl_decision_t decision, gpointer user_data)
+{
+  AuditRowLookup *lookup = user_data;
+
+  if (decision != WYL_DECISION_ALLOW
+      || g_strcmp0 (action, lookup->action) != 0
+      || g_strcmp0 (subject_id, lookup->subject) != 0
+      || g_strcmp0 (resource_id, lookup->resource) != 0
+      || g_strcmp0 (deny_reason, lookup->reason) != 0
+      || g_strcmp0 (deny_origin, lookup->origin) != 0)
+    return WYRELOG_E_OK;
+
+  lookup->matches++;
+  g_free (lookup->id);
+  lookup->id = g_strdup (id);
+  lookup->created_at_us = created_at_us;
+  return WYRELOG_E_OK;
+}
+
+static gboolean
+lookup_policy_audit_row (WylHandle *handle, const gchar *action,
+    const gchar *subject, const gchar *resource, const gchar *reason,
+    const gchar *origin, gchar **out_id, gint64 *out_created_at_us)
+{
+  AuditRowLookup lookup = {
+    .action = action,
+    .subject = subject,
+    .resource = resource,
+    .reason = reason,
+    .origin = origin,
+    .created_at_us = -1,
+  };
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  wyrelog_error_t rc = wyl_policy_store_foreach_audit_event (store,
+      lookup_audit_row_cb, &lookup);
+  if (rc != WYRELOG_E_OK || lookup.matches != 1) {
+    g_free (lookup.id);
+    return FALSE;
+  }
+
+  *out_id = g_steal_pointer (&lookup.id);
+  *out_created_at_us = lookup.created_at_us;
+  return TRUE;
+}
+
+static wyrelog_error_t
+drop_audit_events_table (WylHandle *handle)
 {
   duckdb_connection conn =
       wyl_audit_conn_get_connection (wyl_handle_get_audit_conn (handle));
@@ -39,8 +137,19 @@ break_audit_events_table (WylHandle *handle)
     return WYRELOG_E_IO;
   }
   duckdb_destroy_result (&result);
+  return WYRELOG_E_OK;
+}
 
-  memset (&result, 0, sizeof (result));
+static wyrelog_error_t
+malform_audit_events_table (WylHandle *handle)
+{
+  duckdb_result result = { 0 };
+  wyrelog_error_t rc = drop_audit_events_table (handle);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  duckdb_connection conn =
+      wyl_audit_conn_get_connection (wyl_handle_get_audit_conn (handle));
   if (duckdb_query (conn,
           "CREATE TABLE audit_events (id VARCHAR PRIMARY KEY);", &result)
       != DuckDBSuccess) {
@@ -52,7 +161,7 @@ break_audit_events_table (WylHandle *handle)
 }
 
 static gint
-check_delta_callback_counts_audit_failure (void)
+check_delta_callback_ignores_runtime_projection_failure (void)
 {
   g_autoptr (WylHandle) handle = NULL;
   gint64 row[3];
@@ -63,7 +172,7 @@ check_delta_callback_counts_audit_failure (void)
   runtime.handle = handle;
   if (wyl_daemon_start_delta_callbacks (handle, &runtime) != WYRELOG_E_OK)
     return 11;
-  if (break_audit_events_table (handle) != WYRELOG_E_OK)
+  if (malform_audit_events_table (handle) != WYRELOG_E_OK)
     return 12;
   if (intern3 (handle, "daemon-delta-audit-user", "wr.viewer",
           "daemon-delta-audit-scope", row) != WYRELOG_E_OK)
@@ -73,28 +182,68 @@ check_delta_callback_counts_audit_failure (void)
     return 14;
   if (runtime.inserted != 1)
     return 15;
-  if (runtime.audit_errors != 1)
+  if (runtime.audit_errors != 0)
     return 16;
-  if (runtime.last_audit_error == WYRELOG_E_OK)
+  if (runtime.last_audit_error != WYRELOG_E_OK)
     return 17;
+
+  g_autofree gchar *id = NULL;
+  gint64 created_at_us = -1;
+  if (!lookup_policy_audit_row (handle, "effective_member_delta",
+          "daemon-delta-audit-user", "wr.viewer", "insert",
+          "daemon-delta-audit-scope", &id, &created_at_us))
+    return 18;
+  gboolean contains = FALSE;
+  if (contains_audit_event_fact (handle, id, created_at_us, &contains)
+      != WYRELOG_E_OK || !contains)
+    return 19;
+  if (contains_audit_event_attr_fact (handle, "audit_event_action", id,
+          "effective_member_delta", &contains) != WYRELOG_E_OK || !contains)
+    return 20;
+  if (contains_audit_event_attr_fact (handle, "audit_event_subject", id,
+          "daemon-delta-audit-user", &contains) != WYRELOG_E_OK || !contains)
+    return 21;
+  if (contains_audit_event_attr_fact (handle, "audit_event_resource", id,
+          "wr.viewer", &contains) != WYRELOG_E_OK || !contains)
+    return 22;
+  if (contains_audit_event_attr_fact (handle, "audit_event_deny_reason", id,
+          "insert", &contains) != WYRELOG_E_OK || !contains)
+    return 23;
+  if (contains_audit_event_attr_fact (handle, "audit_event_deny_origin", id,
+          "daemon-delta-audit-scope", &contains) != WYRELOG_E_OK || !contains)
+    return 24;
 
   if (wyl_handle_engine_set_delta_callback (handle, NULL, NULL)
       != WYRELOG_E_OK)
-    return 18;
+    return 25;
   return 0;
 }
 
 static gint
-check_delta_readiness_fails_on_audit_failure (void)
+check_delta_readiness_recovers_audit_table_loss (void)
 {
   g_autoptr (WylHandle) handle = NULL;
 
   if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
     return 30;
-  if (break_audit_events_table (handle) != WYRELOG_E_OK)
+  if (drop_audit_events_table (handle) != WYRELOG_E_OK)
     return 31;
-  if (wyl_daemon_check_delta_ready (handle) != WYRELOG_E_IO)
+  if (wyl_daemon_check_delta_ready (handle) != WYRELOG_E_OK)
     return 32;
+  return 0;
+}
+
+static gint
+check_delta_readiness_fails_on_malformed_audit_projection (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 40;
+  if (malform_audit_events_table (handle) != WYRELOG_E_OK)
+    return 41;
+  if (wyl_daemon_check_delta_ready (handle) != WYRELOG_E_IO)
+    return 42;
   return 0;
 }
 
@@ -103,9 +252,11 @@ main (void)
 {
   gint rc;
 
-  if ((rc = check_delta_callback_counts_audit_failure ()) != 0)
+  if ((rc = check_delta_callback_ignores_runtime_projection_failure ()) != 0)
     return rc;
-  if ((rc = check_delta_readiness_fails_on_audit_failure ()) != 0)
+  if ((rc = check_delta_readiness_recovers_audit_table_loss ()) != 0)
+    return rc;
+  if ((rc = check_delta_readiness_fails_on_malformed_audit_projection ()) != 0)
     return rc;
   return 0;
 }

--- a/wyrelog/audit/event.c
+++ b/wyrelog/audit/event.c
@@ -249,7 +249,6 @@ wyl_audit_emit (WylHandle *handle, const WylAuditEvent *event)
 {
 #ifdef WYL_HAS_AUDIT
   gchar id_buf[WYL_ID_STRING_BUF];
-  gboolean inserted = FALSE;
   gboolean store_inserted = FALSE;
 
   if (handle == NULL || event == NULL)
@@ -258,38 +257,17 @@ wyl_audit_emit (WylHandle *handle, const WylAuditEvent *event)
   if (wyl_id_format (&event->id, id_buf, sizeof id_buf) != WYRELOG_E_OK)
     return WYRELOG_E_INTERNAL;
 
-  wyl_audit_conn_t *audit_conn = wyl_handle_get_audit_conn (handle);
-  if (audit_conn == NULL)
-    return WYRELOG_E_INTERNAL;
-
-  wyrelog_error_t rc = wyl_audit_conn_create_schema (audit_conn);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-
-  rc = wyl_audit_conn_insert_event_full (audit_conn, id_buf,
-      event->created_at_us, event->subject_id, event->action,
-      event->resource_id, event->deny_reason, event->deny_origin,
-      event->decision, &inserted);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-
   wyrelog_error_t store_rc =
       wyl_policy_store_append_audit_event_full (wyl_handle_get_policy_store
       (handle), id_buf, event->created_at_us,
       event->subject_id, event->action, event->resource_id,
       event->deny_reason, event->deny_origin, event->decision,
       &store_inserted);
-  if (store_rc != WYRELOG_E_OK) {
-    if (inserted) {
-      wyrelog_error_t cleanup_rc =
-          wyl_audit_conn_delete_event (audit_conn, id_buf);
-      if (cleanup_rc != WYRELOG_E_OK)
-        return cleanup_rc;
-    }
+  if (store_rc != WYRELOG_E_OK)
     return store_rc;
-  }
 
-  rc = wyl_handle_insert_audit_fact (handle, id_buf, event->created_at_us,
+  wyrelog_error_t rc = wyl_handle_insert_audit_fact (handle, id_buf,
+      event->created_at_us,
       event->subject_id, event->action, event->resource_id,
       event->deny_reason, event->deny_origin, event->decision);
   if (rc != WYRELOG_E_OK) {
@@ -300,14 +278,22 @@ wyl_audit_emit (WylHandle *handle, const WylAuditEvent *event)
       if (cleanup_rc != WYRELOG_E_OK)
         return cleanup_rc;
     }
-    if (inserted) {
-      wyrelog_error_t cleanup_rc =
-          wyl_audit_conn_delete_event (audit_conn, id_buf);
-      if (cleanup_rc != WYRELOG_E_OK)
-        return cleanup_rc;
-    }
     return rc;
   }
+
+  wyl_audit_conn_t *audit_conn = wyl_handle_get_audit_conn (handle);
+  if (audit_conn == NULL)
+    return WYRELOG_E_OK;
+
+  rc = wyl_audit_conn_create_schema (audit_conn);
+  if (rc != WYRELOG_E_OK)
+    return WYRELOG_E_OK;
+
+  gboolean inserted = FALSE;
+  (void) wyl_audit_conn_insert_event_full (audit_conn, id_buf,
+      event->created_at_us, event->subject_id, event->action,
+      event->resource_id, event->deny_reason, event->deny_origin,
+      event->decision, &inserted);
 
   return WYRELOG_E_OK;
 #else

--- a/wyrelog/daemon/delta.c
+++ b/wyrelog/daemon/delta.c
@@ -358,6 +358,9 @@ wyl_daemon_check_delta_ready (WylHandle *handle)
         runtime.last_audit_error : WYRELOG_E_IO;
     goto cleanup;
   }
+  rc = wyl_handle_load_policy_store_audit_events (handle);
+  if (rc != WYRELOG_E_OK)
+    goto cleanup;
   rc = check_wirelog_delta_audit_rows (handle);
   if (rc != WYRELOG_E_OK)
     goto cleanup;

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -501,11 +501,6 @@ authorize_guarded_session_action (SoupServer *server, SoupServerMessage *msg,
 static wyrelog_error_t
 reconcile_audit_query_projection (WylHandle *handle)
 {
-  wyrelog_error_t rc =
-      wyl_audit_conn_create_schema (wyl_handle_get_audit_conn (handle));
-  if (rc != WYRELOG_E_OK)
-    return rc;
-
   return wyl_handle_load_policy_store_audit_events (handle);
 }
 #endif

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -482,6 +482,10 @@ wyl_handle_load_policy_store_audit_events (WylHandle *self)
   if (self->policy_store == NULL || self->audit_conn == NULL)
     return WYRELOG_E_INVALID;
 
+  wyrelog_error_t rc = wyl_audit_conn_create_schema (self->audit_conn);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
   duckdb_connection conn = wyl_audit_conn_get_connection (self->audit_conn);
   duckdb_result result;
   memset (&result, 0, sizeof (result));
@@ -492,7 +496,7 @@ wyl_handle_load_policy_store_audit_events (WylHandle *self)
   }
   duckdb_destroy_result (&result);
 
-  wyrelog_error_t rc = wyl_policy_store_foreach_audit_event (self->policy_store,
+  rc = wyl_policy_store_foreach_audit_event (self->policy_store,
       insert_policy_store_audit_event, self);
   if (rc != WYRELOG_E_OK) {
     memset (&result, 0, sizeof (result));


### PR DESCRIPTION
## Summary
- make direct audit emission durable through the Policy DB before runtime projection
- let Policy DB audit replay repair dropped runtime audit projections before checks
- preserve fail-closed behavior for malformed runtime audit schemas
- keep decision and daemon delta paths tied to live wirelog audit facts

## Verification
- meson test -C builddir-audit --print-errorlogs
- meson test -C builddir daemon-http-decide client-audit-daemon audit-event --print-errorlogs
- git diff --check
