### PR TITLE
daemon: add request id response header

### DIFF
--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -11,6 +11,7 @@
 #include "wyrelog/client.h"
 #include "wyrelog/policy/store-private.h"
 #include "wyrelog/wyl-handle-private.h"
+#include "wyrelog/wyl-request-id-private.h"
 
 #ifndef WYL_TEST_TEMPLATE_DIR
 #error "WYL_TEST_TEMPLATE_DIR must be defined by the build."
@@ -43,6 +44,18 @@ typedef struct
   const gchar *to_state;
   guint matches;
 } PermissionStateProbe;
+
+static gboolean
+is_request_id_shape (const gchar *request_id)
+{
+  if (request_id == NULL || strlen (request_id) != WYL_REQUEST_ID_STRING_LEN)
+    return FALSE;
+  for (gsize i = 0; i < WYL_REQUEST_ID_STRING_LEN; i++) {
+    if (!g_ascii_isalnum (request_id[i]))
+      return FALSE;
+  }
+  return TRUE;
+}
 
 static gpointer
 test_http_server_thread (gpointer data)
@@ -243,6 +256,86 @@ send_raw_decide (SoupSession *session, const gchar *method,
   const gchar *body_data = g_bytes_get_data (body, &body_size);
   *out_status = soup_message_get_status (msg);
   *out_body = g_strndup (body_data, body_size);
+  return 0;
+}
+
+static gint
+send_request_id_probe (SoupSession *session, const gchar *method,
+    const gchar *uri, const gchar *inbound_request_id, guint *out_status,
+    gchar **out_request_id)
+{
+  if (out_status == NULL || out_request_id == NULL)
+    return 1800;
+  *out_status = 0;
+  *out_request_id = NULL;
+
+  g_autoptr (SoupMessage) msg = soup_message_new (method, uri);
+  if (msg == NULL)
+    return 1801;
+  if (inbound_request_id != NULL) {
+    soup_message_headers_replace (soup_message_get_request_headers (msg),
+        "X-Wyrelog-Request-Id", inbound_request_id);
+  }
+
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GBytes) body = soup_session_send_and_read (session, msg, NULL,
+      &error);
+  if (body == NULL)
+    return 1802;
+  *out_status = soup_message_get_status (msg);
+  const gchar *request_id = soup_message_headers_get_one
+      (soup_message_get_response_headers (msg), "X-Wyrelog-Request-Id");
+  if (!is_request_id_shape (request_id))
+    return 1803;
+  *out_request_id = g_strdup (request_id);
+  return 0;
+}
+
+static gint
+check_request_id_header_contract (const gchar *base_url)
+{
+  g_autoptr (SoupSession) session = soup_session_new ();
+  g_autofree gchar *root = g_strdup (base_url);
+  while (root[0] != '\0' && g_str_has_suffix (root, "/"))
+    root[strlen (root) - 1] = '\0';
+
+  guint status = 0;
+  g_autofree gchar *health_id = NULL;
+  g_autofree gchar *health_uri = g_strdup_printf ("%s/healthz", root);
+  gint rc = send_request_id_probe (session, "GET", health_uri, NULL, &status,
+      &health_id);
+  if (rc != 0)
+    return rc;
+  if (status != 200)
+    return 1804;
+
+  g_autofree gchar *bad_decide_id = NULL;
+  g_autofree gchar *bad_decide_uri =
+      g_strdup_printf ("%s/decide?user=request-id-user", root);
+  rc = send_request_id_probe (session, "POST", bad_decide_uri, NULL, &status,
+      &bad_decide_id);
+  if (rc != 0)
+    return rc;
+  if (status != 400)
+    return 1805;
+  if (g_strcmp0 (health_id, bad_decide_id) == 0)
+    return 1806;
+
+  g_autofree gchar *spoofed_id = NULL;
+  g_autofree gchar *deny_uri =
+      build_decide_uri (root, "request-id-user", "wr.audit.read",
+      "request-id-scope", NULL);
+  rc = send_request_id_probe (session, "POST", deny_uri, "attacker", &status,
+      &spoofed_id);
+  if (rc != 0)
+    return rc;
+  if (status != 200)
+    return 1807;
+  if (g_strcmp0 (spoofed_id, "attacker") == 0)
+    return 1808;
+  if (g_strcmp0 (bad_decide_id, spoofed_id) == 0)
+    return 1809;
+
   return 0;
 }
 
@@ -1959,6 +2052,10 @@ main (void)
   g_autoptr (WylClient) client = NULL;
   if (wyl_client_new (base_url, &client) != WYRELOG_E_OK)
     return 5;
+
+  gint request_id_rc = check_request_id_header_contract (base_url);
+  if (request_id_rc != 0)
+    return request_id_rc;
 
   gint raw_rc = check_raw_decide_contract (base_url);
   if (raw_rc != 0)

--- a/tests/test-id.c
+++ b/tests/test-id.c
@@ -4,6 +4,7 @@
 
 #include <chronoid/ksuid.h>
 
+#include "wyrelog/wyl-request-id-private.h"
 #include "wyrelog/wyl-id-private.h"
 
 static gint
@@ -369,6 +370,82 @@ check_rng_failure_fail_closed (void)
   return 0;
 }
 
+static gboolean
+is_base62_request_id (const gchar *buf)
+{
+  if (strlen (buf) != WYL_REQUEST_ID_STRING_LEN)
+    return FALSE;
+  for (gsize i = 0; i < WYL_REQUEST_ID_STRING_LEN; i++) {
+    if (!g_ascii_isalnum (buf[i]))
+      return FALSE;
+  }
+  return TRUE;
+}
+
+static gint
+check_request_id_generation (void)
+{
+  gchar buf[WYL_REQUEST_ID_STRING_BUF];
+  if (wyl_request_id_new (buf, sizeof buf) != WYRELOG_E_OK)
+    return 250;
+  if (!is_base62_request_id (buf))
+    return 251;
+  return 0;
+}
+
+static gint
+check_request_id_generation_validation (void)
+{
+  gchar buf[WYL_REQUEST_ID_STRING_BUF];
+  if (wyl_request_id_new (NULL, sizeof buf) != WYRELOG_E_INVALID)
+    return 260;
+  if (wyl_request_id_new (buf, WYL_REQUEST_ID_STRING_LEN)
+      != WYRELOG_E_INVALID)
+    return 261;
+  return 0;
+}
+
+static gint
+check_request_id_uniqueness (void)
+{
+  GHashTable *seen = g_hash_table_new_full (g_str_hash, g_str_equal,
+      g_free, NULL);
+  for (guint i = 0; i < 1000; i++) {
+    gchar buf[WYL_REQUEST_ID_STRING_BUF];
+    if (wyl_request_id_new (buf, sizeof buf) != WYRELOG_E_OK) {
+      g_hash_table_destroy (seen);
+      return 270;
+    }
+    if (g_hash_table_contains (seen, buf)) {
+      g_hash_table_destroy (seen);
+      return 271;
+    }
+    g_hash_table_add (seen, g_strdup (buf));
+  }
+  g_hash_table_destroy (seen);
+  return 0;
+}
+
+static gint
+check_request_id_rng_failure_fail_closed (void)
+{
+  gchar buf[WYL_REQUEST_ID_STRING_BUF];
+  wyrelog_error_t rc;
+
+  memset (buf, 'x', sizeof buf);
+  chronoid_set_rand (failing_rng, NULL);
+  rc = wyl_request_id_new (buf, sizeof buf);
+  chronoid_set_rand (NULL, NULL);
+
+  if (rc != WYRELOG_E_CRYPTO)
+    return 280;
+  for (gsize i = 0; i < sizeof buf; i++) {
+    if (buf[i] != 'x')
+      return 281;
+  }
+  return 0;
+}
+
 int
 main (void)
 {
@@ -421,6 +498,14 @@ main (void)
   if ((rc = check_compare_null_handling ()) != 0)
     return rc;
   if ((rc = check_rng_failure_fail_closed ()) != 0)
+    return rc;
+  if ((rc = check_request_id_generation ()) != 0)
+    return rc;
+  if ((rc = check_request_id_generation_validation ()) != 0)
+    return rc;
+  if ((rc = check_request_id_uniqueness ()) != 0)
+    return rc;
+  if ((rc = check_request_id_rng_failure_fail_closed ()) != 0)
     return rc;
 
   return 0;

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -10,12 +10,14 @@
 #include "wyrelog/auth/jwt-private.h"
 #include "wyrelog/wyl-handle-private.h"
 #include "wyrelog/wyl-id-private.h"
+#include "wyrelog/wyl-request-id-private.h"
 #include "wyrelog/wyl-fsm-permission-scope-private.h"
 #include "wyrelog/wyl-permission-scope-private.h"
 
 #define WYL_DAEMON_JWT_ISSUER "wyrelogd"
 #define WYL_DAEMON_JWT_AUDIENCE "wyrelog-client"
 #define WYL_DAEMON_JWT_KEY_LEN 32
+#define WYL_DAEMON_REQUEST_ID_HEADER "X-Wyrelog-Request-Id"
 
 typedef struct
 {
@@ -362,8 +364,22 @@ resolve_bearer_session (SoupServer *server, WylDaemonHttpContext *ctx,
 }
 
 static void
+attach_request_id_header (SoupServerMessage *msg)
+{
+  gchar request_id[WYL_REQUEST_ID_STRING_BUF];
+  if (wyl_request_id_new (request_id, sizeof request_id) != WYRELOG_E_OK)
+    return;
+
+  SoupMessageHeaders *headers = soup_server_message_get_response_headers (msg);
+  soup_message_headers_replace (headers, WYL_DAEMON_REQUEST_ID_HEADER,
+      request_id);
+}
+
+static void
 set_json_error (SoupServerMessage *msg, guint status, const gchar *code)
 {
+  attach_request_id_header (msg);
+
   g_autoptr (GString) body = g_string_new ("{\"error\":");
   append_json_string (body, code);
   g_string_append_c (body, '}');
@@ -398,6 +414,7 @@ healthz_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
   (void) user_data;
 
   const gchar *body = "ok\n";
+  attach_request_id_header (msg);
   soup_server_message_set_status (msg, 200, NULL);
   soup_server_message_set_response (msg, "text/plain", SOUP_MEMORY_COPY, body,
       strlen (body));
@@ -535,17 +552,11 @@ audit_events_handler (SoupServer *server, SoupServerMessage *msg,
     rc = wyl_audit_conn_query_events_json (wyl_handle_get_audit_conn (handle),
         filter, &body);
   if (rc == WYRELOG_E_INVALID) {
-    const gchar *error_body = "{\"error\":\"invalid_filter\"}";
-    soup_server_message_set_status (msg, 400, NULL);
-    soup_server_message_set_response (msg, "application/json",
-        SOUP_MEMORY_COPY, error_body, strlen (error_body));
+    set_json_error (msg, 400, "invalid_filter");
     return;
   }
   if (rc != WYRELOG_E_OK) {
-    const gchar *error_body = "{\"error\":\"audit_query_failed\"}";
-    soup_server_message_set_status (msg, 500, NULL);
-    soup_server_message_set_response (msg, "application/json",
-        SOUP_MEMORY_COPY, error_body, strlen (error_body));
+    set_json_error (msg, 500, "audit_query_failed");
     return;
   }
 #else
@@ -554,6 +565,7 @@ audit_events_handler (SoupServer *server, SoupServerMessage *msg,
   const gchar *body = "[]";
 #endif
 
+  attach_request_id_header (msg);
   soup_server_message_set_status (msg, 200, NULL);
   soup_server_message_set_response (msg, "application/json",
       SOUP_MEMORY_COPY, body, strlen (body));
@@ -563,6 +575,7 @@ static void
 set_json_ok (SoupServerMessage *msg)
 {
   const gchar *body = "{\"ok\":true}";
+  attach_request_id_header (msg);
   soup_server_message_set_status (msg, 200, NULL);
   soup_server_message_set_response (msg, "application/json",
       SOUP_MEMORY_COPY, body, strlen (body));
@@ -923,6 +936,7 @@ login_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
 
   g_autofree gchar *body = build_login_json (session_token, username,
       principal_state, access_token);
+  attach_request_id_header (msg);
   soup_server_message_set_status (msg, 200, NULL);
   soup_server_message_set_response (msg, "application/json",
       SOUP_MEMORY_COPY, body, strlen (body));
@@ -991,6 +1005,7 @@ logout_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
   }
 
   const gchar *body = "{\"ok\":true}";
+  attach_request_id_header (msg);
   soup_server_message_set_status (msg, 200, NULL);
   soup_server_message_set_response (msg, "application/json",
       SOUP_MEMORY_COPY, body, strlen (body));
@@ -1066,6 +1081,7 @@ decide_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
   }
 
   g_autofree gchar *body = build_decide_json (resp);
+  attach_request_id_header (msg);
   soup_server_message_set_status (msg, 200, NULL);
   soup_server_message_set_response (msg, "application/json",
       SOUP_MEMORY_COPY, body, strlen (body));

--- a/wyrelog/meson.build
+++ b/wyrelog/meson.build
@@ -29,6 +29,7 @@ wyrelog_sources = files(
   'wyl-fsm-session.c',
   'wyl-guard-expr.c',
   'wyl-handle.c',
+  'wyl-request-id.c',
   'wyl-id.c',
   'wyl-keyprovider-dev.c',
   'wyl-log.c',

--- a/wyrelog/wyl-request-id-private.h
+++ b/wyrelog/wyl-request-id-private.h
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+
+#include <glib.h>
+
+#include "wyrelog/error.h"
+
+G_BEGIN_DECLS;
+
+#define WYL_REQUEST_ID_STRING_LEN 27
+#define WYL_REQUEST_ID_STRING_BUF 28
+
+wyrelog_error_t wyl_request_id_new (gchar * buf, gsize buf_len);
+
+G_END_DECLS;

--- a/wyrelog/wyl-request-id.c
+++ b/wyrelog/wyl-request-id.c
@@ -1,0 +1,34 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "wyl-request-id-private.h"
+
+#include <string.h>
+
+#include <chronoid/ksuid.h>
+
+G_STATIC_ASSERT (WYL_REQUEST_ID_STRING_LEN == CHRONOID_KSUID_STRING_LEN);
+
+wyrelog_error_t
+wyl_request_id_new (gchar *buf, gsize buf_len)
+{
+  if (buf == NULL || buf_len < WYL_REQUEST_ID_STRING_BUF)
+    return WYRELOG_E_INVALID;
+
+  chronoid_ksuid_t id;
+  chronoid_ksuid_err_t rc = chronoid_ksuid_new (&id);
+  switch (rc) {
+    case CHRONOID_KSUID_OK:
+      break;
+    case CHRONOID_KSUID_ERR_RNG:
+      return WYRELOG_E_CRYPTO;
+    case CHRONOID_KSUID_ERR_TIME_RANGE:
+      return WYRELOG_E_INTERNAL;
+    default:
+      return WYRELOG_E_INTERNAL;
+  }
+
+  gchar tmp[WYL_REQUEST_ID_STRING_BUF];
+  chronoid_ksuid_format (&id, tmp);
+  tmp[WYL_REQUEST_ID_STRING_LEN] = '\0';
+  memcpy (buf, tmp, sizeof tmp);
+  return WYRELOG_E_OK;
+}


### PR DESCRIPTION
## Summary
- add a private external request id helper backed by libchronoid KSUIDs
- attach server-generated X-Wyrelog-Request-Id headers to daemon responses
- keep header generation best-effort and preserve existing JSON bodies

## Tests
- git diff --check origin/main..HEAD
- meson test -C builddir-ci-pr id daemon-http-decide wyrelogd-healthz client-smoke daemon-checks handle-engine-pair policy-store audit-emit --print-errorlogs
