### PR TITLE
Harden JWT access-token identity handling

### DIFF
--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -420,9 +420,10 @@ verify_login_access_token (const gchar *body, const gchar *session_token,
 
 #ifdef WYL_HAS_AUDIT
 static wyrelog_error_t
-sign_test_access_token (SoupServer *server, const gchar *session_id,
-    const gchar *subject, const gchar *principal_state, const gchar *issuer,
-    const gchar *audience, gint64 issued_at, gchar **out_token)
+sign_test_access_token_with_jti (SoupServer *server, const gchar *jti,
+    const gchar *session_id, const gchar *subject,
+    const gchar *principal_state, const gchar *issuer, const gchar *audience,
+    gint64 issued_at, gchar **out_token)
 {
   if (out_token == NULL)
     return WYRELOG_E_INVALID;
@@ -435,7 +436,7 @@ sign_test_access_token (SoupServer *server, const gchar *session_id,
     return rc;
 
   wyl_jwt_issue_input_t input = {
-    .jti = "test-access-token",
+    .jti = jti,
     .subject = subject,
     .issuer = issuer,
     .audience = audience,
@@ -448,6 +449,16 @@ sign_test_access_token (SoupServer *server, const gchar *session_id,
   rc = wyl_jwt_sign_hs256 (&input, secret, sizeof secret, out_token);
   memset (secret, 0, sizeof secret);
   return rc;
+}
+
+static wyrelog_error_t
+sign_test_access_token (SoupServer *server, const gchar *session_id,
+    const gchar *subject, const gchar *principal_state, const gchar *issuer,
+    const gchar *audience, gint64 issued_at, gchar **out_token)
+{
+  return sign_test_access_token_with_jti (server, "test-access-token",
+      session_id, subject, principal_state, issuer, audience, issued_at,
+      out_token);
 }
 #endif
 
@@ -1581,6 +1592,21 @@ check_raw_audit_contract (SoupServer *server, WylHandle *handle,
     if (status != 401 || strstr (body, "\"audit_auth_required\"") == NULL)
       return invalid_tokens[i].failure_code;
   }
+
+  g_autofree gchar *session_jti_token = NULL;
+  if (sign_test_access_token_with_jti (server, session_token, session_token,
+          "http-audit-user", "authenticated", "wyrelogd", "wyrelog-client",
+          now, &session_jti_token) != WYRELOG_E_OK)
+    return 158;
+
+  g_clear_pointer (&body, g_free);
+  rc = send_raw_audit_bearer (session, base_url,
+      "guard_timestamp=123&guard_loc_class=public&guard_risk=69",
+      session_jti_token, &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 401 || strstr (body, "\"audit_auth_required\"") == NULL)
+    return 159;
 
   g_autoptr (WylAuditIter) invalid_filter = NULL;
   if (wyl_client_audit_query_with_guard_context (client, "action()", 123,

--- a/tests/test-jwt.c
+++ b/tests/test-jwt.c
@@ -243,6 +243,22 @@ check_hs256_access_token_claims_and_time (void)
     return 91;
   if (payload == NULL)
     return 92;
+  wyl_jwt_access_claims_t claims = { 0 };
+  if (wyl_jwt_parse_access_claims_json (payload, &claims) != WYRELOG_E_OK)
+    return 99;
+  gint claims_rc = 0;
+  if (g_strcmp0 (claims.jti, "01890c10-2e3f-7000-8000-000000000101") != 0)
+    claims_rc = 100;
+  else if (g_strcmp0 (claims.subject, "alice") != 0)
+    claims_rc = 101;
+  else if (g_strcmp0 (claims.tenant, "__wr_default") != 0)
+    claims_rc = 102;
+  else if (g_strcmp0 (claims.session_id,
+          "01890c10-2e3f-7000-8000-000000000102") != 0)
+    claims_rc = 103;
+  wyl_jwt_access_claims_clear (&claims);
+  if (claims_rc != 0)
+    return claims_rc;
 
   g_clear_pointer (&payload, g_bytes_unref);
   if (wyl_jwt_verify_hs256_access_token (token, secret,

--- a/wyrelog/auth/jwt-private.h
+++ b/wyrelog/auth/jwt-private.h
@@ -24,9 +24,11 @@ typedef struct
 
 typedef struct
 {
+  gchar *jti;
   gchar *subject;
   gchar *issuer;
   gchar *audience;
+  gchar *tenant;
   gchar *principal_state_at_issue;
   gchar *session_id;
   gint64 not_before;

--- a/wyrelog/auth/jwt.c
+++ b/wyrelog/auth/jwt.c
@@ -468,9 +468,11 @@ wyl_jwt_access_claims_clear (wyl_jwt_access_claims_t *claims)
 {
   if (claims == NULL)
     return;
+  g_free (claims->jti);
   g_free (claims->subject);
   g_free (claims->issuer);
   g_free (claims->audience);
+  g_free (claims->tenant);
   g_free (claims->principal_state_at_issue);
   g_free (claims->session_id);
   memset (claims, 0, sizeof *claims);
@@ -537,7 +539,8 @@ parse_jwt_payload_claims (const gchar *payload, ParsedJwtClaims *claims)
     skip_json_ws (&p);
 
     if (g_strcmp0 (key, "jti") == 0)
-      rc = parse_string_claim_value (&p, claims, CLAIM_JTI, NULL);
+      rc = parse_string_claim_value (&p, claims, CLAIM_JTI,
+          &claims->claims.jti);
     else if (g_strcmp0 (key, "sub") == 0)
       rc = parse_string_claim_value (&p, claims, CLAIM_SUB,
           &claims->claims.subject);
@@ -557,7 +560,8 @@ parse_jwt_payload_claims (const gchar *payload, ParsedJwtClaims *claims)
       rc = parse_int_claim_value (&p, claims, CLAIM_EXP,
           &claims->claims.expires_at);
     else if (g_strcmp0 (key, "tenant") == 0)
-      rc = parse_string_claim_value (&p, claims, CLAIM_TENANT, NULL);
+      rc = parse_string_claim_value (&p, claims, CLAIM_TENANT,
+          &claims->claims.tenant);
     else if (g_strcmp0 (key, "principal_state_at_issue") == 0)
       rc = parse_string_claim_value (&p, claims, CLAIM_PRINCIPAL_STATE,
           &claims->claims.principal_state_at_issue);

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -337,6 +337,10 @@ resolve_bearer_session (SoupServer *server, WylDaemonHttpContext *ctx,
     wyl_jwt_access_claims_clear (&claims);
     return WYRELOG_E_POLICY;
   }
+  if (g_strcmp0 (claims.jti, claims.session_id) == 0) {
+    wyl_jwt_access_claims_clear (&claims);
+    return WYRELOG_E_POLICY;
+  }
 
   g_autoptr (WylSession) session =
       wyl_daemon_http_ref_session (server, claims.session_id);


### PR DESCRIPTION
## Summary

Retain parsed JWT identity claims in the private access-claims structure so
later token lifecycle code can consume structured `jti` and `tenant` fields.

Reject bearer access tokens whose `jti` is the same as the backing session id,
keeping access-token identity distinct from live session identity.

## Tests

- `meson test -C builddir jwt --print-errorlogs`
- `meson test -C builddir-audit daemon-http-decide --print-errorlogs`
- `git diff --check`
