### PR TITLE
Project guard compound metadata in templates

### DIFF
--- a/templates/access/fsm/permission_scope.dl
+++ b/templates/access/fsm/permission_scope.dl
@@ -21,6 +21,10 @@
 //   perm_window_guard(perm, window)              -- guarded permission
 //                                                   requires a named
 //                                                   timestamp window
+//   guard_row(handle, root)                      -- guard compound payload
+//                                                   projections
+//   guard_cmp_row(handle, field, op, value)
+//   guard_and_row(handle, left, right)
 //   context_now(user, scope, ctx)                -- scope(metadata(ts,
 //                                                   loc_class, risk),
 //                                                   scope) activation
@@ -41,6 +45,9 @@
 .decl perm_state(user: symbol, perm: symbol, scope: symbol, state: symbol)
 .decl perm_arm_rule(perm: symbol, guard_handle: int64)
 .decl perm_window_guard(perm: symbol, window: symbol)
+.decl guard_row(handle: int64, root: int64)
+.decl guard_cmp_row(handle: int64, field: symbol, op: symbol, value: symbol)
+.decl guard_and_row(handle: int64, left: int64, right: int64)
 .decl context_now(user: symbol, scope: symbol, ctx: scope/2 side)
 .decl guard_context(ctx: scope/2 side, user: symbol, scope: symbol,
     timestamp: int64, loc_class: symbol, risk: int64)
@@ -66,6 +73,9 @@
 
 perm_arm_rule_observed(P, G) :- perm_arm_rule(P, G).
 perm_window_guard_observed(P, W) :- perm_window_guard(P, W).
+guard_row(H, R) :- __compound_guard_1(H, R).
+guard_cmp_row(H, F, O, V) :- __compound_guard_cmp_3(H, F, O, V).
+guard_and_row(H, L, R) :- __compound_guard_and_2(H, L, R).
 
 // --- guard context field views ---------------------------------------
 

--- a/templates/access/fsm/permission_scope.dl
+++ b/templates/access/fsm/permission_scope.dl
@@ -18,9 +18,6 @@
 //                                                   bootstrap.dl
 //   perm_arm_rule(perm, guard_handle)            -- guard(root) side
 //                                                   payload handle
-//   perm_window_guard(perm, window)              -- guarded permission
-//                                                   requires a named
-//                                                   timestamp window
 //   guard_row(handle, root)                      -- guard compound payload
 //                                                   projections
 //   guard_cmp_row(handle, field, op, value)
@@ -36,6 +33,11 @@
 //   guard_context_in_window(user, scope, ts,     -- host-confirmed
 //       window)                                      timestamp window
 //   eval_guard(user, perm, scope, ctx)           -- host guard result
+//
+// Derived schemas:
+//   perm_window_guard(perm, window)              -- guarded permission
+//                                                   requires a named
+//                                                   timestamp window
 //
 // perm_arm_rule rows are runtime-seeded from the C catalogue so the
 // session-local guard-handle column can later move to side-tier
@@ -72,10 +74,24 @@
 // mirror, not an evaluator input yet.
 
 perm_arm_rule_observed(P, G) :- perm_arm_rule(P, G).
-perm_window_guard_observed(P, W) :- perm_window_guard(P, W).
 guard_row(H, R) :- __compound_guard_1(H, R).
 guard_cmp_row(H, F, O, V) :- __compound_guard_cmp_3(H, F, O, V).
 guard_and_row(H, L, R) :- __compound_guard_and_2(H, L, R).
+perm_window_guard(P, W) :-
+    perm_arm_rule(P, G),
+    guard_row(G, R),
+    guard_cmp_row(R, "timestamp", "in", W).
+perm_window_guard(P, W) :-
+    perm_arm_rule(P, G),
+    guard_row(G, R),
+    guard_and_row(R, L, _),
+    guard_cmp_row(L, "timestamp", "in", W).
+perm_window_guard(P, W) :-
+    perm_arm_rule(P, G),
+    guard_row(G, R),
+    guard_and_row(R, _, L),
+    guard_cmp_row(L, "timestamp", "in", W).
+perm_window_guard_observed(P, W) :- perm_window_guard(P, W).
 
 // --- guard context field views ---------------------------------------
 

--- a/tests/fixtures/engine-io-templates/bootstrap.dl
+++ b/tests/fixtures/engine-io-templates/bootstrap.dl
@@ -1,0 +1,13 @@
+.decl role(id: symbol)
+.decl role_permission(role: symbol, perm: symbol)
+.decl direct_permission(user: symbol, perm: symbol, scope: symbol)
+.decl member_of(user: symbol, role: symbol, scope: symbol)
+.decl effective_member(user: symbol, role: symbol, scope: symbol)
+.decl has_permission(user: symbol, perm: symbol, scope: symbol)
+
+role("wr.viewer").
+effective_member(U, R, S) :- member_of(U, R, S).
+has_permission(U, P, S) :- direct_permission(U, P, S).
+has_permission(U, P, S) :-
+    effective_member(U, R, S),
+    role_permission(R, P).

--- a/tests/fixtures/engine-io-templates/fsm/permission_scope.dl
+++ b/tests/fixtures/engine-io-templates/fsm/permission_scope.dl
@@ -1,0 +1,1 @@
+// engine-io fixture stub

--- a/tests/fixtures/engine-io-templates/fsm/principal.dl
+++ b/tests/fixtures/engine-io-templates/fsm/principal.dl
@@ -1,0 +1,1 @@
+// engine-io fixture stub

--- a/tests/fixtures/engine-io-templates/fsm/session.dl
+++ b/tests/fixtures/engine-io-templates/fsm/session.dl
@@ -1,0 +1,1 @@
+// engine-io fixture stub

--- a/tests/fixtures/engine-io-templates/lobac/decision.dl
+++ b/tests/fixtures/engine-io-templates/lobac/decision.dl
@@ -1,0 +1,1 @@
+// engine-io fixture stub

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -428,7 +428,7 @@ test('engine-intern', test_engine_intern)
 test_engine_io = executable('test-engine-io',
   'test-engine-io.c',
   c_args : [
-    '-DWYL_TEST_TEMPLATE_DIR="' + meson.project_source_root() / 'templates' / 'access' + '"',
+    '-DWYL_TEST_TEMPLATE_DIR="' + meson.project_source_root() / 'tests' / 'fixtures' / 'engine-io-templates' + '"',
   ],
   dependencies : [wyrelog_dep, wirelog_dep],
 )

--- a/tests/test-engine-io.c
+++ b/tests/test-engine-io.c
@@ -32,7 +32,7 @@ typedef struct
 } DeltaExpect;
 
 static WylEngine *
-open_engine_from_real_templates (void)
+open_engine_from_test_templates (void)
 {
   WylEngine *engine = NULL;
   wyrelog_error_t rc = wyl_engine_open (WYL_TEST_TEMPLATE_DIR, 1, &engine);
@@ -216,7 +216,7 @@ delta_expect_reset (DeltaExpect *expect)
 static void
 test_insert_nominal (void)
 {
-  g_autoptr (WylEngine) engine = open_engine_from_real_templates ();
+  g_autoptr (WylEngine) engine = open_engine_from_test_templates ();
   gint64 row[3];
 
   build_member_of_row (engine, row);
@@ -228,7 +228,7 @@ test_insert_nominal (void)
 static void
 test_remove_nominal (void)
 {
-  g_autoptr (WylEngine) engine = open_engine_from_real_templates ();
+  g_autoptr (WylEngine) engine = open_engine_from_test_templates ();
   gint64 row[3];
 
   build_member_of_row (engine, row);
@@ -242,7 +242,7 @@ test_remove_nominal (void)
 static void
 test_insert_remove_idempotent_remove (void)
 {
-  g_autoptr (WylEngine) engine = open_engine_from_real_templates ();
+  g_autoptr (WylEngine) engine = open_engine_from_test_templates ();
   gint64 row[3];
 
   build_member_of_row (engine, row);
@@ -261,7 +261,7 @@ test_insert_remove_idempotent_remove (void)
 static void
 test_step_nominal (void)
 {
-  g_autoptr (WylEngine) engine = open_engine_from_real_templates ();
+  g_autoptr (WylEngine) engine = open_engine_from_test_templates ();
   gint64 row[3];
 
   build_member_of_row (engine, row);
@@ -274,10 +274,10 @@ test_step_nominal (void)
 static void
 test_step_after_snapshot_rejected (void)
 {
-  g_autoptr (WylEngine) engine = open_engine_from_real_templates ();
+  g_autoptr (WylEngine) engine = open_engine_from_test_templates ();
   guint seen = 0;
 
-  g_assert_cmpint (wyl_engine_snapshot (engine, "member_of",
+  g_assert_cmpint (wyl_engine_snapshot (engine, "role",
           snapshot_count_cb, &seen), ==, WYRELOG_E_OK);
   g_assert_cmpint (wyl_engine_step (engine), ==, WYRELOG_E_INVALID);
 }
@@ -285,7 +285,7 @@ test_step_after_snapshot_rejected (void)
 static void
 test_snapshot_after_step_rejected (void)
 {
-  g_autoptr (WylEngine) engine = open_engine_from_real_templates ();
+  g_autoptr (WylEngine) engine = open_engine_from_test_templates ();
   guint seen = 0;
 
   g_assert_cmpint (wyl_engine_step (engine), ==, WYRELOG_E_OK);
@@ -296,7 +296,7 @@ test_snapshot_after_step_rejected (void)
 static void
 test_snapshot_observes_inserted_row (void)
 {
-  g_autoptr (WylEngine) engine = open_engine_from_real_templates ();
+  g_autoptr (WylEngine) engine = open_engine_from_test_templates ();
   gint64 member_row[3];
   gint64 role_permission_row[2];
   gint64 expected_permission_row[3];
@@ -323,7 +323,7 @@ test_snapshot_observes_inserted_row (void)
 static void
 test_snapshot_observes_direct_permission (void)
 {
-  g_autoptr (WylEngine) engine = open_engine_from_real_templates ();
+  g_autoptr (WylEngine) engine = open_engine_from_test_templates ();
   gint64 row[3];
   SnapshotExpect expect;
 
@@ -349,7 +349,7 @@ test_snapshot_observes_direct_permission (void)
 static void
 test_snapshot_observes_removed_row (void)
 {
-  g_autoptr (WylEngine) engine = open_engine_from_real_templates ();
+  g_autoptr (WylEngine) engine = open_engine_from_test_templates ();
   gint64 member_row[3];
   gint64 role_permission_row[2];
   gint64 expected_permission_row[3];
@@ -372,7 +372,7 @@ test_snapshot_observes_removed_row (void)
 static void
 test_delta_nominal (void)
 {
-  g_autoptr (WylEngine) engine = open_engine_from_real_templates ();
+  g_autoptr (WylEngine) engine = open_engine_from_test_templates ();
   gint64 member_row[3];
   gint64 expected_member_rows[1][3];
   DeltaExpect expect = {
@@ -403,7 +403,7 @@ test_delta_nominal (void)
 static void
 test_delta_remove (void)
 {
-  g_autoptr (WylEngine) engine = open_engine_from_real_templates ();
+  g_autoptr (WylEngine) engine = open_engine_from_test_templates ();
   gint64 member_row[3];
   gint64 expected_member_rows[1][3];
   DeltaExpect expect = {
@@ -442,7 +442,7 @@ test_delta_remove (void)
 static void
 test_delta_clear (void)
 {
-  g_autoptr (WylEngine) engine = open_engine_from_real_templates ();
+  g_autoptr (WylEngine) engine = open_engine_from_test_templates ();
   gint64 member_row[3];
   gint64 expected_member_rows[1][3];
   DeltaExpect expect = {
@@ -472,7 +472,7 @@ test_delta_clear (void)
 static void
 test_delta_replace (void)
 {
-  g_autoptr (WylEngine) engine = open_engine_from_real_templates ();
+  g_autoptr (WylEngine) engine = open_engine_from_test_templates ();
   gint64 member_row[3];
   gint64 expected_member_rows[1][3];
   DeltaExpect expect_a = {
@@ -516,10 +516,10 @@ test_delta_replace (void)
 static void
 test_delta_after_snapshot_rejected (void)
 {
-  g_autoptr (WylEngine) engine = open_engine_from_real_templates ();
+  g_autoptr (WylEngine) engine = open_engine_from_test_templates ();
   guint seen = 0;
 
-  g_assert_cmpint (wyl_engine_snapshot (engine, "member_of",
+  g_assert_cmpint (wyl_engine_snapshot (engine, "role",
           snapshot_count_cb, &seen), ==, WYRELOG_E_OK);
   g_assert_cmpint (wyl_engine_set_delta_callback (engine, delta_expect_cb,
           NULL), ==, WYRELOG_E_INVALID);
@@ -535,7 +535,7 @@ test_delta_null_self (void)
 static void
 test_delta_after_close (void)
 {
-  WylEngine *engine = open_engine_from_real_templates ();
+  WylEngine *engine = open_engine_from_test_templates ();
 
   wl_easy_close (engine->session);
   engine->session = NULL;
@@ -562,7 +562,7 @@ test_insert_null_self (void)
 static void
 test_insert_null_relation (void)
 {
-  g_autoptr (WylEngine) engine = open_engine_from_real_templates ();
+  g_autoptr (WylEngine) engine = open_engine_from_test_templates ();
   gint64 row[3] = { 1, 2, 3 };
 
   g_assert_cmpint (wyl_engine_insert (engine, NULL, row, 3),
@@ -572,7 +572,7 @@ test_insert_null_relation (void)
 static void
 test_insert_null_row (void)
 {
-  g_autoptr (WylEngine) engine = open_engine_from_real_templates ();
+  g_autoptr (WylEngine) engine = open_engine_from_test_templates ();
 
   g_assert_cmpint (wyl_engine_insert (engine, "member_of", NULL, 3),
       ==, WYRELOG_E_INVALID);
@@ -581,7 +581,7 @@ test_insert_null_row (void)
 static void
 test_insert_zero_ncols (void)
 {
-  g_autoptr (WylEngine) engine = open_engine_from_real_templates ();
+  g_autoptr (WylEngine) engine = open_engine_from_test_templates ();
   gint64 row[3] = { 1, 2, 3 };
 
   g_assert_cmpint (wyl_engine_insert (engine, "member_of", row, 0),
@@ -591,7 +591,7 @@ test_insert_zero_ncols (void)
 static void
 test_insert_after_close (void)
 {
-  WylEngine *engine = open_engine_from_real_templates ();
+  WylEngine *engine = open_engine_from_test_templates ();
   gint64 row[3] = { 1, 2, 3 };
 
   wl_easy_close (engine->session);
@@ -616,7 +616,7 @@ test_step_null_self (void)
 static void
 test_step_after_close (void)
 {
-  WylEngine *engine = open_engine_from_real_templates ();
+  WylEngine *engine = open_engine_from_test_templates ();
 
   wl_easy_close (engine->session);
   engine->session = NULL;
@@ -642,7 +642,7 @@ test_snapshot_null_self (void)
 static void
 test_snapshot_null_relation (void)
 {
-  g_autoptr (WylEngine) engine = open_engine_from_real_templates ();
+  g_autoptr (WylEngine) engine = open_engine_from_test_templates ();
   guint seen = 0;
 
   g_assert_cmpint (wyl_engine_snapshot (engine, NULL, snapshot_count_cb,
@@ -652,7 +652,7 @@ test_snapshot_null_relation (void)
 static void
 test_snapshot_null_cb (void)
 {
-  g_autoptr (WylEngine) engine = open_engine_from_real_templates ();
+  g_autoptr (WylEngine) engine = open_engine_from_test_templates ();
   guint seen = 0;
 
   g_assert_cmpint (wyl_engine_snapshot (engine, "member_of", NULL, &seen),
@@ -662,7 +662,7 @@ test_snapshot_null_cb (void)
 static void
 test_snapshot_after_close (void)
 {
-  WylEngine *engine = open_engine_from_real_templates ();
+  WylEngine *engine = open_engine_from_test_templates ();
   guint seen = 0;
 
   wl_easy_close (engine->session);
@@ -690,7 +690,7 @@ test_remove_null_self (void)
 static void
 test_remove_null_relation (void)
 {
-  g_autoptr (WylEngine) engine = open_engine_from_real_templates ();
+  g_autoptr (WylEngine) engine = open_engine_from_test_templates ();
   gint64 row[3] = { 1, 2, 3 };
 
   g_assert_cmpint (wyl_engine_remove (engine, NULL, row, 3),
@@ -700,7 +700,7 @@ test_remove_null_relation (void)
 static void
 test_remove_null_row (void)
 {
-  g_autoptr (WylEngine) engine = open_engine_from_real_templates ();
+  g_autoptr (WylEngine) engine = open_engine_from_test_templates ();
 
   g_assert_cmpint (wyl_engine_remove (engine, "member_of", NULL, 3),
       ==, WYRELOG_E_INVALID);
@@ -709,7 +709,7 @@ test_remove_null_row (void)
 static void
 test_remove_zero_ncols (void)
 {
-  g_autoptr (WylEngine) engine = open_engine_from_real_templates ();
+  g_autoptr (WylEngine) engine = open_engine_from_test_templates ();
   gint64 row[3] = { 1, 2, 3 };
 
   g_assert_cmpint (wyl_engine_remove (engine, "member_of", row, 0),
@@ -719,7 +719,7 @@ test_remove_zero_ncols (void)
 static void
 test_remove_after_close (void)
 {
-  WylEngine *engine = open_engine_from_real_templates ();
+  WylEngine *engine = open_engine_from_test_templates ();
   gint64 row[3] = { 1, 2, 3 };
 
   wl_easy_close (engine->session);

--- a/tests/test-fsm-permission-scope.c
+++ b/tests/test-fsm-permission-scope.c
@@ -14,12 +14,15 @@
 /* --- Stratification self-check ---------------------------------- */
 
 /*
- * Lifts the two armed/3 rules + the eval_guard host bridge fact
- * into wyl_dl_rule_t form and asserts the program is stratified.
+ * Lifts the window guard derivation rules, the two armed/3 rules,
+ * and the eval_guard host bridge fact into wyl_dl_rule_t form and
+ * asserts the program is stratified.
  * The negation edge in the state-driven rule references
  * \+ perm_arm_rule, and the guarded rule goes through eval_guard /
- * context_now / guard_context. No edge can close a cycle because
- * perm_arm_rule, perm_state, has_permission, context_now,
+ * context_now / guard_context. The window guard rules depend only
+ * on the guard catalogue projection. No edge can close a cycle because
+ * perm_arm_rule, guard_row, guard_cmp_row, guard_and_row,
+ * perm_state, has_permission, context_now,
  * guard_context, guard_context_timestamp,
  * guard_context_loc_class, guard_context_risk,
  * guard_context_in_window and eval_guard are EDB-only.
@@ -27,6 +30,20 @@
 static gint
 check_stratification (void)
 {
+  static const wyl_dl_body_atom_t window_direct_body[] = {
+    {.predicate = "perm_arm_rule",.negated = FALSE},
+    {.predicate = "guard_row",.negated = FALSE},
+    {.predicate = "guard_cmp_row",.negated = FALSE},
+  };
+  static const wyl_dl_body_atom_t window_and_body[] = {
+    {.predicate = "perm_arm_rule",.negated = FALSE},
+    {.predicate = "guard_row",.negated = FALSE},
+    {.predicate = "guard_and_row",.negated = FALSE},
+    {.predicate = "guard_cmp_row",.negated = FALSE},
+  };
+  static const wyl_dl_body_atom_t window_observed_body[] = {
+    {.predicate = "perm_window_guard",.negated = FALSE},
+  };
   static const wyl_dl_body_atom_t rule1_body[] = {
     {.predicate = "perm_state",.negated = FALSE},
     {.predicate = "perm_arm_rule",.negated = TRUE},
@@ -55,6 +72,14 @@ check_stratification (void)
     {.predicate = "eval_guard",.negated = FALSE},
   };
   wyl_dl_rule_t rules[] = {
+    {.head = "perm_window_guard",.body = window_direct_body,.body_len =
+          G_N_ELEMENTS (window_direct_body)},
+    {.head = "perm_window_guard",.body = window_and_body,.body_len =
+          G_N_ELEMENTS (window_and_body)},
+    {.head = "perm_window_guard",.body = window_and_body,.body_len =
+          G_N_ELEMENTS (window_and_body)},
+    {.head = "perm_window_guard_observed",.body = window_observed_body,
+        .body_len = G_N_ELEMENTS (window_observed_body)},
     {.head = "armed",.body = rule1_body,.body_len = G_N_ELEMENTS (rule1_body)},
     {.head = "armed",.body = rule3_body,.body_len = G_N_ELEMENTS (rule3_body)},
     {.head = "armed",.body = rule4_body,.body_len = G_N_ELEMENTS (rule4_body)},

--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -122,8 +122,8 @@ typedef struct
 
 typedef struct
 {
-  guint guard_deltas;
-} GuardProjectionDeltaExpect;
+  guint internal_deltas;
+} InternalProjectionDeltaExpect;
 
 typedef struct
 {
@@ -501,10 +501,10 @@ delta_count_cb (const gchar *relation, const gint64 *row, guint ncols,
 }
 
 static void
-guard_projection_delta_cb (const gchar *relation, const gint64 *row,
+internal_projection_delta_cb (const gchar *relation, const gint64 *row,
     guint ncols, WylDeltaKind kind, gpointer user_data)
 {
-  GuardProjectionDeltaExpect *expect = user_data;
+  InternalProjectionDeltaExpect *expect = user_data;
 
   (void) row;
   (void) ncols;
@@ -512,8 +512,10 @@ guard_projection_delta_cb (const gchar *relation, const gint64 *row,
 
   if (g_strcmp0 (relation, "guard_row") == 0
       || g_strcmp0 (relation, "guard_cmp_row") == 0
-      || g_strcmp0 (relation, "guard_and_row") == 0)
-    expect->guard_deltas++;
+      || g_strcmp0 (relation, "guard_and_row") == 0
+      || g_strcmp0 (relation, "perm_window_guard") == 0
+      || g_strcmp0 (relation, "perm_window_guard_observed") == 0)
+    expect->internal_deltas++;
 }
 
 static wyrelog_error_t
@@ -1385,7 +1387,7 @@ check_perm_arm_rule_guard_payload_contract_after_reload (void)
 }
 
 static gint
-check_perm_window_guard_seed_contract (void)
+check_perm_window_guard_derivation_contract (void)
 {
   g_autoptr (WylHandle) handle = NULL;
   gint64 stream_perm_id = -1;
@@ -1590,24 +1592,24 @@ check_perm_arm_rule_guard_payload_projection (void)
 }
 
 static gint
-check_guard_projection_rows_skip_delta_callbacks (void)
+check_internal_projection_rows_skip_delta_callbacks (void)
 {
   g_autoptr (WylHandle) handle = NULL;
-  GuardProjectionDeltaExpect expect = { 0 };
+  InternalProjectionDeltaExpect expect = { 0 };
 
   if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
     return 199;
   if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
       != WYRELOG_E_OK)
     return 200;
-  if (wyl_handle_engine_set_delta_callback (handle, guard_projection_delta_cb,
-          &expect) != WYRELOG_E_OK)
+  if (wyl_handle_engine_set_delta_callback (handle,
+          internal_projection_delta_cb, &expect) != WYRELOG_E_OK)
     return 201;
   for (guint i = 0; i < 8; i++) {
     if (wyl_handle_engine_step_delta (handle) != WYRELOG_E_OK)
       return 202;
   }
-  if (expect.guard_deltas != 0)
+  if (expect.internal_deltas != 0)
     return 203;
   if (wyl_handle_engine_set_delta_callback (handle, NULL, NULL)
       != WYRELOG_E_OK)
@@ -3607,11 +3609,11 @@ main (void)
     return rc;
   if ((rc = check_perm_arm_rule_guard_payload_contract_after_reload ()) != 0)
     return rc;
-  if ((rc = check_perm_window_guard_seed_contract ()) != 0)
+  if ((rc = check_perm_window_guard_derivation_contract ()) != 0)
     return rc;
   if ((rc = check_perm_arm_rule_guard_payload_projection ()) != 0)
     return rc;
-  if ((rc = check_guard_projection_rows_skip_delta_callbacks ()) != 0)
+  if ((rc = check_internal_projection_rows_skip_delta_callbacks ()) != 0)
     return rc;
   if ((rc = check_insert_fanout_reaches_read_engine ()) != 0)
     return rc;

--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -122,6 +122,11 @@ typedef struct
 
 typedef struct
 {
+  guint guard_deltas;
+} GuardProjectionDeltaExpect;
+
+typedef struct
+{
   gint64 and_handle;
   gint64 left_handle;
   gint64 right_handle;
@@ -213,39 +218,6 @@ write_guard_context_compound_templates (const gchar *dir)
       "compound_scope_row(H, M, S) :- __compound_scope_2(H, M, S).\n"
       "compound_metadata_row(H, T, L, R) :- __compound_metadata_3(H, T, L,"
       " R).\n")
-      && write_file_in_dir (dir, "fsm/principal.dl",
-      ".decl principal_transition(from_state: symbol, event: symbol,"
-      " to_state: symbol)\n")
-      && write_file_in_dir (dir, "fsm/session.dl",
-      ".decl session_active(state: symbol)\n"
-      ".decl session_transition(from_state: symbol, event: symbol,"
-      " to_state: symbol)\n")
-      && write_file_in_dir (dir, "fsm/permission_scope.dl",
-      ".decl perm_arm_rule(perm: symbol, guard_handle: int64)\n"
-      ".decl perm_window_guard(perm: symbol, window: symbol)\n")
-      && write_file_in_dir (dir, "lobac/decision.dl", "// decision stub\n");
-}
-
-static gboolean
-write_guard_payload_templates (const gchar *dir)
-{
-  g_autofree gchar *fsm_dir = g_build_filename (dir, "fsm", NULL);
-  if (g_mkdir (fsm_dir, 0755) != 0)
-    return FALSE;
-  g_autofree gchar *lobac_dir = g_build_filename (dir, "lobac", NULL);
-  if (g_mkdir (lobac_dir, 0755) != 0)
-    return FALSE;
-
-  return write_file_in_dir (dir, "bootstrap.dl",
-      ".decl perm_arm_rule_observed(perm: symbol, guard_handle: int64)\n"
-      ".decl guard_row(handle: int64, root: int64)\n"
-      ".decl guard_cmp_row(handle: int64, field: symbol, op: symbol,"
-      " value: symbol)\n"
-      ".decl guard_and_row(handle: int64, left: int64, right: int64)\n"
-      "perm_arm_rule_observed(P, G) :- perm_arm_rule(P, G).\n"
-      "guard_row(H, R) :- __compound_guard_1(H, R).\n"
-      "guard_cmp_row(H, F, O, V) :- __compound_guard_cmp_3(H, F, O, V).\n"
-      "guard_and_row(H, L, R) :- __compound_guard_and_2(H, L, R).\n")
       && write_file_in_dir (dir, "fsm/principal.dl",
       ".decl principal_transition(from_state: symbol, event: symbol,"
       " to_state: symbol)\n")
@@ -526,6 +498,22 @@ delta_count_cb (const gchar *relation, const gint64 *row, guint ncols,
   (void) kind;
 
   (*seen)++;
+}
+
+static void
+guard_projection_delta_cb (const gchar *relation, const gint64 *row,
+    guint ncols, WylDeltaKind kind, gpointer user_data)
+{
+  GuardProjectionDeltaExpect *expect = user_data;
+
+  (void) row;
+  (void) ncols;
+  (void) kind;
+
+  if (g_strcmp0 (relation, "guard_row") == 0
+      || g_strcmp0 (relation, "guard_cmp_row") == 0
+      || g_strcmp0 (relation, "guard_and_row") == 0)
+    expect->guard_deltas++;
 }
 
 static wyrelog_error_t
@@ -1454,7 +1442,6 @@ static gint
 check_perm_arm_rule_guard_payload_projection (void)
 {
   g_autoptr (WylHandle) handle = NULL;
-  g_autofree gchar *tmpdir = NULL;
   gsize nperms = wyl_perm_arm_rule_count ();
   g_autofree gint64 *perm_ids = g_new0 (gint64, nperms);
   g_autofree guint *seen_counts = g_new0 (guint, nperms);
@@ -1462,24 +1449,14 @@ check_perm_arm_rule_guard_payload_projection (void)
 
   if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
     return 171;
-  tmpdir = make_tmpdir ();
-  if (tmpdir == NULL)
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
     return 172;
-  if (!write_guard_payload_templates (tmpdir)) {
-    rmdir_recursive (tmpdir);
-    return 173;
-  }
-  if (wyl_handle_open_engine_pair (handle, tmpdir) != WYRELOG_E_OK) {
-    rmdir_recursive (tmpdir);
-    return 174;
-  }
 
   for (gsize i = 0; i < nperms; i++) {
     if (wyl_handle_intern_engine_symbol (handle, wyl_perm_arm_rule_perm_id (i),
-            &perm_ids[i]) != WYRELOG_E_OK) {
-      rmdir_recursive (tmpdir);
+            &perm_ids[i]) != WYRELOG_E_OK)
       return 175;
-    }
   }
 
   gint64 placeholder_id = -1;
@@ -1491,43 +1468,27 @@ check_perm_arm_rule_guard_payload_projection (void)
   gint64 value_30_id = -1;
   gint64 trusted_id = -1;
   if (wyl_handle_intern_engine_symbol (handle, "_v0_deferred",
-          &placeholder_id) != WYRELOG_E_OK) {
-    rmdir_recursive (tmpdir);
+          &placeholder_id) != WYRELOG_E_OK)
     return 176;
-  }
   if (wyl_handle_intern_engine_symbol (handle, "risk", &risk_id)
-      != WYRELOG_E_OK) {
-    rmdir_recursive (tmpdir);
+      != WYRELOG_E_OK)
     return 177;
-  }
   if (wyl_handle_intern_engine_symbol (handle, "loc_class", &loc_class_id)
-      != WYRELOG_E_OK) {
-    rmdir_recursive (tmpdir);
+      != WYRELOG_E_OK)
     return 178;
-  }
-  if (wyl_handle_intern_engine_symbol (handle, "lt", &lt_id) != WYRELOG_E_OK) {
-    rmdir_recursive (tmpdir);
+  if (wyl_handle_intern_engine_symbol (handle, "lt", &lt_id) != WYRELOG_E_OK)
     return 179;
-  }
-  if (wyl_handle_intern_engine_symbol (handle, "eq", &eq_id) != WYRELOG_E_OK) {
-    rmdir_recursive (tmpdir);
+  if (wyl_handle_intern_engine_symbol (handle, "eq", &eq_id) != WYRELOG_E_OK)
     return 180;
-  }
   if (wyl_handle_intern_engine_symbol (handle, "70", &value_70_id)
-      != WYRELOG_E_OK) {
-    rmdir_recursive (tmpdir);
+      != WYRELOG_E_OK)
     return 181;
-  }
   if (wyl_handle_intern_engine_symbol (handle, "30", &value_30_id)
-      != WYRELOG_E_OK) {
-    rmdir_recursive (tmpdir);
+      != WYRELOG_E_OK)
     return 182;
-  }
   if (wyl_handle_intern_engine_symbol (handle, "trusted", &trusted_id)
-      != WYRELOG_E_OK) {
-    rmdir_recursive (tmpdir);
+      != WYRELOG_E_OK)
     return 183;
-  }
 
   PermArmRuleSnapshotExpect expect = {
     .perm_ids = perm_ids,
@@ -1541,21 +1502,15 @@ check_perm_arm_rule_guard_payload_projection (void)
   };
   if (wyl_engine_snapshot (wyl_handle_get_read_engine (handle),
           "perm_arm_rule_observed", perm_arm_rule_snapshot_cb, &expect)
-      != WYRELOG_E_OK) {
-    rmdir_recursive (tmpdir);
+      != WYRELOG_E_OK)
     return 184;
-  }
 
   gint audit_idx = find_perm_arm_rule_index ("wr.audit.read");
   gint admin_idx = find_perm_arm_rule_index ("wr.sys.admin");
-  if (audit_idx < 0 || admin_idx < 0) {
-    rmdir_recursive (tmpdir);
+  if (audit_idx < 0 || admin_idx < 0)
     return 185;
-  }
-  if (guard_handles[audit_idx] <= 0 || guard_handles[admin_idx] <= 0) {
-    rmdir_recursive (tmpdir);
+  if (guard_handles[audit_idx] <= 0 || guard_handles[admin_idx] <= 0)
     return 186;
-  }
 
   GuardWrapperExpect audit_wrapper = {
     .guard_handle = guard_handles[audit_idx],
@@ -1563,14 +1518,10 @@ check_perm_arm_rule_guard_payload_projection (void)
     .matches = 0,
   };
   if (wyl_engine_snapshot (wyl_handle_get_read_engine (handle), "guard_row",
-          guard_wrapper_cb, &audit_wrapper) != WYRELOG_E_OK) {
-    rmdir_recursive (tmpdir);
+          guard_wrapper_cb, &audit_wrapper) != WYRELOG_E_OK)
     return 187;
-  }
-  if (audit_wrapper.matches < 1 || audit_wrapper.root_handle <= 0) {
-    rmdir_recursive (tmpdir);
+  if (audit_wrapper.matches < 1 || audit_wrapper.root_handle <= 0)
     return 188;
-  }
 
   GuardCmpExpect audit_cmp = {
     .cmp_handle = audit_wrapper.root_handle,
@@ -1580,14 +1531,10 @@ check_perm_arm_rule_guard_payload_projection (void)
     .matches = 0,
   };
   if (wyl_engine_snapshot (wyl_handle_get_read_engine (handle),
-          "guard_cmp_row", guard_cmp_cb, &audit_cmp) != WYRELOG_E_OK) {
-    rmdir_recursive (tmpdir);
+          "guard_cmp_row", guard_cmp_cb, &audit_cmp) != WYRELOG_E_OK)
     return 189;
-  }
-  if (audit_cmp.matches < 1) {
-    rmdir_recursive (tmpdir);
+  if (audit_cmp.matches < 1)
     return 190;
-  }
 
   GuardWrapperExpect admin_wrapper = {
     .guard_handle = guard_handles[admin_idx],
@@ -1595,14 +1542,10 @@ check_perm_arm_rule_guard_payload_projection (void)
     .matches = 0,
   };
   if (wyl_engine_snapshot (wyl_handle_get_read_engine (handle), "guard_row",
-          guard_wrapper_cb, &admin_wrapper) != WYRELOG_E_OK) {
-    rmdir_recursive (tmpdir);
+          guard_wrapper_cb, &admin_wrapper) != WYRELOG_E_OK)
     return 191;
-  }
-  if (admin_wrapper.matches < 1 || admin_wrapper.root_handle <= 0) {
-    rmdir_recursive (tmpdir);
+  if (admin_wrapper.matches < 1 || admin_wrapper.root_handle <= 0)
     return 192;
-  }
 
   GuardAndExpect admin_and = {
     .and_handle = admin_wrapper.root_handle,
@@ -1611,15 +1554,11 @@ check_perm_arm_rule_guard_payload_projection (void)
     .matches = 0,
   };
   if (wyl_engine_snapshot (wyl_handle_get_read_engine (handle),
-          "guard_and_row", guard_and_cb, &admin_and) != WYRELOG_E_OK) {
-    rmdir_recursive (tmpdir);
+          "guard_and_row", guard_and_cb, &admin_and) != WYRELOG_E_OK)
     return 193;
-  }
   if (admin_and.matches < 1 || admin_and.left_handle <= 0
-      || admin_and.right_handle <= 0) {
-    rmdir_recursive (tmpdir);
+      || admin_and.right_handle <= 0)
     return 194;
-  }
 
   GuardCmpExpect admin_risk = {
     .cmp_handle = admin_and.left_handle,
@@ -1629,14 +1568,10 @@ check_perm_arm_rule_guard_payload_projection (void)
     .matches = 0,
   };
   if (wyl_engine_snapshot (wyl_handle_get_read_engine (handle),
-          "guard_cmp_row", guard_cmp_cb, &admin_risk) != WYRELOG_E_OK) {
-    rmdir_recursive (tmpdir);
+          "guard_cmp_row", guard_cmp_cb, &admin_risk) != WYRELOG_E_OK)
     return 195;
-  }
-  if (admin_risk.matches < 1) {
-    rmdir_recursive (tmpdir);
+  if (admin_risk.matches < 1)
     return 196;
-  }
 
   GuardCmpExpect admin_loc = {
     .cmp_handle = admin_and.right_handle,
@@ -1646,16 +1581,37 @@ check_perm_arm_rule_guard_payload_projection (void)
     .matches = 0,
   };
   if (wyl_engine_snapshot (wyl_handle_get_read_engine (handle),
-          "guard_cmp_row", guard_cmp_cb, &admin_loc) != WYRELOG_E_OK) {
-    rmdir_recursive (tmpdir);
+          "guard_cmp_row", guard_cmp_cb, &admin_loc) != WYRELOG_E_OK)
     return 197;
-  }
-  if (admin_loc.matches < 1) {
-    rmdir_recursive (tmpdir);
+  if (admin_loc.matches < 1)
     return 198;
-  }
 
-  rmdir_recursive (tmpdir);
+  return 0;
+}
+
+static gint
+check_guard_projection_rows_skip_delta_callbacks (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  GuardProjectionDeltaExpect expect = { 0 };
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 199;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 200;
+  if (wyl_handle_engine_set_delta_callback (handle, guard_projection_delta_cb,
+          &expect) != WYRELOG_E_OK)
+    return 201;
+  for (guint i = 0; i < 8; i++) {
+    if (wyl_handle_engine_step_delta (handle) != WYRELOG_E_OK)
+      return 202;
+  }
+  if (expect.guard_deltas != 0)
+    return 203;
+  if (wyl_handle_engine_set_delta_callback (handle, NULL, NULL)
+      != WYRELOG_E_OK)
+    return 204;
   return 0;
 }
 
@@ -3654,6 +3610,8 @@ main (void)
   if ((rc = check_perm_window_guard_seed_contract ()) != 0)
     return rc;
   if ((rc = check_perm_arm_rule_guard_payload_projection ()) != 0)
+    return rc;
+  if ((rc = check_guard_projection_rows_skip_delta_callbacks ()) != 0)
     return rc;
   if ((rc = check_insert_fanout_reaches_read_engine ()) != 0)
     return rc;

--- a/wyrelog/wyl-engine.c
+++ b/wyrelog/wyl-engine.c
@@ -48,12 +48,26 @@ wyl_engine_tuple_trampoline (const char *relation, const int64_t *row,
   cookie->cb (relation, (const gint64 *) row, (guint) ncols, cookie->user_data);
 }
 
+static gboolean
+relation_emits_delta_callback (const char *relation)
+{
+  if (g_strcmp0 (relation, "guard_row") == 0
+      || g_strcmp0 (relation, "guard_cmp_row") == 0
+      || g_strcmp0 (relation, "guard_and_row") == 0)
+    return FALSE;
+
+  return TRUE;
+}
+
 static void
 wyl_engine_delta_trampoline (const char *relation, const int64_t *row,
     uint32_t ncols, int32_t diff, void *user)
 {
   const WylDeltaCookie *cookie = user;
   WylDeltaKind kind;
+
+  if (!relation_emits_delta_callback (relation))
+    return;
 
   if (diff == 1) {
     kind = WYL_DELTA_INSERT;

--- a/wyrelog/wyl-engine.c
+++ b/wyrelog/wyl-engine.c
@@ -53,7 +53,9 @@ relation_emits_delta_callback (const char *relation)
 {
   if (g_strcmp0 (relation, "guard_row") == 0
       || g_strcmp0 (relation, "guard_cmp_row") == 0
-      || g_strcmp0 (relation, "guard_and_row") == 0)
+      || g_strcmp0 (relation, "guard_and_row") == 0
+      || g_strcmp0 (relation, "perm_window_guard") == 0
+      || g_strcmp0 (relation, "perm_window_guard_observed") == 0)
     return FALSE;
 
   return TRUE;

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -242,17 +242,6 @@ wyl_handle_seed_perm_arm_rules (WylHandle *self)
     rc = wyl_handle_engine_insert (self, "perm_arm_rule", row, 2);
     if (rc != WYRELOG_E_OK)
       return rc;
-
-    const gchar *window = wyl_guard_expr_timestamp_window (guard);
-    if (window != NULL) {
-      gint64 window_row[2] = { row[0], 0 };
-      rc = wyl_handle_intern_engine_symbol (self, window, &window_row[1]);
-      if (rc != WYRELOG_E_OK)
-        return rc;
-      rc = wyl_handle_engine_insert (self, "perm_window_guard", window_row, 2);
-      if (rc != WYRELOG_E_OK)
-        return rc;
-    }
   }
   return WYRELOG_E_OK;
 }


### PR DESCRIPTION
## Summary

- expose guard compound payload rows from the production permission scope template
- derive permission timestamp window guards from those projection rows
- suppress internal projection rows from delta callbacks while preserving snapshot visibility

## Tests

- `meson test -C builddir decide handle-engine-pair fsm-permission-scope daemon-http-decide --print-errorlogs`
- `meson test -C builddir-audit decide daemon-delta handle-engine-pair fsm-permission-scope daemon-http-decide --print-errorlogs`
- `git diff --check`
