### PR TITLE
daemon: gate permission state transitions

### DIFF
--- a/tests/test-daemon-checks.c
+++ b/tests/test-daemon-checks.c
@@ -34,6 +34,54 @@ typedef struct
   guint matches;
 } AuditActionProbe;
 
+typedef struct
+{
+  guint matches;
+} PermissionStateEventProbe;
+
+typedef struct
+{
+  guint matches;
+} AuditEventProbe;
+
+static wyrelog_error_t
+permission_state_event_probe_cb (gint64 event_id, const gchar *subject_id,
+    const gchar *perm_id, const gchar *scope, const gchar *event,
+    const gchar *from_state, const gchar *to_state, gpointer user_data)
+{
+  (void) event_id;
+  (void) scope;
+  PermissionStateEventProbe *probe = user_data;
+
+  if (g_strcmp0 (subject_id, "wyrelogd-perm-state-user") == 0
+      && g_strcmp0 (perm_id, "wyrelogd.perm_state.read") == 0
+      && g_strcmp0 (event, "grant") == 0
+      && g_strcmp0 (from_state, "dormant") == 0
+      && g_strcmp0 (to_state, "armed") == 0)
+    probe->matches++;
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+audit_event_probe_cb (const gchar *id, gint64 created_at_us,
+    const gchar *subject_id, const gchar *action, const gchar *resource_id,
+    const gchar *deny_reason, const gchar *deny_origin,
+    wyl_decision_t decision, gpointer user_data)
+{
+  (void) id;
+  (void) created_at_us;
+  (void) deny_origin;
+  AuditEventProbe *probe = user_data;
+
+  if (g_strcmp0 (subject_id, "wyrelogd") == 0
+      && g_strcmp0 (action, "permission_state.grant") == 0
+      && g_strcmp0 (resource_id, "wyrelogd.perm_state.read") == 0
+      && g_strcmp0 (deny_reason, "daemon_check") == 0
+      && decision == WYL_DECISION_ALLOW)
+    probe->matches++;
+  return WYRELOG_E_OK;
+}
+
 static void
 count_audit_action_cb (const gchar *relation, const gint64 *row, guint ncols,
     gpointer user_data)
@@ -246,6 +294,47 @@ check_direct_permission_grant_ready_allows_decide (void)
   return 0;
 }
 
+static gint
+check_permission_state_transition_ready_allows_decide (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  gint64 count = 0;
+
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 74;
+  if (wyl_daemon_check_permission_state_transition_ready (handle)
+      != WYRELOG_E_OK)
+    return 75;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  PermissionStateEventProbe probe = { 0 };
+  if (wyl_policy_store_foreach_permission_state_event (store,
+          permission_state_event_probe_cb, &probe) != WYRELOG_E_OK)
+    return 76;
+  if (probe.matches != 1)
+    return 77;
+
+  AuditEventProbe audit_probe = { 0 };
+  if (wyl_policy_store_foreach_audit_event (store, audit_event_probe_cb,
+          &audit_probe) != WYRELOG_E_OK)
+    return 78;
+  if (audit_probe.matches != 1)
+    return 79;
+
+  duckdb_connection conn =
+      wyl_audit_conn_get_connection (wyl_handle_get_audit_conn (handle));
+  if (!count_duckdb_rows (conn,
+          "SELECT COUNT(*) FROM audit_events "
+          "WHERE action = 'permission_state.grant' "
+          "AND subject_id = 'wyrelogd' "
+          "AND resource_id = 'wyrelogd.perm_state.read' "
+          "AND deny_reason = 'daemon_check' " "AND decision = 1;", &count))
+    return 80;
+  if (count != 1)
+    return 81;
+  return 0;
+}
+
 int
 main (void)
 {
@@ -254,6 +343,8 @@ main (void)
   if ((rc = check_policy_audit_facts_ready_loads_read_engine ()) != 0)
     return rc;
   if ((rc = check_direct_permission_grant_ready_allows_decide ()) != 0)
+    return rc;
+  if ((rc = check_permission_state_transition_ready_allows_decide ()) != 0)
     return rc;
   if ((rc = check_login_skip_mfa_ready_rejects_production_path ()) != 0)
     return rc;

--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -22,6 +22,16 @@ typedef struct
   GMainLoop *loop;
 } TestHttpServer;
 
+typedef struct
+{
+  const gchar *subject_id;
+  const gchar *action;
+  const gchar *resource_id;
+  const gchar *deny_reason;
+  const gchar *deny_origin;
+  guint matches;
+} AuditEventProbe;
+
 static gpointer
 test_http_server_thread (gpointer data)
 {
@@ -1007,6 +1017,38 @@ direct_permission_exists (WylHandle *handle, const gchar *subject,
 }
 
 static gboolean
+permission_state_exists (WylHandle *handle, const gchar *subject,
+    const gchar *perm, const gchar *scope)
+{
+  gboolean exists = FALSE;
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (wyl_policy_store_permission_state_exists (store, subject, perm, scope,
+          &exists) != WYRELOG_E_OK)
+    return FALSE;
+  return exists;
+}
+
+static wyrelog_error_t
+audit_event_probe_cb (const gchar *id, gint64 created_at_us,
+    const gchar *subject_id, const gchar *action, const gchar *resource_id,
+    const gchar *deny_reason, const gchar *deny_origin,
+    wyl_decision_t decision, gpointer user_data)
+{
+  (void) id;
+  (void) created_at_us;
+  AuditEventProbe *probe = user_data;
+
+  if (decision == WYL_DECISION_ALLOW
+      && g_strcmp0 (subject_id, probe->subject_id) == 0
+      && g_strcmp0 (action, probe->action) == 0
+      && g_strcmp0 (resource_id, probe->resource_id) == 0
+      && g_strcmp0 (deny_reason, probe->deny_reason) == 0
+      && g_strcmp0 (deny_origin, probe->deny_origin) == 0)
+    probe->matches++;
+  return WYRELOG_E_OK;
+}
+
+static gboolean
 role_membership_exists (WylHandle *handle, const gchar *subject,
     const gchar *role, const gchar *scope)
 {
@@ -1052,6 +1094,15 @@ check_policy_permission_mutation_contract (WylHandle *handle,
     return 126;
   g_clear_pointer (&body, g_free);
 
+  rc = send_raw_policy_mutation (session, "GET", base_url,
+      "/policy/permissions/transition", "subject=state-target"
+      "&perm=site.policy.read&scope=tenant-a&event=grant", &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 405 || strstr (body, "\"method_not_allowed\"") == NULL)
+    return 167;
+  g_clear_pointer (&body, g_free);
+
   rc = send_raw_policy_mutation (session, "POST", base_url,
       "/policy/permissions/grant", "perm=site.policy.read&scope=tenant-a",
       &status, &body);
@@ -1059,6 +1110,26 @@ check_policy_permission_mutation_contract (WylHandle *handle,
     return rc;
   if (status != 400 || strstr (body, "\"invalid_policy_mutation\"") == NULL)
     return 127;
+  g_clear_pointer (&body, g_free);
+
+  rc = send_raw_policy_mutation (session, "POST", base_url,
+      "/policy/permissions/transition",
+      "subject=state-target&perm=site.policy.read&scope=tenant-a",
+      &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 400 || strstr (body, "\"invalid_policy_mutation\"") == NULL)
+    return 168;
+  g_clear_pointer (&body, g_free);
+
+  rc = send_raw_policy_mutation (session, "POST", base_url,
+      "/policy/permissions/transition",
+      "subject=state-target&perm=site.policy.read&scope=tenant-a&event=nope",
+      &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 400 || strstr (body, "\"invalid_policy_mutation\"") == NULL)
+    return 169;
   g_clear_pointer (&body, g_free);
 
   rc = send_raw_policy_mutation (session, "POST", base_url,
@@ -1106,6 +1177,22 @@ check_policy_permission_mutation_contract (WylHandle *handle,
     return 131;
   g_clear_pointer (&body, g_free);
 
+  g_autofree gchar *transition_denied_query =
+      g_strdup_printf ("subject=state-target&perm=site.policy.read"
+      "&scope=tenant-a&event=grant&session_token=%s&guard_timestamp=123"
+      "&guard_loc_class=public&guard_risk=49", session_token);
+  rc = send_raw_policy_mutation (session, "POST", base_url,
+      "/policy/permissions/transition", transition_denied_query, &status,
+      &body);
+  if (rc != 0)
+    return rc;
+  if (status != 403 || strstr (body, "\"policy_denied\"") == NULL)
+    return 170;
+  if (permission_state_exists (handle, "state-target", "site.policy.read",
+          "tenant-a"))
+    return 171;
+  g_clear_pointer (&body, g_free);
+
   g_autofree gchar *missing_perm_grant_query =
       g_strdup_printf ("subject=target&perm=site.missing&scope=tenant-a"
       "&session_token=%s&guard_timestamp=123&guard_loc_class=public"
@@ -1130,6 +1217,35 @@ check_policy_permission_mutation_contract (WylHandle *handle,
     return 155;
   g_clear_pointer (&body, g_free);
 
+  g_autofree gchar *missing_perm_transition_query =
+      g_strdup_printf ("subject=state-target&perm=site.missing"
+      "&scope=tenant-a&event=grant&session_token=%s&guard_timestamp=123"
+      "&guard_loc_class=public&guard_risk=49", session_token);
+  rc = send_raw_policy_mutation (session, "POST", base_url,
+      "/policy/permissions/transition", missing_perm_transition_query,
+      &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 400 || strstr (body, "\"invalid_policy_mutation\"") == NULL)
+    return 172;
+  g_clear_pointer (&body, g_free);
+
+  g_autofree gchar *invalid_edge_transition_query =
+      g_strdup_printf ("subject=state-target&perm=site.policy.read"
+      "&scope=tenant-a&event=revoke&session_token=%s&guard_timestamp=123"
+      "&guard_loc_class=public&guard_risk=49", session_token);
+  rc = send_raw_policy_mutation (session, "POST", base_url,
+      "/policy/permissions/transition", invalid_edge_transition_query,
+      &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 400 || strstr (body, "\"invalid_policy_mutation\"") == NULL)
+    return 173;
+  if (permission_state_exists (handle, "state-target", "site.policy.read",
+          "tenant-a"))
+    return 174;
+  g_clear_pointer (&body, g_free);
+
   g_autofree gchar *guard_denied_query =
       g_strdup_printf ("subject=target&perm=site.policy.read&scope=tenant-a"
       "&session_token=%s&guard_timestamp=123&guard_loc_class=public"
@@ -1143,6 +1259,33 @@ check_policy_permission_mutation_contract (WylHandle *handle,
   if (direct_permission_exists (handle, "target", "site.policy.read",
           "tenant-a"))
     return 134;
+  g_clear_pointer (&body, g_free);
+
+  rc = send_raw_policy_mutation (session, "POST", base_url,
+      "/policy/permissions/transition", transition_denied_query, &status,
+      &body);
+  if (rc != 0)
+    return rc;
+  if (status != 200 || strstr (body, "\"ok\":true") == NULL)
+    return 175;
+  if (!permission_state_exists (handle, "state-target", "site.policy.read",
+          "tenant-a"))
+    return 176;
+  if (direct_permission_exists (handle, "state-target", "site.policy.read",
+          "tenant-a"))
+    return 177;
+  AuditEventProbe transition_audit = {
+    .subject_id = "http-policy-admin",
+    .action = "permission_state.grant",
+    .resource_id = "site.policy.read",
+    .deny_reason = "grant",
+    .deny_origin = "tenant-a",
+  };
+  if (wyl_policy_store_foreach_audit_event (store, audit_event_probe_cb,
+          &transition_audit) != WYRELOG_E_OK)
+    return 178;
+  if (transition_audit.matches != 1)
+    return 179;
   g_clear_pointer (&body, g_free);
 
   g_autofree gchar *grant_query =

--- a/wyrelog/daemon/checks.c
+++ b/wyrelog/daemon/checks.c
@@ -305,6 +305,68 @@ wyl_daemon_check_direct_permission_grant_ready (WylHandle *handle)
       WYRELOG_E_OK : WYRELOG_E_POLICY;
 }
 
+wyrelog_error_t
+wyl_daemon_check_permission_state_transition_ready (WylHandle *handle)
+{
+  static const gchar *user = "wyrelogd-perm-state-user";
+  static const gchar *perm = "wyrelogd.perm_state.read";
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+
+  wyrelog_error_t rc = wyl_policy_store_upsert_permission (store, perm,
+      "permission state readiness read", "basic");
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  g_autoptr (WylSession) session = NULL;
+  rc = login_check_principal (handle, user, &session);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  g_autofree gchar *session_id = wyl_session_dup_id_string (session);
+  if (session_id == NULL)
+    return WYRELOG_E_INTERNAL;
+
+  rc = wyl_policy_store_grant_direct_permission (store, user, perm, session_id);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  g_autoptr (WylAuditEvent) audit_event = wyl_audit_event_new ();
+  wyl_audit_event_set_subject_id (audit_event, "wyrelogd");
+  wyl_audit_event_set_action (audit_event, "permission_state.grant");
+  wyl_audit_event_set_resource_id (audit_event, perm);
+  wyl_audit_event_set_deny_reason (audit_event, "daemon_check");
+  wyl_audit_event_set_deny_origin (audit_event, "dormant");
+  wyl_audit_event_set_decision (audit_event, WYL_DECISION_ALLOW);
+
+  gint64 event_id = -1;
+  rc = wyl_handle_apply_permission_state_transition (handle, user, perm,
+      session_id, "grant", audit_event, &event_id);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if (event_id <= 0)
+    return WYRELOG_E_POLICY;
+
+  gboolean found = FALSE;
+  rc = wyl_policy_store_permission_state_exists (store, user, perm, session_id,
+      &found);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if (!found)
+    return WYRELOG_E_POLICY;
+
+  g_autoptr (wyl_decide_req_t) decide = wyl_decide_req_new ();
+  wyl_decide_req_set_subject_id (decide, user);
+  wyl_decide_req_set_action (decide, perm);
+  wyl_decide_req_set_resource_id (decide, session_id);
+
+  g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
+  rc = wyl_decide (handle, decide, resp);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_decide_resp_get_decision (resp) == WYL_DECISION_ALLOW ?
+      WYRELOG_E_OK : WYRELOG_E_POLICY;
+}
+
 static wyrelog_error_t
 insert_symbol_row (WylHandle *handle, const gchar *relation,
     const gchar *const *symbols, gsize ncols)
@@ -453,6 +515,13 @@ wyl_daemon_run_checks (WylHandle *handle)
   rc = wyl_daemon_check_direct_permission_grant_ready (handle);
   if (rc != WYRELOG_E_OK) {
     g_printerr ("wyrelogd: direct permission grant check failed: %s\n",
+        wyrelog_error_string (rc));
+    return 1;
+  }
+
+  rc = wyl_daemon_check_permission_state_transition_ready (handle);
+  if (rc != WYRELOG_E_OK) {
+    g_printerr ("wyrelogd: permission state transition check failed: %s\n",
         wyrelog_error_string (rc));
     return 1;
   }

--- a/wyrelog/daemon/checks.h
+++ b/wyrelog/daemon/checks.h
@@ -13,6 +13,8 @@ wyrelog_error_t wyl_daemon_check_policy_snapshot_reload_ready (WylHandle *
 wyrelog_error_t
 wyl_daemon_check_direct_permission_grant_ready (WylHandle * handle);
 wyrelog_error_t
+wyl_daemon_check_permission_state_transition_ready (WylHandle * handle);
+wyrelog_error_t
 wyl_daemon_check_role_permission_snapshot_reload_ready (WylHandle * handle);
 wyrelog_error_t wyl_daemon_emit_start_event (WylHandle * handle);
 int wyl_daemon_run_checks (WylHandle * handle);

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -10,6 +10,7 @@
 #include "wyrelog/auth/jwt-private.h"
 #include "wyrelog/wyl-handle-private.h"
 #include "wyrelog/wyl-id-private.h"
+#include "wyrelog/wyl-fsm-permission-scope-private.h"
 #include "wyrelog/wyl-permission-scope-private.h"
 
 #define WYL_DAEMON_JWT_ISSUER "wyrelogd"
@@ -592,6 +593,16 @@ set_policy_mutation_error (SoupServerMessage *msg, wyrelog_error_t rc)
   set_json_error (msg, 500, "policy_mutation_failed");
 }
 
+static void
+set_policy_transition_error (SoupServerMessage *msg, wyrelog_error_t rc)
+{
+  if (rc == WYRELOG_E_INVALID || rc == WYRELOG_E_POLICY) {
+    set_json_error (msg, 400, "invalid_policy_mutation");
+    return;
+  }
+  set_json_error (msg, 500, "policy_mutation_failed");
+}
+
 static gboolean
 ensure_policy_permission_exists (SoupServerMessage *msg,
     WylDaemonHttpContext *ctx, const gchar *perm)
@@ -605,6 +616,16 @@ ensure_policy_permission_exists (SoupServerMessage *msg,
     return FALSE;
   }
   if (!exists) {
+    set_json_error (msg, 400, "invalid_policy_mutation");
+    return FALSE;
+  }
+  return TRUE;
+}
+
+static gboolean
+ensure_permission_transition_event (SoupServerMessage *msg, const gchar *event)
+{
+  if (wyl_perm_event_from_name (event) == WYL_PERM_EVENT_LAST_) {
     set_json_error (msg, 400, "invalid_policy_mutation");
     return FALSE;
   }
@@ -696,6 +717,59 @@ policy_permission_revoke_handler (SoupServer *server, SoupServerMessage *msg,
 {
   direct_permission_mutation_handler (server, msg, path, query, user_data,
       FALSE);
+}
+
+static void
+policy_permission_transition_handler (SoupServer *server,
+    SoupServerMessage *msg, const char *path, GHashTable *query,
+    gpointer user_data)
+{
+  (void) path;
+
+  if (g_strcmp0 (soup_server_message_get_method (msg), "POST") != 0) {
+    set_json_error (msg, 405, "method_not_allowed");
+    return;
+  }
+
+  const gchar *subject = lookup_required_query_string (query, "subject");
+  const gchar *perm = lookup_required_query_string (query, "perm");
+  const gchar *scope = lookup_required_query_string (query, "scope");
+  const gchar *event = lookup_required_query_string (query, "event");
+  if (subject == NULL || perm == NULL || scope == NULL || event == NULL) {
+    set_json_error (msg, 400, "invalid_policy_mutation");
+    return;
+  }
+  if (!ensure_permission_transition_event (msg, event))
+    return;
+
+  WylDaemonHttpContext *ctx = user_data;
+  g_autofree gchar *actor = NULL;
+  if (!authorize_guarded_session_action (server, msg, query, ctx,
+          "wr.policy.write", scope, "policy_auth_required",
+          "invalid_policy_auth", "policy_denied", "policy_auth_failed", &actor))
+    return;
+
+  if (!ensure_policy_permission_exists (msg, ctx, perm))
+    return;
+
+  g_autoptr (WylAuditEvent) audit_event = wyl_audit_event_new ();
+  wyl_audit_event_set_subject_id (audit_event, actor);
+  g_autofree gchar *audit_action = g_strdup_printf ("permission_state.%s",
+      event);
+  wyl_audit_event_set_action (audit_event, audit_action);
+  wyl_audit_event_set_resource_id (audit_event, perm);
+  wyl_audit_event_set_deny_reason (audit_event, event);
+  wyl_audit_event_set_deny_origin (audit_event, scope);
+  wyl_audit_event_set_decision (audit_event, WYL_DECISION_ALLOW);
+
+  wyrelog_error_t rc = wyl_handle_apply_permission_state_transition
+      (ctx->handle, subject, perm, scope, event, audit_event, NULL);
+  if (rc != WYRELOG_E_OK) {
+    set_policy_transition_error (msg, rc);
+    return;
+  }
+
+  set_json_ok (msg);
 }
 
 static void
@@ -1022,6 +1096,8 @@ wyl_daemon_start_http_server (const WylDaemonOptions *opts, WylHandle *handle,
       policy_permission_grant_handler, ctx, NULL);
   soup_server_add_handler (server, "/policy/permissions/revoke",
       policy_permission_revoke_handler, ctx, NULL);
+  soup_server_add_handler (server, "/policy/permissions/transition",
+      policy_permission_transition_handler, ctx, NULL);
   soup_server_add_handler (server, "/policy/roles/grant",
       policy_role_grant_handler, ctx, NULL);
   soup_server_add_handler (server, "/policy/roles/revoke",


### PR DESCRIPTION
## Summary
- add a daemon readiness check for permission-state transition plumbing
- expose a guarded HTTP endpoint for permission-state transitions
- verify durable audit attribution and avoid legacy direct grants

## Tests
- git diff --check origin/main..HEAD
- meson test -C builddir-ci-pr daemon-http-decide daemon-checks handle-engine-pair policy-store audit-emit --print-errorlogs
