### PR TITLE
Add permission-state FSM persistence and replay

### DIFF
--- a/templates/access/fsm/permission_scope.dl
+++ b/templates/access/fsm/permission_scope.dl
@@ -53,6 +53,10 @@
 .decl perm_state(user: symbol, perm: symbol, scope: symbol, state: symbol)
 .decl perm_state_transition(from: symbol, event: symbol, to: symbol)
 .decl perm_state_step(from: symbol, event: symbol, to: symbol)
+.decl perm_state_event(event_id: int64, user: symbol, perm: symbol,
+    scope: symbol, event: symbol, from_state: symbol, to_state: symbol)
+.decl perm_state_fired(event_id: int64, user: symbol, perm: symbol,
+    scope: symbol, from_state: symbol, event: symbol, to_state: symbol)
 .decl perm_arm_rule(perm: symbol, guard_handle: int64)
 .decl perm_window_guard(perm: symbol, window: symbol)
 .decl guard_row(handle: int64, root: int64)
@@ -81,6 +85,10 @@ perm_state_transition("cooldown", "reset",    "armed").
 perm_state_transition("cooldown", "expire",   "dormant").
 
 perm_state_step(From, Ev, To) :- perm_state_transition(From, Ev, To).
+
+perm_state_fired(EventId, U, P, S, From, Ev, To) :-
+    perm_state_event(EventId, U, P, S, Ev, From, To),
+    perm_state_transition(From, Ev, To).
 
 // --- perm_arm_rule catalogue seed ------------------------------------
 //

--- a/templates/access/fsm/permission_scope.dl
+++ b/templates/access/fsm/permission_scope.dl
@@ -12,10 +12,11 @@
 // context_now/3 compound, guard_context/6, and eval_guard/4 bridge
 // facts for a satisfied guard expression.
 //
-// v0 still declares the permission-state transition schema so downstream
-// tools can depend on a stable FSM surface. No transition facts are present;
-// perm_state_step/3 is therefore intentionally empty until a later lifecycle
-// phase defines concrete dormant/armed/firing/cooldown transitions.
+// v0 defines the permission-state transition surface for host mutation
+// code and downstream tooling. The transition table is intentionally
+// small: only "armed" participates in allow/3, while "dormant",
+// "firing", and "cooldown" remain non-armed states until explicit host
+// events move them.
 //
 // EDB schemas (host-populated, no clauses below):
 //   perm_state(user, perm, scope, state)        -- v0 row count = 0
@@ -71,6 +72,13 @@
 .decl armed(user: symbol, perm: symbol, scope: symbol)
 
 // --- permission-state FSM schema -------------------------------------
+
+perm_state_transition("dormant",  "grant",    "armed").
+perm_state_transition("armed",    "revoke",   "dormant").
+perm_state_transition("armed",    "trigger",  "firing").
+perm_state_transition("firing",   "complete", "cooldown").
+perm_state_transition("cooldown", "reset",    "armed").
+perm_state_transition("cooldown", "expire",   "dormant").
 
 perm_state_step(From, Ev, To) :- perm_state_transition(From, Ev, To).
 

--- a/templates/access/sqlite-schema.sql
+++ b/templates/access/sqlite-schema.sql
@@ -164,6 +164,25 @@ CREATE INDEX IF NOT EXISTS idx_direct_permission_events_perm
     ON direct_permission_events (perm_id);
 
 -- ---------------------------------------------------------------------------
+-- Table: permission_states
+-- Durable permission lifecycle state mirrored into perm_state/4.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS permission_states (
+    subject_id TEXT    NOT NULL,
+    perm_id    TEXT    NOT NULL,
+    scope      TEXT    NOT NULL,
+    state      TEXT    NOT NULL,
+    updated_at INTEGER,
+    PRIMARY KEY (subject_id, perm_id, scope)
+);
+
+CREATE INDEX IF NOT EXISTS idx_permission_states_state
+    ON permission_states (state);
+
+CREATE INDEX IF NOT EXISTS idx_permission_states_perm
+    ON permission_states (perm_id);
+
+-- ---------------------------------------------------------------------------
 -- Table: principal_states
 -- Durable principal authentication state mirrored into principal_state/2.
 -- ---------------------------------------------------------------------------

--- a/templates/access/sqlite-schema.sql
+++ b/templates/access/sqlite-schema.sql
@@ -183,6 +183,31 @@ CREATE INDEX IF NOT EXISTS idx_permission_states_perm
     ON permission_states (perm_id);
 
 -- ---------------------------------------------------------------------------
+-- Table: permission_state_events
+-- Append-only permission-state FSM transition ledger. Current state is kept in
+-- permission_states; this table preserves the event edge that produced it.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS permission_state_events (
+    event_id   INTEGER PRIMARY KEY AUTOINCREMENT,
+    subject_id TEXT    NOT NULL,
+    perm_id    TEXT    NOT NULL,
+    scope      TEXT    NOT NULL,
+    event      TEXT    NOT NULL,
+    from_state TEXT    NOT NULL,
+    to_state   TEXT    NOT NULL,
+    created_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_permission_state_events_subject
+    ON permission_state_events (subject_id);
+
+CREATE INDEX IF NOT EXISTS idx_permission_state_events_perm
+    ON permission_state_events (perm_id);
+
+CREATE INDEX IF NOT EXISTS idx_permission_state_events_event
+    ON permission_state_events (event);
+
+-- ---------------------------------------------------------------------------
 -- Table: principal_states
 -- Durable principal authentication state mirrored into principal_state/2.
 -- ---------------------------------------------------------------------------

--- a/tests/test-fsm-permission-scope.c
+++ b/tests/test-fsm-permission-scope.c
@@ -96,6 +96,10 @@ check_stratification (void)
   static const wyl_dl_body_atom_t perm_state_step_body[] = {
     {.predicate = "perm_state_transition",.negated = FALSE},
   };
+  static const wyl_dl_body_atom_t perm_state_fired_body[] = {
+    {.predicate = "perm_state_event",.negated = FALSE},
+    {.predicate = "perm_state_transition",.negated = FALSE},
+  };
   static const wyl_dl_body_atom_t rule1_body[] = {
     {.predicate = "perm_state",.negated = FALSE},
     {.predicate = "perm_arm_rule",.negated = TRUE},
@@ -134,6 +138,8 @@ check_stratification (void)
         .body_len = G_N_ELEMENTS (window_observed_body)},
     {.head = "perm_state_step",.body = perm_state_step_body,.body_len =
           G_N_ELEMENTS (perm_state_step_body)},
+    {.head = "perm_state_fired",.body = perm_state_fired_body,.body_len =
+          G_N_ELEMENTS (perm_state_fired_body)},
     {.head = "armed",.body = rule1_body,.body_len = G_N_ELEMENTS (rule1_body)},
     {.head = "armed",.body = rule3_body,.body_len = G_N_ELEMENTS (rule3_body)},
     {.head = "armed",.body = rule4_body,.body_len = G_N_ELEMENTS (rule4_body)},

--- a/tests/test-fsm-permission-scope.c
+++ b/tests/test-fsm-permission-scope.c
@@ -4,6 +4,7 @@
 #include <stdio.h>
 
 #include "wyrelog/wyl-permission-scope-private.h"
+#include "wyrelog/wyl-fsm-permission-scope-private.h"
 #include "wyrelog/wyl-guard-expr-private.h"
 #include "wyrelog/wyl-dl-static-private.h"
 #include "wyrelog/wyl-handle-private.h"
@@ -584,23 +585,6 @@ line_is_static_perm_arm_rule_fact (const gchar *line)
   return *p == '"';
 }
 
-static gboolean
-line_is_static_perm_state_transition_fact (const gchar *line)
-{
-  const gchar *prefix = "perm_state_transition";
-  if (!g_str_has_prefix (line, prefix))
-    return FALSE;
-  const gchar *p = line + strlen (prefix);
-  while (*p == ' ' || *p == '\t')
-    p++;
-  if (*p != '(')
-    return FALSE;
-  p++;
-  while (*p == ' ' || *p == '\t')
-    p++;
-  return *p == '"';
-}
-
 static gint
 check_template_static_fact_guards (void)
 {
@@ -622,8 +606,6 @@ check_template_static_fact_guards (void)
       continue;
     if (line_is_static_perm_arm_rule_fact (trimmed))
       return 210;
-    if (line_is_static_perm_state_transition_fact (trimmed))
-      return 211;
   }
   return 0;
 }
@@ -642,43 +624,259 @@ count_rows_cb (const gchar *relation, const gint64 *row, guint ncols,
 }
 
 static gint
-check_perm_state_transition_schema_only (void)
+expect_engine_row_count (WylEngine *engine, const gchar *relation,
+    guint expected, gint error_base)
+{
+  guint count = 0;
+  if (wyl_engine_snapshot (engine, relation, count_rows_cb, &count)
+      != WYRELOG_E_OK)
+    return error_base;
+  if (count != expected)
+    return error_base + 1;
+  return 0;
+}
+
+typedef struct
+{
+  wyl_perm_state_t from;
+  wyl_perm_event_t event;
+  wyrelog_error_t expected_rc;
+  wyl_perm_state_t expected_to;
+} perm_step_case_t;
+
+static gint
+check_perm_state_golden_trace (void)
+{
+  static const perm_step_case_t cases[] = {
+    {WYL_PERM_STATE_DORMANT, WYL_PERM_EVENT_GRANT, WYRELOG_E_OK,
+        WYL_PERM_STATE_ARMED},
+    {WYL_PERM_STATE_ARMED, WYL_PERM_EVENT_TRIGGER, WYRELOG_E_OK,
+        WYL_PERM_STATE_FIRING},
+    {WYL_PERM_STATE_FIRING, WYL_PERM_EVENT_COMPLETE, WYRELOG_E_OK,
+        WYL_PERM_STATE_COOLDOWN},
+    {WYL_PERM_STATE_COOLDOWN, WYL_PERM_EVENT_RESET, WYRELOG_E_OK,
+        WYL_PERM_STATE_ARMED},
+    {WYL_PERM_STATE_ARMED, WYL_PERM_EVENT_REVOKE, WYRELOG_E_OK,
+        WYL_PERM_STATE_DORMANT},
+    {WYL_PERM_STATE_COOLDOWN, WYL_PERM_EVENT_EXPIRE, WYRELOG_E_OK,
+        WYL_PERM_STATE_DORMANT},
+    {WYL_PERM_STATE_DORMANT, WYL_PERM_EVENT_TRIGGER, WYRELOG_E_POLICY,
+        WYL_PERM_STATE_DORMANT /* unused */ },
+    {WYL_PERM_STATE_COOLDOWN, WYL_PERM_EVENT_TRIGGER, WYRELOG_E_POLICY,
+        WYL_PERM_STATE_COOLDOWN /* unused */ },
+    {WYL_PERM_STATE_FIRING, WYL_PERM_EVENT_REVOKE, WYRELOG_E_POLICY,
+        WYL_PERM_STATE_FIRING /* unused */ },
+  };
+
+  for (gsize i = 0; i < G_N_ELEMENTS (cases); i++) {
+    wyl_perm_state_t to = WYL_PERM_STATE_LAST_;
+    wyrelog_error_t rc =
+        wyl_fsm_permission_scope_step (cases[i].from, cases[i].event, &to);
+    if (rc != cases[i].expected_rc)
+      return (gint) (220 + i);
+    if (rc == WYRELOG_E_OK && to != cases[i].expected_to)
+      return (gint) (240 + i);
+  }
+  return 0;
+}
+
+static gint
+check_perm_state_functional_ic (void)
+{
+  gsize n = 0;
+  const wyl_perm_transition_t *table = wyl_fsm_permission_scope_table (&n);
+
+  for (gsize i = 0; i < n; i++) {
+    for (gsize j = i + 1; j < n; j++) {
+      if (table[i].from == table[j].from && table[i].event == table[j].event)
+        return 260;
+    }
+  }
+  return 0;
+}
+
+static gint
+check_perm_state_name_roundtrip (void)
+{
+  for (guint s = 0; s < WYL_PERM_STATE_LAST_; s++) {
+    const gchar *name = wyl_perm_state_name ((wyl_perm_state_t) s);
+    if (name == NULL)
+      return 270;
+    if (wyl_perm_state_from_name (name) != (wyl_perm_state_t) s)
+      return 271;
+  }
+  if (wyl_perm_state_name (WYL_PERM_STATE_LAST_) != NULL)
+    return 272;
+  if (wyl_perm_state_from_name (NULL) != WYL_PERM_STATE_LAST_)
+    return 273;
+  if (wyl_perm_state_from_name ("missing") != WYL_PERM_STATE_LAST_)
+    return 274;
+
+  for (guint ev = 0; ev < WYL_PERM_EVENT_LAST_; ev++) {
+    const gchar *name = wyl_perm_event_name ((wyl_perm_event_t) ev);
+    if (name == NULL)
+      return 275;
+    if (wyl_perm_event_from_name (name) != (wyl_perm_event_t) ev)
+      return 276;
+  }
+  if (wyl_perm_event_name (WYL_PERM_EVENT_LAST_) != NULL)
+    return 277;
+  if (wyl_perm_event_from_name (NULL) != WYL_PERM_EVENT_LAST_)
+    return 278;
+  if (wyl_perm_event_from_name ("missing") != WYL_PERM_EVENT_LAST_)
+    return 279;
+  return 0;
+}
+
+static gchar *
+strip_dl_symbol (const gchar *raw)
+{
+  g_autofree gchar *s = g_strstrip (g_strdup (raw));
+  gsize n = strlen (s);
+  if (n >= 2 && s[0] == '"' && s[n - 1] == '"') {
+    s[n - 1] = '\0';
+    return g_strdup (s + 1);
+  }
+  return g_steal_pointer (&s);
+}
+
+static gboolean
+parse_perm_transition_row (const gchar *line, gchar **out_from,
+    gchar **out_event, gchar **out_to)
+{
+  const gchar *prefix = "perm_state_transition";
+  if (!g_str_has_prefix (line, prefix))
+    return FALSE;
+  const gchar *p = line + strlen (prefix);
+  while (*p == ' ' || *p == '\t')
+    p++;
+  if (*p != '(')
+    return FALSE;
+  p++;
+
+  const gchar *close = strchr (p, ')');
+  if (close == NULL)
+    return FALSE;
+  g_autofree gchar *inner = g_strndup (p, (gsize) (close - p));
+  if (strchr (inner, '(') != NULL)
+    return FALSE;
+  g_auto (GStrv) fields = g_strsplit (inner, ",", -1);
+  if (g_strv_length (fields) != 3)
+    return FALSE;
+
+  *out_from = strip_dl_symbol (fields[0]);
+  *out_event = strip_dl_symbol (fields[1]);
+  *out_to = strip_dl_symbol (fields[2]);
+  return TRUE;
+}
+
+static gint
+check_perm_state_text_mirror (void)
+{
+  g_autofree gchar *contents = NULL;
+  gsize len = 0;
+  g_autoptr (GError) err = NULL;
+  if (!g_file_get_contents (WYL_TEST_FSM_PERMISSION_SCOPE_DL_PATH, &contents,
+          &len, &err))
+    return 280;
+
+  g_auto (GStrv) lines = g_strsplit (contents, "\n", -1);
+  gsize parsed_n = 0;
+  gsize table_n = 0;
+  const wyl_perm_transition_t *table =
+      wyl_fsm_permission_scope_table (&table_n);
+
+  for (gsize i = 0; lines[i] != NULL; i++) {
+    g_autofree gchar *trimmed = g_strdup (g_strchug (lines[i]));
+    if (trimmed[0] == '%' || trimmed[0] == '\0'
+        || g_str_has_prefix (trimmed, "//")
+        || g_str_has_prefix (trimmed, ".decl"))
+      continue;
+    if (!g_str_has_prefix (trimmed, "perm_state_transition"))
+      continue;
+    if (strstr (trimmed, ":-") != NULL || strchr (trimmed, '"') == NULL)
+      continue;
+
+    g_autofree gchar *from = NULL;
+    g_autofree gchar *event = NULL;
+    g_autofree gchar *to = NULL;
+    if (!parse_perm_transition_row (trimmed, &from, &event, &to))
+      return (gint) (290 + parsed_n);
+    if (parsed_n >= table_n)
+      return 310;
+
+    const gchar *expect_from = wyl_perm_state_name (table[parsed_n].from);
+    const gchar *expect_event = wyl_perm_event_name (table[parsed_n].event);
+    const gchar *expect_to = wyl_perm_state_name (table[parsed_n].to);
+    if (g_strcmp0 (from, expect_from) != 0)
+      return (gint) (320 + parsed_n);
+    if (g_strcmp0 (event, expect_event) != 0)
+      return (gint) (340 + parsed_n);
+    if (g_strcmp0 (to, expect_to) != 0)
+      return (gint) (360 + parsed_n);
+    parsed_n++;
+  }
+
+  if (parsed_n != table_n)
+    return 380;
+  return 0;
+}
+
+static gint
+check_perm_state_transition_engine_rows (void)
 {
   g_autoptr (WylHandle) handle = NULL;
   if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
-    return 220;
+    return 400;
 
-  static const gchar *relations[] = {
-    "perm_state_transition",
-    "perm_state_step",
-  };
-  for (gsize i = 0; i < G_N_ELEMENTS (relations); i++) {
-    guint count = 0;
-    if (wyl_engine_snapshot (wyl_handle_get_read_engine (handle),
-            relations[i], count_rows_cb, &count) != WYRELOG_E_OK)
-      return (gint) (221 + i);
-    if (count != 0)
-      return (gint) (230 + i);
-  }
+  gsize table_n = 0;
+  (void) wyl_fsm_permission_scope_table (&table_n);
+
+  if (table_n > G_MAXUINT)
+    return 401;
+  guint expected = (guint) table_n;
+
+  gint rc = expect_engine_row_count (wyl_handle_get_read_engine (handle),
+      "perm_state_step", expected, 410);
+  if (rc != 0)
+    return rc;
 
   if (insert_symbol_row4 (handle, "perm_state", "schema-user",
           "schema-perm", "schema-scope", "armed") != WYRELOG_E_OK)
-    return 240;
+    return 450;
   gboolean found = FALSE;
   if (contains_armed (handle, "schema-user", "schema-perm", "schema-scope",
           &found) != WYRELOG_E_OK)
-    return 241;
+    return 451;
   if (!found)
-    return 242;
+    return 452;
+
+  static const gchar *const non_armed_states[] = {
+    "dormant",
+    "firing",
+    "cooldown",
+  };
+  for (gsize i = 0; i < G_N_ELEMENTS (non_armed_states); i++) {
+    g_autofree gchar *user = g_strdup_printf ("schema-%s-user",
+        non_armed_states[i]);
+    if (insert_symbol_row4 (handle, "perm_state", user, "schema-perm",
+            "schema-scope", non_armed_states[i]) != WYRELOG_E_OK)
+      return (gint) (460 + i);
+    if (contains_armed (handle, user, "schema-perm", "schema-scope", &found)
+        != WYRELOG_E_OK)
+      return (gint) (470 + i);
+    if (found)
+      return (gint) (480 + i);
+  }
 
   if (insert_symbol_row4 (handle, "perm_state", "schema-guard-user",
           "wr.audit.read", "schema-guard-scope", "armed") != WYRELOG_E_OK)
-    return 243;
+    return 490;
   if (contains_armed (handle, "schema-guard-user", "wr.audit.read",
           "schema-guard-scope", &found) != WYRELOG_E_OK)
-    return 244;
+    return 491;
   if (found)
-    return 245;
+    return 492;
 
   return 0;
 }
@@ -705,7 +903,15 @@ main (void)
     return rc;
   if ((rc = check_template_static_fact_guards ()) != 0)
     return rc;
-  if ((rc = check_perm_state_transition_schema_only ()) != 0)
+  if ((rc = check_perm_state_golden_trace ()) != 0)
+    return rc;
+  if ((rc = check_perm_state_functional_ic ()) != 0)
+    return rc;
+  if ((rc = check_perm_state_name_roundtrip ()) != 0)
+    return rc;
+  if ((rc = check_perm_state_text_mirror ()) != 0)
+    return rc;
+  if ((rc = check_perm_state_transition_engine_rows ()) != 0)
     return rc;
   return 0;
 }

--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -67,23 +67,6 @@ typedef struct
 
 typedef struct
 {
-  gint64 context_id;
-  gint64 expected_scope_id;
-  gint64 metadata_id;
-  guint matches;
-} GuardScopeCompoundExpect;
-
-typedef struct
-{
-  gint64 metadata_id;
-  gint64 expected_timestamp;
-  gint64 expected_loc_class_id;
-  gint64 expected_risk;
-  guint matches;
-} GuardMetadataCompoundExpect;
-
-typedef struct
-{
   const gint64 *perm_ids;
   guint *seen_counts;
   gint64 *guard_handles;
@@ -212,13 +195,10 @@ write_guard_context_compound_templates (const gchar *dir)
     return FALSE;
 
   return write_file_in_dir (dir, "bootstrap.dl",
-      ".decl compound_scope_row(handle: int64, metadata: int64,"
+      ".decl __compound_scope_2(handle: int64, metadata: int64,"
       " scope: symbol)\n"
-      ".decl compound_metadata_row(handle: int64, timestamp: int64,"
-      " loc_class: symbol, risk: int64)\n"
-      "compound_scope_row(H, M, S) :- __compound_scope_2(H, M, S).\n"
-      "compound_metadata_row(H, T, L, R) :- __compound_metadata_3(H, T, L,"
-      " R).\n")
+      ".decl __compound_metadata_3(handle: int64, timestamp: int64,"
+      " loc_class: symbol, risk: int64)\n")
       && write_file_in_dir (dir, "fsm/principal.dl",
       ".decl principal_transition(from_state: symbol, event: symbol,"
       " to_state: symbol)\n")
@@ -349,39 +329,6 @@ seen_expect_cb (const gchar *relation, const gint64 *row, guint ncols,
     return;
   if (row[0] == expect->expected_id)
     expect->matches++;
-}
-
-static void
-guard_scope_compound_cb (const gchar *relation, const gint64 *row, guint ncols,
-    gpointer user_data)
-{
-  GuardScopeCompoundExpect *expect = user_data;
-
-  if (g_strcmp0 (relation, "compound_scope_row") != 0 || ncols != 3)
-    return;
-  if (row[0] != expect->context_id || row[2] != expect->expected_scope_id)
-    return;
-
-  expect->metadata_id = row[1];
-  expect->matches++;
-}
-
-static void
-guard_metadata_compound_cb (const gchar *relation, const gint64 *row,
-    guint ncols, gpointer user_data)
-{
-  GuardMetadataCompoundExpect *expect = user_data;
-
-  if (g_strcmp0 (relation, "compound_metadata_row") != 0 || ncols != 4)
-    return;
-  if (row[0] != expect->metadata_id)
-    return;
-  if (row[1] != expect->expected_timestamp
-      || row[2] != expect->expected_loc_class_id
-      || row[3] != expect->expected_risk)
-    return;
-
-  expect->matches++;
 }
 
 static void
@@ -562,6 +509,13 @@ intern3 (WylHandle *handle, const gchar *a, const gchar *b, const gchar *c,
   if (rc != WYRELOG_E_OK)
     return rc;
   return wyl_handle_intern_engine_symbol (handle, c, &row[2]);
+}
+
+static wyrelog_error_t
+intern_read_symbol (WylHandle *handle, const gchar *symbol, gint64 *out_id)
+{
+  return wyl_engine_intern_symbol (wyl_handle_get_read_engine (handle),
+      symbol, out_id);
 }
 
 static gint
@@ -1115,7 +1069,7 @@ check_compound_make_rejects_missing_pair (void)
 }
 
 static gint
-check_compound_make_reaches_engine_pair (void)
+check_compound_make_reaches_read_engine (void)
 {
   g_autoptr (WylHandle) handle = NULL;
   gint64 loc_class = -1;
@@ -1135,7 +1089,7 @@ check_compound_make_reaches_engine_pair (void)
     {WIRELOG_TYPE_STRING, loc_class},
     {WIRELOG_TYPE_INT64, 10},
   };
-  if (wyl_handle_make_engine_compound (handle, "metadata", args,
+  if (wyl_handle_make_read_engine_compound (handle, "metadata", args,
           G_N_ELEMENTS (args), &compound) != WYRELOG_E_OK)
     return 102;
   if (compound <= 0)
@@ -1167,7 +1121,7 @@ check_compound_make_result_is_insertable (void)
   wirelog_compound_arg_t args[1] = {
     {WIRELOG_TYPE_INT64, 42},
   };
-  if (wyl_handle_make_engine_compound (handle, "scope", args,
+  if (wyl_handle_make_read_engine_compound (handle, "scope", args,
           G_N_ELEMENTS (args), &payload) != WYRELOG_E_OK) {
     rmdir_recursive (tmpdir);
     return 108;
@@ -1196,7 +1150,7 @@ check_compound_make_result_is_insertable (void)
 }
 
 static gint
-check_guard_context_compound_carries_request_payload (void)
+check_guard_context_compound_allocates_request_handles (void)
 {
   g_autoptr (WylHandle) handle = NULL;
   g_autofree gchar *tmpdir = NULL;
@@ -1259,79 +1213,6 @@ check_guard_context_compound_carries_request_payload (void)
     rmdir_recursive (tmpdir);
     return 123;
   }
-  GuardScopeCompoundExpect first_scope = {
-    .context_id = first_context_id,
-    .expected_scope_id = alpha_scope_id,
-    .metadata_id = -1,
-    .matches = 0,
-  };
-  if (wyl_engine_snapshot (wyl_handle_get_read_engine (handle),
-          "compound_scope_row", guard_scope_compound_cb, &first_scope)
-      != WYRELOG_E_OK) {
-    rmdir_recursive (tmpdir);
-    return 124;
-  }
-  if (first_scope.matches < 1 || first_scope.metadata_id <= 0) {
-    rmdir_recursive (tmpdir);
-    return 125;
-  }
-
-  GuardScopeCompoundExpect second_scope = {
-    .context_id = second_context_id,
-    .expected_scope_id = beta_scope_id,
-    .metadata_id = -1,
-    .matches = 0,
-  };
-  if (wyl_engine_snapshot (wyl_handle_get_read_engine (handle),
-          "compound_scope_row", guard_scope_compound_cb, &second_scope)
-      != WYRELOG_E_OK) {
-    rmdir_recursive (tmpdir);
-    return 126;
-  }
-  if (second_scope.matches < 1 || second_scope.metadata_id <= 0) {
-    rmdir_recursive (tmpdir);
-    return 127;
-  }
-  if (first_scope.metadata_id == second_scope.metadata_id) {
-    rmdir_recursive (tmpdir);
-    return 128;
-  }
-
-  GuardMetadataCompoundExpect first_metadata = {
-    .metadata_id = first_scope.metadata_id,
-    .expected_timestamp = 1700000001,
-    .expected_loc_class_id = trusted_id,
-    .expected_risk = 25,
-    .matches = 0,
-  };
-  if (wyl_engine_snapshot (wyl_handle_get_read_engine (handle),
-          "compound_metadata_row", guard_metadata_compound_cb,
-          &first_metadata) != WYRELOG_E_OK) {
-    rmdir_recursive (tmpdir);
-    return 129;
-  }
-  if (first_metadata.matches < 1) {
-    rmdir_recursive (tmpdir);
-    return 130;
-  }
-
-  GuardMetadataCompoundExpect second_metadata = {
-    .metadata_id = second_scope.metadata_id,
-    .expected_timestamp = 1700000002,
-    .expected_loc_class_id = public_id,
-    .expected_risk = 80,
-    .matches = 0,
-  };
-  if (wyl_engine_snapshot (wyl_handle_get_read_engine (handle),
-          "compound_metadata_row", guard_metadata_compound_cb,
-          &second_metadata) != WYRELOG_E_OK) {
-    rmdir_recursive (tmpdir);
-    return 131;
-  }
-  if (second_metadata.matches < 1) {
-    rmdir_recursive (tmpdir);
-    return 132;
-  }
 
   rmdir_recursive (tmpdir);
   return 0;
@@ -1346,14 +1227,14 @@ assert_perm_arm_rule_guard_payload_snapshot (WylHandle *handle, gint base_code)
   g_autofree gint64 *guard_handles = g_new0 (gint64, nperms);
 
   for (gsize i = 0; i < nperms; i++) {
-    if (wyl_handle_intern_engine_symbol (handle, wyl_perm_arm_rule_perm_id (i),
+    if (intern_read_symbol (handle, wyl_perm_arm_rule_perm_id (i),
             &perm_ids[i]) != WYRELOG_E_OK)
       return base_code;
   }
 
   gint64 placeholder_id = -1;
-  if (wyl_handle_intern_engine_symbol (handle, "_v0_deferred",
-          &placeholder_id) != WYRELOG_E_OK)
+  if (intern_read_symbol (handle, "_v0_deferred", &placeholder_id)
+      != WYRELOG_E_OK)
     return base_code + 1;
 
   PermArmRuleSnapshotExpect expect = {
@@ -1482,7 +1363,7 @@ check_perm_arm_rule_guard_payload_projection (void)
     return 172;
 
   for (gsize i = 0; i < nperms; i++) {
-    if (wyl_handle_intern_engine_symbol (handle, wyl_perm_arm_rule_perm_id (i),
+    if (intern_read_symbol (handle, wyl_perm_arm_rule_perm_id (i),
             &perm_ids[i]) != WYRELOG_E_OK)
       return 175;
   }
@@ -1495,27 +1376,23 @@ check_perm_arm_rule_guard_payload_projection (void)
   gint64 value_70_id = -1;
   gint64 value_30_id = -1;
   gint64 trusted_id = -1;
-  if (wyl_handle_intern_engine_symbol (handle, "_v0_deferred",
-          &placeholder_id) != WYRELOG_E_OK)
-    return 176;
-  if (wyl_handle_intern_engine_symbol (handle, "risk", &risk_id)
+  if (intern_read_symbol (handle, "_v0_deferred", &placeholder_id)
       != WYRELOG_E_OK)
+    return 176;
+  if (intern_read_symbol (handle, "risk", &risk_id) != WYRELOG_E_OK)
     return 177;
-  if (wyl_handle_intern_engine_symbol (handle, "loc_class", &loc_class_id)
+  if (intern_read_symbol (handle, "loc_class", &loc_class_id)
       != WYRELOG_E_OK)
     return 178;
-  if (wyl_handle_intern_engine_symbol (handle, "lt", &lt_id) != WYRELOG_E_OK)
+  if (intern_read_symbol (handle, "lt", &lt_id) != WYRELOG_E_OK)
     return 179;
-  if (wyl_handle_intern_engine_symbol (handle, "eq", &eq_id) != WYRELOG_E_OK)
+  if (intern_read_symbol (handle, "eq", &eq_id) != WYRELOG_E_OK)
     return 180;
-  if (wyl_handle_intern_engine_symbol (handle, "70", &value_70_id)
-      != WYRELOG_E_OK)
+  if (intern_read_symbol (handle, "70", &value_70_id) != WYRELOG_E_OK)
     return 181;
-  if (wyl_handle_intern_engine_symbol (handle, "30", &value_30_id)
-      != WYRELOG_E_OK)
+  if (intern_read_symbol (handle, "30", &value_30_id) != WYRELOG_E_OK)
     return 182;
-  if (wyl_handle_intern_engine_symbol (handle, "trusted", &trusted_id)
-      != WYRELOG_E_OK)
+  if (intern_read_symbol (handle, "trusted", &trusted_id) != WYRELOG_E_OK)
     return 183;
 
   PermArmRuleSnapshotExpect expect = {
@@ -4105,11 +3982,11 @@ main (void)
     return rc;
   if ((rc = check_compound_make_rejects_missing_pair ()) != 0)
     return rc;
-  if ((rc = check_compound_make_reaches_engine_pair ()) != 0)
+  if ((rc = check_compound_make_reaches_read_engine ()) != 0)
     return rc;
   if ((rc = check_compound_make_result_is_insertable ()) != 0)
     return rc;
-  if ((rc = check_guard_context_compound_carries_request_payload ()) != 0)
+  if ((rc = check_guard_context_compound_allocates_request_handles ()) != 0)
     return rc;
   if ((rc = check_perm_arm_rule_guard_payload_contract ()) != 0)
     return rc;

--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -2842,6 +2842,228 @@ check_policy_store_direct_permissions_require_engine_pair (void)
 }
 
 static gint
+check_policy_store_permission_states_autoload_on_open (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 576;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (wyl_policy_store_upsert_permission (store, "site.permstate.read",
+          "permission state read", "basic") != WYRELOG_E_OK)
+    return 577;
+  if (wyl_policy_store_grant_direct_permission (store, "permstate-user",
+          "site.permstate.read", "permstate-scope") != WYRELOG_E_OK)
+    return 578;
+  if (wyl_policy_store_set_principal_state (store, "permstate-user",
+          "authenticated") != WYRELOG_E_OK)
+    return 579;
+  if (wyl_policy_store_set_session_state (store, "permstate-scope", "active")
+      != WYRELOG_E_OK)
+    return 580;
+  if (wyl_policy_store_set_permission_state (store, "permstate-user",
+          "site.permstate.read", "permstate-scope", "armed") != WYRELOG_E_OK)
+    return 581;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 582;
+
+  gint64 row[3];
+  if (intern3 (handle, "permstate-user", "site.permstate.read",
+          "permstate-scope", row) != WYRELOG_E_OK)
+    return 583;
+  gboolean allowed = FALSE;
+  if (wyl_handle_engine_decide (handle, row, &allowed) != WYRELOG_E_OK)
+    return 584;
+  return allowed ? 0 : 585;
+}
+
+static gint
+check_policy_store_permission_states_override_auto_arm (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 586;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (wyl_policy_store_upsert_permission (store, "site.permstate.override",
+          "permission state override", "basic") != WYRELOG_E_OK)
+    return 587;
+  if (wyl_policy_store_grant_direct_permission (store,
+          "permstate-override-user", "site.permstate.override",
+          "permstate-override-scope")
+      != WYRELOG_E_OK)
+    return 588;
+  if (wyl_policy_store_set_principal_state (store, "permstate-override-user",
+          "authenticated") != WYRELOG_E_OK)
+    return 589;
+  if (wyl_policy_store_set_session_state (store, "permstate-override-scope",
+          "active") != WYRELOG_E_OK)
+    return 590;
+  if (wyl_policy_store_set_permission_state (store, "permstate-override-user",
+          "site.permstate.override", "permstate-override-scope", "dormant")
+      != WYRELOG_E_OK)
+    return 591;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 592;
+
+  gint64 row[3];
+  if (intern3 (handle, "permstate-override-user", "site.permstate.override",
+          "permstate-override-scope", row) != WYRELOG_E_OK)
+    return 593;
+  gboolean allowed = TRUE;
+  if (wyl_handle_engine_decide (handle, row, &allowed) != WYRELOG_E_OK)
+    return 594;
+  return allowed ? 595 : 0;
+}
+
+static gint
+check_policy_store_permission_states_reject_non_armed (void)
+{
+  static const gchar *const states[] = {
+    "dormant",
+    "firing",
+    "cooldown",
+  };
+
+  for (gsize i = 0; i < G_N_ELEMENTS (states); i++) {
+    g_autoptr (WylHandle) handle = NULL;
+    if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+      return (gint) (596 + i);
+
+    wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+    g_autofree gchar *user = g_strdup_printf ("permstate-%s-user", states[i]);
+    g_autofree gchar *perm = g_strdup_printf ("site.permstate.%s", states[i]);
+    g_autofree gchar *scope = g_strdup_printf ("permstate-%s-scope", states[i]);
+    if (wyl_policy_store_upsert_permission (store, perm, perm, "basic")
+        != WYRELOG_E_OK)
+      return (gint) (606 + i);
+    if (wyl_policy_store_grant_direct_permission (store, user, perm, scope)
+        != WYRELOG_E_OK)
+      return (gint) (616 + i);
+    if (wyl_policy_store_set_principal_state (store, user, "authenticated")
+        != WYRELOG_E_OK)
+      return (gint) (626 + i);
+    if (wyl_policy_store_set_session_state (store, scope, "active")
+        != WYRELOG_E_OK)
+      return (gint) (636 + i);
+    if (wyl_policy_store_set_permission_state (store, user, perm, scope,
+            states[i]) != WYRELOG_E_OK)
+      return (gint) (646 + i);
+    if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+        != WYRELOG_E_OK)
+      return (gint) (656 + i);
+
+    gint64 row[3];
+    if (intern3 (handle, user, perm, scope, row) != WYRELOG_E_OK)
+      return (gint) (666 + i);
+    gboolean allowed = TRUE;
+    if (wyl_handle_engine_decide (handle, row, &allowed) != WYRELOG_E_OK)
+      return (gint) (676 + i);
+    if (allowed)
+      return (gint) (686 + i);
+  }
+  return 0;
+}
+
+static gint
+check_policy_store_guarded_permission_state_stays_guarded (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 696;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (wyl_policy_store_grant_direct_permission (store, "permstate-guard-user",
+          "wr.audit.read", "permstate-guard-scope") != WYRELOG_E_OK)
+    return 697;
+  if (wyl_policy_store_set_principal_state (store, "permstate-guard-user",
+          "authenticated") != WYRELOG_E_OK)
+    return 698;
+  if (wyl_policy_store_set_session_state (store, "permstate-guard-scope",
+          "active") != WYRELOG_E_OK)
+    return 699;
+  if (wyl_policy_store_set_permission_state (store, "permstate-guard-user",
+          "wr.audit.read", "permstate-guard-scope", "armed") != WYRELOG_E_OK)
+    return 700;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 701;
+
+  gint64 row[3];
+  if (intern3 (handle, "permstate-guard-user", "wr.audit.read",
+          "permstate-guard-scope", row) != WYRELOG_E_OK)
+    return 702;
+  gboolean allowed = TRUE;
+  if (wyl_handle_engine_decide (handle, row, &allowed) != WYRELOG_E_OK)
+    return 703;
+  return allowed ? 704 : 0;
+}
+
+static gint
+check_policy_store_permission_states_reject_unknown_state (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 705;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (wyl_policy_store_set_permission_state (store, "permstate-bad-user",
+          "wr.audit.read", "permstate-bad-scope", "missing") != WYRELOG_E_OK)
+    return 706;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_POLICY)
+    return 707;
+  return 0;
+}
+
+static gint
+check_policy_store_permission_states_reload_failure_preserves_pair (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 711;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 712;
+  WylEngine *read_engine = wyl_handle_get_read_engine (handle);
+  WylEngine *delta_engine = wyl_handle_get_delta_engine (handle);
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (wyl_policy_store_set_permission_state (store, "permstate-reload-user",
+          "wr.audit.read", "permstate-reload-scope", "missing")
+      != WYRELOG_E_OK)
+    return 713;
+  if (wyl_handle_reload_engine_pair (handle) != WYRELOG_E_POLICY)
+    return 714;
+  if (wyl_handle_get_read_engine (handle) != read_engine)
+    return 715;
+  return wyl_handle_get_delta_engine (handle) == delta_engine ? 0 : 716;
+}
+
+static gint
+check_policy_store_permission_states_require_engine_pair (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 708;
+  if (wyl_handle_load_policy_store_permission_states (NULL)
+      != WYRELOG_E_INVALID)
+    return 709;
+  if (wyl_handle_load_policy_store_permission_states (handle)
+      != WYRELOG_E_INVALID)
+    return 710;
+  return 0;
+}
+
+static gint
 check_policy_store_principal_states_autoload_on_open (void)
 {
   g_autoptr (WylHandle) handle = NULL;
@@ -3810,6 +4032,22 @@ main (void)
       != 0)
     return rc;
   if ((rc = check_policy_store_direct_permissions_require_engine_pair ()) != 0)
+    return rc;
+  if ((rc = check_policy_store_permission_states_autoload_on_open ()) != 0)
+    return rc;
+  if ((rc = check_policy_store_permission_states_override_auto_arm ()) != 0)
+    return rc;
+  if ((rc = check_policy_store_permission_states_reject_non_armed ()) != 0)
+    return rc;
+  if ((rc = check_policy_store_guarded_permission_state_stays_guarded ()) != 0)
+    return rc;
+  if ((rc = check_policy_store_permission_states_reject_unknown_state ()) != 0)
+    return rc;
+  if ((rc =
+          check_policy_store_permission_states_reload_failure_preserves_pair ())
+      != 0)
+    return rc;
+  if ((rc = check_policy_store_permission_states_require_engine_pair ()) != 0)
     return rc;
   if ((rc = check_policy_store_principal_states_autoload_on_open ()) != 0)
     return rc;

--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -195,6 +195,7 @@ write_compound_templates (const gchar *dir)
       ".decl session_transition(from_state: symbol, event: symbol,"
       " to_state: symbol)\n")
       && write_file_in_dir (dir, "fsm/permission_scope.dl",
+      ".decl perm_state_transition(from: symbol, event: symbol, to: symbol)\n"
       ".decl perm_arm_rule(perm: symbol, guard_handle: int64)\n"
       ".decl perm_window_guard(perm: symbol, window: symbol)\n")
       && write_file_in_dir (dir, "lobac/decision.dl", "// decision stub\n");
@@ -226,6 +227,7 @@ write_guard_context_compound_templates (const gchar *dir)
       ".decl session_transition(from_state: symbol, event: symbol,"
       " to_state: symbol)\n")
       && write_file_in_dir (dir, "fsm/permission_scope.dl",
+      ".decl perm_state_transition(from: symbol, event: symbol, to: symbol)\n"
       ".decl perm_arm_rule(perm: symbol, guard_handle: int64)\n"
       ".decl perm_window_guard(perm: symbol, window: symbol)\n")
       && write_file_in_dir (dir, "lobac/decision.dl", "// decision stub\n");
@@ -1684,6 +1686,37 @@ check_insert_fanout_reaches_delta_engine (void)
     return 104;
   if (expect.matching == 0)
     return 105;
+  return 0;
+}
+
+static gint
+check_perm_state_transition_fanout_reaches_delta_engine (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  gint64 transition_row[3];
+  DeltaExpect expect = {
+    "perm_state_step",
+    transition_row,
+    WYL_DELTA_INSERT,
+    0,
+  };
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 106;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 107;
+  if (intern3 (handle, "fanout-dormant", "fanout-grant", "fanout-armed",
+          transition_row) != WYRELOG_E_OK)
+    return 108;
+  if (wyl_handle_engine_set_delta_callback (handle, delta_expect_cb, &expect)
+      != WYRELOG_E_OK)
+    return 109;
+  if (wyl_handle_engine_insert (handle, "perm_state_transition",
+          transition_row, 3) != WYRELOG_E_OK)
+    return 110;
+  if (expect.matching == 0)
+    return 111;
   return 0;
 }
 
@@ -3700,6 +3733,8 @@ main (void)
   if ((rc = check_insert_fanout_reaches_read_engine ()) != 0)
     return rc;
   if ((rc = check_insert_fanout_reaches_delta_engine ()) != 0)
+    return rc;
+  if ((rc = check_perm_state_transition_fanout_reaches_delta_engine ()) != 0)
     return rc;
   if ((rc = check_principal_event_fanout_derives_delta ()) != 0)
     return rc;

--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -630,6 +630,30 @@ intern_event5 (WylHandle *handle, gint64 event_id, const gchar *a,
 }
 
 static wyrelog_error_t
+intern_event7 (WylHandle *handle, gint64 event_id, const gchar *a,
+    const gchar *b, const gchar *c, const gchar *d, const gchar *e,
+    const gchar *f, gint64 row[7])
+{
+  row[0] = event_id;
+  wyrelog_error_t rc = wyl_handle_intern_engine_symbol (handle, a, &row[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, b, &row[2]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, c, &row[3]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, d, &row[4]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, e, &row[5]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_intern_engine_symbol (handle, f, &row[6]);
+}
+
+static wyrelog_error_t
 insert1_symbol (WylHandle *handle, const gchar *relation, const gchar *a)
 {
   gint64 row[1];
@@ -3064,6 +3088,151 @@ check_policy_store_permission_states_require_engine_pair (void)
 }
 
 static gint
+check_policy_store_permission_state_events_autoload_on_open (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 717;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  gint64 event_id = -1;
+  if (wyl_policy_store_append_permission_state_event (store,
+          "perm-event-load-user", "wr.perm.event", "perm-event-load-scope",
+          "grant", "dormant", "armed", &event_id) != WYRELOG_E_OK)
+    return 718;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 719;
+
+  gint64 fired_row[7];
+  if (intern_event7 (handle, event_id, "perm-event-load-user", "wr.perm.event",
+          "perm-event-load-scope", "dormant", "grant", "armed", fired_row)
+      != WYRELOG_E_OK)
+    return 720;
+  RelationSnapshotExpect fired_expect = {
+    .expected_relation = "perm_state_fired",
+    .expected_row = fired_row,
+    .ncols = 7,
+  };
+  if (wyl_engine_snapshot (wyl_handle_get_read_engine (handle),
+          "perm_state_fired", relation_snapshot_expect_cb, &fired_expect)
+      != WYRELOG_E_OK)
+    return 721;
+  return fired_expect.seen == 1 ? 0 : 722;
+}
+
+static gint
+check_policy_store_permission_state_event_duplicates_autoload_on_open (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 723;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  gint64 first_event_id = -1;
+  gint64 second_event_id = -1;
+  if (wyl_policy_store_append_permission_state_event (store,
+          "perm-event-dup-user", "wr.perm.dup", "perm-event-dup-scope",
+          "grant", "dormant", "armed", &first_event_id) != WYRELOG_E_OK)
+    return 724;
+  if (wyl_policy_store_append_permission_state_event (store,
+          "perm-event-dup-user", "wr.perm.dup", "perm-event-dup-scope",
+          "grant", "dormant", "armed", &second_event_id) != WYRELOG_E_OK)
+    return 725;
+  if (second_event_id <= first_event_id)
+    return 726;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 727;
+
+  gint64 first_fired[7];
+  if (intern_event7 (handle, first_event_id, "perm-event-dup-user",
+          "wr.perm.dup", "perm-event-dup-scope", "dormant", "grant", "armed",
+          first_fired) != WYRELOG_E_OK)
+    return 728;
+  gint64 second_fired[7];
+  if (intern_event7 (handle, second_event_id, "perm-event-dup-user",
+          "wr.perm.dup", "perm-event-dup-scope", "dormant", "grant", "armed",
+          second_fired) != WYRELOG_E_OK)
+    return 729;
+  RelationPairSnapshotExpect fired_expect = {
+    .expected_relation = "perm_state_fired",
+    .first_row = first_fired,
+    .second_row = second_fired,
+    .ncols = 7,
+  };
+  if (wyl_engine_snapshot (wyl_handle_get_read_engine (handle),
+          "perm_state_fired", relation_pair_snapshot_expect_cb, &fired_expect)
+      != WYRELOG_E_OK)
+    return 730;
+  if (fired_expect.first_seen != 1)
+    return 731;
+  return fired_expect.second_seen == 1 ? 0 : 732;
+}
+
+static gint
+check_policy_store_permission_state_events_reject_invalid_edges (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 733;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (wyl_policy_store_append_permission_state_event (store,
+          "perm-event-invalid-user", "wr.perm.invalid",
+          "perm-event-invalid-scope", "trigger", "dormant", "firing", NULL)
+      != WYRELOG_E_OK)
+    return 734;
+  return wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      == WYRELOG_E_POLICY ? 0 : 735;
+}
+
+static gint
+check_policy_store_permission_state_events_reload_failure_preserves_pair (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 736;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 737;
+  WylEngine *read_engine = wyl_handle_get_read_engine (handle);
+  WylEngine *delta_engine = wyl_handle_get_delta_engine (handle);
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (wyl_policy_store_append_permission_state_event (store,
+          "perm-event-reload-user", "wr.perm.reload",
+          "perm-event-reload-scope", "missing", "dormant", "armed", NULL)
+      != WYRELOG_E_OK)
+    return 738;
+  if (wyl_handle_reload_engine_pair (handle) != WYRELOG_E_POLICY)
+    return 739;
+  if (wyl_handle_get_read_engine (handle) != read_engine)
+    return 740;
+  return wyl_handle_get_delta_engine (handle) == delta_engine ? 0 : 741;
+}
+
+static gint
+check_policy_store_permission_state_events_require_engine_pair (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 742;
+  if (wyl_handle_load_policy_store_permission_state_events (NULL)
+      != WYRELOG_E_INVALID)
+    return 743;
+  if (wyl_handle_load_policy_store_permission_state_events (handle)
+      != WYRELOG_E_INVALID)
+    return 744;
+  return 0;
+}
+
+static gint
 check_policy_store_principal_states_autoload_on_open (void)
 {
   g_autoptr (WylHandle) handle = NULL;
@@ -4048,6 +4217,23 @@ main (void)
       != 0)
     return rc;
   if ((rc = check_policy_store_permission_states_require_engine_pair ()) != 0)
+    return rc;
+  if ((rc =
+          check_policy_store_permission_state_events_autoload_on_open ()) != 0)
+    return rc;
+  if ((rc =
+          check_policy_store_permission_state_event_duplicates_autoload_on_open
+          ()) != 0)
+    return rc;
+  if ((rc = check_policy_store_permission_state_events_reject_invalid_edges ())
+      != 0)
+    return rc;
+  if ((rc =
+          check_policy_store_permission_state_events_reload_failure_preserves_pair
+          ()) != 0)
+    return rc;
+  if ((rc = check_policy_store_permission_state_events_require_engine_pair ())
+      != 0)
     return rc;
   if ((rc = check_policy_store_principal_states_autoload_on_open ()) != 0)
     return rc;

--- a/tests/test-policy-store.c
+++ b/tests/test-policy-store.c
@@ -29,6 +29,7 @@ check_store_creates_authority_schema (void)
     "role_membership_events",
     "direct_permissions",
     "direct_permission_events",
+    "permission_states",
     "principal_events",
     "principal_states",
     "session_states",
@@ -78,6 +79,7 @@ check_template_schema_creates_state_tables (void)
     "role_membership_events",
     "direct_permissions",
     "direct_permission_events",
+    "permission_states",
     "principal_events",
     "principal_states",
     "session_states",
@@ -436,6 +438,15 @@ direct_permission_event_expect_cb (const gchar *subject_id,
 typedef struct
 {
   const gchar *subject_id;
+  const gchar *perm_id;
+  const gchar *scope;
+  const gchar *state;
+  guint matches;
+} PermissionStateExpect;
+
+typedef struct
+{
+  const gchar *subject_id;
   const gchar *state;
   guint matches;
 } PrincipalStateExpect;
@@ -449,6 +460,20 @@ typedef struct
   const gchar *to_state;
   guint matches;
 } PrincipalEventExpect;
+
+static wyrelog_error_t
+permission_state_expect_cb (const gchar *subject_id, const gchar *perm_id,
+    const gchar *scope, const gchar *state, gpointer user_data)
+{
+  PermissionStateExpect *expect = user_data;
+
+  if (g_strcmp0 (subject_id, expect->subject_id) == 0
+      && g_strcmp0 (perm_id, expect->perm_id) == 0
+      && g_strcmp0 (scope, expect->scope) == 0
+      && g_strcmp0 (state, expect->state) == 0)
+    expect->matches++;
+  return WYRELOG_E_OK;
+}
 
 static wyrelog_error_t
 principal_state_expect_cb (const gchar *subject_id, const gchar *state,
@@ -1154,6 +1179,48 @@ check_direct_permission_revoke_rolls_back_on_event_failure (void)
 }
 
 static gint
+check_store_sets_permission_state (void)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 218;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 219;
+  if (wyl_policy_store_set_permission_state (store, "perm-user",
+          "wr.perm.read", "perm-scope", "armed") != WYRELOG_E_OK)
+    return 220;
+  if (wyl_policy_store_set_permission_state (store, "perm-user",
+          "wr.perm.read", "perm-scope", "dormant") != WYRELOG_E_OK)
+    return 221;
+
+  gboolean exists = FALSE;
+  if (wyl_policy_store_permission_state_exists (store, "perm-user",
+          "wr.perm.read", "perm-scope", &exists) != WYRELOG_E_OK)
+    return 222;
+  if (!exists)
+    return 223;
+  if (wyl_policy_store_permission_state_exists (store, "perm-user",
+          "wr.perm.read", "missing-scope", &exists) != WYRELOG_E_OK)
+    return 224;
+  if (exists)
+    return 225;
+
+  PermissionStateExpect expect = {
+    .subject_id = "perm-user",
+    .perm_id = "wr.perm.read",
+    .scope = "perm-scope",
+    .state = "dormant",
+  };
+  if (wyl_policy_store_foreach_permission_state (store,
+          permission_state_expect_cb, &expect) != WYRELOG_E_OK)
+    return 226;
+  if (expect.matches != 1)
+    return 227;
+  return 0;
+}
+
+static gint
 check_store_sets_principal_state (void)
 {
   g_autoptr (wyl_policy_store_t) store = NULL;
@@ -1586,6 +1653,34 @@ check_store_rejects_bad_role_permission (void)
   if (wyl_policy_store_foreach_role_membership_event (store, NULL, NULL)
       != WYRELOG_E_INVALID)
     return 104;
+  if (wyl_policy_store_set_permission_state (store, NULL, "wr.read", "scope",
+          "armed") != WYRELOG_E_INVALID)
+    return 105;
+  if (wyl_policy_store_set_permission_state (store, "user", NULL, "scope",
+          "armed") != WYRELOG_E_INVALID)
+    return 106;
+  if (wyl_policy_store_set_permission_state (store, "user", "wr.read", NULL,
+          "armed") != WYRELOG_E_INVALID)
+    return 107;
+  if (wyl_policy_store_set_permission_state (store, "user", "wr.read", "scope",
+          NULL) != WYRELOG_E_INVALID)
+    return 108;
+  gboolean permission_state_exists = FALSE;
+  if (wyl_policy_store_permission_state_exists (store, NULL, "wr.read", "scope",
+          &permission_state_exists) != WYRELOG_E_INVALID)
+    return 109;
+  if (wyl_policy_store_permission_state_exists (store, "user", NULL, "scope",
+          &permission_state_exists) != WYRELOG_E_INVALID)
+    return 110;
+  if (wyl_policy_store_permission_state_exists (store, "user", "wr.read", NULL,
+          &permission_state_exists) != WYRELOG_E_INVALID)
+    return 111;
+  if (wyl_policy_store_permission_state_exists (store, "user", "wr.read",
+          "scope", NULL) != WYRELOG_E_INVALID)
+    return 112;
+  if (wyl_policy_store_foreach_permission_state (store, NULL, NULL)
+      != WYRELOG_E_INVALID)
+    return 113;
   if (wyl_policy_store_set_principal_state (store, NULL, "authenticated")
       != WYRELOG_E_INVALID)
     return 56;
@@ -1674,6 +1769,8 @@ main (void)
     return rc;
   if ((rc = check_direct_permission_revoke_rolls_back_on_event_failure ())
       != 0)
+    return rc;
+  if ((rc = check_store_sets_permission_state ()) != 0)
     return rc;
   if ((rc = check_store_sets_principal_state ()) != 0)
     return rc;

--- a/tests/test-policy-store.c
+++ b/tests/test-policy-store.c
@@ -30,6 +30,7 @@ check_store_creates_authority_schema (void)
     "direct_permissions",
     "direct_permission_events",
     "permission_states",
+    "permission_state_events",
     "principal_events",
     "principal_states",
     "session_states",
@@ -80,6 +81,7 @@ check_template_schema_creates_state_tables (void)
     "direct_permissions",
     "direct_permission_events",
     "permission_states",
+    "permission_state_events",
     "principal_events",
     "principal_states",
     "session_states",
@@ -446,6 +448,18 @@ typedef struct
 
 typedef struct
 {
+  gint64 event_id;
+  const gchar *subject_id;
+  const gchar *perm_id;
+  const gchar *scope;
+  const gchar *event;
+  const gchar *from_state;
+  const gchar *to_state;
+  guint matches;
+} PermissionStateEventExpect;
+
+typedef struct
+{
   const gchar *subject_id;
   const gchar *state;
   guint matches;
@@ -471,6 +485,24 @@ permission_state_expect_cb (const gchar *subject_id, const gchar *perm_id,
       && g_strcmp0 (perm_id, expect->perm_id) == 0
       && g_strcmp0 (scope, expect->scope) == 0
       && g_strcmp0 (state, expect->state) == 0)
+    expect->matches++;
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+permission_state_event_expect_cb (gint64 event_id, const gchar *subject_id,
+    const gchar *perm_id, const gchar *scope, const gchar *event,
+    const gchar *from_state, const gchar *to_state, gpointer user_data)
+{
+  PermissionStateEventExpect *expect = user_data;
+
+  if ((expect->event_id <= 0 || event_id == expect->event_id)
+      && g_strcmp0 (subject_id, expect->subject_id) == 0
+      && g_strcmp0 (perm_id, expect->perm_id) == 0
+      && g_strcmp0 (scope, expect->scope) == 0
+      && g_strcmp0 (event, expect->event) == 0
+      && g_strcmp0 (from_state, expect->from_state) == 0
+      && g_strcmp0 (to_state, expect->to_state) == 0)
     expect->matches++;
   return WYRELOG_E_OK;
 }
@@ -1221,6 +1253,38 @@ check_store_sets_permission_state (void)
 }
 
 static gint
+check_store_appends_permission_state_event (void)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 228;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 229;
+  gint64 event_id = -1;
+  if (wyl_policy_store_append_permission_state_event (store, "perm-event-user",
+          "wr.perm.event", "perm-event-scope", "grant", "dormant", "armed",
+          &event_id) != WYRELOG_E_OK)
+    return 230;
+
+  PermissionStateEventExpect expect = {
+    .event_id = event_id,
+    .subject_id = "perm-event-user",
+    .perm_id = "wr.perm.event",
+    .scope = "perm-event-scope",
+    .event = "grant",
+    .from_state = "dormant",
+    .to_state = "armed",
+  };
+  if (wyl_policy_store_foreach_permission_state_event (store,
+          permission_state_event_expect_cb, &expect) != WYRELOG_E_OK)
+    return 231;
+  if (expect.matches != 1)
+    return 232;
+  return 0;
+}
+
+static gint
 check_store_sets_principal_state (void)
 {
   g_autoptr (wyl_policy_store_t) store = NULL;
@@ -1393,6 +1457,31 @@ check_store_distinguishes_duplicate_events (void)
     return 112;
   if (session_expect.matches != 2)
     return 113;
+  gint64 perm_first = -1;
+  gint64 perm_second = -1;
+  if (wyl_policy_store_append_permission_state_event (store, "perm-dup-user",
+          "wr.perm.dup", "perm-dup-scope", "grant", "dormant", "armed",
+          &perm_first) != WYRELOG_E_OK)
+    return 233;
+  if (wyl_policy_store_append_permission_state_event (store, "perm-dup-user",
+          "wr.perm.dup", "perm-dup-scope", "grant", "dormant", "armed",
+          &perm_second) != WYRELOG_E_OK)
+    return 234;
+  if (perm_first <= 0 || perm_second <= perm_first)
+    return 235;
+  PermissionStateEventExpect perm_expect = {
+    .subject_id = "perm-dup-user",
+    .perm_id = "wr.perm.dup",
+    .scope = "perm-dup-scope",
+    .event = "grant",
+    .from_state = "dormant",
+    .to_state = "armed",
+  };
+  if (wyl_policy_store_foreach_permission_state_event (store,
+          permission_state_event_expect_cb, &perm_expect) != WYRELOG_E_OK)
+    return 236;
+  if (perm_expect.matches != 2)
+    return 237;
   return 0;
 }
 
@@ -1681,6 +1770,27 @@ check_store_rejects_bad_role_permission (void)
   if (wyl_policy_store_foreach_permission_state (store, NULL, NULL)
       != WYRELOG_E_INVALID)
     return 113;
+  if (wyl_policy_store_append_permission_state_event (store, NULL, "wr.read",
+          "scope", "grant", "dormant", "armed", NULL) != WYRELOG_E_INVALID)
+    return 114;
+  if (wyl_policy_store_append_permission_state_event (store, "user", NULL,
+          "scope", "grant", "dormant", "armed", NULL) != WYRELOG_E_INVALID)
+    return 115;
+  if (wyl_policy_store_append_permission_state_event (store, "user", "wr.read",
+          NULL, "grant", "dormant", "armed", NULL) != WYRELOG_E_INVALID)
+    return 116;
+  if (wyl_policy_store_append_permission_state_event (store, "user", "wr.read",
+          "scope", NULL, "dormant", "armed", NULL) != WYRELOG_E_INVALID)
+    return 117;
+  if (wyl_policy_store_append_permission_state_event (store, "user", "wr.read",
+          "scope", "grant", NULL, "armed", NULL) != WYRELOG_E_INVALID)
+    return 118;
+  if (wyl_policy_store_append_permission_state_event (store, "user", "wr.read",
+          "scope", "grant", "dormant", NULL, NULL) != WYRELOG_E_INVALID)
+    return 119;
+  if (wyl_policy_store_foreach_permission_state_event (store, NULL, NULL)
+      != WYRELOG_E_INVALID)
+    return 120;
   if (wyl_policy_store_set_principal_state (store, NULL, "authenticated")
       != WYRELOG_E_INVALID)
     return 56;
@@ -1771,6 +1881,8 @@ main (void)
       != 0)
     return rc;
   if ((rc = check_store_sets_permission_state ()) != 0)
+    return rc;
+  if ((rc = check_store_appends_permission_state_event ()) != 0)
     return rc;
   if ((rc = check_store_sets_principal_state ()) != 0)
     return rc;

--- a/wyrelog/daemon/checks.c
+++ b/wyrelog/daemon/checks.c
@@ -38,6 +38,7 @@ wyl_daemon_check_policy_store_ready (WylHandle *handle)
     "role_membership_events",
     "direct_permissions",
     "direct_permission_events",
+    "permission_states",
     "principal_events",
     "principal_states",
     "session_states",

--- a/wyrelog/daemon/checks.c
+++ b/wyrelog/daemon/checks.c
@@ -39,6 +39,7 @@ wyl_daemon_check_policy_store_ready (WylHandle *handle)
     "direct_permissions",
     "direct_permission_events",
     "permission_states",
+    "permission_state_events",
     "principal_events",
     "principal_states",
     "session_states",

--- a/wyrelog/meson.build
+++ b/wyrelog/meson.build
@@ -24,6 +24,7 @@ wyrelog_sources = files(
   'wyl-engine.c',
   'wyl-error.c',
   'wyl-events.c',
+  'wyl-fsm-permission-scope.c',
   'wyl-fsm-principal.c',
   'wyl-fsm-session.c',
   'wyl-guard-expr.c',

--- a/wyrelog/policy/store-private.h
+++ b/wyrelog/policy/store-private.h
@@ -25,6 +25,9 @@ typedef wyrelog_error_t (*wyl_policy_direct_permission_cb) (const gchar *
 typedef wyrelog_error_t (*wyl_policy_direct_permission_event_cb) (const gchar *
     subject_id, const gchar * perm_id, const gchar * scope,
     const gchar * operation, gpointer user_data);
+typedef wyrelog_error_t (*wyl_policy_permission_state_cb) (const gchar *
+    subject_id, const gchar * perm_id, const gchar * scope,
+    const gchar * state, gpointer user_data);
 typedef wyrelog_error_t (*wyl_policy_principal_state_cb) (const gchar *
     subject_id, const gchar * state, gpointer user_data);
 typedef wyrelog_error_t (*wyl_policy_principal_event_cb) (gint64 event_id,
@@ -150,6 +153,14 @@ wyl_policy_store_append_direct_permission_event (wyl_policy_store_t * store,
 wyrelog_error_t
 wyl_policy_store_foreach_direct_permission_event (wyl_policy_store_t * store,
     wyl_policy_direct_permission_event_cb cb, gpointer user_data);
+wyrelog_error_t wyl_policy_store_set_permission_state (wyl_policy_store_t *
+    store, const gchar * subject_id, const gchar * perm_id,
+    const gchar * scope, const gchar * state);
+wyrelog_error_t wyl_policy_store_permission_state_exists (wyl_policy_store_t *
+    store, const gchar * subject_id, const gchar * perm_id, const gchar * scope,
+    gboolean * out_exists);
+wyrelog_error_t wyl_policy_store_foreach_permission_state (wyl_policy_store_t *
+    store, wyl_policy_permission_state_cb cb, gpointer user_data);
 wyrelog_error_t wyl_policy_store_set_principal_state (wyl_policy_store_t *
     store, const gchar * subject_id, const gchar * state);
 wyrelog_error_t wyl_policy_store_foreach_principal_state (wyl_policy_store_t *

--- a/wyrelog/policy/store-private.h
+++ b/wyrelog/policy/store-private.h
@@ -28,6 +28,10 @@ typedef wyrelog_error_t (*wyl_policy_direct_permission_event_cb) (const gchar *
 typedef wyrelog_error_t (*wyl_policy_permission_state_cb) (const gchar *
     subject_id, const gchar * perm_id, const gchar * scope,
     const gchar * state, gpointer user_data);
+typedef wyrelog_error_t (*wyl_policy_permission_state_event_cb) (gint64
+    event_id, const gchar * subject_id, const gchar * perm_id,
+    const gchar * scope, const gchar * event, const gchar * from_state,
+    const gchar * to_state, gpointer user_data);
 typedef wyrelog_error_t (*wyl_policy_principal_state_cb) (const gchar *
     subject_id, const gchar * state, gpointer user_data);
 typedef wyrelog_error_t (*wyl_policy_principal_event_cb) (gint64 event_id,
@@ -161,6 +165,13 @@ wyrelog_error_t wyl_policy_store_permission_state_exists (wyl_policy_store_t *
     gboolean * out_exists);
 wyrelog_error_t wyl_policy_store_foreach_permission_state (wyl_policy_store_t *
     store, wyl_policy_permission_state_cb cb, gpointer user_data);
+wyrelog_error_t wyl_policy_store_append_permission_state_event
+    (wyl_policy_store_t * store, const gchar * subject_id,
+    const gchar * perm_id, const gchar * scope, const gchar * event,
+    const gchar * from_state, const gchar * to_state, gint64 * out_event_id);
+wyrelog_error_t wyl_policy_store_foreach_permission_state_event
+    (wyl_policy_store_t * store, wyl_policy_permission_state_event_cb cb,
+    gpointer user_data);
 wyrelog_error_t wyl_policy_store_set_principal_state (wyl_policy_store_t *
     store, const gchar * subject_id, const gchar * state);
 wyrelog_error_t wyl_policy_store_foreach_principal_state (wyl_policy_store_t *

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -573,6 +573,22 @@ wyl_policy_store_create_schema (wyl_policy_store_t *store)
       "  ON permission_states (state);"
       "CREATE INDEX IF NOT EXISTS idx_permission_states_perm "
       "  ON permission_states (perm_id);"
+      "CREATE TABLE IF NOT EXISTS permission_state_events ("
+      "  event_id INTEGER PRIMARY KEY AUTOINCREMENT,"
+      "  subject_id TEXT NOT NULL,"
+      "  perm_id TEXT NOT NULL,"
+      "  scope TEXT NOT NULL,"
+      "  event TEXT NOT NULL,"
+      "  from_state TEXT NOT NULL,"
+      "  to_state TEXT NOT NULL,"
+      "  created_at INTEGER NOT NULL"
+      ");"
+      "CREATE INDEX IF NOT EXISTS idx_permission_state_events_subject "
+      "  ON permission_state_events (subject_id);"
+      "CREATE INDEX IF NOT EXISTS idx_permission_state_events_perm "
+      "  ON permission_state_events (perm_id);"
+      "CREATE INDEX IF NOT EXISTS idx_permission_state_events_event "
+      "  ON permission_state_events (event);"
       "CREATE TABLE IF NOT EXISTS principal_states ("
       "  subject_id TEXT PRIMARY KEY,"
       "  state TEXT NOT NULL,"
@@ -1393,6 +1409,90 @@ wyl_policy_store_foreach_permission_state (wyl_policy_store_t *store,
     const gchar *scope = (const gchar *) sqlite3_column_text (stmt, 2);
     const gchar *state = (const gchar *) sqlite3_column_text (stmt, 3);
     rc = cb (subject_id, perm_id, scope, state, user_data);
+    if (rc != WYRELOG_E_OK) {
+      sqlite3_finalize (stmt);
+      return rc;
+    }
+  }
+
+  sqlite3_finalize (stmt);
+  return (step_rc == SQLITE_DONE) ? WYRELOG_E_OK : WYRELOG_E_IO;
+}
+
+wyrelog_error_t
+wyl_policy_store_append_permission_state_event (wyl_policy_store_t *store,
+    const gchar *subject_id, const gchar *perm_id, const gchar *scope,
+    const gchar *event, const gchar *from_state, const gchar *to_state,
+    gint64 *out_event_id)
+{
+  sqlite3_stmt *stmt = NULL;
+
+  if (store == NULL || store->db == NULL || subject_id == NULL
+      || perm_id == NULL || scope == NULL || event == NULL
+      || from_state == NULL || to_state == NULL)
+    return WYRELOG_E_INVALID;
+
+  static const gchar *sql =
+      "INSERT INTO permission_state_events "
+      "  (subject_id, perm_id, scope, event, from_state, to_state, created_at) "
+      "VALUES (?, ?, ?, ?, ?, ?, unixepoch());";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if ((rc = bind_text (stmt, 1, subject_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 2, perm_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 3, scope)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 4, event)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 5, from_state)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 6, to_state)) != WYRELOG_E_OK) {
+    sqlite3_finalize (stmt);
+    return rc;
+  }
+
+  int step_rc = sqlite3_step (stmt);
+  sqlite3_finalize (stmt);
+  if (step_rc != SQLITE_DONE)
+    return WYRELOG_E_IO;
+  if (out_event_id != NULL) {
+    sqlite3_int64 event_id = sqlite3_last_insert_rowid (store->db);
+    if (event_id <= 0)
+      return WYRELOG_E_IO;
+    *out_event_id = event_id;
+  }
+  return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
+wyl_policy_store_foreach_permission_state_event (wyl_policy_store_t *store,
+    wyl_policy_permission_state_event_cb cb, gpointer user_data)
+{
+  sqlite3_stmt *stmt = NULL;
+
+  if (store == NULL || store->db == NULL || cb == NULL)
+    return WYRELOG_E_INVALID;
+
+  static const gchar *sql =
+      "SELECT event_id, subject_id, perm_id, scope, event, from_state, to_state "
+      "FROM permission_state_events ORDER BY event_id;";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  int step_rc;
+  while ((step_rc = sqlite3_step (stmt)) == SQLITE_ROW) {
+    gint64 event_id = sqlite3_column_int64 (stmt, 0);
+    const gchar *subject_id = (const gchar *) sqlite3_column_text (stmt, 1);
+    const gchar *perm_id = (const gchar *) sqlite3_column_text (stmt, 2);
+    const gchar *scope = (const gchar *) sqlite3_column_text (stmt, 3);
+    const gchar *event = (const gchar *) sqlite3_column_text (stmt, 4);
+    const gchar *from_state = (const gchar *) sqlite3_column_text (stmt, 5);
+    const gchar *to_state = (const gchar *) sqlite3_column_text (stmt, 6);
+    if (event_id <= 0) {
+      sqlite3_finalize (stmt);
+      return WYRELOG_E_POLICY;
+    }
+    rc = cb (event_id, subject_id, perm_id, scope, event, from_state, to_state,
+        user_data);
     if (rc != WYRELOG_E_OK) {
       sqlite3_finalize (stmt);
       return rc;

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -561,6 +561,18 @@ wyl_policy_store_create_schema (wyl_policy_store_t *store)
       "  ON direct_permission_events (subject_id);"
       "CREATE INDEX IF NOT EXISTS idx_direct_permission_events_perm "
       "  ON direct_permission_events (perm_id);"
+      "CREATE TABLE IF NOT EXISTS permission_states ("
+      "  subject_id TEXT NOT NULL,"
+      "  perm_id TEXT NOT NULL,"
+      "  scope TEXT NOT NULL,"
+      "  state TEXT NOT NULL,"
+      "  updated_at INTEGER,"
+      "  PRIMARY KEY (subject_id, perm_id, scope)"
+      ");"
+      "CREATE INDEX IF NOT EXISTS idx_permission_states_state "
+      "  ON permission_states (state);"
+      "CREATE INDEX IF NOT EXISTS idx_permission_states_perm "
+      "  ON permission_states (perm_id);"
       "CREATE TABLE IF NOT EXISTS principal_states ("
       "  subject_id TEXT PRIMARY KEY,"
       "  state TEXT NOT NULL,"
@@ -1278,6 +1290,109 @@ wyl_policy_store_foreach_direct_permission_event (wyl_policy_store_t *store,
     const gchar *scope = (const gchar *) sqlite3_column_text (stmt, 2);
     const gchar *operation = (const gchar *) sqlite3_column_text (stmt, 3);
     rc = cb (subject_id, perm_id, scope, operation, user_data);
+    if (rc != WYRELOG_E_OK) {
+      sqlite3_finalize (stmt);
+      return rc;
+    }
+  }
+
+  sqlite3_finalize (stmt);
+  return (step_rc == SQLITE_DONE) ? WYRELOG_E_OK : WYRELOG_E_IO;
+}
+
+wyrelog_error_t
+wyl_policy_store_set_permission_state (wyl_policy_store_t *store,
+    const gchar *subject_id, const gchar *perm_id, const gchar *scope,
+    const gchar *state)
+{
+  sqlite3_stmt *stmt = NULL;
+
+  if (store == NULL || store->db == NULL || subject_id == NULL
+      || perm_id == NULL || scope == NULL || state == NULL)
+    return WYRELOG_E_INVALID;
+
+  static const gchar *sql =
+      "INSERT INTO permission_states "
+      "  (subject_id, perm_id, scope, state, updated_at) "
+      "VALUES (?, ?, ?, ?, unixepoch()) "
+      "ON CONFLICT(subject_id, perm_id, scope) DO UPDATE SET "
+      "  state = excluded.state," "  updated_at = excluded.updated_at;";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if ((rc = bind_text (stmt, 1, subject_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 2, perm_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 3, scope)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 4, state)) != WYRELOG_E_OK) {
+    sqlite3_finalize (stmt);
+    return rc;
+  }
+
+  int step_rc = sqlite3_step (stmt);
+  sqlite3_finalize (stmt);
+  return (step_rc == SQLITE_DONE) ? WYRELOG_E_OK : WYRELOG_E_IO;
+}
+
+wyrelog_error_t
+wyl_policy_store_permission_state_exists (wyl_policy_store_t *store,
+    const gchar *subject_id, const gchar *perm_id, const gchar *scope,
+    gboolean *out_exists)
+{
+  sqlite3_stmt *stmt = NULL;
+
+  if (store == NULL || store->db == NULL || subject_id == NULL
+      || perm_id == NULL || scope == NULL || out_exists == NULL)
+    return WYRELOG_E_INVALID;
+
+  *out_exists = FALSE;
+  static const gchar *sql =
+      "SELECT 1 FROM permission_states "
+      "WHERE subject_id = ? AND perm_id = ? AND scope = ?;";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if ((rc = bind_text (stmt, 1, subject_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 2, perm_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 3, scope)) != WYRELOG_E_OK) {
+    sqlite3_finalize (stmt);
+    return rc;
+  }
+
+  int step_rc = sqlite3_step (stmt);
+  if (step_rc == SQLITE_ROW)
+    *out_exists = TRUE;
+  else if (step_rc != SQLITE_DONE) {
+    sqlite3_finalize (stmt);
+    return WYRELOG_E_IO;
+  }
+
+  sqlite3_finalize (stmt);
+  return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
+wyl_policy_store_foreach_permission_state (wyl_policy_store_t *store,
+    wyl_policy_permission_state_cb cb, gpointer user_data)
+{
+  sqlite3_stmt *stmt = NULL;
+
+  if (store == NULL || store->db == NULL || cb == NULL)
+    return WYRELOG_E_INVALID;
+
+  static const gchar *sql =
+      "SELECT subject_id, perm_id, scope, state "
+      "FROM permission_states ORDER BY subject_id, perm_id, scope;";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  int step_rc;
+  while ((step_rc = sqlite3_step (stmt)) == SQLITE_ROW) {
+    const gchar *subject_id = (const gchar *) sqlite3_column_text (stmt, 0);
+    const gchar *perm_id = (const gchar *) sqlite3_column_text (stmt, 1);
+    const gchar *scope = (const gchar *) sqlite3_column_text (stmt, 2);
+    const gchar *state = (const gchar *) sqlite3_column_text (stmt, 3);
+    rc = cb (subject_id, perm_id, scope, state, user_data);
     if (rc != WYRELOG_E_OK) {
       sqlite3_finalize (stmt);
       return rc;

--- a/wyrelog/wyl-fsm-permission-scope-private.h
+++ b/wyrelog/wyl-fsm-permission-scope-private.h
@@ -1,0 +1,56 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+
+#include <glib.h>
+
+#include "wyrelog/error.h"
+
+G_BEGIN_DECLS;
+
+/*
+ * Permission-state FSM reference stepper.
+ *
+ * Mirrors the transition table shipped at
+ * <datadir>/wyrelog/access/fsm/permission_scope.dl. The .dl file is the
+ * system of record; tests parse the template and assert row-for-row equality
+ * with this C mirror.
+ */
+
+typedef enum wyl_perm_state_t
+{
+  WYL_PERM_STATE_DORMANT = 0,
+  WYL_PERM_STATE_ARMED,
+  WYL_PERM_STATE_FIRING,
+  WYL_PERM_STATE_COOLDOWN,
+  WYL_PERM_STATE_LAST_,
+} wyl_perm_state_t;
+
+typedef enum wyl_perm_event_t
+{
+  WYL_PERM_EVENT_GRANT = 0,
+  WYL_PERM_EVENT_REVOKE,
+  WYL_PERM_EVENT_TRIGGER,
+  WYL_PERM_EVENT_COMPLETE,
+  WYL_PERM_EVENT_RESET,
+  WYL_PERM_EVENT_EXPIRE,
+  WYL_PERM_EVENT_LAST_,
+} wyl_perm_event_t;
+
+typedef struct wyl_perm_transition_t
+{
+  wyl_perm_state_t from;
+  wyl_perm_event_t event;
+  wyl_perm_state_t to;
+} wyl_perm_transition_t;
+
+wyrelog_error_t wyl_fsm_permission_scope_step (wyl_perm_state_t from,
+    wyl_perm_event_t event, wyl_perm_state_t * out_to);
+
+const wyl_perm_transition_t *wyl_fsm_permission_scope_table (gsize * out_len);
+
+const gchar *wyl_perm_state_name (wyl_perm_state_t s);
+const gchar *wyl_perm_event_name (wyl_perm_event_t ev);
+wyl_perm_state_t wyl_perm_state_from_name (const gchar * name);
+wyl_perm_event_t wyl_perm_event_from_name (const gchar * name);
+
+G_END_DECLS;

--- a/wyrelog/wyl-fsm-permission-scope.c
+++ b/wyrelog/wyl-fsm-permission-scope.c
@@ -1,0 +1,98 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "wyl-fsm-permission-scope-private.h"
+
+static const wyl_perm_transition_t fsm_table[] = {
+  {WYL_PERM_STATE_DORMANT, WYL_PERM_EVENT_GRANT, WYL_PERM_STATE_ARMED},
+  {WYL_PERM_STATE_ARMED, WYL_PERM_EVENT_REVOKE, WYL_PERM_STATE_DORMANT},
+  {WYL_PERM_STATE_ARMED, WYL_PERM_EVENT_TRIGGER, WYL_PERM_STATE_FIRING},
+  {WYL_PERM_STATE_FIRING, WYL_PERM_EVENT_COMPLETE, WYL_PERM_STATE_COOLDOWN},
+  {WYL_PERM_STATE_COOLDOWN, WYL_PERM_EVENT_RESET, WYL_PERM_STATE_ARMED},
+  {WYL_PERM_STATE_COOLDOWN, WYL_PERM_EVENT_EXPIRE, WYL_PERM_STATE_DORMANT},
+};
+
+static const gchar *const state_names[] = {
+  "dormant",
+  "armed",
+  "firing",
+  "cooldown",
+};
+
+static const gchar *const event_names[] = {
+  "grant",
+  "revoke",
+  "trigger",
+  "complete",
+  "reset",
+  "expire",
+};
+
+G_STATIC_ASSERT (G_N_ELEMENTS (state_names) == WYL_PERM_STATE_LAST_);
+G_STATIC_ASSERT (G_N_ELEMENTS (event_names) == WYL_PERM_EVENT_LAST_);
+
+wyrelog_error_t
+wyl_fsm_permission_scope_step (wyl_perm_state_t from, wyl_perm_event_t event,
+    wyl_perm_state_t *out_to)
+{
+  if (out_to == NULL)
+    return WYRELOG_E_INVALID;
+  if ((guint) from >= WYL_PERM_STATE_LAST_)
+    return WYRELOG_E_INVALID;
+  if ((guint) event >= WYL_PERM_EVENT_LAST_)
+    return WYRELOG_E_INVALID;
+
+  for (gsize i = 0; i < G_N_ELEMENTS (fsm_table); i++) {
+    if (fsm_table[i].from == from && fsm_table[i].event == event) {
+      *out_to = fsm_table[i].to;
+      return WYRELOG_E_OK;
+    }
+  }
+  return WYRELOG_E_POLICY;
+}
+
+const wyl_perm_transition_t *
+wyl_fsm_permission_scope_table (gsize *out_len)
+{
+  if (out_len != NULL)
+    *out_len = G_N_ELEMENTS (fsm_table);
+  return fsm_table;
+}
+
+const gchar *
+wyl_perm_state_name (wyl_perm_state_t s)
+{
+  if ((guint) s >= WYL_PERM_STATE_LAST_)
+    return NULL;
+  return state_names[s];
+}
+
+const gchar *
+wyl_perm_event_name (wyl_perm_event_t ev)
+{
+  if ((guint) ev >= WYL_PERM_EVENT_LAST_)
+    return NULL;
+  return event_names[ev];
+}
+
+wyl_perm_state_t
+wyl_perm_state_from_name (const gchar *name)
+{
+  if (name == NULL)
+    return WYL_PERM_STATE_LAST_;
+  for (guint i = 0; i < WYL_PERM_STATE_LAST_; i++) {
+    if (g_strcmp0 (name, state_names[i]) == 0)
+      return (wyl_perm_state_t) i;
+  }
+  return WYL_PERM_STATE_LAST_;
+}
+
+wyl_perm_event_t
+wyl_perm_event_from_name (const gchar *name)
+{
+  if (name == NULL)
+    return WYL_PERM_EVENT_LAST_;
+  for (guint i = 0; i < WYL_PERM_EVENT_LAST_; i++) {
+    if (g_strcmp0 (name, event_names[i]) == 0)
+      return (wyl_perm_event_t) i;
+  }
+  return WYL_PERM_EVENT_LAST_;
+}

--- a/wyrelog/wyl-handle-private.h
+++ b/wyrelog/wyl-handle-private.h
@@ -231,6 +231,14 @@ wyrelog_error_t wyl_handle_load_policy_store_permission_states (WylHandle *
     self);
 
 /*
+ * Loads permission_state_event rows from the handle-owned policy authority
+ * store into the attached read/delta engine pair as perm_state_event/7 facts.
+ * Rejected unless both the store and engine pair are available.
+ */
+wyrelog_error_t wyl_handle_load_policy_store_permission_state_events
+    (WylHandle * self);
+
+/*
  * Loads principal_state rows from the handle-owned policy authority store into
  * the attached read/delta engine pair. Rejected unless both the store and
  * engine pair are available.

--- a/wyrelog/wyl-handle-private.h
+++ b/wyrelog/wyl-handle-private.h
@@ -223,6 +223,14 @@ wyrelog_error_t wyl_handle_load_policy_store_direct_permissions (WylHandle *
     self);
 
 /*
+ * Loads permission_states rows from the handle-owned policy authority store into
+ * the attached read/delta engine pair as perm_state/4 facts. Rejected unless
+ * both the store and engine pair are available.
+ */
+wyrelog_error_t wyl_handle_load_policy_store_permission_states (WylHandle *
+    self);
+
+/*
  * Loads principal_state rows from the handle-owned policy authority store into
  * the attached read/delta engine pair. Rejected unless both the store and
  * engine pair are available.

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -603,6 +603,9 @@ load_current_engine_pair (WylHandle *self)
   rc = wyl_handle_load_policy_store_direct_permissions (self);
   if (rc != WYRELOG_E_OK)
     return rc;
+  rc = wyl_handle_load_policy_store_permission_states (self);
+  if (rc != WYRELOG_E_OK)
+    return rc;
   rc = wyl_handle_load_policy_store_principal_states (self);
   if (rc != WYRELOG_E_OK)
     return rc;
@@ -1066,6 +1069,14 @@ insert_policy_store_direct_permission (const gchar *subject_id,
   if (wyl_perm_arm_rule_lookup (perm_id) != NULL)
     return WYRELOG_E_OK;
 
+  gboolean has_durable_state = FALSE;
+  rc = wyl_policy_store_permission_state_exists (self->policy_store, subject_id,
+      perm_id, scope, &has_durable_state);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if (has_durable_state)
+    return WYRELOG_E_OK;
+
   gint64 state_row[4];
   state_row[0] = row[0];
   state_row[1] = row[1];
@@ -1087,6 +1098,46 @@ wyl_handle_load_policy_store_direct_permissions (WylHandle *self)
 
   return wyl_policy_store_foreach_direct_permission (self->policy_store,
       insert_policy_store_direct_permission, self);
+}
+
+static wyrelog_error_t
+insert_policy_store_permission_state (const gchar *subject_id,
+    const gchar *perm_id, const gchar *scope, const gchar *state,
+    gpointer user_data)
+{
+  WylHandle *self = user_data;
+  gint64 row[4];
+
+  if (wyl_perm_state_from_name (state) == WYL_PERM_STATE_LAST_)
+    return WYRELOG_E_POLICY;
+
+  wyrelog_error_t rc =
+      wyl_handle_intern_engine_symbol (self, subject_id, &row[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (self, perm_id, &row[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (self, scope, &row[2]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (self, state, &row[3]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_engine_insert (self, "perm_state", row, 4);
+}
+
+wyrelog_error_t
+wyl_handle_load_policy_store_permission_states (WylHandle *self)
+{
+  if (self == NULL || !WYL_IS_HANDLE (self))
+    return WYRELOG_E_INVALID;
+  if (self->policy_store == NULL || self->read_engine == NULL
+      || self->delta_engine == NULL)
+    return WYRELOG_E_INVALID;
+
+  return wyl_policy_store_foreach_permission_state (self->policy_store,
+      insert_policy_store_permission_state, self);
 }
 
 static wyrelog_error_t

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -86,35 +86,58 @@ wyl_handle_init (WylHandle *self)
 }
 
 static wyrelog_error_t wyl_handle_make_guard_expr_node_compound (WylHandle *
-    self, const wyl_guard_expr_t * expr, gint64 * out_id);
+    self, WylEngine * engine, const wyl_guard_expr_t * expr, gint64 * out_id);
+
+static wyrelog_error_t
+wyl_handle_intern_symbol_on_engine (WylHandle *self, WylEngine *engine,
+    const gchar *symbol, gboolean cache_symbol, gint64 *out_id)
+{
+  if (self == NULL || !WYL_IS_HANDLE (self))
+    return WYRELOG_E_INVALID;
+  if (engine == NULL || symbol == NULL || out_id == NULL)
+    return WYRELOG_E_INVALID;
+
+  wyrelog_error_t rc = wyl_engine_intern_symbol (engine, symbol, out_id);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  if (cache_symbol) {
+    gint64 *key = g_new (gint64, 1);
+    *key = *out_id;
+    g_hash_table_replace (self->engine_symbols_by_id, key, g_strdup (symbol));
+  }
+  return WYRELOG_E_OK;
+}
 
 static wyrelog_error_t
 wyl_handle_intern_guard_symbol (WylHandle *self, const gchar *symbol,
-    gint64 *out_id)
+    WylEngine *engine, gint64 *out_id)
 {
   if (symbol == NULL)
     return WYRELOG_E_INVALID;
-  return wyl_handle_intern_engine_symbol (self, symbol, out_id);
+  return wyl_handle_intern_symbol_on_engine (self, engine, symbol,
+      engine == self->read_engine, out_id);
 }
 
 static wyrelog_error_t
 wyl_handle_make_guard_cmp_compound (WylHandle *self,
-    const wyl_guard_expr_t *expr, gint64 *out_id)
+    WylEngine *engine, const wyl_guard_expr_t *expr, gint64 *out_id)
 {
   gint64 field_id = 0;
   wyrelog_error_t rc = wyl_handle_intern_guard_symbol (self,
-      wyl_guard_field_name (expr->u.cmp.field), &field_id);
+      wyl_guard_field_name (expr->u.cmp.field), engine, &field_id);
   if (rc != WYRELOG_E_OK)
     return rc;
 
   gint64 op_id = 0;
   rc = wyl_handle_intern_guard_symbol (self,
-      wyl_guard_op_name (expr->u.cmp.op), &op_id);
+      wyl_guard_op_name (expr->u.cmp.op), engine, &op_id);
   if (rc != WYRELOG_E_OK)
     return rc;
 
   gint64 value_id = 0;
-  rc = wyl_handle_intern_guard_symbol (self, expr->u.cmp.value, &value_id);
+  rc = wyl_handle_intern_guard_symbol (self, expr->u.cmp.value, engine,
+      &value_id);
   if (rc != WYRELOG_E_OK)
     return rc;
 
@@ -123,56 +146,59 @@ wyl_handle_make_guard_cmp_compound (WylHandle *self,
     {WIRELOG_TYPE_STRING, op_id},
     {WIRELOG_TYPE_STRING, value_id},
   };
-  return wyl_handle_make_engine_compound (self, "guard_cmp", args,
+  return wyl_engine_make_compound (engine, "guard_cmp", args,
       G_N_ELEMENTS (args), out_id);
 }
 
 static wyrelog_error_t
 wyl_handle_make_guard_tag_compound (WylHandle *self,
-    const wyl_guard_expr_t *expr, gint64 *out_id)
+    WylEngine *engine, const wyl_guard_expr_t *expr, gint64 *out_id)
 {
   gint64 atom_id = 0;
-  wyrelog_error_t rc =
-      wyl_handle_intern_guard_symbol (self, expr->u.tag.atom, &atom_id);
+  wyrelog_error_t rc = wyl_handle_intern_guard_symbol (self,
+      expr->u.tag.atom, engine, &atom_id);
   if (rc != WYRELOG_E_OK)
     return rc;
 
   wirelog_compound_arg_t args[1] = {
     {WIRELOG_TYPE_STRING, atom_id},
   };
-  return wyl_handle_make_engine_compound (self, "guard_tag", args,
+  return wyl_engine_make_compound (engine, "guard_tag", args,
       G_N_ELEMENTS (args), out_id);
 }
 
 static wyrelog_error_t
-wyl_handle_make_guard_unary_compound (WylHandle *self, const gchar *functor,
-    const wyl_guard_expr_t *child, gint64 *out_id)
+wyl_handle_make_guard_unary_compound (WylHandle *self, WylEngine *engine,
+    const gchar *functor, const wyl_guard_expr_t *child, gint64 *out_id)
 {
   gint64 child_id = 0;
   wyrelog_error_t rc =
-      wyl_handle_make_guard_expr_node_compound (self, child, &child_id);
+      wyl_handle_make_guard_expr_node_compound (self, engine, child,
+      &child_id);
   if (rc != WYRELOG_E_OK)
     return rc;
 
   wirelog_compound_arg_t args[1] = {
     {WIRELOG_TYPE_INT64, child_id},
   };
-  return wyl_handle_make_engine_compound (self, functor, args,
-      G_N_ELEMENTS (args), out_id);
+  return wyl_engine_make_compound (engine, functor, args, G_N_ELEMENTS (args),
+      out_id);
 }
 
 static wyrelog_error_t
-wyl_handle_make_guard_binary_compound (WylHandle *self, const gchar *functor,
-    const wyl_guard_expr_t *left, const wyl_guard_expr_t *right, gint64 *out_id)
+wyl_handle_make_guard_binary_compound (WylHandle *self, WylEngine *engine,
+    const gchar *functor, const wyl_guard_expr_t *left,
+    const wyl_guard_expr_t *right, gint64 *out_id)
 {
   gint64 left_id = 0;
   wyrelog_error_t rc =
-      wyl_handle_make_guard_expr_node_compound (self, left, &left_id);
+      wyl_handle_make_guard_expr_node_compound (self, engine, left, &left_id);
   if (rc != WYRELOG_E_OK)
     return rc;
 
   gint64 right_id = 0;
-  rc = wyl_handle_make_guard_expr_node_compound (self, right, &right_id);
+  rc = wyl_handle_make_guard_expr_node_compound (self, engine, right,
+      &right_id);
   if (rc != WYRELOG_E_OK)
     return rc;
 
@@ -180,12 +206,12 @@ wyl_handle_make_guard_binary_compound (WylHandle *self, const gchar *functor,
     {WIRELOG_TYPE_INT64, left_id},
     {WIRELOG_TYPE_INT64, right_id},
   };
-  return wyl_handle_make_engine_compound (self, functor, args,
-      G_N_ELEMENTS (args), out_id);
+  return wyl_engine_make_compound (engine, functor, args, G_N_ELEMENTS (args),
+      out_id);
 }
 
 static wyrelog_error_t
-wyl_handle_make_guard_expr_node_compound (WylHandle *self,
+wyl_handle_make_guard_expr_node_compound (WylHandle *self, WylEngine *engine,
     const wyl_guard_expr_t *expr, gint64 *out_id)
 {
   if (out_id != NULL)
@@ -195,17 +221,17 @@ wyl_handle_make_guard_expr_node_compound (WylHandle *self,
 
   switch (expr->kind) {
     case WYL_GUARD_KIND_CMP:
-      return wyl_handle_make_guard_cmp_compound (self, expr, out_id);
+      return wyl_handle_make_guard_cmp_compound (self, engine, expr, out_id);
     case WYL_GUARD_KIND_TAG:
-      return wyl_handle_make_guard_tag_compound (self, expr, out_id);
+      return wyl_handle_make_guard_tag_compound (self, engine, expr, out_id);
     case WYL_GUARD_KIND_NOT:
-      return wyl_handle_make_guard_unary_compound (self, "guard_not",
+      return wyl_handle_make_guard_unary_compound (self, engine, "guard_not",
           expr->u.unary.child, out_id);
     case WYL_GUARD_KIND_AND:
-      return wyl_handle_make_guard_binary_compound (self, "guard_and",
+      return wyl_handle_make_guard_binary_compound (self, engine, "guard_and",
           expr->u.binop.left, expr->u.binop.right, out_id);
     case WYL_GUARD_KIND_OR:
-      return wyl_handle_make_guard_binary_compound (self, "guard_or",
+      return wyl_handle_make_guard_binary_compound (self, engine, "guard_or",
           expr->u.binop.left, expr->u.binop.right, out_id);
     case WYL_GUARD_KIND_LAST_:
     default:
@@ -214,36 +240,56 @@ wyl_handle_make_guard_expr_node_compound (WylHandle *self,
 }
 
 static wyrelog_error_t
-wyl_handle_make_guard_expr_compound (WylHandle *self,
+wyl_handle_make_guard_expr_compound (WylHandle *self, WylEngine *engine,
     const wyl_guard_expr_t *expr, gint64 *out_id)
 {
   gint64 root_id = 0;
   wyrelog_error_t rc =
-      wyl_handle_make_guard_expr_node_compound (self, expr, &root_id);
+      wyl_handle_make_guard_expr_node_compound (self, engine, expr, &root_id);
   if (rc != WYRELOG_E_OK)
     return rc;
 
   wirelog_compound_arg_t args[1] = {
     {WIRELOG_TYPE_INT64, root_id},
   };
-  return wyl_handle_make_engine_compound (self, "guard", args,
-      G_N_ELEMENTS (args), out_id);
+  return wyl_engine_make_compound (engine, "guard", args, G_N_ELEMENTS (args),
+      out_id);
+}
+
+static wyrelog_error_t
+wyl_handle_seed_perm_arm_rule_on_engine (WylHandle *self, WylEngine *engine,
+    const gchar *perm_id, const wyl_guard_expr_t *guard)
+{
+  gint64 row[2];
+  wyrelog_error_t rc = wyl_handle_intern_symbol_on_engine (self, engine,
+      perm_id, engine == self->read_engine, &row[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  rc = wyl_handle_make_guard_expr_compound (self, engine, guard, &row[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  rc = wyl_engine_insert (engine, "perm_arm_rule", row, 2);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if (engine == self->delta_engine)
+    return wyl_engine_step (engine);
+  return WYRELOG_E_OK;
 }
 
 static wyrelog_error_t
 wyl_handle_seed_perm_arm_rules (WylHandle *self)
 {
   for (gsize i = 0; i < wyl_perm_arm_rule_count (); i++) {
-    gint64 row[2];
     const wyl_guard_expr_t *guard = wyl_perm_arm_rule_expr (i);
-    wyrelog_error_t rc = wyl_handle_intern_engine_symbol (self,
-        wyl_perm_arm_rule_perm_id (i), &row[0]);
+    const gchar *perm_id = wyl_perm_arm_rule_perm_id (i);
+    wyrelog_error_t rc = wyl_handle_seed_perm_arm_rule_on_engine (self,
+        self->read_engine, perm_id, guard);
     if (rc != WYRELOG_E_OK)
       return rc;
-    rc = wyl_handle_make_guard_expr_compound (self, guard, &row[1]);
-    if (rc != WYRELOG_E_OK)
-      return rc;
-    rc = wyl_handle_engine_insert (self, "perm_arm_rule", row, 2);
+    rc = wyl_handle_seed_perm_arm_rule_on_engine (self, self->delta_engine,
+        perm_id, guard);
     if (rc != WYRELOG_E_OK)
       return rc;
   }
@@ -808,11 +854,25 @@ wyl_handle_make_read_engine_compound (WylHandle *self, const gchar *functor,
     return WYRELOG_E_INVALID;
   if (nargs == 0 || nargs > G_MAXUINT32)
     return WYRELOG_E_INVALID;
-  if (self->read_engine == NULL)
+  if (self->read_engine == NULL || self->delta_engine == NULL)
     return WYRELOG_E_INVALID;
 
-  return wyl_engine_make_compound (self->read_engine, functor, args, nargs,
+  gint64 functor_id = 0;
+  wyrelog_error_t rc = wyl_handle_intern_engine_symbol (self, functor,
+      &functor_id);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  rc = wyl_engine_make_compound (self->read_engine, functor, args, nargs,
       out_id);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  /* Keep the handle-owned engines' intern and side-arena streams aligned.
+   * The returned handle remains read-engine-local and request-scoped. */
+  gint64 delta_id = 0;
+  return wyl_engine_make_compound (self->delta_engine, functor, args, nargs,
+      &delta_id);
 }
 
 wyrelog_error_t

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -606,6 +606,9 @@ load_current_engine_pair (WylHandle *self)
   rc = wyl_handle_load_policy_store_permission_states (self);
   if (rc != WYRELOG_E_OK)
     return rc;
+  rc = wyl_handle_load_policy_store_permission_state_events (self);
+  if (rc != WYRELOG_E_OK)
+    return rc;
   rc = wyl_handle_load_policy_store_principal_states (self);
   if (rc != WYRELOG_E_OK)
     return rc;
@@ -850,6 +853,7 @@ relation_fans_out_to_delta (const gchar *relation)
       || g_strcmp0 (relation, "principal_transition") == 0
       || g_strcmp0 (relation, "session_transition") == 0
       || g_strcmp0 (relation, "perm_state_transition") == 0
+      || g_strcmp0 (relation, "perm_state_event") == 0
       || g_strcmp0 (relation, "principal_event") == 0
       || g_strcmp0 (relation, "session_event") == 0;
 }
@@ -1138,6 +1142,65 @@ wyl_handle_load_policy_store_permission_states (WylHandle *self)
 
   return wyl_policy_store_foreach_permission_state (self->policy_store,
       insert_policy_store_permission_state, self);
+}
+
+static wyrelog_error_t
+insert_policy_store_permission_state_event (gint64 event_id,
+    const gchar *subject_id, const gchar *perm_id, const gchar *scope,
+    const gchar *event, const gchar *from_state, const gchar *to_state,
+    gpointer user_data)
+{
+  WylHandle *self = user_data;
+  gint64 row[7];
+  wyl_perm_state_t from = wyl_perm_state_from_name (from_state);
+  wyl_perm_event_t ev = wyl_perm_event_from_name (event);
+  wyl_perm_state_t to = wyl_perm_state_from_name (to_state);
+
+  if (event_id <= 0)
+    return WYRELOG_E_POLICY;
+  if (from == WYL_PERM_STATE_LAST_ || ev == WYL_PERM_EVENT_LAST_
+      || to == WYL_PERM_STATE_LAST_)
+    return WYRELOG_E_POLICY;
+  wyl_perm_state_t validated = WYL_PERM_STATE_LAST_;
+  wyrelog_error_t rc = wyl_fsm_permission_scope_step (from, ev, &validated);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if (validated != to)
+    return WYRELOG_E_POLICY;
+
+  row[0] = event_id;
+  rc = wyl_handle_intern_engine_symbol (self, subject_id, &row[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (self, perm_id, &row[2]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (self, scope, &row[3]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (self, event, &row[4]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (self, from_state, &row[5]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (self, to_state, &row[6]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_engine_insert (self, "perm_state_event", row, 7);
+}
+
+wyrelog_error_t
+wyl_handle_load_policy_store_permission_state_events (WylHandle *self)
+{
+  if (self == NULL || !WYL_IS_HANDLE (self))
+    return WYRELOG_E_INVALID;
+  if (self->policy_store == NULL || self->read_engine == NULL
+      || self->delta_engine == NULL)
+    return WYRELOG_E_INVALID;
+
+  return wyl_policy_store_foreach_permission_state_event (self->policy_store,
+      insert_policy_store_permission_state_event, self);
 }
 
 static wyrelog_error_t

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -4,6 +4,7 @@
 #include <string.h>
 
 #include "wyrelog/engine.h"
+#include "wyl-fsm-permission-scope-private.h"
 #include "wyl-fsm-principal-private.h"
 #include "wyl-fsm-session-private.h"
 #include "wyl-handle-compound-private.h"
@@ -334,6 +335,37 @@ wyl_handle_seed_session_transitions (WylHandle *self)
   return WYRELOG_E_OK;
 }
 
+static wyrelog_error_t
+wyl_handle_seed_perm_state_transitions (WylHandle *self)
+{
+  gsize n = 0;
+  const wyl_perm_transition_t *table = wyl_fsm_permission_scope_table (&n);
+
+  for (gsize i = 0; i < n; i++) {
+    gint64 row[3];
+    const gchar *from_name = wyl_perm_state_name (table[i].from);
+    const gchar *event_name = wyl_perm_event_name (table[i].event);
+    const gchar *to_name = wyl_perm_state_name (table[i].to);
+    if (from_name == NULL || event_name == NULL || to_name == NULL)
+      return WYRELOG_E_INTERNAL;
+
+    wyrelog_error_t rc =
+        wyl_handle_intern_engine_symbol (self, from_name, &row[0]);
+    if (rc != WYRELOG_E_OK)
+      return rc;
+    rc = wyl_handle_intern_engine_symbol (self, event_name, &row[1]);
+    if (rc != WYRELOG_E_OK)
+      return rc;
+    rc = wyl_handle_intern_engine_symbol (self, to_name, &row[2]);
+    if (rc != WYRELOG_E_OK)
+      return rc;
+    rc = wyl_handle_engine_insert (self, "perm_state_transition", row, 3);
+    if (rc != WYRELOG_E_OK)
+      return rc;
+  }
+  return WYRELOG_E_OK;
+}
+
 wyrelog_error_t
 wyl_init (const gchar *config_path, WylHandle **out_handle)
 {
@@ -557,6 +589,9 @@ load_current_engine_pair (WylHandle *self)
   if (rc != WYRELOG_E_OK)
     return rc;
   rc = wyl_handle_seed_session_transitions (self);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_seed_perm_state_transitions (self);
   if (rc != WYRELOG_E_OK)
     return rc;
   rc = wyl_handle_load_policy_store_role_permissions (self);
@@ -811,6 +846,7 @@ relation_fans_out_to_delta (const gchar *relation)
   return g_strcmp0 (relation, "member_of") == 0
       || g_strcmp0 (relation, "principal_transition") == 0
       || g_strcmp0 (relation, "session_transition") == 0
+      || g_strcmp0 (relation, "perm_state_transition") == 0
       || g_strcmp0 (relation, "principal_event") == 0
       || g_strcmp0 (relation, "session_event") == 0;
 }


### PR DESCRIPTION
## Summary
- define the permission-state FSM table and private C mirror
- persist permission-state current rows and replay them into perm_state/4
- persist permission-state event rows and derive perm_state_fired/7
- keep guarded permissions from being armed by persisted state alone

## Tests
- meson test -C builddir fsm-permission-scope fsm-principal fsm-session fsm-bisim dl-static check-no-derived-fsm-replay policy-store handle-engine-pair daemon-http-decide --print-errorlogs
- meson test -C builddir-audit fsm-permission-scope policy-store handle-engine-pair daemon-checks --print-errorlogs