### PR TITLE
Add permission state transition API

### DIFF
--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -3094,6 +3094,144 @@ check_policy_store_permission_state_events_reload_failure_preserves_pair (void)
 }
 
 static gint
+check_handle_permission_state_transition_reloads_snapshot (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 800;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 801;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (wyl_policy_store_upsert_permission (store, "site.perm.transition",
+          "permission transition", "basic") != WYRELOG_E_OK)
+    return 804;
+  if (wyl_policy_store_grant_direct_permission (store, "perm-transition-user",
+          "site.perm.transition", "perm-transition-scope") != WYRELOG_E_OK)
+    return 805;
+  if (wyl_policy_store_set_principal_state (store, "perm-transition-user",
+          "authenticated") != WYRELOG_E_OK)
+    return 806;
+  if (wyl_policy_store_set_session_state (store, "perm-transition-scope",
+          "active") != WYRELOG_E_OK)
+    return 807;
+
+  gint64 event_id = -1;
+  if (wyl_handle_apply_permission_state_transition (handle,
+          "perm-transition-user", "site.perm.transition",
+          "perm-transition-scope", "grant", NULL, &event_id) != WYRELOG_E_OK)
+    return 802;
+  if (event_id <= 0)
+    return 803;
+
+  gint64 decision_row[3];
+  if (intern3 (handle, "perm-transition-user", "site.perm.transition",
+          "perm-transition-scope", decision_row) != WYRELOG_E_OK)
+    return 808;
+  gboolean allowed = FALSE;
+  if (wyl_handle_engine_decide (handle, decision_row, &allowed)
+      != WYRELOG_E_OK)
+    return 809;
+  if (!allowed)
+    return 810;
+
+  return 0;
+}
+
+static gint
+check_handle_permission_state_transition_projects_audit_fact (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 810;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 811;
+
+  g_autoptr (WylAuditEvent) audit_event = wyl_audit_event_new ();
+  wyl_audit_event_set_subject_id (audit_event, "perm-audit-actor");
+  wyl_audit_event_set_action (audit_event, "permission_state.grant");
+  wyl_audit_event_set_resource_id (audit_event, "site.perm.audit.runtime");
+  wyl_audit_event_set_deny_reason (audit_event, "allowed");
+  wyl_audit_event_set_deny_origin (audit_event, "permission_state");
+  wyl_audit_event_set_decision (audit_event, WYL_DECISION_ALLOW);
+  g_autofree gchar *audit_id = wyl_audit_event_dup_id_string (audit_event);
+  if (audit_id == NULL)
+    return 812;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (wyl_policy_store_upsert_permission (store, "site.perm.audit.runtime",
+          "runtime audit permission", "basic") != WYRELOG_E_OK)
+    return 819;
+
+  gint64 event_id = -1;
+  if (wyl_handle_apply_permission_state_transition (handle,
+          "perm-audit-runtime-user", "site.perm.audit.runtime",
+          "perm-audit-runtime-scope", "grant", audit_event, &event_id)
+      != WYRELOG_E_OK)
+    return 813;
+  if (event_id <= 0)
+    return 814;
+
+  gint64 audit_action_row[2];
+  if (wyl_handle_intern_engine_symbol (handle, audit_id, &audit_action_row[0])
+      != WYRELOG_E_OK)
+    return 815;
+  if (wyl_handle_intern_engine_symbol (handle, "permission_state.grant",
+          &audit_action_row[1]) != WYRELOG_E_OK)
+    return 816;
+  gboolean found = FALSE;
+  if (wyl_handle_engine_contains (handle, "audit_event_action",
+          audit_action_row, 2, &found) != WYRELOG_E_OK)
+    return 817;
+  return found ? 0 : 818;
+}
+
+static gint
+check_handle_permission_state_transition_reload_failure_preserves_pair (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 819;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 820;
+  WylEngine *read_engine = wyl_handle_get_read_engine (handle);
+  WylEngine *delta_engine = wyl_handle_get_delta_engine (handle);
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (wyl_policy_store_upsert_permission (store, "site.perm.transition.fail",
+          "failing transition permission", "basic") != WYRELOG_E_OK)
+    return 827;
+
+  wyl_handle_set_engine_insert_fault_once (handle, "perm_state_event",
+      WYRELOG_E_IO);
+  gint64 event_id = -1;
+  if (wyl_handle_apply_permission_state_transition (handle,
+          "perm-transition-fail-user", "site.perm.transition.fail",
+          "perm-transition-fail-scope", "grant", NULL, &event_id)
+      != WYRELOG_E_IO)
+    return 821;
+  if (event_id <= 0)
+    return 822;
+  if (wyl_handle_get_read_engine (handle) != read_engine)
+    return 823;
+  if (wyl_handle_get_delta_engine (handle) != delta_engine)
+    return 824;
+
+  gboolean exists = FALSE;
+  if (wyl_policy_store_permission_state_exists (store,
+          "perm-transition-fail-user", "site.perm.transition.fail",
+          "perm-transition-fail-scope", &exists) != WYRELOG_E_OK)
+    return 825;
+  return exists ? 0 : 826;
+}
+
+static gint
 check_policy_store_permission_state_events_require_engine_pair (void)
 {
   g_autoptr (WylHandle) handle = NULL;
@@ -4107,6 +4245,15 @@ main (void)
     return rc;
   if ((rc =
           check_policy_store_permission_state_events_reload_failure_preserves_pair
+          ()) != 0)
+    return rc;
+  if ((rc = check_handle_permission_state_transition_reloads_snapshot ()) != 0)
+    return rc;
+  if ((rc =
+          check_handle_permission_state_transition_projects_audit_fact ()) != 0)
+    return rc;
+  if ((rc =
+          check_handle_permission_state_transition_reload_failure_preserves_pair
           ()) != 0)
     return rc;
   if ((rc = check_policy_store_permission_state_events_require_engine_pair ())

--- a/tests/test-policy-store.c
+++ b/tests/test-policy-store.c
@@ -129,6 +129,24 @@ check_store_rejects_invalid_args (void)
   if (wyl_policy_store_get_deployment_mode (store, NULL)
       != WYRELOG_E_INVALID)
     return 38;
+  if (wyl_policy_store_apply_permission_state_transition (NULL, "user",
+          "perm", "scope", "grant", NULL) != WYRELOG_E_INVALID)
+    return 39;
+  if (wyl_policy_store_apply_permission_state_transition (store, NULL,
+          "perm", "scope", "grant", NULL) != WYRELOG_E_INVALID)
+    return 56;
+  if (wyl_policy_store_apply_permission_state_transition (store, "user",
+          NULL, "scope", "grant", NULL) != WYRELOG_E_INVALID)
+    return 57;
+  if (wyl_policy_store_apply_permission_state_transition (store, "user",
+          "perm", NULL, "grant", NULL) != WYRELOG_E_INVALID)
+    return 62;
+  if (wyl_policy_store_apply_permission_state_transition (store, "user",
+          "perm", "scope", NULL, NULL) != WYRELOG_E_INVALID)
+    return 63;
+  if (wyl_policy_store_apply_permission_state_transition (store, "user",
+          "perm", "scope", "bogus", NULL) != WYRELOG_E_INVALID)
+    return 64;
   return 0;
 }
 
@@ -1285,6 +1303,320 @@ check_store_appends_permission_state_event (void)
 }
 
 static gint
+check_store_applies_permission_state_transition (void)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 238;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 239;
+
+  gint64 grant_event_id = -1;
+  if (wyl_policy_store_apply_permission_state_transition (store,
+          "perm-apply-user", "wr.perm.apply", "perm-apply-scope", "grant",
+          &grant_event_id) != WYRELOG_E_OK)
+    return 240;
+  if (grant_event_id <= 0)
+    return 241;
+
+  PermissionStateExpect state_expect = {
+    .subject_id = "perm-apply-user",
+    .perm_id = "wr.perm.apply",
+    .scope = "perm-apply-scope",
+    .state = "armed",
+  };
+  if (wyl_policy_store_foreach_permission_state (store,
+          permission_state_expect_cb, &state_expect) != WYRELOG_E_OK)
+    return 242;
+  if (state_expect.matches != 1)
+    return 243;
+
+  PermissionStateEventExpect grant_expect = {
+    .event_id = grant_event_id,
+    .subject_id = "perm-apply-user",
+    .perm_id = "wr.perm.apply",
+    .scope = "perm-apply-scope",
+    .event = "grant",
+    .from_state = "dormant",
+    .to_state = "armed",
+  };
+  if (wyl_policy_store_foreach_permission_state_event (store,
+          permission_state_event_expect_cb, &grant_expect) != WYRELOG_E_OK)
+    return 244;
+  if (grant_expect.matches != 1)
+    return 245;
+
+  gint64 revoke_event_id = -1;
+  if (wyl_policy_store_apply_permission_state_transition (store,
+          "perm-apply-user", "wr.perm.apply", "perm-apply-scope", "revoke",
+          &revoke_event_id) != WYRELOG_E_OK)
+    return 246;
+  if (revoke_event_id <= grant_event_id)
+    return 247;
+
+  PermissionStateExpect dormant_expect = {
+    .subject_id = "perm-apply-user",
+    .perm_id = "wr.perm.apply",
+    .scope = "perm-apply-scope",
+    .state = "dormant",
+  };
+  if (wyl_policy_store_foreach_permission_state (store,
+          permission_state_expect_cb, &dormant_expect) != WYRELOG_E_OK)
+    return 248;
+  if (dormant_expect.matches != 1)
+    return 249;
+
+  gint64 trigger_event_id = -1;
+  if (wyl_policy_store_apply_permission_state_transition (store,
+          "perm-trigger-user", "wr.perm.trigger", "perm-trigger-scope",
+          "grant", NULL) != WYRELOG_E_OK)
+    return 279;
+  if (wyl_policy_store_apply_permission_state_transition (store,
+          "perm-trigger-user", "wr.perm.trigger", "perm-trigger-scope",
+          "trigger", &trigger_event_id) != WYRELOG_E_OK)
+    return 280;
+  if (trigger_event_id <= revoke_event_id)
+    return 281;
+
+  PermissionStateExpect firing_expect = {
+    .subject_id = "perm-trigger-user",
+    .perm_id = "wr.perm.trigger",
+    .scope = "perm-trigger-scope",
+    .state = "firing",
+  };
+  if (wyl_policy_store_foreach_permission_state (store,
+          permission_state_expect_cb, &firing_expect) != WYRELOG_E_OK)
+    return 282;
+  if (firing_expect.matches != 1)
+    return 283;
+
+  PermissionStateEventExpect trigger_expect = {
+    .event_id = trigger_event_id,
+    .subject_id = "perm-trigger-user",
+    .perm_id = "wr.perm.trigger",
+    .scope = "perm-trigger-scope",
+    .event = "trigger",
+    .from_state = "armed",
+    .to_state = "firing",
+  };
+  if (wyl_policy_store_foreach_permission_state_event (store,
+          permission_state_event_expect_cb, &trigger_expect) != WYRELOG_E_OK)
+    return 284;
+  if (trigger_expect.matches != 1)
+    return 285;
+  return 0;
+}
+
+static gint
+check_store_permission_state_transition_rejects_invalid_edge (void)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 250;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 251;
+
+  gint64 event_id = 77;
+  if (wyl_policy_store_apply_permission_state_transition (store,
+          "perm-invalid-user", "wr.perm.invalid", "perm-invalid-scope",
+          "revoke", &event_id) != WYRELOG_E_POLICY)
+    return 252;
+  if (event_id != -1)
+    return 253;
+
+  gboolean exists = TRUE;
+  if (wyl_policy_store_permission_state_exists (store, "perm-invalid-user",
+          "wr.perm.invalid", "perm-invalid-scope", &exists) != WYRELOG_E_OK)
+    return 254;
+  if (exists)
+    return 255;
+
+  PermissionStateEventExpect expect = {
+    .event_id = -1,
+    .subject_id = "perm-invalid-user",
+    .perm_id = "wr.perm.invalid",
+    .scope = "perm-invalid-scope",
+    .event = "revoke",
+    .from_state = "dormant",
+    .to_state = "dormant",
+  };
+  if (wyl_policy_store_foreach_permission_state_event (store,
+          permission_state_event_expect_cb, &expect) != WYRELOG_E_OK)
+    return 256;
+  if (expect.matches != 0)
+    return 257;
+  return 0;
+}
+
+static gint
+check_store_permission_state_transition_rolls_back_event_failure (void)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 258;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 259;
+  if (sqlite3_exec (wyl_policy_store_get_db (store),
+          "CREATE TRIGGER fail_permission_state_event "
+          "BEFORE INSERT ON permission_state_events "
+          "BEGIN SELECT RAISE(ABORT, 'fail event'); END;",
+          NULL, NULL, NULL) != SQLITE_OK)
+    return 260;
+
+  if (wyl_policy_store_apply_permission_state_transition (store,
+          "perm-rollback-user", "wr.perm.rollback", "perm-rollback-scope",
+          "grant", NULL) != WYRELOG_E_IO)
+    return 261;
+
+  gboolean exists = TRUE;
+  if (wyl_policy_store_permission_state_exists (store, "perm-rollback-user",
+          "wr.perm.rollback", "perm-rollback-scope", &exists)
+      != WYRELOG_E_OK)
+    return 262;
+  if (exists)
+    return 263;
+  return 0;
+}
+
+static gint
+check_store_permission_state_transition_appends_audit (void)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 264;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 265;
+
+  gint64 event_id = -1;
+  if (wyl_policy_store_apply_permission_state_transition_with_audit (store,
+          "perm-audit-user", "wr.perm.audit", "perm-audit-scope", "grant",
+          &event_id, "01890c10-2e3f-7000-8000-000000000010", 999,
+          "perm-audit-user", "permission_state.grant", "wr.perm.audit",
+          "allowed", "permission_state", WYL_DECISION_ALLOW) != WYRELOG_E_OK)
+    return 266;
+  if (event_id <= 0)
+    return 267;
+
+  AuditEventExpect audit_expect = {
+    .id = "01890c10-2e3f-7000-8000-000000000010",
+    .created_at_us = 999,
+    .subject_id = "perm-audit-user",
+    .action = "permission_state.grant",
+    .resource_id = "wr.perm.audit",
+    .deny_reason = "allowed",
+    .deny_origin = "permission_state",
+    .decision = WYL_DECISION_ALLOW,
+  };
+  if (wyl_policy_store_foreach_audit_event (store, audit_event_expect_cb,
+          &audit_expect) != WYRELOG_E_OK)
+    return 268;
+  if (audit_expect.matches != 1)
+    return 269;
+  return 0;
+}
+
+static gint
+check_store_permission_state_transition_rolls_back_audit_failure (void)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 270;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 271;
+  if (sqlite3_exec (wyl_policy_store_get_db (store),
+          "CREATE TRIGGER fail_permission_state_audit "
+          "BEFORE INSERT ON audit_events "
+          "BEGIN SELECT RAISE(ABORT, 'fail audit'); END;",
+          NULL, NULL, NULL) != SQLITE_OK)
+    return 272;
+
+  gint64 event_id = 99;
+  if (wyl_policy_store_apply_permission_state_transition_with_audit (store,
+          "perm-audit-rollback-user", "wr.perm.audit.rollback",
+          "perm-audit-rollback-scope", "grant", &event_id,
+          "01890c10-2e3f-7000-8000-000000000011", 1000,
+          "perm-audit-rollback-user", "permission_state.grant",
+          "wr.perm.audit.rollback", "allowed", "permission_state",
+          WYL_DECISION_ALLOW) != WYRELOG_E_IO)
+    return 273;
+  if (event_id != -1)
+    return 274;
+
+  gboolean exists = TRUE;
+  if (wyl_policy_store_permission_state_exists (store,
+          "perm-audit-rollback-user", "wr.perm.audit.rollback",
+          "perm-audit-rollback-scope", &exists) != WYRELOG_E_OK)
+    return 275;
+  if (exists)
+    return 276;
+
+  PermissionStateEventExpect event_expect = {
+    .subject_id = "perm-audit-rollback-user",
+    .perm_id = "wr.perm.audit.rollback",
+    .scope = "perm-audit-rollback-scope",
+    .event = "grant",
+    .from_state = "dormant",
+    .to_state = "armed",
+  };
+  if (wyl_policy_store_foreach_permission_state_event (store,
+          permission_state_event_expect_cb, &event_expect) != WYRELOG_E_OK)
+    return 277;
+  if (event_expect.matches != 0)
+    return 278;
+  return 0;
+}
+
+static gint
+check_store_permission_state_transition_rejects_invalid_audit (void)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 286;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 287;
+
+  gint64 event_id = 101;
+  if (wyl_policy_store_apply_permission_state_transition_with_audit (store,
+          "perm-bad-audit-user", "wr.perm.bad.audit",
+          "perm-bad-audit-scope", "grant", &event_id, "not-a-wyl-id", 1000,
+          "perm-bad-audit-user", "permission_state.grant",
+          "wr.perm.bad.audit", "allowed", "permission_state",
+          WYL_DECISION_ALLOW) != WYRELOG_E_INVALID)
+    return 288;
+  if (event_id != -1)
+    return 289;
+
+  gboolean exists = TRUE;
+  if (wyl_policy_store_permission_state_exists (store, "perm-bad-audit-user",
+          "wr.perm.bad.audit", "perm-bad-audit-scope", &exists)
+      != WYRELOG_E_OK)
+    return 290;
+  if (exists)
+    return 291;
+
+  PermissionStateEventExpect event_expect = {
+    .subject_id = "perm-bad-audit-user",
+    .perm_id = "wr.perm.bad.audit",
+    .scope = "perm-bad-audit-scope",
+    .event = "grant",
+    .from_state = "dormant",
+    .to_state = "armed",
+  };
+  if (wyl_policy_store_foreach_permission_state_event (store,
+          permission_state_event_expect_cb, &event_expect) != WYRELOG_E_OK)
+    return 292;
+  if (event_expect.matches != 0)
+    return 293;
+  return 0;
+}
+
+static gint
 check_store_sets_principal_state (void)
 {
   g_autoptr (wyl_policy_store_t) store = NULL;
@@ -1883,6 +2215,22 @@ main (void)
   if ((rc = check_store_sets_permission_state ()) != 0)
     return rc;
   if ((rc = check_store_appends_permission_state_event ()) != 0)
+    return rc;
+  if ((rc = check_store_applies_permission_state_transition ()) != 0)
+    return rc;
+  if ((rc = check_store_permission_state_transition_rejects_invalid_edge ())
+      != 0)
+    return rc;
+  if ((rc = check_store_permission_state_transition_rolls_back_event_failure ())
+      != 0)
+    return rc;
+  if ((rc = check_store_permission_state_transition_appends_audit ()) != 0)
+    return rc;
+  if ((rc = check_store_permission_state_transition_rolls_back_audit_failure ())
+      != 0)
+    return rc;
+  if ((rc = check_store_permission_state_transition_rejects_invalid_audit ())
+      != 0)
     return rc;
   if ((rc = check_store_sets_principal_state ()) != 0)
     return rc;

--- a/wyrelog/policy/store-private.h
+++ b/wyrelog/policy/store-private.h
@@ -169,6 +169,19 @@ wyrelog_error_t wyl_policy_store_append_permission_state_event
     (wyl_policy_store_t * store, const gchar * subject_id,
     const gchar * perm_id, const gchar * scope, const gchar * event,
     const gchar * from_state, const gchar * to_state, gint64 * out_event_id);
+wyrelog_error_t wyl_policy_store_apply_permission_state_transition
+    (wyl_policy_store_t * store, const gchar * subject_id,
+    const gchar * perm_id, const gchar * scope, const gchar * event,
+    gint64 * out_event_id);
+wyrelog_error_t
+    wyl_policy_store_apply_permission_state_transition_with_audit
+    (wyl_policy_store_t * store, const gchar * subject_id,
+    const gchar * perm_id, const gchar * scope, const gchar * event,
+    gint64 * out_event_id, const gchar * audit_id,
+    gint64 audit_created_at_us, const gchar * audit_subject_id,
+    const gchar * audit_action, const gchar * audit_resource_id,
+    const gchar * audit_deny_reason, const gchar * audit_deny_origin,
+    wyl_decision_t audit_decision);
 wyrelog_error_t wyl_policy_store_foreach_permission_state_event
     (wyl_policy_store_t * store, wyl_policy_permission_state_event_cb cb,
     gpointer user_data);

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -2,6 +2,7 @@
 #include "store-private.h"
 
 #include "wyrelog/wyl-id-private.h"
+#include "wyrelog/wyl-fsm-permission-scope-private.h"
 
 struct wyl_policy_store_t
 {
@@ -1386,6 +1387,48 @@ wyl_policy_store_permission_state_exists (wyl_policy_store_t *store,
   return WYRELOG_E_OK;
 }
 
+static wyrelog_error_t
+wyl_policy_store_get_permission_state (wyl_policy_store_t *store,
+    const gchar *subject_id, const gchar *perm_id, const gchar *scope,
+    gchar **out_state)
+{
+  sqlite3_stmt *stmt = NULL;
+
+  if (store == NULL || store->db == NULL || subject_id == NULL
+      || perm_id == NULL || scope == NULL || out_state == NULL)
+    return WYRELOG_E_INVALID;
+
+  *out_state = NULL;
+  static const gchar *sql =
+      "SELECT state FROM permission_states "
+      "WHERE subject_id = ? AND perm_id = ? AND scope = ?;";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if ((rc = bind_text (stmt, 1, subject_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 2, perm_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 3, scope)) != WYRELOG_E_OK) {
+    sqlite3_finalize (stmt);
+    return rc;
+  }
+
+  int step_rc = sqlite3_step (stmt);
+  if (step_rc == SQLITE_ROW) {
+    const gchar *state = (const gchar *) sqlite3_column_text (stmt, 0);
+    if (state == NULL) {
+      sqlite3_finalize (stmt);
+      return WYRELOG_E_POLICY;
+    }
+    *out_state = g_strdup (state);
+  } else if (step_rc != SQLITE_DONE) {
+    sqlite3_finalize (stmt);
+    return WYRELOG_E_IO;
+  }
+
+  sqlite3_finalize (stmt);
+  return WYRELOG_E_OK;
+}
+
 wyrelog_error_t
 wyl_policy_store_foreach_permission_state (wyl_policy_store_t *store,
     wyl_policy_permission_state_cb cb, gpointer user_data)
@@ -1460,6 +1503,94 @@ wyl_policy_store_append_permission_state_event (wyl_policy_store_t *store,
     *out_event_id = event_id;
   }
   return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
+    wyl_policy_store_apply_permission_state_transition_with_audit
+    (wyl_policy_store_t * store, const gchar * subject_id,
+    const gchar * perm_id, const gchar * scope, const gchar * event,
+    gint64 * out_event_id, const gchar * audit_id,
+    gint64 audit_created_at_us, const gchar * audit_subject_id,
+    const gchar * audit_action, const gchar * audit_resource_id,
+    const gchar * audit_deny_reason, const gchar * audit_deny_origin,
+    wyl_decision_t audit_decision)
+{
+  if (out_event_id != NULL)
+    *out_event_id = -1;
+  if (store == NULL || store->db == NULL || subject_id == NULL
+      || perm_id == NULL || scope == NULL || event == NULL)
+    return WYRELOG_E_INVALID;
+
+  wyl_perm_event_t ev = wyl_perm_event_from_name (event);
+  if (ev == WYL_PERM_EVENT_LAST_)
+    return WYRELOG_E_INVALID;
+
+  wyrelog_error_t rc = wyl_policy_store_begin_mutation (store);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  g_autofree gchar *from_state_name = NULL;
+  rc = wyl_policy_store_get_permission_state (store, subject_id, perm_id,
+      scope, &from_state_name);
+  if (rc == WYRELOG_E_OK && from_state_name == NULL)
+    from_state_name = g_strdup (wyl_perm_state_name (WYL_PERM_STATE_DORMANT));
+
+  wyl_perm_state_t from = WYL_PERM_STATE_LAST_;
+  wyl_perm_state_t to = WYL_PERM_STATE_LAST_;
+  const gchar *to_state_name = NULL;
+  if (rc == WYRELOG_E_OK) {
+    from = wyl_perm_state_from_name (from_state_name);
+    if (from == WYL_PERM_STATE_LAST_)
+      rc = WYRELOG_E_POLICY;
+  }
+  if (rc == WYRELOG_E_OK)
+    rc = wyl_fsm_permission_scope_step (from, ev, &to);
+  if (rc == WYRELOG_E_OK) {
+    to_state_name = wyl_perm_state_name (to);
+    if (to_state_name == NULL)
+      rc = WYRELOG_E_INTERNAL;
+  }
+  if (rc == WYRELOG_E_OK) {
+    rc = wyl_policy_store_set_permission_state (store, subject_id, perm_id,
+        scope, to_state_name);
+  }
+
+  gint64 event_id = -1;
+  if (rc == WYRELOG_E_OK) {
+    rc = wyl_policy_store_append_permission_state_event (store, subject_id,
+        perm_id, scope, event, from_state_name, to_state_name, &event_id);
+  }
+  if (rc == WYRELOG_E_OK && audit_id != NULL) {
+    rc = wyl_policy_store_append_audit_event (store, audit_id,
+        audit_created_at_us, audit_subject_id, audit_action,
+        audit_resource_id, audit_deny_reason, audit_deny_origin,
+        audit_decision);
+  }
+  if (rc == WYRELOG_E_OK)
+    rc = wyl_policy_store_validate_snapshot (store);
+  if (rc != WYRELOG_E_OK) {
+    wyl_policy_store_rollback_mutation (store);
+    return rc;
+  }
+
+  rc = wyl_policy_store_commit_mutation (store);
+  if (rc != WYRELOG_E_OK) {
+    wyl_policy_store_rollback_mutation (store);
+    return rc;
+  }
+  if (out_event_id != NULL)
+    *out_event_id = event_id;
+  return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
+wyl_policy_store_apply_permission_state_transition (wyl_policy_store_t *store,
+    const gchar *subject_id, const gchar *perm_id, const gchar *scope,
+    const gchar *event, gint64 *out_event_id)
+{
+  return wyl_policy_store_apply_permission_state_transition_with_audit (store,
+      subject_id, perm_id, scope, event, out_event_id, NULL, 0, NULL, NULL,
+      NULL, NULL, NULL, WYL_DECISION_DENY);
 }
 
 wyrelog_error_t

--- a/wyrelog/wyl-handle-private.h
+++ b/wyrelog/wyl-handle-private.h
@@ -5,6 +5,7 @@
 
 #include "wyrelog/handle.h"
 #include "wyrelog/engine.h"
+#include "wyrelog/audit.h"
 #include "policy/store-private.h"
 
 #ifdef WYL_HAS_AUDIT
@@ -63,6 +64,18 @@ wyl_policy_store_t *wyl_handle_get_policy_store (WylHandle * self);
  */
 void wyl_handle_set_login_skip_mfa_allowed (WylHandle * self, gboolean allowed);
 gboolean wyl_handle_get_login_skip_mfa_allowed (WylHandle * self);
+
+/*
+ * Applies a permission-state transition to the handle-owned policy store, then
+ * reloads the engine pair so perm_state/4 and perm_state_fired/7 reflect the
+ * durable state. The policy store commit is the source of truth: if reload
+ * fails, the previous engine pair remains installed and the returned error is
+ * the reload failure.
+ */
+wyrelog_error_t wyl_handle_apply_permission_state_transition (WylHandle * self,
+    const gchar * subject_id, const gchar * perm_id, const gchar * scope,
+    const gchar * event, const WylAuditEvent * audit_event,
+    gint64 * out_event_id);
 
 /*
  * Opens the handle-owned policy engine pair from @template_dir.

--- a/wyrelog/wyl-perm.c
+++ b/wyrelog/wyl-perm.c
@@ -43,6 +43,9 @@ struct _wyl_role_revoke_req
   gchar *actor_id;
 };
 
+static wyrelog_error_t finish_policy_mutation (WylHandle * handle,
+    const WylAuditEvent * audit_event);
+
 wyl_login_req_t *
 wyl_login_req_new (void)
 {
@@ -460,6 +463,43 @@ update_role_membership_store (WylHandle *handle, const gchar *subject_id,
       wyl_audit_event_get_deny_reason (audit_event),
       wyl_audit_event_get_deny_origin (audit_event),
       wyl_audit_event_get_decision (audit_event));
+}
+
+wyrelog_error_t
+wyl_handle_apply_permission_state_transition (WylHandle *handle,
+    const gchar *subject_id, const gchar *perm_id, const gchar *scope,
+    const gchar *event, const WylAuditEvent *audit_event, gint64 *out_event_id)
+{
+  if (handle == NULL || !WYL_IS_HANDLE (handle))
+    return WYRELOG_E_INVALID;
+  if (subject_id == NULL || perm_id == NULL || scope == NULL || event == NULL)
+    return WYRELOG_E_INVALID;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (store == NULL)
+    return WYRELOG_E_INVALID;
+
+  wyrelog_error_t rc = WYRELOG_E_OK;
+  if (audit_event == NULL) {
+    rc = wyl_policy_store_apply_permission_state_transition (store,
+        subject_id, perm_id, scope, event, out_event_id);
+  } else {
+    g_autofree gchar *audit_id = wyl_audit_event_dup_id_string (audit_event);
+    if (audit_id == NULL)
+      return WYRELOG_E_INTERNAL;
+    rc = wyl_policy_store_apply_permission_state_transition_with_audit (store,
+        subject_id, perm_id, scope, event, out_event_id, audit_id,
+        wyl_audit_event_get_created_at_us (audit_event),
+        wyl_audit_event_get_subject_id (audit_event),
+        wyl_audit_event_get_action (audit_event),
+        wyl_audit_event_get_resource_id (audit_event),
+        wyl_audit_event_get_deny_reason (audit_event),
+        wyl_audit_event_get_deny_origin (audit_event),
+        wyl_audit_event_get_decision (audit_event));
+  }
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return finish_policy_mutation (handle, audit_event);
 }
 
 static wyrelog_error_t


### PR DESCRIPTION
## Summary

- add a policy-store helper that applies permission-state transitions through
  the FSM mirror in one mutation savepoint
- persist transition event rows and optional audit rows with the same durable
  transaction semantics
- add a private handle helper that applies the transition and reloads the
  engine pair through the existing mutation completion path
- cover rollback, audit consistency, runtime decision refresh, audit fact
  projection, and reload-failure pair preservation

## Tests

- `git diff --check`
- `meson test -C builddir-ci-pr handle-engine-pair policy-store audit-emit daemon-http-decide --print-errorlogs`
- `meson test -C builddir-ci-pr --print-errorlogs --suite wyrelog`
- `meson test -C builddir handle-engine-pair policy-store daemon-http-decide --print-errorlogs`
