### PR TITLE
client: add permission transition contract

### DIFF
--- a/tests/test-client-smoke.c
+++ b/tests/test-client-smoke.c
@@ -20,6 +20,7 @@ typedef struct
   gchar *last_perm;
   gchar *last_role;
   gchar *last_scope;
+  gchar *last_event;
   gchar *last_session_token;
   gchar *last_authorization;
   gchar *last_password;
@@ -69,6 +70,7 @@ test_http_server_handler (SoupServer *server, SoupServerMessage *msg,
   g_free (http->last_perm);
   g_free (http->last_role);
   g_free (http->last_scope);
+  g_free (http->last_event);
   g_free (http->last_session_token);
   g_free (http->last_authorization);
   g_free (http->last_password);
@@ -94,6 +96,8 @@ test_http_server_handler (SoupServer *server, SoupServerMessage *msg,
       query != NULL ? g_strdup (g_hash_table_lookup (query, "role")) : NULL;
   http->last_scope =
       query != NULL ? g_strdup (g_hash_table_lookup (query, "scope")) : NULL;
+  http->last_event =
+      query != NULL ? g_strdup (g_hash_table_lookup (query, "event")) : NULL;
   http->last_session_token =
       query != NULL ? g_strdup (g_hash_table_lookup (query,
           "session_token")) : NULL;
@@ -335,6 +339,30 @@ main (void)
   if (wyl_client_policy_permission_grant (local_client, "target", "read",
           "scope", 123, "unknown", 49) != WYRELOG_E_INVALID)
     return 516;
+  if (wyl_client_policy_permission_transition (NULL, "target", "read",
+          "scope", "grant", 123, "public", 49) != WYRELOG_E_INVALID)
+    return 529;
+  if (wyl_client_policy_permission_transition (local_client, NULL, "read",
+          "scope", "grant", 123, "public", 49) != WYRELOG_E_INVALID)
+    return 530;
+  if (wyl_client_policy_permission_transition (local_client, "target", NULL,
+          "scope", "grant", 123, "public", 49) != WYRELOG_E_INVALID)
+    return 531;
+  if (wyl_client_policy_permission_transition (local_client, "target", "read",
+          NULL, "grant", 123, "public", 49) != WYRELOG_E_INVALID)
+    return 532;
+  if (wyl_client_policy_permission_transition (local_client, "target", "read",
+          "scope", NULL, 123, "public", 49) != WYRELOG_E_INVALID)
+    return 533;
+  if (wyl_client_policy_permission_transition (local_client, "target", "read",
+          "scope", "", 123, "public", 49) != WYRELOG_E_INVALID)
+    return 534;
+  if (wyl_client_policy_permission_transition (local_client, "target", "read",
+          "scope", "grant", -1, "public", 49) != WYRELOG_E_INVALID)
+    return 535;
+  if (wyl_client_policy_permission_transition (local_client, "target", "read",
+          "scope", "grant", 123, "unknown", 49) != WYRELOG_E_INVALID)
+    return 536;
 
   http.body = "{\"ok\":true}";
   if (wyl_client_policy_permission_grant (local_client, "target user",
@@ -358,6 +386,21 @@ main (void)
       http.last_session_token != NULL ||
       g_strcmp0 (http.last_authorization, "Bearer access-2") != 0)
     return 520;
+  if (wyl_client_policy_permission_transition (local_client, "target user",
+          "site.policy.read", "tenant/a", "grant", 123, "public", 49)
+      != WYRELOG_E_OK)
+    return 537;
+  if (g_strcmp0 (http.last_path, "/policy/permissions/transition") != 0 ||
+      g_strcmp0 (http.last_subject, "target user") != 0 ||
+      g_strcmp0 (http.last_perm, "site.policy.read") != 0 ||
+      g_strcmp0 (http.last_scope, "tenant/a") != 0 ||
+      g_strcmp0 (http.last_event, "grant") != 0 ||
+      http.last_session_token != NULL ||
+      g_strcmp0 (http.last_authorization, "Bearer access-2") != 0 ||
+      g_strcmp0 (http.last_guard_timestamp, "123") != 0 ||
+      g_strcmp0 (http.last_guard_loc_class, "public") != 0 ||
+      g_strcmp0 (http.last_guard_risk, "49") != 0)
+    return 538;
   if (wyl_client_policy_role_grant (local_client, "target user",
           "site.reader", "tenant/b", 123, "public", 29) != WYRELOG_E_OK)
     return 521;
@@ -656,6 +699,7 @@ main (void)
   g_clear_pointer (&http.last_perm, g_free);
   g_clear_pointer (&http.last_role, g_free);
   g_clear_pointer (&http.last_scope, g_free);
+  g_clear_pointer (&http.last_event, g_free);
   g_clear_pointer (&http.last_session_token, g_free);
   g_clear_pointer (&http.last_authorization, g_free);
   g_clear_pointer (&http.last_password, g_free);

--- a/tests/test-session-username.c
+++ b/tests/test-session-username.c
@@ -1034,6 +1034,61 @@ check_login_skip_mfa_uses_policy_permission (void)
 }
 
 static gint
+check_login_skip_mfa_does_not_use_state_without_permission (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 187;
+
+  gint64 event_id = -1;
+  if (wyl_handle_apply_permission_state_transition (handle,
+          "skip-mfa-state-only-user", "wr.login.skip_mfa", "login", "grant",
+          NULL, &event_id) != WYRELOG_E_OK)
+    return 188;
+  if (event_id <= 0)
+    return 189;
+
+  g_autoptr (WylSession) session = NULL;
+  if (login_skip_mfa_user (handle, "skip-mfa-state-only-user", &session)
+      != WYRELOG_E_POLICY)
+    return 190;
+  return session == NULL ? 0 : 191;
+}
+
+static gint
+check_login_skip_mfa_policy_permission_ignores_state_lifecycle (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 192;
+
+  if (grant_direct (handle, "skip-mfa-dormant-user", "wr.login.skip_mfa",
+          "login") != WYRELOG_E_OK)
+    return 193;
+
+  gint64 event_id = -1;
+  if (wyl_handle_apply_permission_state_transition (handle,
+          "skip-mfa-dormant-user", "wr.login.skip_mfa", "login", "grant",
+          NULL, &event_id) != WYRELOG_E_OK)
+    return 194;
+  if (event_id <= 0)
+    return 195;
+  event_id = -1;
+  if (wyl_handle_apply_permission_state_transition (handle,
+          "skip-mfa-dormant-user", "wr.login.skip_mfa", "login", "revoke",
+          NULL, &event_id) != WYRELOG_E_OK)
+    return 196;
+  if (event_id <= 0)
+    return 197;
+
+  g_autoptr (WylSession) session = NULL;
+  if (login_skip_mfa_user (handle, "skip-mfa-dormant-user", &session)
+      != WYRELOG_E_OK)
+    return 198;
+  return session != NULL ? 0 : 199;
+}
+
+static gint
 check_login_skip_mfa_inserts_wirelog_principal_fired (void)
 {
   g_autoptr (WylHandle) handle = NULL;
@@ -1741,6 +1796,12 @@ main (void)
   if ((rc = check_login_skip_mfa_uses_deployment_mode ()) != 0)
     return rc;
   if ((rc = check_login_skip_mfa_uses_policy_permission ()) != 0)
+    return rc;
+  if ((rc = check_login_skip_mfa_does_not_use_state_without_permission ())
+      != 0)
+    return rc;
+  if ((rc = check_login_skip_mfa_policy_permission_ignores_state_lifecycle ())
+      != 0)
     return rc;
   if ((rc = check_login_skip_mfa_inserts_wirelog_principal_fired ()) != 0)
     return rc;

--- a/wyrelog/client.h
+++ b/wyrelog/client.h
@@ -86,6 +86,12 @@ wyrelog_error_t wyl_client_policy_permission_revoke (WylClient * client,
     const gchar * perm,
     const gchar * scope,
     gint64 guard_timestamp, const gchar * guard_loc_class, gint64 guard_risk);
+wyrelog_error_t wyl_client_policy_permission_transition (WylClient * client,
+    const gchar * subject,
+    const gchar * perm,
+    const gchar * scope,
+    const gchar * event,
+    gint64 guard_timestamp, const gchar * guard_loc_class, gint64 guard_risk);
 wyrelog_error_t wyl_client_policy_role_grant (WylClient * client,
     const gchar * subject,
     const gchar * role,

--- a/wyrelog/wyl-client.c
+++ b/wyrelog/wyl-client.c
@@ -249,13 +249,15 @@ wyl_client_mfa_verify (WylClient *client, const gchar *otp)
 static wyrelog_error_t
 client_policy_mutation_request (WylClient *client, const gchar *path,
     const gchar *subject, const gchar *target_name, const gchar *target_value,
-    const gchar *scope, gint64 guard_timestamp, const gchar *guard_loc_class,
-    gint64 guard_risk)
+    const gchar *scope, const gchar *event, gint64 guard_timestamp,
+    const gchar *guard_loc_class, gint64 guard_risk)
 {
   if (client == NULL || !WYL_IS_CLIENT (client) || path == NULL ||
       subject == NULL || subject[0] == '\0' || target_name == NULL ||
       target_value == NULL || target_value[0] == '\0' || scope == NULL ||
       scope[0] == '\0')
+    return WYRELOG_E_INVALID;
+  if (event != NULL && event[0] == '\0')
     return WYRELOG_E_INVALID;
   if (guard_timestamp < 0 || guard_loc_class == NULL || guard_risk < 0 ||
       guard_risk > 100 || !wyl_guard_loc_class_is_valid (guard_loc_class))
@@ -277,24 +279,44 @@ client_policy_mutation_request (WylClient *client, const gchar *path,
   g_autofree gchar *escaped_target =
       g_uri_escape_string (target_value, NULL, TRUE);
   g_autofree gchar *escaped_scope = g_uri_escape_string (scope, NULL, TRUE);
+  g_autofree gchar *escaped_event =
+      event != NULL ? g_uri_escape_string (event, NULL, TRUE) : NULL;
   g_autofree gchar *escaped_loc =
       g_uri_escape_string (guard_loc_class, NULL, TRUE);
   g_autofree gchar *uri = NULL;
   if (use_access_token) {
-    uri = g_strdup_printf ("%s/%s?subject=%s&%s=%s&scope=%s"
-        "&guard_timestamp=%" G_GINT64_FORMAT
-        "&guard_loc_class=%s&guard_risk=%" G_GINT64_FORMAT,
-        base_url, path, escaped_subject, target_name, escaped_target,
-        escaped_scope, guard_timestamp, escaped_loc, guard_risk);
+    if (escaped_event != NULL) {
+      uri = g_strdup_printf ("%s/%s?subject=%s&%s=%s&scope=%s&event=%s"
+          "&guard_timestamp=%" G_GINT64_FORMAT
+          "&guard_loc_class=%s&guard_risk=%" G_GINT64_FORMAT,
+          base_url, path, escaped_subject, target_name, escaped_target,
+          escaped_scope, escaped_event, guard_timestamp, escaped_loc,
+          guard_risk);
+    } else {
+      uri = g_strdup_printf ("%s/%s?subject=%s&%s=%s&scope=%s"
+          "&guard_timestamp=%" G_GINT64_FORMAT
+          "&guard_loc_class=%s&guard_risk=%" G_GINT64_FORMAT,
+          base_url, path, escaped_subject, target_name, escaped_target,
+          escaped_scope, guard_timestamp, escaped_loc, guard_risk);
+    }
   } else {
     g_autofree gchar *escaped_session =
         g_uri_escape_string (session_token, NULL, TRUE);
-    uri = g_strdup_printf ("%s/%s?subject=%s&%s=%s&scope=%s&session_token=%s"
-        "&guard_timestamp=%" G_GINT64_FORMAT
-        "&guard_loc_class=%s&guard_risk=%" G_GINT64_FORMAT,
-        base_url, path, escaped_subject, target_name, escaped_target,
-        escaped_scope, escaped_session, guard_timestamp, escaped_loc,
-        guard_risk);
+    if (escaped_event != NULL) {
+      uri = g_strdup_printf ("%s/%s?subject=%s&%s=%s&scope=%s&event=%s"
+          "&session_token=%s&guard_timestamp=%" G_GINT64_FORMAT
+          "&guard_loc_class=%s&guard_risk=%" G_GINT64_FORMAT,
+          base_url, path, escaped_subject, target_name, escaped_target,
+          escaped_scope, escaped_event, escaped_session, guard_timestamp,
+          escaped_loc, guard_risk);
+    } else {
+      uri = g_strdup_printf ("%s/%s?subject=%s&%s=%s&scope=%s"
+          "&session_token=%s&guard_timestamp=%" G_GINT64_FORMAT
+          "&guard_loc_class=%s&guard_risk=%" G_GINT64_FORMAT,
+          base_url, path, escaped_subject, target_name, escaped_target,
+          escaped_scope, escaped_session, guard_timestamp, escaped_loc,
+          guard_risk);
+    }
   }
 
   g_autoptr (SoupMessage) message = soup_message_new ("POST", uri);
@@ -331,7 +353,7 @@ wyl_client_policy_permission_grant (WylClient *client, const gchar *subject,
     const gchar *guard_loc_class, gint64 guard_risk)
 {
   return client_policy_mutation_request (client, "policy/permissions/grant",
-      subject, "perm", perm, scope, guard_timestamp, guard_loc_class,
+      subject, "perm", perm, scope, NULL, guard_timestamp, guard_loc_class,
       guard_risk);
 }
 
@@ -341,8 +363,21 @@ wyl_client_policy_permission_revoke (WylClient *client, const gchar *subject,
     const gchar *guard_loc_class, gint64 guard_risk)
 {
   return client_policy_mutation_request (client, "policy/permissions/revoke",
-      subject, "perm", perm, scope, guard_timestamp, guard_loc_class,
+      subject, "perm", perm, scope, NULL, guard_timestamp, guard_loc_class,
       guard_risk);
+}
+
+wyrelog_error_t
+wyl_client_policy_permission_transition (WylClient *client,
+    const gchar *subject, const gchar *perm, const gchar *scope,
+    const gchar *event, gint64 guard_timestamp, const gchar *guard_loc_class,
+    gint64 guard_risk)
+{
+  if (event == NULL)
+    return WYRELOG_E_INVALID;
+  return client_policy_mutation_request (client,
+      "policy/permissions/transition", subject, "perm", perm, scope, event,
+      guard_timestamp, guard_loc_class, guard_risk);
 }
 
 wyrelog_error_t
@@ -351,7 +386,7 @@ wyl_client_policy_role_grant (WylClient *client, const gchar *subject,
     const gchar *guard_loc_class, gint64 guard_risk)
 {
   return client_policy_mutation_request (client, "policy/roles/grant",
-      subject, "role", role, scope, guard_timestamp, guard_loc_class,
+      subject, "role", role, scope, NULL, guard_timestamp, guard_loc_class,
       guard_risk);
 }
 
@@ -361,7 +396,7 @@ wyl_client_policy_role_revoke (WylClient *client, const gchar *subject,
     const gchar *guard_loc_class, gint64 guard_risk)
 {
   return client_policy_mutation_request (client, "policy/roles/revoke",
-      subject, "role", role, scope, guard_timestamp, guard_loc_class,
+      subject, "role", role, scope, NULL, guard_timestamp, guard_loc_class,
       guard_risk);
 }
 


### PR DESCRIPTION
## Summary
- add a public client helper for guarded permission-state transitions
- cover transition request validation, routing, auth, and guard serialization
- lock skip-MFA behavior to effective policy permission instead of state rows

## Tests
- git diff --check origin/main..HEAD
- meson test -C builddir-ci-pr client-smoke session-username daemon-http-decide daemon-checks handle-engine-pair policy-store audit-emit --print-errorlogs
