### PR TITLE
Authorize skip-MFA through read-engine projection

### DIFF
--- a/templates/access/bootstrap.dl
+++ b/templates/access/bootstrap.dl
@@ -46,6 +46,7 @@
 .decl effective_member(user: symbol, role: symbol, scope: symbol)
 .decl effective_permission(role: symbol, perm: symbol)
 .decl has_permission(user: symbol, perm: symbol, scope: symbol)
+.decl login_skip_mfa_authz(user: symbol)
 .decl is_admin(user: symbol)
 .decl can_read_audit(user: symbol)
 .decl can_manage_role(user: symbol, role: symbol)

--- a/templates/access/decision.dl
+++ b/templates/access/decision.dl
@@ -66,6 +66,8 @@
 .decl audit_event_deny_reason(id: symbol, reason: symbol)
 .decl audit_event_deny_origin(id: symbol, origin: symbol)
 .decl principal_state_observed(user: symbol, state: symbol)
+.decl login_skip_mfa_authz(user: symbol)
+.decl login_skip_mfa_authz_observed(user: symbol)
 
 .decl allow(user: symbol, perm: symbol, scope: symbol)
 .decl allow_guard_base(user: symbol, perm: symbol, scope: symbol)
@@ -96,6 +98,9 @@ audit_event_deny_origin(ID, Origin) :-
 
 principal_state_observed(U, State) :-
     principal_state(U, State).
+
+login_skip_mfa_authz_observed(U) :-
+    login_skip_mfa_authz(U).
 
 // --- allow / allow_bool ----------------------------------------------
 

--- a/templates/access/lobac/decision.dl
+++ b/templates/access/lobac/decision.dl
@@ -63,6 +63,8 @@
 .decl audit_event_deny_reason(id: symbol, reason: symbol)
 .decl audit_event_deny_origin(id: symbol, origin: symbol)
 .decl principal_state_observed(user: symbol, state: symbol)
+.decl login_skip_mfa_authz(user: symbol)
+.decl login_skip_mfa_authz_observed(user: symbol)
 
 .decl allow(user: symbol, perm: symbol, scope: symbol)
 .decl allow_guard_base(user: symbol, perm: symbol, scope: symbol)
@@ -93,6 +95,9 @@ audit_event_deny_origin(ID, Origin) :-
 
 principal_state_observed(U, State) :-
     principal_state(U, State).
+
+login_skip_mfa_authz_observed(U) :-
+    login_skip_mfa_authz(U).
 
 // --- allow / allow_bool ----------------------------------------------
 

--- a/tests/test-access-decision.c
+++ b/tests/test-access-decision.c
@@ -47,6 +47,9 @@ check_stratification (void)
   static const wyl_dl_body_atom_t allow_bool_body[] = {
     {.predicate = "allow",.negated = FALSE},
   };
+  static const wyl_dl_body_atom_t login_skip_mfa_observed_body[] = {
+    {.predicate = "login_skip_mfa_authz",.negated = FALSE},
+  };
   static const wyl_dl_body_atom_t dr_frozen_body[] = {
     {.predicate = "has_permission",.negated = FALSE},
     {.predicate = "frozen",.negated = FALSE},
@@ -84,6 +87,9 @@ check_stratification (void)
     {.head = "allow",.body = allow_body,.body_len = G_N_ELEMENTS (allow_body)},
     {.head = "allow_bool",.body = allow_bool_body,
         .body_len = G_N_ELEMENTS (allow_bool_body)},
+    {.head = "login_skip_mfa_authz_observed",
+          .body = login_skip_mfa_observed_body,
+        .body_len = G_N_ELEMENTS (login_skip_mfa_observed_body)},
     {.head = "deny_reason",.body = dr_frozen_body,
         .body_len = G_N_ELEMENTS (dr_frozen_body)},
     {.head = "deny_reason",.body = dr_disabled_role_body,
@@ -375,6 +381,9 @@ check_decision_rule_bodies (void)
     "allow(U, P, S) :-\n"
         "    allow_guard_base(U, P, S),\n" "    armed(U, P, S).",
     "allow_bool(U, P, S) :- allow(U, P, S).",
+    ".decl login_skip_mfa_authz(user: symbol)",
+    ".decl login_skip_mfa_authz_observed(user: symbol)",
+    "login_skip_mfa_authz_observed(U) :-\n" "    login_skip_mfa_authz(U).",
     "deny_reason(U, P, S, \"frozen\", \"frozen\") :-\n"
         "    has_permission(U, P, S),\n" "    frozen(S).",
     "deny_reason(U, P, S, \"disabled_role\", \"disabled_role_for\") :-\n"

--- a/tests/test-daemon-checks.c
+++ b/tests/test-daemon-checks.c
@@ -124,6 +124,8 @@ check_login_skip_mfa_ready_allows_policy_path (void)
           (handle), "wyrelogd-skip-mfa-user", "wr.login.skip_mfa", "login")
       != WYRELOG_E_OK)
     return 41;
+  if (wyl_handle_reload_engine_pair (handle) != WYRELOG_E_OK)
+    return 45;
   if (wyl_daemon_check_login_skip_mfa_ready (handle) != WYRELOG_E_OK)
     return 42;
 
@@ -138,6 +140,52 @@ check_login_skip_mfa_ready_allows_policy_path (void)
     return 43;
   if (count != 1)
     return 44;
+  return 0;
+}
+
+static gint
+check_login_skip_mfa_ready_allows_role_policy_path (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  gint64 count = 0;
+  wyl_policy_store_t *store = NULL;
+
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 46;
+  store = wyl_handle_get_policy_store (handle);
+  if (wyl_policy_store_upsert_role (store, "wyrelogd-skip-mfa-role",
+          "skip mfa role") != WYRELOG_E_OK)
+    return 47;
+  if (wyl_policy_store_grant_role_permission (store,
+          "wyrelogd-skip-mfa-role", "wr.login.skip_mfa") != WYRELOG_E_OK)
+    return 48;
+  if (wyl_policy_store_grant_role_membership (store,
+          "wyrelogd-skip-mfa-user", "wyrelogd-skip-mfa-role", "login")
+      != WYRELOG_E_OK)
+    return 49;
+  if (wyl_handle_reload_engine_pair (handle) != WYRELOG_E_OK)
+    return 60;
+
+  g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
+  g_autoptr (WylSession) session = NULL;
+  wyl_login_req_set_username (login, "wyrelogd-skip-mfa-user");
+  wyl_login_req_set_skip_mfa (login, TRUE);
+  if (wyl_session_login (handle, login, &session) != WYRELOG_E_OK)
+    return 61;
+  if (session == NULL)
+    return 64;
+
+  duckdb_connection conn =
+      wyl_audit_conn_get_connection (wyl_handle_get_audit_conn (handle));
+  if (!count_duckdb_rows (conn,
+          "SELECT COUNT(*) FROM audit_events "
+          "WHERE action = 'principal_state' "
+          "AND subject_id = 'wyrelogd-skip-mfa-user' "
+          "AND deny_reason = 'login_skip_mfa' "
+          "AND resource_id = 'authenticated' AND decision = 1;", &count))
+    return 62;
+  if (count != 1)
+    return 63;
   return 0;
 }
 
@@ -212,6 +260,8 @@ main (void)
   if ((rc = check_login_skip_mfa_ready_allows_development_path ()) != 0)
     return rc;
   if ((rc = check_login_skip_mfa_ready_allows_policy_path ()) != 0)
+    return rc;
+  if ((rc = check_login_skip_mfa_ready_allows_role_policy_path ()) != 0)
     return rc;
   return 0;
 }

--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -601,6 +601,8 @@ check_raw_login_contract (SoupServer *server, WylHandle *handle,
           (handle), "login-user", "wr.login.skip_mfa", "login")
       != WYRELOG_E_OK)
     return 484;
+  if (wyl_handle_reload_engine_pair (handle) != WYRELOG_E_OK)
+    return 487;
 
   rc = send_raw_login (session, "POST", base_url,
       "username=login-user&skip_mfa=true", &status, &body);

--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -2374,9 +2374,28 @@ check_login_skip_mfa_projection_autoload_on_open (void)
           "skip-mfa-wrong-scope-user", "wr.login.skip_mfa", "other")
       != WYRELOG_E_OK)
     return 365;
+  if (wyl_policy_store_upsert_role (store, "skip-mfa-role",
+          "skip mfa role") != WYRELOG_E_OK)
+    return 366;
+  if (wyl_policy_store_grant_role_permission (store, "skip-mfa-role",
+          "wr.login.skip_mfa") != WYRELOG_E_OK)
+    return 367;
+  if (wyl_policy_store_grant_role_membership (store, "skip-mfa-role-user",
+          "skip-mfa-role", "login") != WYRELOG_E_OK)
+    return 368;
+  if (wyl_policy_store_upsert_role (store, "skip-mfa-child-role",
+          "skip mfa child role") != WYRELOG_E_OK)
+    return 369;
+  if (wyl_policy_store_grant_role_inheritance (store, "skip-mfa-child-role",
+          "skip-mfa-role") != WYRELOG_E_OK)
+    return 370;
+  if (wyl_policy_store_grant_role_membership (store,
+          "skip-mfa-inherited-user", "skip-mfa-child-role", "login")
+      != WYRELOG_E_OK)
+    return 371;
   if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
       != WYRELOG_E_OK)
-    return 366;
+    return 372;
 
   struct
   {
@@ -2384,8 +2403,10 @@ check_login_skip_mfa_projection_autoload_on_open (void)
     gboolean expected;
     gint code;
   } cases[] = {
-    {"skip-mfa-direct-user", TRUE, 367},
-    {"skip-mfa-wrong-scope-user", FALSE, 368},
+    {"skip-mfa-direct-user", TRUE, 373},
+    {"skip-mfa-role-user", TRUE, 374},
+    {"skip-mfa-inherited-user", TRUE, 375},
+    {"skip-mfa-wrong-scope-user", FALSE, 376},
   };
 
   for (gsize i = 0; i < G_N_ELEMENTS (cases); i++) {

--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -2355,6 +2355,67 @@ check_policy_store_role_inheritances_autoload_on_open (void)
 }
 
 static gint
+check_login_skip_mfa_projection_autoload_on_open (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 362;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (wyl_policy_store_upsert_permission (store, "wr.login.skip_mfa",
+          "login skip mfa", "critical") != WYRELOG_E_OK)
+    return 363;
+  if (wyl_policy_store_grant_direct_permission (store,
+          "skip-mfa-direct-user", "wr.login.skip_mfa", "login")
+      != WYRELOG_E_OK)
+    return 364;
+  if (wyl_policy_store_grant_direct_permission (store,
+          "skip-mfa-wrong-scope-user", "wr.login.skip_mfa", "other")
+      != WYRELOG_E_OK)
+    return 365;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 366;
+
+  struct
+  {
+    const gchar *user;
+    gboolean expected;
+    gint code;
+  } cases[] = {
+    {"skip-mfa-direct-user", TRUE, 367},
+    {"skip-mfa-wrong-scope-user", FALSE, 368},
+  };
+
+  for (gsize i = 0; i < G_N_ELEMENTS (cases); i++) {
+    gint64 row[1];
+    gboolean found = FALSE;
+    if (wyl_handle_intern_engine_symbol (handle, cases[i].user, &row[0])
+        != WYRELOG_E_OK)
+      return cases[i].code;
+    if (wyl_handle_engine_contains (handle, "login_skip_mfa_authz",
+            row, 1, &found) != WYRELOG_E_OK)
+      return cases[i].code + 10;
+    if (found != cases[i].expected)
+      return cases[i].code + 20;
+  }
+
+  gint64 decision_row[3];
+  gboolean allowed = TRUE;
+  if (intern3 (handle, "skip-mfa-direct-user", "wr.login.skip_mfa", "login",
+          decision_row) != WYRELOG_E_OK)
+    return 393;
+  if (wyl_handle_engine_decide (handle, decision_row, &allowed)
+      != WYRELOG_E_OK)
+    return 394;
+  if (allowed)
+    return 395;
+
+  return 0;
+}
+
+static gint
 check_policy_store_role_permissions_require_engine_pair (void)
 {
   g_autoptr (WylHandle) handle = NULL;
@@ -3662,6 +3723,8 @@ main (void)
   if ((rc = check_policy_store_role_permissions_autoload_on_open ()) != 0)
     return rc;
   if ((rc = check_policy_store_role_inheritances_autoload_on_open ()) != 0)
+    return rc;
+  if ((rc = check_login_skip_mfa_projection_autoload_on_open ()) != 0)
     return rc;
   if ((rc = check_policy_store_role_permissions_require_engine_pair ()) != 0)
     return rc;

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -13,6 +13,9 @@
 #include "wyl-permission-scope-private.h"
 #include "policy/store-private.h"
 
+#define WYL_LOGIN_SKIP_MFA_PERMISSION "wr.login.skip_mfa"
+#define WYL_LOGIN_SKIP_MFA_SCOPE "login"
+
 #ifdef WYL_HAS_AUDIT
 #include "audit/conn-private.h"
 #endif
@@ -994,6 +997,14 @@ insert_policy_store_direct_permission (const gchar *subject_id,
   if (rc != WYRELOG_E_OK)
     return rc;
 
+  if (g_strcmp0 (perm_id, WYL_LOGIN_SKIP_MFA_PERMISSION) == 0
+      && g_strcmp0 (scope, WYL_LOGIN_SKIP_MFA_SCOPE) == 0) {
+    gint64 authz_row[1] = { row[0] };
+    rc = wyl_handle_engine_insert (self, "login_skip_mfa_authz", authz_row, 1);
+    if (rc != WYRELOG_E_OK)
+      return rc;
+  }
+
   /* Guarded permissions are granted membership only. Their armed state
    * comes from request-local guard evaluation, not persisted perm_state. */
   if (wyl_perm_arm_rule_lookup (perm_id) != NULL)
@@ -1358,6 +1369,8 @@ wyl_handle_engine_contains (WylHandle *self, const gchar *relation,
    * the template mirror while preserving the handle-level relation name. */
   if (g_strcmp0 (relation, "principal_state") == 0)
     snapshot_relation = "principal_state_observed";
+  else if (g_strcmp0 (relation, "login_skip_mfa_authz") == 0)
+    snapshot_relation = "login_skip_mfa_authz_observed";
 
   WylRowProbe probe = { relation, snapshot_relation, row, ncols, FALSE };
   wyrelog_error_t rc = wyl_engine_snapshot (self->read_engine,

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -914,6 +914,27 @@ wyl_handle_engine_set_delta_callback (WylHandle *self, WylDeltaCallback cb,
 }
 
 static wyrelog_error_t
+insert_login_skip_mfa_authz_if_allowed (WylHandle *self,
+    const gchar *subject_id, const gchar *scope)
+{
+  if (g_strcmp0 (scope, WYL_LOGIN_SKIP_MFA_SCOPE) != 0)
+    return WYRELOG_E_OK;
+
+  gboolean allowed = FALSE;
+  wyrelog_error_t rc = wyl_policy_store_subject_has_permission
+      (self->policy_store, subject_id, WYL_LOGIN_SKIP_MFA_PERMISSION,
+      WYL_LOGIN_SKIP_MFA_SCOPE, &allowed);
+  if (rc != WYRELOG_E_OK || !allowed)
+    return rc;
+
+  gint64 row[1];
+  rc = wyl_handle_intern_engine_symbol (self, subject_id, &row[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_engine_insert (self, "login_skip_mfa_authz", row, 1);
+}
+
+static wyrelog_error_t
 insert_policy_store_role_permission (const gchar *role_id,
     const gchar *perm_id, gpointer user_data)
 {
@@ -959,7 +980,10 @@ insert_policy_store_role_membership (const gchar *subject_id,
   rc = wyl_handle_intern_engine_symbol (self, scope, &row[2]);
   if (rc != WYRELOG_E_OK)
     return rc;
-  return wyl_handle_engine_insert (self, "member_of", row, 3);
+  rc = wyl_handle_engine_insert (self, "member_of", row, 3);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return insert_login_skip_mfa_authz_if_allowed (self, subject_id, scope);
 }
 
 wyrelog_error_t
@@ -997,13 +1021,9 @@ insert_policy_store_direct_permission (const gchar *subject_id,
   if (rc != WYRELOG_E_OK)
     return rc;
 
-  if (g_strcmp0 (perm_id, WYL_LOGIN_SKIP_MFA_PERMISSION) == 0
-      && g_strcmp0 (scope, WYL_LOGIN_SKIP_MFA_SCOPE) == 0) {
-    gint64 authz_row[1] = { row[0] };
-    rc = wyl_handle_engine_insert (self, "login_skip_mfa_authz", authz_row, 1);
-    if (rc != WYRELOG_E_OK)
-      return rc;
-  }
+  rc = insert_login_skip_mfa_authz_if_allowed (self, subject_id, scope);
+  if (rc != WYRELOG_E_OK)
+    return rc;
 
   /* Guarded permissions are granted membership only. Their armed state
    * comes from request-local guard evaluation, not persisted perm_state. */

--- a/wyrelog/wyl-session.c
+++ b/wyrelog/wyl-session.c
@@ -8,9 +8,6 @@
 #include "wyl-id-private.h"
 #include "policy/store-private.h"
 
-#define WYL_LOGIN_SKIP_MFA_PERMISSION "wr.login.skip_mfa"
-#define WYL_LOGIN_SKIP_MFA_SCOPE "login"
-
 struct _WylSession
 {
   GObject parent_instance;
@@ -82,9 +79,29 @@ login_skip_mfa_allowed (WylHandle *handle, const wyl_login_req_t *req,
   if (username == NULL || username[0] == '\0')
     return WYRELOG_E_OK;
 
-  return wyl_policy_store_subject_has_permission (wyl_handle_get_policy_store
-      (handle), username, WYL_LOGIN_SKIP_MFA_PERMISSION,
-      WYL_LOGIN_SKIP_MFA_SCOPE, out_allowed);
+  if (wyl_handle_get_read_engine (handle) == NULL
+      || wyl_handle_get_delta_engine (handle) == NULL)
+    return WYRELOG_E_OK;
+
+  wyrelog_error_t rc = reload_session_snapshot (handle);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  gint64 row[1];
+  rc = wyl_handle_intern_engine_symbol (handle, username, &row[0]);
+  if (rc != WYRELOG_E_OK)
+    return WYRELOG_E_OK;
+
+  rc = wyl_handle_engine_contains (handle, "login_skip_mfa_authz", row, 1,
+      out_allowed);
+  wyrelog_error_t reload_rc = reload_session_snapshot (handle);
+  if (reload_rc != WYRELOG_E_OK)
+    return reload_rc;
+  if (rc != WYRELOG_E_OK) {
+    *out_allowed = FALSE;
+    return WYRELOG_E_OK;
+  }
+  return WYRELOG_E_OK;
 }
 
 #ifdef WYL_HAS_AUDIT


### PR DESCRIPTION
## Summary
- project login_skip_mfa_authz rows for direct and effective grants
- route production skip-MFA login authorization through the read engine
- refresh projection-aware daemon, HTTP, and session tests

## Tests
- git diff --check
- meson test -C builddir-audit session-username daemon-checks daemon-http-decide handle-engine-pair --print-errorlogs
- meson test -C builddir session-username handle-engine-pair --print-errorlogs
