### PR TITLE
Route lifecycle deltas through event facts

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -447,6 +447,14 @@ check_public_headers = find_program(
 
 test('check-public-headers-no-novelty-tokens', check_public_headers)
 
+check_no_derived_fsm_replay = find_program(
+  '../tools/check-no-derived-fsm-replay.sh',
+)
+
+test('check-no-derived-fsm-replay', check_no_derived_fsm_replay,
+  args : [meson.project_source_root()],
+)
+
 if get_option('enable_audit').allowed()
   audit_conn_test_env = environment()
   if host_machine.system() == 'windows' \

--- a/tests/test-login-projection.c
+++ b/tests/test-login-projection.c
@@ -342,6 +342,75 @@ check_anonymous_login_reload_failure_keeps_session_state (void)
 }
 
 static gint
+check_login_event_projection_failure_is_reported (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 140;
+
+  wyl_handle_set_engine_insert_fault_once (handle, "principal_event",
+      WYRELOG_E_INTERNAL);
+
+  g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
+  wyl_login_req_set_username (login, "projection-event-fail-user");
+  g_autoptr (WylSession) session = NULL;
+  if (wyl_session_login (handle, login, &session) != WYRELOG_E_INTERNAL)
+    return 141;
+  if (session != NULL)
+    return 142;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  gint64 count = -1;
+  if (!policy_count_rows (store,
+          "SELECT COUNT(*) FROM principal_events "
+          "WHERE subject_id = 'projection-event-fail-user' "
+          "AND event = 'login_ok' "
+          "AND from_state = 'unverified' "
+          "AND to_state = 'mfa_required';", &count))
+    return 143;
+  if (count != 1)
+    return 144;
+  if (!policy_count_rows (store,
+          "SELECT COUNT(*) FROM session_events "
+          "WHERE event = 'request' AND from_state = 'idle' "
+          "AND to_state = 'active';", &count))
+    return 145;
+  if (count != 1)
+    return 146;
+  return 0;
+}
+
+static gint
+check_anonymous_session_event_projection_failure_is_reported (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 150;
+
+  wyl_handle_set_engine_insert_fault_once (handle, "session_event",
+      WYRELOG_E_INTERNAL);
+
+  g_autoptr (WylSession) session = NULL;
+  if (wyl_session_login (handle, NULL, &session) != WYRELOG_E_INTERNAL)
+    return 151;
+  if (session != NULL)
+    return 152;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  gint64 count = -1;
+  if (!policy_count_rows (store,
+          "SELECT COUNT(*) FROM session_events "
+          "WHERE event = 'request' AND from_state = 'idle' "
+          "AND to_state = 'active';", &count))
+    return 153;
+  if (count != 1)
+    return 154;
+  return 0;
+}
+
+static gint
 check_skip_mfa_login_projects_authority_state (void)
 {
   static const gchar *username = "projection-skip-mfa-user";
@@ -643,6 +712,11 @@ main (void)
   if ((rc = check_login_reload_failure_keeps_durable_state_repairable ()) != 0)
     return rc;
   if ((rc = check_anonymous_login_reload_failure_keeps_session_state ()) != 0)
+    return rc;
+  if ((rc = check_login_event_projection_failure_is_reported ()) != 0)
+    return rc;
+  if ((rc =
+          check_anonymous_session_event_projection_failure_is_reported ()) != 0)
     return rc;
   if ((rc = check_skip_mfa_login_projects_authority_state ()) != 0)
     return rc;

--- a/tests/test-login-projection.c
+++ b/tests/test-login-projection.c
@@ -378,6 +378,35 @@ check_login_event_projection_failure_is_reported (void)
     return 145;
   if (count != 1)
     return 146;
+  gint64 principal_event_id = -1;
+  if (!policy_select_int64_params (store,
+          "SELECT event_id FROM principal_events "
+          "WHERE subject_id = 'projection-event-fail-user' "
+          "AND event = 'login_ok' "
+          "AND from_state = 'unverified' "
+          "AND to_state = 'mfa_required';", NULL, 0, &principal_event_id))
+    return 147;
+  gint64 session_event_id = -1;
+  if (!policy_select_int64_params (store,
+          "SELECT event_id FROM session_events "
+          "WHERE event = 'request' AND from_state = 'idle' "
+          "AND to_state = 'active';", NULL, 0, &session_event_id))
+    return 148;
+  g_autofree gchar *session_id = NULL;
+  if (!policy_select_text_params (store,
+          "SELECT session_id FROM session_events "
+          "WHERE event = 'request' AND from_state = 'idle' "
+          "AND to_state = 'active';", NULL, 0, &session_id))
+    return 149;
+  if (wyl_handle_reload_engine_pair (handle) != WYRELOG_E_OK)
+    return 155;
+  if (!engine_contains_event_row5 (handle, "principal_fired",
+          principal_event_id, "projection-event-fail-user", "unverified",
+          "login_ok", "mfa_required"))
+    return 156;
+  if (!engine_contains_event_row5 (handle, "session_fired", session_event_id,
+          session_id, "idle", "request", "active"))
+    return 157;
   return 0;
 }
 
@@ -407,6 +436,23 @@ check_anonymous_session_event_projection_failure_is_reported (void)
     return 153;
   if (count != 1)
     return 154;
+  gint64 event_id = -1;
+  if (!policy_select_int64_params (store,
+          "SELECT event_id FROM session_events "
+          "WHERE event = 'request' AND from_state = 'idle' "
+          "AND to_state = 'active';", NULL, 0, &event_id))
+    return 158;
+  g_autofree gchar *session_id = NULL;
+  if (!policy_select_text_params (store,
+          "SELECT session_id FROM session_events "
+          "WHERE event = 'request' AND from_state = 'idle' "
+          "AND to_state = 'active';", NULL, 0, &session_id))
+    return 159;
+  if (wyl_handle_reload_engine_pair (handle) != WYRELOG_E_OK)
+    return 160;
+  if (!engine_contains_event_row5 (handle, "session_fired", event_id,
+          session_id, "idle", "request", "active"))
+    return 161;
   return 0;
 }
 

--- a/tools/check-no-derived-fsm-replay.sh
+++ b/tools/check-no-derived-fsm-replay.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-or-later
+set -eu
+
+root=${1:-.}
+
+matches=$(
+  find "$root/wyrelog" -type f \( -name '*.c' -o -name '*.h' \) \
+    ! -name 'wyl-handle.c' \
+    ! -name 'wyl-handle-private.h' \
+    -exec grep -n 'wyl_handle_replay_delta_insert' {} + || true
+)
+
+if [ -n "$matches" ]; then
+  printf '%s\n' "$matches" >&2
+  printf '%s\n' \
+    'error: derived FSM delta replay must stay inside WylHandle internals' >&2
+  exit 1
+fi
+
+printf '%s\n' 'OK: no derived FSM delta replay outside WylHandle internals'

--- a/wyrelog/wyl-session.c
+++ b/wyrelog/wyl-session.c
@@ -128,7 +128,8 @@ insert_principal_event_fact (WylHandle *handle, gint64 event_id,
     const gchar *username, wyl_principal_state_t old_state,
     wyl_principal_event_t event, wyl_principal_state_t new_state)
 {
-  if (wyl_handle_get_read_engine (handle) == NULL)
+  if (wyl_handle_get_read_engine (handle) == NULL
+      || wyl_handle_get_delta_engine (handle) == NULL)
     return WYRELOG_E_OK;
   if (event_id <= 0)
     return WYRELOG_E_OK;
@@ -145,16 +146,16 @@ insert_principal_event_fact (WylHandle *handle, gint64 event_id,
       wyl_handle_intern_engine_symbol (handle, username, &row[1]);
   if (rc != WYRELOG_E_OK)
     return rc;
-  rc = wyl_handle_intern_engine_symbol (handle, old_state_name, &row[2]);
+  rc = wyl_handle_intern_engine_symbol (handle, event_name, &row[2]);
   if (rc != WYRELOG_E_OK)
     return rc;
-  rc = wyl_handle_intern_engine_symbol (handle, event_name, &row[3]);
+  rc = wyl_handle_intern_engine_symbol (handle, old_state_name, &row[3]);
   if (rc != WYRELOG_E_OK)
     return rc;
   rc = wyl_handle_intern_engine_symbol (handle, new_state_name, &row[4]);
   if (rc != WYRELOG_E_OK)
     return rc;
-  return wyl_handle_replay_delta_insert (handle, "principal_fired", row, 5);
+  return wyl_handle_engine_insert (handle, "principal_event", row, 5);
 }
 
 static wyrelog_error_t
@@ -261,11 +262,11 @@ transition_principal_state (WylHandle *handle, const gchar *username,
       old_state, WYL_PRINCIPAL_EVENT_MFA_OK, new_state, ev, &event_id);
   if (rc != WYRELOG_E_OK)
     return rc;
-  rc = finish_session_mutation (handle, ev);
+  rc = insert_principal_event_fact (handle, event_id, username, old_state,
+      WYL_PRINCIPAL_EVENT_MFA_OK, new_state);
   if (rc != WYRELOG_E_OK)
     return rc;
-  return insert_principal_event_fact (handle, event_id, username, old_state,
-      WYL_PRINCIPAL_EVENT_MFA_OK, new_state);
+  return finish_session_mutation (handle, ev);
 }
 
 #ifdef WYL_HAS_AUDIT
@@ -288,7 +289,8 @@ insert_session_event_fact (WylHandle *handle, gint64 event_id,
     const gchar *session_id, wyl_session_state_t old_state,
     wyl_session_event_t event, wyl_session_state_t new_state)
 {
-  if (wyl_handle_get_read_engine (handle) == NULL)
+  if (wyl_handle_get_read_engine (handle) == NULL
+      || wyl_handle_get_delta_engine (handle) == NULL)
     return WYRELOG_E_OK;
   if (event_id <= 0)
     return WYRELOG_E_OK;
@@ -305,16 +307,16 @@ insert_session_event_fact (WylHandle *handle, gint64 event_id,
       wyl_handle_intern_engine_symbol (handle, session_id, &row[1]);
   if (rc != WYRELOG_E_OK)
     return rc;
-  rc = wyl_handle_intern_engine_symbol (handle, old_state_name, &row[2]);
+  rc = wyl_handle_intern_engine_symbol (handle, event_name, &row[2]);
   if (rc != WYRELOG_E_OK)
     return rc;
-  rc = wyl_handle_intern_engine_symbol (handle, event_name, &row[3]);
+  rc = wyl_handle_intern_engine_symbol (handle, old_state_name, &row[3]);
   if (rc != WYRELOG_E_OK)
     return rc;
   rc = wyl_handle_intern_engine_symbol (handle, new_state_name, &row[4]);
   if (rc != WYRELOG_E_OK)
     return rc;
-  return wyl_handle_replay_delta_insert (handle, "session_fired", row, 5);
+  return wyl_handle_engine_insert (handle, "session_event", row, 5);
 }
 
 static wyrelog_error_t
@@ -518,11 +520,11 @@ transition_session_state (WylHandle *handle, WylSession *session,
       old_state, event, new_state, ev, &event_id);
   if (rc != WYRELOG_E_OK)
     return rc;
-  rc = finish_session_mutation (handle, ev);
-  if (rc != WYRELOG_E_OK)
-    return rc;
   rc = insert_session_event_fact (handle, event_id, session_id, old_state,
       event, new_state);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = finish_session_mutation (handle, ev);
   if (rc != WYRELOG_E_OK)
     return rc;
   session->state = new_state;
@@ -600,16 +602,6 @@ wyl_session_login (WylHandle *handle, const wyl_login_req_t *req,
       g_object_unref (session);
       return rc;
     }
-    rc = reload_session_snapshot (handle);
-    if (rc != WYRELOG_E_OK) {
-      g_object_unref (session);
-      return rc;
-    }
-#ifdef WYL_HAS_AUDIT
-    /* Policy-store audit is durable; the live audit sink is best effort. */
-    (void) wyl_audit_mirror_event (handle, principal_ev);
-    (void) wyl_audit_mirror_event (handle, session_ev);
-#endif
     rc = insert_principal_event_fact (handle, principal_event_id, username,
         WYL_PRINCIPAL_STATE_UNVERIFIED, event, state);
     if (rc != WYRELOG_E_OK) {
@@ -623,6 +615,16 @@ wyl_session_login (WylHandle *handle, const wyl_login_req_t *req,
       g_object_unref (session);
       return rc;
     }
+    rc = reload_session_snapshot (handle);
+    if (rc != WYRELOG_E_OK) {
+      g_object_unref (session);
+      return rc;
+    }
+#ifdef WYL_HAS_AUDIT
+    /* Policy-store audit is durable; the live audit sink is best effort. */
+    (void) wyl_audit_mirror_event (handle, principal_ev);
+    (void) wyl_audit_mirror_event (handle, session_ev);
+#endif
     session->state = WYL_SESSION_STATE_ACTIVE;
     *out_session = session;
     return WYRELOG_E_OK;
@@ -641,14 +643,14 @@ wyl_session_login (WylHandle *handle, const wyl_login_req_t *req,
     g_object_unref (session);
     return rc;
   }
-  rc = finish_session_mutation (handle, ev);
+  rc = insert_session_event_fact (handle, event_id, session_id,
+      WYL_SESSION_STATE_IDLE, WYL_SESSION_EVENT_REQUEST,
+      WYL_SESSION_STATE_ACTIVE);
   if (rc != WYRELOG_E_OK) {
     g_object_unref (session);
     return rc;
   }
-  rc = insert_session_event_fact (handle, event_id, session_id,
-      WYL_SESSION_STATE_IDLE, WYL_SESSION_EVENT_REQUEST,
-      WYL_SESSION_STATE_ACTIVE);
+  rc = finish_session_mutation (handle, ev);
   if (rc != WYRELOG_E_OK) {
     g_object_unref (session);
     return rc;


### PR DESCRIPTION
## Summary
- project live principal and session lifecycle changes through event facts
- let templates derive fired lifecycle facts for both live and replay paths
- add repair coverage for projection failures and a static regression check

## Verification
- meson test -C builddir-audit --print-errorlogs
- meson test -C builddir check-no-derived-fsm-replay session-username handle-engine-pair daemon-http-decide --print-errorlogs
- git diff --check
