### PR TITLE
audit: add request id projection foundation

### DIFF
--- a/templates/access/decision.dl
+++ b/templates/access/decision.dl
@@ -28,6 +28,7 @@
 //   audit_event_resource_input(id, resource)
 //   audit_event_deny_reason_input(id, reason)
 //   audit_event_deny_origin_input(id, origin)
+//   audit_event_request_id_input(id, request_id)
 //
 // Audit fact projections (host-observable):
 //   audit_event(id, created_at_us, decision)
@@ -36,6 +37,7 @@
 //   audit_event_resource(id, resource)
 //   audit_event_deny_reason(id, reason)
 //   audit_event_deny_origin(id, origin)
+//   audit_event_request_id(id, request_id)
 //
 // `has_permission/3` and `armed/3` are IDB rules defined elsewhere
 // (bootstrap.dl and permission_scope.dl respectively); both are
@@ -59,12 +61,14 @@
 .decl audit_event_resource_input(id: symbol, resource: symbol)
 .decl audit_event_deny_reason_input(id: symbol, reason: symbol)
 .decl audit_event_deny_origin_input(id: symbol, origin: symbol)
+.decl audit_event_request_id_input(id: symbol, request_id: symbol)
 .decl audit_event(id: symbol, created_at_us: int64, decision: symbol)
 .decl audit_event_subject(id: symbol, subject: symbol)
 .decl audit_event_action(id: symbol, action: symbol)
 .decl audit_event_resource(id: symbol, resource: symbol)
 .decl audit_event_deny_reason(id: symbol, reason: symbol)
 .decl audit_event_deny_origin(id: symbol, origin: symbol)
+.decl audit_event_request_id(id: symbol, request_id: symbol)
 .decl principal_state_observed(user: symbol, state: symbol)
 .decl login_skip_mfa_authz(user: symbol)
 .decl login_skip_mfa_authz_observed(user: symbol)
@@ -95,6 +99,9 @@ audit_event_deny_reason(ID, Reason) :-
 
 audit_event_deny_origin(ID, Origin) :-
     audit_event_deny_origin_input(ID, Origin).
+
+audit_event_request_id(ID, RequestID) :-
+    audit_event_request_id_input(ID, RequestID).
 
 principal_state_observed(U, State) :-
     principal_state(U, State).

--- a/templates/access/duckdb-schema.sql
+++ b/templates/access/duckdb-schema.sql
@@ -60,6 +60,7 @@ CREATE TABLE IF NOT EXISTS audit_events (
     resource_id   VARCHAR,
     deny_reason   VARCHAR,
     deny_origin   VARCHAR,
+    request_id    VARCHAR,
     decision      SMALLINT NOT NULL
 );
 

--- a/templates/access/lobac/decision.dl
+++ b/templates/access/lobac/decision.dl
@@ -25,6 +25,7 @@
 //   audit_event_resource_input(id, resource)
 //   audit_event_deny_reason_input(id, reason)
 //   audit_event_deny_origin_input(id, origin)
+//   audit_event_request_id_input(id, request_id)
 //
 // Audit fact projections (host-observable):
 //   audit_event(id, created_at_us, decision)
@@ -33,6 +34,7 @@
 //   audit_event_resource(id, resource)
 //   audit_event_deny_reason(id, reason)
 //   audit_event_deny_origin(id, origin)
+//   audit_event_request_id(id, request_id)
 //
 // `has_permission/3` and `armed/3` are IDB rules defined elsewhere
 // (bootstrap.dl and permission_scope.dl respectively); both are
@@ -56,12 +58,14 @@
 .decl audit_event_resource_input(id: symbol, resource: symbol)
 .decl audit_event_deny_reason_input(id: symbol, reason: symbol)
 .decl audit_event_deny_origin_input(id: symbol, origin: symbol)
+.decl audit_event_request_id_input(id: symbol, request_id: symbol)
 .decl audit_event(id: symbol, created_at_us: int64, decision: symbol)
 .decl audit_event_subject(id: symbol, subject: symbol)
 .decl audit_event_action(id: symbol, action: symbol)
 .decl audit_event_resource(id: symbol, resource: symbol)
 .decl audit_event_deny_reason(id: symbol, reason: symbol)
 .decl audit_event_deny_origin(id: symbol, origin: symbol)
+.decl audit_event_request_id(id: symbol, request_id: symbol)
 .decl principal_state_observed(user: symbol, state: symbol)
 .decl login_skip_mfa_authz(user: symbol)
 .decl login_skip_mfa_authz_observed(user: symbol)
@@ -92,6 +96,9 @@ audit_event_deny_reason(ID, Reason) :-
 
 audit_event_deny_origin(ID, Origin) :-
     audit_event_deny_origin_input(ID, Origin).
+
+audit_event_request_id(ID, RequestID) :-
+    audit_event_request_id_input(ID, RequestID).
 
 principal_state_observed(U, State) :-
     principal_state(U, State).

--- a/templates/access/sqlite-schema.sql
+++ b/templates/access/sqlite-schema.sql
@@ -285,6 +285,7 @@ CREATE TABLE IF NOT EXISTS audit_events (
     resource_id   TEXT,
     deny_reason   TEXT,
     deny_origin   TEXT,
+    request_id    TEXT,
     decision      INTEGER NOT NULL CHECK (decision IN (0, 1))
 );
 

--- a/tests/test-access-decision.c
+++ b/tests/test-access-decision.c
@@ -324,6 +324,7 @@ check_audit_fact_declarations (void)
     ".decl audit_event_resource(id: symbol, resource: symbol)",
     ".decl audit_event_deny_reason(id: symbol, reason: symbol)",
     ".decl audit_event_deny_origin(id: symbol, origin: symbol)",
+    ".decl audit_event_request_id(id: symbol, request_id: symbol)",
     "audit_event(ID, CreatedAtUs, Decision) :-",
   };
   g_autofree gchar *contents = NULL;

--- a/tests/test-audit-emit.c
+++ b/tests/test-audit-emit.c
@@ -378,6 +378,7 @@ check_emit_persists_event_fields (void)
   wyl_audit_event_set_resource_id (ev, "doc/99");
   wyl_audit_event_set_deny_reason (ev, "not_armed");
   wyl_audit_event_set_deny_origin (ev, "perm_state");
+  wyl_audit_event_set_request_id (ev, "req-audit-emit");
   wyl_audit_event_set_decision (ev, WYL_DECISION_DENY);
 
   g_autofree gchar *expected_id = wyl_audit_event_dup_id_string (ev);
@@ -392,7 +393,7 @@ check_emit_persists_event_fields (void)
   duckdb_result result;
   if (duckdb_query (conn,
           "SELECT id, subject_id, action, resource_id, deny_reason, "
-          "deny_origin, decision "
+          "deny_origin, request_id, decision "
           "FROM audit_events;", &result) != DuckDBSuccess) {
     duckdb_destroy_result (&result);
     g_object_unref (handle);
@@ -405,7 +406,8 @@ check_emit_persists_event_fields (void)
   const gchar *resource = duckdb_value_varchar (&result, 3, 0);
   const gchar *deny_reason = duckdb_value_varchar (&result, 4, 0);
   const gchar *deny_origin = duckdb_value_varchar (&result, 5, 0);
-  gint16 decision = (gint16) duckdb_value_int64 (&result, 6, 0);
+  const gchar *request_id = duckdb_value_varchar (&result, 6, 0);
+  gint16 decision = (gint16) duckdb_value_int64 (&result, 7, 0);
 
   if (g_strcmp0 (id, expected_id) != 0)
     rc = 23;
@@ -419,6 +421,8 @@ check_emit_persists_event_fields (void)
     rc = 27;
   else if (g_strcmp0 (deny_origin, "perm_state") != 0)
     rc = 28;
+  else if (g_strcmp0 (request_id, "req-audit-emit") != 0)
+    rc = 30;
   else if (decision != WYL_DECISION_DENY)
     rc = 29;
 
@@ -428,6 +432,7 @@ check_emit_persists_event_fields (void)
   duckdb_free ((void *) resource);
   duckdb_free ((void *) deny_reason);
   duckdb_free ((void *) deny_origin);
+  duckdb_free ((void *) request_id);
   duckdb_destroy_result (&result);
   g_object_unref (handle);
   return rc;
@@ -446,6 +451,7 @@ check_query_events_json_filters_rows (void)
   wyl_audit_event_set_resource_id (denied, "doc/99");
   wyl_audit_event_set_deny_reason (denied, "not_armed");
   wyl_audit_event_set_deny_origin (denied, "perm_state");
+  wyl_audit_event_set_request_id (denied, "req-json-bob");
   wyl_audit_event_set_decision (denied, WYL_DECISION_DENY);
 
   g_autoptr (WylAuditEvent) allowed = wyl_audit_event_new ();
@@ -513,6 +519,21 @@ check_query_events_json_filters_rows (void)
           "\"deny_reason\":\"not_armed\"") == NULL) {
     g_object_unref (handle);
     return 1543;
+  }
+
+  g_autofree gchar *request_json = NULL;
+  if (wyl_audit_conn_query_events_json (conn, "request_id(\"req-json-bob\")",
+          &request_json) != WYRELOG_E_OK) {
+    g_object_unref (handle);
+    return 1544;
+  }
+  if (g_strstr_len (request_json, -1, "\"subject_id\":\"json-bob\"")
+      == NULL || g_strstr_len (request_json, -1,
+          "\"request_id\":\"req-json-bob\"") == NULL
+      || g_strstr_len (request_json, -1, "\"subject_id\":\"json-alice\"")
+      != NULL) {
+    g_object_unref (handle);
+    return 1545;
   }
 
   g_autofree gchar *all_json = NULL;
@@ -651,11 +672,17 @@ check_policy_store_audit_replay_loads_runtime_query (void)
     return 172;
   }
   static const gchar *full_replay_id = "01890c10-2e3f-7000-8000-000000000012";
-  if (wyl_policy_store_append_audit_event (store, full_replay_id, 790,
+  gboolean full_inserted = FALSE;
+  if (wyl_policy_store_append_audit_event_full (store, full_replay_id, 790,
           "replay-user", "audit.replay.full", "replay-full-resource",
-          "not_armed", "perm_state", WYL_DECISION_DENY) != WYRELOG_E_OK) {
+          "not_armed", "perm_state", "req-replay-full", WYL_DECISION_DENY,
+          &full_inserted) != WYRELOG_E_OK) {
     g_object_unref (handle);
     return 205;
+  }
+  if (!full_inserted) {
+    g_object_unref (handle);
+    return 216;
   }
   if (wyl_handle_load_policy_store_audit_events (handle) != WYRELOG_E_OK) {
     g_object_unref (handle);
@@ -706,6 +733,8 @@ check_policy_store_audit_replay_loads_runtime_query (void)
     rc = 179;
   else if (g_strstr_len (json, -1, "\"deny_origin\":null") == NULL)
     rc = 180;
+  else if (g_strstr_len (json, -1, "\"request_id\":null") == NULL)
+    rc = 214;
   else if (g_strstr_len (json, -1, "\"decision\":1") == NULL)
     rc = 181;
   if (rc != 0) {
@@ -734,6 +763,9 @@ check_policy_store_audit_replay_loads_runtime_query (void)
     rc = 211;
   else if (g_strstr_len (json, -1, "\"deny_origin\":\"perm_state\"") == NULL)
     rc = 212;
+  else if (g_strstr_len (json, -1, "\"request_id\":\"req-replay-full\"")
+      == NULL)
+    rc = 215;
   else if (g_strstr_len (json, -1, "\"decision\":0") == NULL)
     rc = 213;
 
@@ -2453,6 +2485,7 @@ check_emit_projects_sparse_wirelog_facts_immediately (void)
     "audit_event_resource",
     "audit_event_deny_reason",
     "audit_event_deny_origin",
+    "audit_event_request_id",
   };
   for (gsize i = 0; i < G_N_ELEMENTS (relations); i++) {
     guint count = 0;
@@ -2560,6 +2593,7 @@ check_emit_rolls_back_partial_live_projection_failure (void)
     "audit_event_resource_input",
     "audit_event_deny_reason_input",
     "audit_event_deny_origin_input",
+    "audit_event_request_id_input",
   };
   static const gchar *projected_relations[] = {
     "audit_event",
@@ -2568,6 +2602,7 @@ check_emit_rolls_back_partial_live_projection_failure (void)
     "audit_event_resource",
     "audit_event_deny_reason",
     "audit_event_deny_origin",
+    "audit_event_request_id",
   };
 
   for (gsize i = 0; i < G_N_ELEMENTS (fault_relations); i++) {
@@ -2584,6 +2619,7 @@ check_emit_rolls_back_partial_live_projection_failure (void)
     wyl_audit_event_set_resource_id (ev, "audit-live-partial-resource");
     wyl_audit_event_set_deny_reason (ev, "not_armed");
     wyl_audit_event_set_deny_origin (ev, "perm_state");
+    wyl_audit_event_set_request_id (ev, "req-partial");
     wyl_audit_event_set_decision (ev, WYL_DECISION_DENY);
     g_autofree gchar *id = wyl_audit_event_dup_id_string (ev);
 
@@ -2694,11 +2730,17 @@ check_policy_store_audit_rows_load_wirelog_facts (void)
 
   wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
   static const gchar *full_id = "01890c10-2e3f-7000-8000-000000000010";
-  if (wyl_policy_store_append_audit_event (store, full_id, 1001,
+  gboolean full_inserted = FALSE;
+  if (wyl_policy_store_append_audit_event_full (store, full_id, 1001,
           "audit-fact-user", "audit-fact-action", "audit-fact-resource",
-          "not_armed", "perm_state", WYL_DECISION_DENY) != WYRELOG_E_OK) {
+          "not_armed", "perm_state", "req-audit-fact", WYL_DECISION_DENY,
+          &full_inserted) != WYRELOG_E_OK) {
     g_object_unref (handle);
     return 162;
+  }
+  if (!full_inserted) {
+    g_object_unref (handle);
+    return 194;
   }
   if (wyl_handle_reload_engine_pair (handle) != WYRELOG_E_OK) {
     g_object_unref (handle);
@@ -2741,6 +2783,11 @@ check_policy_store_audit_rows_load_wirelog_facts (void)
     g_object_unref (handle);
     return 169;
   }
+  if (contains_audit_event_attr_fact (handle, "audit_event_request_id",
+          full_id, "req-audit-fact", &contains) != WYRELOG_E_OK || !contains) {
+    g_object_unref (handle);
+    return 193;
+  }
 
   static const gchar *sparse_id = "01890c10-2e3f-7000-8000-000000000011";
   if (wyl_policy_store_append_audit_event (store, sparse_id, 1002, NULL,
@@ -2773,6 +2820,7 @@ check_policy_store_audit_rows_load_wirelog_facts (void)
     {"audit_event_resource", 0},
     {"audit_event_deny_reason", 0},
     {"audit_event_deny_origin", 0},
+    {"audit_event_request_id", 0},
   };
   for (gsize i = 0; i < G_N_ELEMENTS (optional_counts); i++) {
     guint count = 0;

--- a/tests/test-audit-event.c
+++ b/tests/test-audit-event.c
@@ -89,8 +89,8 @@ check_private_rehydrate_preserves_fields (void)
   const gchar *id = "018f3f9b-7f4d-7a2e-8a51-467a0bc7d001";
   g_autoptr (WylAuditEvent) ev = NULL;
   if (wyl_audit_event_new_from_fields (id, 1234567, "alice", "read",
-          "doc/42", "not_armed", "perm_state", WYL_DECISION_ALLOW, &ev)
-      != WYRELOG_E_OK)
+          "doc/42", "not_armed", "perm_state", "req-123",
+          WYL_DECISION_ALLOW, &ev) != WYRELOG_E_OK)
     return 65;
 
   g_autofree gchar *actual_id = wyl_audit_event_dup_id_string (ev);
@@ -108,6 +108,8 @@ check_private_rehydrate_preserves_fields (void)
     return 73;
   if (g_strcmp0 (wyl_audit_event_get_deny_origin (ev), "perm_state") != 0)
     return 74;
+  if (g_strcmp0 (wyl_audit_event_get_request_id (ev), "req-123") != 0)
+    return 76;
   if (wyl_audit_event_get_decision (ev) != WYL_DECISION_ALLOW)
     return 75;
   return 0;
@@ -118,16 +120,16 @@ check_private_rehydrate_rejects_invalid_fields (void)
 {
   WylAuditEvent *ev = (WylAuditEvent *) (gpointer) 0x1;
   if (wyl_audit_event_new_from_fields (NULL, 1, NULL, NULL, NULL, NULL, NULL,
-          WYL_DECISION_DENY, &ev) != WYRELOG_E_INVALID)
+          NULL, WYL_DECISION_DENY, &ev) != WYRELOG_E_INVALID)
     return 76;
   if (ev != NULL)
     return 77;
   if (wyl_audit_event_new_from_fields ("018f3f9b-7f4d-7a2e-8a51-467a0bc7d001",
-          -1, NULL, NULL, NULL, NULL, NULL, WYL_DECISION_DENY,
+          -1, NULL, NULL, NULL, NULL, NULL, NULL, WYL_DECISION_DENY,
           &ev) != WYRELOG_E_INVALID)
     return 78;
   if (wyl_audit_event_new_from_fields ("018f3f9b-7f4d-7a2e-8a51-467a0bc7d001",
-          1, NULL, NULL, NULL, NULL, NULL, (wyl_decision_t) 99,
+          1, NULL, NULL, NULL, NULL, NULL, NULL, (wyl_decision_t) 99,
           &ev) != WYRELOG_E_INVALID)
     return 79;
   return 0;
@@ -187,6 +189,8 @@ check_string_field_defaults_are_null (void)
     return 143;
   if (wyl_audit_event_get_deny_origin (ev) != NULL)
     return 144;
+  if (wyl_audit_event_get_request_id (ev) != NULL)
+    return 145;
   return 0;
 }
 
@@ -199,6 +203,7 @@ check_string_field_round_trips (void)
   wyl_audit_event_set_resource_id (ev, "doc/42");
   wyl_audit_event_set_deny_reason (ev, "not_authenticated");
   wyl_audit_event_set_deny_origin (ev, "principal_state");
+  wyl_audit_event_set_request_id (ev, "req-123");
   if (g_strcmp0 (wyl_audit_event_get_subject_id (ev), "alice") != 0)
     return 150;
   if (g_strcmp0 (wyl_audit_event_get_action (ev), "read") != 0)
@@ -211,6 +216,8 @@ check_string_field_round_trips (void)
   if (g_strcmp0 (wyl_audit_event_get_deny_origin (ev), "principal_state")
       != 0)
     return 154;
+  if (g_strcmp0 (wyl_audit_event_get_request_id (ev), "req-123") != 0)
+    return 155;
   return 0;
 }
 
@@ -221,15 +228,19 @@ check_string_set_null_clears (void)
   wyl_audit_event_set_subject_id (ev, "alice");
   wyl_audit_event_set_deny_reason (ev, "not_armed");
   wyl_audit_event_set_deny_origin (ev, "perm_state");
+  wyl_audit_event_set_request_id (ev, "req-123");
   wyl_audit_event_set_subject_id (ev, NULL);
   wyl_audit_event_set_deny_reason (ev, NULL);
   wyl_audit_event_set_deny_origin (ev, NULL);
+  wyl_audit_event_set_request_id (ev, NULL);
   if (wyl_audit_event_get_subject_id (ev) != NULL)
     return 160;
   if (wyl_audit_event_get_deny_reason (ev) != NULL)
     return 161;
   if (wyl_audit_event_get_deny_origin (ev) != NULL)
     return 162;
+  if (wyl_audit_event_get_request_id (ev) != NULL)
+    return 163;
   return 0;
 }
 
@@ -258,6 +269,8 @@ check_string_get_null_event (void)
     return 183;
   if (wyl_audit_event_get_deny_origin (NULL) != NULL)
     return 184;
+  if (wyl_audit_event_get_request_id (NULL) != NULL)
+    return 185;
   return 0;
 }
 

--- a/tests/test-client-smoke.c
+++ b/tests/test-client-smoke.c
@@ -38,6 +38,7 @@ static const gchar *two_event_body =
     "\"resource_id\":\"doc/42\","
     "\"deny_reason\":null,"
     "\"deny_origin\":null,"
+    "\"request_id\":null,"
     "\"decision\":1},"
     "{\"id\":\"018f3f9b-7f4d-7a2e-8a51-467a0bc7d002\","
     "\"created_at_us\":1234568,"
@@ -45,7 +46,8 @@ static const gchar *two_event_body =
     "\"action\":\"write\","
     "\"resource_id\":\"doc/43\","
     "\"deny_reason\":\"missing_grant\","
-    "\"deny_origin\":\"policy\"," "\"decision\":0}]";
+    "\"deny_origin\":\"policy\","
+    "\"request_id\":\"req-client-smoke\"," "\"decision\":0}]";
 
 static gpointer
 test_http_server_thread (gpointer data)
@@ -652,6 +654,8 @@ main (void)
     return 42;
   if (g_strcmp0 (wyl_audit_event_get_resource_id (first_event), "doc/42") != 0)
     return 43;
+  if (wyl_audit_event_get_request_id (first_event) != NULL)
+    return 50;
   if (wyl_audit_event_get_decision (first_event) != WYL_DECISION_ALLOW)
     return 44;
   has_next = FALSE;
@@ -669,6 +673,9 @@ main (void)
     return 47;
   if (g_strcmp0 (wyl_audit_event_get_deny_origin (second_event), "policy") != 0)
     return 48;
+  if (g_strcmp0 (wyl_audit_event_get_request_id (second_event),
+          "req-client-smoke") != 0)
+    return 51;
   if (wyl_audit_event_get_decision (second_event) != WYL_DECISION_DENY)
     return 49;
   has_next = TRUE;

--- a/tests/test-daemon-checks.c
+++ b/tests/test-daemon-checks.c
@@ -66,10 +66,11 @@ static wyrelog_error_t
 audit_event_probe_cb (const gchar *id, gint64 created_at_us,
     const gchar *subject_id, const gchar *action, const gchar *resource_id,
     const gchar *deny_reason, const gchar *deny_origin,
-    wyl_decision_t decision, gpointer user_data)
+    const gchar *request_id, wyl_decision_t decision, gpointer user_data)
 {
   (void) id;
   (void) created_at_us;
+  (void) request_id;
   (void) deny_origin;
   AuditEventProbe *probe = user_data;
 

--- a/tests/test-daemon-delta.c
+++ b/tests/test-daemon-delta.c
@@ -79,8 +79,9 @@ static wyrelog_error_t
 lookup_audit_row_cb (const gchar *id, gint64 created_at_us,
     const gchar *subject_id, const gchar *action, const gchar *resource_id,
     const gchar *deny_reason, const gchar *deny_origin,
-    wyl_decision_t decision, gpointer user_data)
+    const gchar *request_id, wyl_decision_t decision, gpointer user_data)
 {
+  (void) request_id;
   AuditRowLookup *lookup = user_data;
 
   if (decision != WYL_DECISION_ALLOW

--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -1548,8 +1548,10 @@ check_policy_permission_mutation_contract (WylHandle *handle,
       g_strdup_printf ("subject=target&perm=site.policy.read&scope=tenant-a"
       "&session_token=%s&guard_timestamp=123&guard_loc_class=public"
       "&guard_risk=49", session_token);
-  rc = send_raw_policy_mutation (session, "POST", base_url,
-      "/policy/permissions/grant", grant_query, &status, &body);
+  g_autofree gchar *grant_request_id = NULL;
+  rc = send_raw_policy_mutation_full (session, "POST", base_url,
+      "/policy/permissions/grant", grant_query, &status, &body,
+      &grant_request_id);
   if (rc != 0)
     return rc;
   if (status != 200 || strstr (body, "\"ok\":true") == NULL)
@@ -1557,6 +1559,18 @@ check_policy_permission_mutation_contract (WylHandle *handle,
   if (!direct_permission_exists (handle, "target", "site.policy.read",
           "tenant-a"))
     return 136;
+  AuditEventProbe grant_audit = {
+    .subject_id = "http-policy-admin",
+    .action = "permission_grant",
+    .resource_id = "tenant-a",
+    .deny_origin = "site.policy.read",
+    .request_id = grant_request_id,
+  };
+  if (wyl_policy_store_foreach_audit_event (store, audit_event_probe_cb,
+          &grant_audit) != WYRELOG_E_OK)
+    return 196;
+  if (grant_audit.matches != 1)
+    return 197;
   g_clear_pointer (&body, g_free);
 
   rc = send_raw_policy_mutation_bearer (session, "POST", base_url,
@@ -1692,8 +1706,10 @@ check_policy_permission_mutation_contract (WylHandle *handle,
       "&session_token=%s&guard_timestamp=123&guard_loc_class=public"
       "&guard_risk=29", session_token);
   g_clear_pointer (&body, g_free);
-  rc = send_raw_policy_mutation (session, "POST", base_url,
-      "/policy/roles/grant", role_grant_query, &status, &body);
+  g_autofree gchar *role_grant_request_id = NULL;
+  rc = send_raw_policy_mutation_full (session, "POST", base_url,
+      "/policy/roles/grant", role_grant_query, &status, &body,
+      &role_grant_request_id);
   if (rc != 0)
     return rc;
   if (status != 200 || strstr (body, "\"ok\":true") == NULL)
@@ -1701,6 +1717,18 @@ check_policy_permission_mutation_contract (WylHandle *handle,
   if (!role_membership_exists (handle, "role-target", "site.reader",
           "tenant-b"))
     return 146;
+  AuditEventProbe role_grant_audit = {
+    .subject_id = "http-policy-admin",
+    .action = "role_grant",
+    .resource_id = "tenant-b",
+    .deny_origin = "site.reader",
+    .request_id = role_grant_request_id,
+  };
+  if (wyl_policy_store_foreach_audit_event (store, audit_event_probe_cb,
+          &role_grant_audit) != WYRELOG_E_OK)
+    return 198;
+  if (role_grant_audit.matches != 1)
+    return 199;
 
   g_autofree gchar *builtin_role_query =
       g_strdup_printf ("subject=builtin-role-target&role=wr.auditor"

--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -1166,10 +1166,11 @@ static wyrelog_error_t
 audit_event_probe_cb (const gchar *id, gint64 created_at_us,
     const gchar *subject_id, const gchar *action, const gchar *resource_id,
     const gchar *deny_reason, const gchar *deny_origin,
-    wyl_decision_t decision, gpointer user_data)
+    const gchar *request_id, wyl_decision_t decision, gpointer user_data)
 {
   (void) id;
   (void) created_at_us;
+  (void) request_id;
   AuditEventProbe *probe = user_data;
 
   if (decision == WYL_DECISION_ALLOW

--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -30,6 +30,7 @@ typedef struct
   const gchar *resource_id;
   const gchar *deny_reason;
   const gchar *deny_origin;
+  const gchar *request_id;
   guint matches;
 } AuditEventProbe;
 
@@ -1043,14 +1044,16 @@ build_policy_mutation_uri (const gchar *base_url, const gchar *path,
 }
 
 static gint
-send_raw_policy_mutation (SoupSession *session, const gchar *method,
+send_raw_policy_mutation_full (SoupSession *session, const gchar *method,
     const gchar *base_url, const gchar *path, const gchar *query,
-    guint *out_status, gchar **out_body)
+    guint *out_status, gchar **out_body, gchar **out_request_id)
 {
   if (out_status == NULL || out_body == NULL)
     return 120;
   *out_status = 0;
   *out_body = NULL;
+  if (out_request_id != NULL)
+    *out_request_id = NULL;
 
   g_autofree gchar *uri = build_policy_mutation_uri (base_url, path, query);
   g_autoptr (SoupMessage) msg = soup_message_new (method, uri);
@@ -1065,11 +1068,25 @@ send_raw_policy_mutation (SoupSession *session, const gchar *method,
   gint rc = check_response_request_id_header (msg, 177);
   if (rc != 0)
     return rc;
+  if (out_request_id != NULL) {
+    const gchar *request_id = soup_message_headers_get_one
+        (soup_message_get_response_headers (msg), "X-Wyrelog-Request-Id");
+    *out_request_id = g_strdup (request_id);
+  }
   gsize size = 0;
   const gchar *data = g_bytes_get_data (bytes, &size);
   *out_status = soup_message_get_status (msg);
   *out_body = g_strndup (data, size);
   return 0;
+}
+
+static gint
+send_raw_policy_mutation (SoupSession *session, const gchar *method,
+    const gchar *base_url, const gchar *path, const gchar *query,
+    guint *out_status, gchar **out_body)
+{
+  return send_raw_policy_mutation_full (session, method, base_url, path, query,
+      out_status, out_body, NULL);
 }
 
 static gint
@@ -1170,7 +1187,6 @@ audit_event_probe_cb (const gchar *id, gint64 created_at_us,
 {
   (void) id;
   (void) created_at_us;
-  (void) request_id;
   AuditEventProbe *probe = user_data;
 
   if (decision == WYL_DECISION_ALLOW
@@ -1178,8 +1194,11 @@ audit_event_probe_cb (const gchar *id, gint64 created_at_us,
       && g_strcmp0 (action, probe->action) == 0
       && g_strcmp0 (resource_id, probe->resource_id) == 0
       && g_strcmp0 (deny_reason, probe->deny_reason) == 0
-      && g_strcmp0 (deny_origin, probe->deny_origin) == 0)
-    probe->matches++;
+      && g_strcmp0 (deny_origin, probe->deny_origin) == 0) {
+    if (probe->request_id == NULL
+        || g_strcmp0 (request_id, probe->request_id) == 0)
+      probe->matches++;
+  }
   return WYRELOG_E_OK;
 }
 
@@ -1428,9 +1447,10 @@ check_policy_permission_mutation_contract (WylHandle *handle,
     return 134;
   g_clear_pointer (&body, g_free);
 
-  rc = send_raw_policy_mutation (session, "POST", base_url,
+  g_autofree gchar *transition_request_id = NULL;
+  rc = send_raw_policy_mutation_full (session, "POST", base_url,
       "/policy/permissions/transition", transition_denied_query, &status,
-      &body);
+      &body, &transition_request_id);
   if (rc != 0)
     return rc;
   if (status != 200 || strstr (body, "\"ok\":true") == NULL)
@@ -1447,6 +1467,7 @@ check_policy_permission_mutation_contract (WylHandle *handle,
     .resource_id = "site.policy.read",
     .deny_reason = "grant",
     .deny_origin = "tenant-a",
+    .request_id = transition_request_id,
   };
   if (wyl_policy_store_foreach_audit_event (store, audit_event_probe_cb,
           &transition_audit) != WYRELOG_E_OK)

--- a/tests/test-policy-store.c
+++ b/tests/test-policy-store.c
@@ -638,6 +638,7 @@ typedef struct
   const gchar *resource_id;
   const gchar *deny_reason;
   const gchar *deny_origin;
+  const gchar *request_id;
   wyl_decision_t decision;
   guint matches;
 } AuditEventExpect;
@@ -697,7 +698,7 @@ role_membership_event_expect_cb (const gchar *subject_id,
 static wyrelog_error_t
 audit_event_expect_cb (const gchar *id, gint64 created_at_us,
     const gchar *subject_id, const gchar *action, const gchar *resource_id,
-    const gchar *deny_reason, const gchar *deny_origin,
+    const gchar *deny_reason, const gchar *deny_origin, const gchar *request_id,
     wyl_decision_t decision, gpointer user_data)
 {
   AuditEventExpect *expect = user_data;
@@ -709,6 +710,7 @@ audit_event_expect_cb (const gchar *id, gint64 created_at_us,
       && g_strcmp0 (resource_id, expect->resource_id) == 0
       && g_strcmp0 (deny_reason, expect->deny_reason) == 0
       && g_strcmp0 (deny_origin, expect->deny_origin) == 0
+      && g_strcmp0 (request_id, expect->request_id) == 0
       && decision == expect->decision)
     expect->matches++;
   return WYRELOG_E_OK;
@@ -1826,46 +1828,52 @@ check_store_appends_audit_event (void)
     return 120;
   if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
     return 121;
-  if (wyl_policy_store_append_audit_event (store,
+  gboolean inserted = FALSE;
+  if (wyl_policy_store_append_audit_event_full (store,
           "01890c10-2e3f-7000-8000-000000000001", 123,
           "audit-user", "read", "doc/1", "not_armed", "perm_state",
-          WYL_DECISION_DENY) != WYRELOG_E_OK)
+          "req-policy-store", WYL_DECISION_DENY, &inserted) != WYRELOG_E_OK)
     return 122;
+  if (!inserted)
+    return 123;
 
   sqlite3_stmt *stmt = NULL;
   static const gchar *sql =
       "SELECT subject_id, action, resource_id, deny_reason, deny_origin, "
-      "decision FROM audit_events WHERE id = ?;";
+      "request_id, decision FROM audit_events WHERE id = ?;";
   if (sqlite3_prepare_v2 (wyl_policy_store_get_db (store), sql, -1, &stmt,
           NULL) != SQLITE_OK)
-    return 123;
+    return 124;
   if (sqlite3_bind_text (stmt, 1, "01890c10-2e3f-7000-8000-000000000001",
           -1, SQLITE_TRANSIENT) != SQLITE_OK) {
     sqlite3_finalize (stmt);
-    return 124;
+    return 125;
   }
 
   int step_rc = sqlite3_step (stmt);
   gint rc = 0;
   if (step_rc != SQLITE_ROW)
-    rc = 125;
+    rc = 126;
   else if (g_strcmp0 ((const gchar *) sqlite3_column_text (stmt, 0),
           "audit-user") != 0)
-    rc = 126;
+    rc = 127;
   else if (g_strcmp0 ((const gchar *) sqlite3_column_text (stmt, 1),
           "read") != 0)
-    rc = 127;
+    rc = 128;
   else if (g_strcmp0 ((const gchar *) sqlite3_column_text (stmt, 2),
           "doc/1") != 0)
-    rc = 128;
+    rc = 129;
   else if (g_strcmp0 ((const gchar *) sqlite3_column_text (stmt, 3),
           "not_armed") != 0)
-    rc = 129;
+    rc = 130;
   else if (g_strcmp0 ((const gchar *) sqlite3_column_text (stmt, 4),
           "perm_state") != 0)
-    rc = 130;
-  else if (sqlite3_column_int (stmt, 5) != WYL_DECISION_DENY)
     rc = 131;
+  else if (g_strcmp0 ((const gchar *) sqlite3_column_text (stmt, 5),
+          "req-policy-store") != 0)
+    rc = 132;
+  else if (sqlite3_column_int (stmt, 6) != WYL_DECISION_DENY)
+    rc = 133;
 
   sqlite3_finalize (stmt);
   return rc;
@@ -1880,10 +1888,11 @@ check_store_iterates_audit_event (void)
     return 132;
   if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
     return 133;
-  if (wyl_policy_store_append_audit_event (store,
+  gboolean inserted = FALSE;
+  if (wyl_policy_store_append_audit_event_full (store,
           "01890c10-2e3f-7000-8000-000000000002", 456,
           "audit-user", "write", "doc/2", "allowed", "test",
-          WYL_DECISION_ALLOW) != WYRELOG_E_OK)
+          "req-iter", WYL_DECISION_ALLOW, &inserted) != WYRELOG_E_OK)
     return 134;
 
   AuditEventExpect expect = {
@@ -1894,6 +1903,7 @@ check_store_iterates_audit_event (void)
     .resource_id = "doc/2",
     .deny_reason = "allowed",
     .deny_origin = "test",
+    .request_id = "req-iter",
     .decision = WYL_DECISION_ALLOW,
   };
   if (wyl_policy_store_foreach_audit_event (store, audit_event_expect_cb,

--- a/tests/test-policy-store.c
+++ b/tests/test-policy-store.c
@@ -1498,7 +1498,8 @@ check_store_permission_state_transition_appends_audit (void)
           "perm-audit-user", "wr.perm.audit", "perm-audit-scope", "grant",
           &event_id, "01890c10-2e3f-7000-8000-000000000010", 999,
           "perm-audit-user", "permission_state.grant", "wr.perm.audit",
-          "allowed", "permission_state", WYL_DECISION_ALLOW) != WYRELOG_E_OK)
+          "allowed", "permission_state", NULL,
+          WYL_DECISION_ALLOW) != WYRELOG_E_OK)
     return 266;
   if (event_id <= 0)
     return 267;
@@ -1544,7 +1545,7 @@ check_store_permission_state_transition_rolls_back_audit_failure (void)
           "01890c10-2e3f-7000-8000-000000000011", 1000,
           "perm-audit-rollback-user", "permission_state.grant",
           "wr.perm.audit.rollback", "allowed", "permission_state",
-          WYL_DECISION_ALLOW) != WYRELOG_E_IO)
+          NULL, WYL_DECISION_ALLOW) != WYRELOG_E_IO)
     return 273;
   if (event_id != -1)
     return 274;
@@ -1589,7 +1590,7 @@ check_store_permission_state_transition_rejects_invalid_audit (void)
           "perm-bad-audit-scope", "grant", &event_id, "not-a-wyl-id", 1000,
           "perm-bad-audit-user", "permission_state.grant",
           "wr.perm.bad.audit", "allowed", "permission_state",
-          WYL_DECISION_ALLOW) != WYRELOG_E_INVALID)
+          NULL, WYL_DECISION_ALLOW) != WYRELOG_E_INVALID)
     return 288;
   if (event_id != -1)
     return 289;

--- a/wyrelog/audit.h
+++ b/wyrelog/audit.h
@@ -65,6 +65,10 @@ void wyl_audit_event_set_deny_origin (WylAuditEvent * self,
     const gchar * deny_origin);
 const gchar *wyl_audit_event_get_deny_origin (const WylAuditEvent * self);
 
+void wyl_audit_event_set_request_id (WylAuditEvent * self,
+    const gchar * request_id);
+const gchar *wyl_audit_event_get_request_id (const WylAuditEvent * self);
+
 /*
  * Records the verdict produced for the request the event describes.
  * Default for a freshly constructed event is WYL_DECISION_DENY so

--- a/wyrelog/audit/conn-private.h
+++ b/wyrelog/audit/conn-private.h
@@ -79,6 +79,7 @@ duckdb_connection wyl_audit_conn_get_connection (wyl_audit_conn_t * conn);
  *   resource_id   VARCHAR
  *   deny_reason   VARCHAR              -- representative deny code
  *   deny_origin   VARCHAR              -- source relation tag
+ *   request_id    VARCHAR              -- optional request lifecycle id
  *   decision      SMALLINT             -- 0 = DENY, 1 = ALLOW
  *
  * Returns WYRELOG_E_OK on success, WYRELOG_E_INVALID for a NULL
@@ -110,7 +111,7 @@ wyrelog_error_t wyl_audit_conn_insert_event_full (wyl_audit_conn_t * conn,
     const gchar * id, gint64 created_at_us, const gchar * subject_id,
     const gchar * action, const gchar * resource_id,
     const gchar * deny_reason, const gchar * deny_origin,
-    wyl_decision_t decision, gboolean * out_inserted);
+    const gchar * request_id, wyl_decision_t decision, gboolean * out_inserted);
 
 wyrelog_error_t wyl_audit_conn_delete_event (wyl_audit_conn_t * conn,
     const gchar * id);
@@ -132,6 +133,8 @@ wyrelog_error_t wyl_audit_conn_delete_event (wyl_audit_conn_t * conn,
  *   deny_reason("<value>")
  *   deny_origin=<value>
  *   deny_origin("<value>")
+ *   request_id=<value>
+ *   request_id("<value>")
  *
  * On success @out_json owns a newly allocated string.
  */

--- a/wyrelog/audit/conn.c
+++ b/wyrelog/audit/conn.c
@@ -93,7 +93,8 @@ static wyrelog_error_t
 audit_event_matches_existing (wyl_audit_conn_t *conn, const gchar *id,
     gint64 created_at_us, const gchar *subject_id, const gchar *action,
     const gchar *resource_id, const gchar *deny_reason,
-    const gchar *deny_origin, wyl_decision_t decision, gboolean *out_exists)
+    const gchar *deny_origin, const gchar *request_id,
+    wyl_decision_t decision, gboolean *out_exists)
 {
   duckdb_prepared_statement stmt = NULL;
   duckdb_result result;
@@ -102,7 +103,8 @@ audit_event_matches_existing (wyl_audit_conn_t *conn, const gchar *id,
   *out_exists = FALSE;
   static const gchar *sql =
       "SELECT created_at_us, subject_id, action, resource_id, "
-      "deny_reason, deny_origin, decision " "FROM audit_events WHERE id = ?;";
+      "deny_reason, deny_origin, request_id, decision "
+      "FROM audit_events WHERE id = ?;";
   if (duckdb_prepare (conn->conn, sql, &stmt) != DuckDBSuccess)
     return WYRELOG_E_IO;
   if (duckdb_bind_varchar (stmt, 1, id) != DuckDBSuccess) {
@@ -135,10 +137,38 @@ audit_event_matches_existing (wyl_audit_conn_t *conn, const gchar *id,
       && result_nullable_varchar_equal (&result, 3, 0, resource_id)
       && result_nullable_varchar_equal (&result, 4, 0, deny_reason)
       && result_nullable_varchar_equal (&result, 5, 0, deny_origin)
-      && duckdb_value_int64 (&result, 6, 0) == decision;
+      && result_nullable_varchar_equal (&result, 6, 0, request_id)
+      && duckdb_value_int64 (&result, 7, 0) == decision;
 
   duckdb_destroy_result (&result);
   return equal ? WYRELOG_E_OK : WYRELOG_E_POLICY;
+}
+
+static wyrelog_error_t
+ensure_audit_events_request_id_column (wyl_audit_conn_t *conn)
+{
+  duckdb_result result = { 0 };
+  static const gchar *probe_sql =
+      "SELECT COUNT(*) FROM information_schema.columns "
+      "WHERE table_name = 'audit_events' AND column_name = 'request_id';";
+
+  if (duckdb_query (conn->conn, probe_sql, &result) != DuckDBSuccess) {
+    duckdb_destroy_result (&result);
+    return WYRELOG_E_IO;
+  }
+  gboolean exists = duckdb_value_int64 (&result, 0, 0) > 0;
+  duckdb_destroy_result (&result);
+  if (exists)
+    return WYRELOG_E_OK;
+
+  if (duckdb_query (conn->conn,
+          "ALTER TABLE audit_events ADD COLUMN request_id VARCHAR;", &result)
+      != DuckDBSuccess) {
+    duckdb_destroy_result (&result);
+    return WYRELOG_E_IO;
+  }
+  duckdb_destroy_result (&result);
+  return WYRELOG_E_OK;
 }
 
 wyrelog_error_t
@@ -153,6 +183,7 @@ wyl_audit_conn_create_schema (wyl_audit_conn_t *conn)
       "  resource_id   VARCHAR,"
       "  deny_reason   VARCHAR,"
       "  deny_origin   VARCHAR,"
+      "  request_id    VARCHAR,"
       "  decision      SMALLINT NOT NULL"
       ");"
       "CREATE INDEX IF NOT EXISTS idx_audit_events_created_at_us "
@@ -175,7 +206,7 @@ wyl_audit_conn_create_schema (wyl_audit_conn_t *conn)
     return WYRELOG_E_IO;
   }
   duckdb_destroy_result (&result);
-  return WYRELOG_E_OK;
+  return ensure_audit_events_request_id_column (conn);
 }
 
 wyrelog_error_t
@@ -217,7 +248,8 @@ wyrelog_error_t
 wyl_audit_conn_insert_event_full (wyl_audit_conn_t *conn, const gchar *id,
     gint64 created_at_us, const gchar *subject_id, const gchar *action,
     const gchar *resource_id, const gchar *deny_reason,
-    const gchar *deny_origin, wyl_decision_t decision, gboolean *out_inserted)
+    const gchar *deny_origin, const gchar *request_id,
+    wyl_decision_t decision, gboolean *out_inserted)
 {
   duckdb_prepared_statement stmt = NULL;
   duckdb_result result;
@@ -236,8 +268,8 @@ wyl_audit_conn_insert_event_full (wyl_audit_conn_t *conn, const gchar *id,
     return WYRELOG_E_INVALID;
 
   wyrelog_error_t rc = audit_event_matches_existing (conn, id, created_at_us,
-      subject_id, action, resource_id, deny_reason, deny_origin, decision,
-      &exists);
+      subject_id, action, resource_id, deny_reason, deny_origin, request_id,
+      decision, &exists);
   if (rc != WYRELOG_E_OK)
     return rc;
   if (exists)
@@ -246,7 +278,8 @@ wyl_audit_conn_insert_event_full (wyl_audit_conn_t *conn, const gchar *id,
   static const gchar *sql =
       "INSERT INTO audit_events "
       "(id, created_at_us, subject_id, action, resource_id, "
-      "deny_reason, deny_origin, decision) " "VALUES (?, ?, ?, ?, ?, ?, ?, ?);";
+      "deny_reason, deny_origin, request_id, decision) "
+      "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);";
   if (duckdb_prepare (conn->conn, sql, &stmt) != DuckDBSuccess) {
     duckdb_destroy_prepare (&stmt);
     return WYRELOG_E_IO;
@@ -259,7 +292,8 @@ wyl_audit_conn_insert_event_full (wyl_audit_conn_t *conn, const gchar *id,
       || bind_nullable_varchar (stmt, 5, resource_id) != WYRELOG_E_OK
       || bind_nullable_varchar (stmt, 6, deny_reason) != WYRELOG_E_OK
       || bind_nullable_varchar (stmt, 7, deny_origin) != WYRELOG_E_OK
-      || duckdb_bind_int16 (stmt, 8, (int16_t) decision) != DuckDBSuccess) {
+      || bind_nullable_varchar (stmt, 8, request_id) != WYRELOG_E_OK
+      || duckdb_bind_int16 (stmt, 9, (int16_t) decision) != DuckDBSuccess) {
     duckdb_destroy_prepare (&stmt);
     return WYRELOG_E_IO;
   }
@@ -283,7 +317,7 @@ wyl_audit_conn_insert_event (wyl_audit_conn_t *conn, const gchar *id,
   gboolean inserted = FALSE;
 
   return wyl_audit_conn_insert_event_full (conn, id, created_at_us,
-      subject_id, action, resource_id, deny_reason, deny_origin, decision,
+      subject_id, action, resource_id, deny_reason, deny_origin, NULL, decision,
       &inserted);
 }
 
@@ -466,6 +500,8 @@ parse_audit_filter (const gchar *filter, const gchar **out_column,
     *out_column = "deny_reason";
   else if (g_strcmp0 (key, "deny_origin") == 0)
     *out_column = "deny_origin";
+  else if (g_strcmp0 (key, "request_id") == 0)
+    *out_column = "request_id";
 
   if (*out_column != NULL) {
     *out_string = g_steal_pointer (&value);
@@ -497,13 +533,13 @@ wyl_audit_conn_query_events_json (wyl_audit_conn_t *conn,
   if (column == NULL) {
     sql =
         g_strdup ("SELECT id, created_at_us, subject_id, action, resource_id, "
-        "deny_reason, deny_origin, decision " "FROM audit_events "
+        "deny_reason, deny_origin, request_id, decision " "FROM audit_events "
         "ORDER BY created_at_us DESC, id DESC " "LIMIT 100;");
   } else {
     sql =
         g_strdup_printf
         ("SELECT id, created_at_us, subject_id, action, resource_id, "
-        "deny_reason, deny_origin, decision " "FROM audit_events "
+        "deny_reason, deny_origin, request_id, decision " "FROM audit_events "
         "WHERE %s = ? " "ORDER BY created_at_us DESC, id DESC " "LIMIT 100;",
         column);
   }
@@ -552,8 +588,10 @@ wyl_audit_conn_query_events_json (wyl_audit_conn_t *conn,
     append_json_member_string (json, "deny_reason", &result, 5, row);
     g_string_append_c (json, ',');
     append_json_member_string (json, "deny_origin", &result, 6, row);
+    g_string_append_c (json, ',');
+    append_json_member_string (json, "request_id", &result, 7, row);
     g_string_append_printf (json, ",\"decision\":%" G_GINT16_FORMAT "}",
-        (gint16) duckdb_value_int64 (&result, 7, row));
+        (gint16) duckdb_value_int64 (&result, 8, row));
   }
   g_string_append_c (json, ']');
 

--- a/wyrelog/audit/event-private.h
+++ b/wyrelog/audit/event-private.h
@@ -17,6 +17,7 @@ wyrelog_error_t wyl_audit_event_new_from_fields (const gchar * id,
     const gchar * resource_id,
     const gchar * deny_reason,
     const gchar * deny_origin,
+    const gchar * request_id,
     wyl_decision_t decision, WylAuditEvent ** out_event);
 
 wyrelog_error_t wyl_audit_mirror_event (WylHandle * handle,

--- a/wyrelog/audit/event.c
+++ b/wyrelog/audit/event.c
@@ -252,9 +252,11 @@ wyl_audit_mirror_event (WylHandle *handle, const WylAuditEvent *event)
   if (wyl_id_format (&event->id, id_buf, sizeof id_buf) != WYRELOG_E_OK)
     return WYRELOG_E_INTERNAL;
 
-  return wyl_audit_conn_insert_event (audit_conn, id_buf, event->created_at_us,
-      event->subject_id, event->action, event->resource_id, event->deny_reason,
-      event->deny_origin, event->decision);
+  gboolean inserted = FALSE;
+  return wyl_audit_conn_insert_event_full (audit_conn, id_buf,
+      event->created_at_us, event->subject_id, event->action,
+      event->resource_id, event->deny_reason, event->deny_origin,
+      event->request_id, event->decision, &inserted);
 #else
   (void) handle;
   (void) event;
@@ -279,7 +281,8 @@ wyl_audit_emit (WylHandle *handle, const WylAuditEvent *event)
       wyl_policy_store_append_audit_event_full (wyl_handle_get_policy_store
       (handle), id_buf, event->created_at_us,
       event->subject_id, event->action, event->resource_id,
-      event->deny_reason, event->deny_origin, event->decision,
+      event->deny_reason, event->deny_origin, event->request_id,
+      event->decision,
       &store_inserted);
   if (store_rc != WYRELOG_E_OK)
     return store_rc;
@@ -287,7 +290,8 @@ wyl_audit_emit (WylHandle *handle, const WylAuditEvent *event)
   wyrelog_error_t rc = wyl_handle_insert_audit_fact (handle, id_buf,
       event->created_at_us,
       event->subject_id, event->action, event->resource_id,
-      event->deny_reason, event->deny_origin, event->decision);
+      event->deny_reason, event->deny_origin, event->request_id,
+      event->decision);
   if (rc != WYRELOG_E_OK) {
     if (store_inserted) {
       wyrelog_error_t cleanup_rc =
@@ -311,7 +315,7 @@ wyl_audit_emit (WylHandle *handle, const WylAuditEvent *event)
   (void) wyl_audit_conn_insert_event_full (audit_conn, id_buf,
       event->created_at_us, event->subject_id, event->action,
       event->resource_id, event->deny_reason, event->deny_origin,
-      event->decision, &inserted);
+      event->request_id, event->decision, &inserted);
 
   return WYRELOG_E_OK;
 #else

--- a/wyrelog/audit/event.c
+++ b/wyrelog/audit/event.c
@@ -20,6 +20,7 @@ struct _WylAuditEvent
   gchar *resource_id;
   gchar *deny_reason;
   gchar *deny_origin;
+  gchar *request_id;
   wyl_decision_t decision;
 };
 
@@ -35,6 +36,7 @@ wyl_audit_event_finalize (GObject *object)
   g_free (self->resource_id);
   g_free (self->deny_reason);
   g_free (self->deny_origin);
+  g_free (self->request_id);
 
   G_OBJECT_CLASS (wyl_audit_event_parent_class)->finalize (object);
 }
@@ -75,7 +77,7 @@ wyrelog_error_t
 wyl_audit_event_new_from_fields (const gchar *id, gint64 created_at_us,
     const gchar *subject_id, const gchar *action, const gchar *resource_id,
     const gchar *deny_reason, const gchar *deny_origin,
-    wyl_decision_t decision, WylAuditEvent **out_event)
+    const gchar *request_id, wyl_decision_t decision, WylAuditEvent **out_event)
 {
   wyl_id_t parsed_id;
 
@@ -98,6 +100,7 @@ wyl_audit_event_new_from_fields (const gchar *id, gint64 created_at_us,
   wyl_audit_event_set_resource_id (self, resource_id);
   wyl_audit_event_set_deny_reason (self, deny_reason);
   wyl_audit_event_set_deny_origin (self, deny_origin);
+  wyl_audit_event_set_request_id (self, request_id);
   wyl_audit_event_set_decision (self, decision);
 
   *out_event = self;
@@ -196,6 +199,21 @@ wyl_audit_event_get_deny_origin (const WylAuditEvent *self)
 {
   g_return_val_if_fail (WYL_IS_AUDIT_EVENT (self), NULL);
   return self->deny_origin;
+}
+
+void
+wyl_audit_event_set_request_id (WylAuditEvent *self, const gchar *request_id)
+{
+  g_return_if_fail (WYL_IS_AUDIT_EVENT (self));
+  g_free (self->request_id);
+  self->request_id = g_strdup (request_id);
+}
+
+const gchar *
+wyl_audit_event_get_request_id (const WylAuditEvent *self)
+{
+  g_return_val_if_fail (WYL_IS_AUDIT_EVENT (self), NULL);
+  return self->request_id;
 }
 
 void

--- a/wyrelog/audit/iter.c
+++ b/wyrelog/audit/iter.c
@@ -346,6 +346,7 @@ parse_audit_event_object (JsonCursor *cursor, WylAuditEvent **out_event)
   g_autofree gchar *resource_id = NULL;
   g_autofree gchar *deny_reason = NULL;
   g_autofree gchar *deny_origin = NULL;
+  g_autofree gchar *request_id = NULL;
   gint64 created_at_us = -1;
   gint64 decision_raw = -1;
   gboolean have_created_at = FALSE;
@@ -390,6 +391,9 @@ parse_audit_event_object (JsonCursor *cursor, WylAuditEvent **out_event)
     } else if (g_strcmp0 (key, "deny_origin") == 0) {
       if (!json_parse_nullable_string (cursor, &deny_origin))
         return WYRELOG_E_IO;
+    } else if (g_strcmp0 (key, "request_id") == 0) {
+      if (!json_parse_nullable_string (cursor, &request_id))
+        return WYRELOG_E_IO;
     } else if (g_strcmp0 (key, "decision") == 0) {
       if (!json_parse_int64 (cursor, &decision_raw))
         return WYRELOG_E_IO;
@@ -416,7 +420,7 @@ parse_audit_event_object (JsonCursor *cursor, WylAuditEvent **out_event)
     return WYRELOG_E_IO;
 
   return wyl_audit_event_new_from_fields (id, created_at_us, subject_id,
-      action, resource_id, deny_reason, deny_origin, NULL,
+      action, resource_id, deny_reason, deny_origin, request_id,
       (wyl_decision_t) decision_raw, out_event);
 }
 

--- a/wyrelog/audit/iter.c
+++ b/wyrelog/audit/iter.c
@@ -416,7 +416,7 @@ parse_audit_event_object (JsonCursor *cursor, WylAuditEvent **out_event)
     return WYRELOG_E_IO;
 
   return wyl_audit_event_new_from_fields (id, created_at_us, subject_id,
-      action, resource_id, deny_reason, deny_origin,
+      action, resource_id, deny_reason, deny_origin, NULL,
       (wyl_decision_t) decision_raw, out_event);
 }
 

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -18,6 +18,8 @@
 #define WYL_DAEMON_JWT_AUDIENCE "wyrelog-client"
 #define WYL_DAEMON_JWT_KEY_LEN 32
 #define WYL_DAEMON_REQUEST_ID_HEADER "X-Wyrelog-Request-Id"
+#define WYL_DAEMON_REQUEST_ID_DATA "wyl-daemon-request-id"
+#define WYL_DAEMON_REQUEST_ID_ATTEMPTED_DATA "wyl-daemon-request-id-attempted"
 
 typedef struct
 {
@@ -363,16 +365,42 @@ resolve_bearer_session (SoupServer *server, WylDaemonHttpContext *ctx,
   return WYRELOG_E_OK;
 }
 
-static void
-attach_request_id_header (SoupServerMessage *msg)
+static const gchar *
+ensure_request_id_header (SoupServerMessage *msg)
 {
+  const gchar *existing = g_object_get_data (G_OBJECT (msg),
+      WYL_DAEMON_REQUEST_ID_DATA);
+  if (existing != NULL) {
+    SoupMessageHeaders *headers =
+        soup_server_message_get_response_headers (msg);
+    soup_message_headers_replace (headers, WYL_DAEMON_REQUEST_ID_HEADER,
+        existing);
+    return existing;
+  }
+
+  if (g_object_get_data (G_OBJECT (msg),
+          WYL_DAEMON_REQUEST_ID_ATTEMPTED_DATA) != NULL)
+    return NULL;
+  g_object_set_data (G_OBJECT (msg), WYL_DAEMON_REQUEST_ID_ATTEMPTED_DATA,
+      GINT_TO_POINTER (1));
+
   gchar request_id[WYL_REQUEST_ID_STRING_BUF];
   if (wyl_request_id_new (request_id, sizeof request_id) != WYRELOG_E_OK)
-    return;
+    return NULL;
+
+  g_object_set_data_full (G_OBJECT (msg), WYL_DAEMON_REQUEST_ID_DATA,
+      g_strdup (request_id), g_free);
 
   SoupMessageHeaders *headers = soup_server_message_get_response_headers (msg);
   soup_message_headers_replace (headers, WYL_DAEMON_REQUEST_ID_HEADER,
       request_id);
+  return g_object_get_data (G_OBJECT (msg), WYL_DAEMON_REQUEST_ID_DATA);
+}
+
+static void
+attach_request_id_header (SoupServerMessage *msg)
+{
+  (void) ensure_request_id_header (msg);
 }
 
 static void
@@ -773,6 +801,7 @@ policy_permission_transition_handler (SoupServer *server,
   wyl_audit_event_set_resource_id (audit_event, perm);
   wyl_audit_event_set_deny_reason (audit_event, event);
   wyl_audit_event_set_deny_origin (audit_event, scope);
+  wyl_audit_event_set_request_id (audit_event, ensure_request_id_header (msg));
   wyl_audit_event_set_decision (audit_event, WYL_DECISION_ALLOW);
 
   wyrelog_error_t rc = wyl_handle_apply_permission_state_transition

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -727,6 +727,7 @@ direct_permission_mutation_handler (SoupServer *server, SoupServerMessage *msg,
     wyl_grant_req_set_action (req, perm);
     wyl_grant_req_set_resource_id (req, scope);
     wyl_grant_req_set_actor_id (req, actor);
+    wyl_grant_req_set_request_id (req, ensure_request_id_header (msg));
     rc = wyl_perm_grant (ctx->handle, req);
   } else {
     g_autoptr (wyl_revoke_req_t) req = wyl_revoke_req_new ();
@@ -734,6 +735,7 @@ direct_permission_mutation_handler (SoupServer *server, SoupServerMessage *msg,
     wyl_revoke_req_set_action (req, perm);
     wyl_revoke_req_set_resource_id (req, scope);
     wyl_revoke_req_set_actor_id (req, actor);
+    wyl_revoke_req_set_request_id (req, ensure_request_id_header (msg));
     rc = wyl_perm_revoke (ctx->handle, req);
   }
   if (rc != WYRELOG_E_OK) {
@@ -850,6 +852,7 @@ role_membership_mutation_handler (SoupServer *server, SoupServerMessage *msg,
     wyl_role_grant_req_set_role_id (req, role);
     wyl_role_grant_req_set_scope (req, scope);
     wyl_role_grant_req_set_actor_id (req, actor);
+    wyl_role_grant_req_set_request_id (req, ensure_request_id_header (msg));
     rc = wyl_role_grant (ctx->handle, req);
   } else {
     g_autoptr (wyl_role_revoke_req_t) req = wyl_role_revoke_req_new ();
@@ -857,6 +860,7 @@ role_membership_mutation_handler (SoupServer *server, SoupServerMessage *msg,
     wyl_role_revoke_req_set_role_id (req, role);
     wyl_role_revoke_req_set_scope (req, scope);
     wyl_role_revoke_req_set_actor_id (req, actor);
+    wyl_role_revoke_req_set_request_id (req, ensure_request_id_header (msg));
     rc = wyl_role_revoke (ctx->handle, req);
   }
   if (rc != WYRELOG_E_OK) {

--- a/wyrelog/perm.h
+++ b/wyrelog/perm.h
@@ -43,6 +43,9 @@ void wyl_grant_req_set_resource_id (wyl_grant_req_t * req,
 const gchar *wyl_grant_req_get_resource_id (const wyl_grant_req_t * req);
 void wyl_grant_req_set_actor_id (wyl_grant_req_t * req, const gchar * actor_id);
 const gchar *wyl_grant_req_get_actor_id (const wyl_grant_req_t * req);
+void wyl_grant_req_set_request_id (wyl_grant_req_t * req,
+    const gchar * request_id);
+const gchar *wyl_grant_req_get_request_id (const wyl_grant_req_t * req);
 
 wyl_revoke_req_t *wyl_revoke_req_new (void);
 void wyl_revoke_req_free (wyl_revoke_req_t * req);
@@ -68,6 +71,9 @@ const gchar *wyl_revoke_req_get_resource_id (const wyl_revoke_req_t * req);
 void wyl_revoke_req_set_actor_id (wyl_revoke_req_t * req,
     const gchar * actor_id);
 const gchar *wyl_revoke_req_get_actor_id (const wyl_revoke_req_t * req);
+void wyl_revoke_req_set_request_id (wyl_revoke_req_t * req,
+    const gchar * request_id);
+const gchar *wyl_revoke_req_get_request_id (const wyl_revoke_req_t * req);
 
 wyrelog_error_t wyl_perm_grant (WylHandle * handle,
     const wyl_grant_req_t * req);
@@ -93,6 +99,10 @@ const gchar *wyl_role_grant_req_get_scope (const wyl_role_grant_req_t * req);
 void wyl_role_grant_req_set_actor_id (wyl_role_grant_req_t * req,
     const gchar * actor_id);
 const gchar *wyl_role_grant_req_get_actor_id (const wyl_role_grant_req_t * req);
+void wyl_role_grant_req_set_request_id (wyl_role_grant_req_t * req,
+    const gchar * request_id);
+const gchar *wyl_role_grant_req_get_request_id (const wyl_role_grant_req_t *
+    req);
 
 wyl_role_revoke_req_t *wyl_role_revoke_req_new (void);
 void wyl_role_revoke_req_free (wyl_role_revoke_req_t * req);
@@ -114,6 +124,10 @@ const gchar *wyl_role_revoke_req_get_scope (const wyl_role_revoke_req_t * req);
 void wyl_role_revoke_req_set_actor_id (wyl_role_revoke_req_t * req,
     const gchar * actor_id);
 const gchar *wyl_role_revoke_req_get_actor_id (const wyl_role_revoke_req_t *
+    req);
+void wyl_role_revoke_req_set_request_id (wyl_role_revoke_req_t * req,
+    const gchar * request_id);
+const gchar *wyl_role_revoke_req_get_request_id (const wyl_role_revoke_req_t *
     req);
 
 wyrelog_error_t wyl_role_grant (WylHandle * handle,

--- a/wyrelog/policy/store-private.h
+++ b/wyrelog/policy/store-private.h
@@ -112,7 +112,8 @@ wyrelog_error_t
     const gchar * audit_id, gint64 audit_created_at_us,
     const gchar * audit_subject_id, const gchar * audit_action,
     const gchar * audit_resource_id, const gchar * audit_deny_reason,
-    const gchar * audit_deny_origin, wyl_decision_t audit_decision);
+    const gchar * audit_deny_origin, const gchar * audit_request_id,
+    wyl_decision_t audit_decision);
 wyrelog_error_t wyl_policy_store_role_membership_exists (wyl_policy_store_t *
     store, const gchar * subject_id, const gchar * role_id,
     const gchar * scope, gboolean * out_exists);
@@ -142,7 +143,8 @@ wyrelog_error_t
     const gchar * audit_id, gint64 audit_created_at_us,
     const gchar * audit_subject_id, const gchar * audit_action,
     const gchar * audit_resource_id, const gchar * audit_deny_reason,
-    const gchar * audit_deny_origin, wyl_decision_t audit_decision);
+    const gchar * audit_deny_origin, const gchar * audit_request_id,
+    wyl_decision_t audit_decision);
 wyrelog_error_t wyl_policy_store_direct_permission_exists (wyl_policy_store_t *
     store, const gchar * subject_id, const gchar * perm_id, const gchar * scope,
     gboolean * out_exists);
@@ -182,7 +184,7 @@ wyrelog_error_t
     gint64 audit_created_at_us, const gchar * audit_subject_id,
     const gchar * audit_action, const gchar * audit_resource_id,
     const gchar * audit_deny_reason, const gchar * audit_deny_origin,
-    wyl_decision_t audit_decision);
+    const gchar * audit_request_id, wyl_decision_t audit_decision);
 wyrelog_error_t wyl_policy_store_foreach_permission_state_event
     (wyl_policy_store_t * store, wyl_policy_permission_state_event_cb cb,
     gpointer user_data);

--- a/wyrelog/policy/store-private.h
+++ b/wyrelog/policy/store-private.h
@@ -45,7 +45,8 @@ typedef wyrelog_error_t (*wyl_policy_session_event_cb) (gint64 event_id,
 typedef wyrelog_error_t (*wyl_policy_audit_event_cb) (const gchar * id,
     gint64 created_at_us, const gchar * subject_id, const gchar * action,
     const gchar * resource_id, const gchar * deny_reason,
-    const gchar * deny_origin, wyl_decision_t decision, gpointer user_data);
+    const gchar * deny_origin, const gchar * request_id,
+    wyl_decision_t decision, gpointer user_data);
 
 /*
  * Policy authority store lifecycle wrapper.
@@ -211,7 +212,7 @@ wyrelog_error_t wyl_policy_store_append_audit_event_full (wyl_policy_store_t *
     store, const gchar * id, gint64 created_at_us, const gchar * subject_id,
     const gchar * action, const gchar * resource_id,
     const gchar * deny_reason, const gchar * deny_origin,
-    wyl_decision_t decision, gboolean * out_inserted);
+    const gchar * request_id, wyl_decision_t decision, gboolean * out_inserted);
 wyrelog_error_t wyl_policy_store_delete_audit_event (wyl_policy_store_t *
     store, const gchar * id);
 wyrelog_error_t wyl_policy_store_foreach_audit_event (wyl_policy_store_t *

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -636,6 +636,7 @@ wyl_policy_store_create_schema (wyl_policy_store_t *store)
       "  resource_id TEXT,"
       "  deny_reason TEXT,"
       "  deny_origin TEXT,"
+      "  request_id TEXT,"
       "  decision INTEGER NOT NULL CHECK (decision IN (0, 1))"
       ");"
       "CREATE INDEX IF NOT EXISTS idx_audit_events_created_at_us "
@@ -659,6 +660,25 @@ wyl_policy_store_create_schema (wyl_policy_store_t *store)
   wyrelog_error_t rc = exec_sql (store->db, ddl);
   if (rc != WYRELOG_E_OK)
     return rc;
+  sqlite3_stmt *stmt = NULL;
+  gboolean has_request_id = FALSE;
+  if (sqlite3_prepare_v2 (store->db, "PRAGMA table_info(audit_events);", -1,
+          &stmt, NULL) != SQLITE_OK)
+    return WYRELOG_E_IO;
+  while (sqlite3_step (stmt) == SQLITE_ROW) {
+    const gchar *name = (const gchar *) sqlite3_column_text (stmt, 1);
+    if (g_strcmp0 (name, "request_id") == 0) {
+      has_request_id = TRUE;
+      break;
+    }
+  }
+  sqlite3_finalize (stmt);
+  if (!has_request_id) {
+    rc = exec_sql (store->db,
+        "ALTER TABLE audit_events ADD COLUMN request_id TEXT;");
+    if (rc != WYRELOG_E_OK)
+      return rc;
+  }
   return seed_builtin_catalog (store->db);
 }
 
@@ -2370,7 +2390,8 @@ wyrelog_error_t
 wyl_policy_store_append_audit_event_full (wyl_policy_store_t *store,
     const gchar *id, gint64 created_at_us, const gchar *subject_id,
     const gchar *action, const gchar *resource_id, const gchar *deny_reason,
-    const gchar *deny_origin, wyl_decision_t decision, gboolean *out_inserted)
+    const gchar *deny_origin, const gchar *request_id,
+    wyl_decision_t decision, gboolean *out_inserted)
 {
   sqlite3_stmt *stmt = NULL;
   wyl_id_t parsed_id;
@@ -2386,7 +2407,8 @@ wyl_policy_store_append_audit_event_full (wyl_policy_store_t *store,
 
   static const gchar *select_sql =
       "SELECT created_at_us, subject_id, action, resource_id, "
-      "deny_reason, deny_origin, decision FROM audit_events WHERE id = ?;";
+      "deny_reason, deny_origin, request_id, decision "
+      "FROM audit_events WHERE id = ?;";
   wyrelog_error_t rc = prepare_stmt (store->db, select_sql, &stmt);
   if (rc != WYRELOG_E_OK)
     return rc;
@@ -2404,7 +2426,8 @@ wyl_policy_store_append_audit_event_full (wyl_policy_store_t *store,
         && column_nullable_text_equal (stmt, 3, resource_id)
         && column_nullable_text_equal (stmt, 4, deny_reason)
         && column_nullable_text_equal (stmt, 5, deny_origin)
-        && sqlite3_column_int (stmt, 6) == (int) decision;
+        && column_nullable_text_equal (stmt, 6, request_id)
+        && sqlite3_column_int (stmt, 7) == (int) decision;
     sqlite3_finalize (stmt);
     return equal ? WYRELOG_E_OK : WYRELOG_E_POLICY;
   }
@@ -2416,8 +2439,8 @@ wyl_policy_store_append_audit_event_full (wyl_policy_store_t *store,
   static const gchar *sql =
       "INSERT INTO audit_events "
       "  (id, created_at_us, subject_id, action, resource_id, "
-      "   deny_reason, deny_origin, decision) "
-      "VALUES (?, ?, ?, ?, ?, ?, ?, ?);";
+      "   deny_reason, deny_origin, request_id, decision) "
+      "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);";
   rc = prepare_stmt (store->db, sql, &stmt);
   if (rc != WYRELOG_E_OK)
     return rc;
@@ -2428,7 +2451,8 @@ wyl_policy_store_append_audit_event_full (wyl_policy_store_t *store,
       || (rc = bind_nullable_text (stmt, 5, resource_id)) != WYRELOG_E_OK
       || (rc = bind_nullable_text (stmt, 6, deny_reason)) != WYRELOG_E_OK
       || (rc = bind_nullable_text (stmt, 7, deny_origin)) != WYRELOG_E_OK
-      || sqlite3_bind_int (stmt, 8, (int) decision) != SQLITE_OK) {
+      || (rc = bind_nullable_text (stmt, 8, request_id)) != WYRELOG_E_OK
+      || sqlite3_bind_int (stmt, 9, (int) decision) != SQLITE_OK) {
     sqlite3_finalize (stmt);
     return WYRELOG_E_IO;
   }
@@ -2450,7 +2474,7 @@ wyl_policy_store_append_audit_event (wyl_policy_store_t *store,
   gboolean inserted = FALSE;
 
   return wyl_policy_store_append_audit_event_full (store, id, created_at_us,
-      subject_id, action, resource_id, deny_reason, deny_origin, decision,
+      subject_id, action, resource_id, deny_reason, deny_origin, NULL, decision,
       &inserted);
 }
 
@@ -2490,7 +2514,7 @@ wyl_policy_store_foreach_audit_event (wyl_policy_store_t *store,
 
   static const gchar *sql =
       "SELECT id, created_at_us, subject_id, action, resource_id, "
-      "deny_reason, deny_origin, decision "
+      "deny_reason, deny_origin, request_id, decision "
       "FROM audit_events ORDER BY created_at_us ASC, id ASC;";
   wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
   if (rc != WYRELOG_E_OK)
@@ -2505,7 +2529,8 @@ wyl_policy_store_foreach_audit_event (wyl_policy_store_t *store,
     const gchar *resource_id = (const gchar *) sqlite3_column_text (stmt, 4);
     const gchar *deny_reason = (const gchar *) sqlite3_column_text (stmt, 5);
     const gchar *deny_origin = (const gchar *) sqlite3_column_text (stmt, 6);
-    int decision = sqlite3_column_int (stmt, 7);
+    const gchar *request_id = (const gchar *) sqlite3_column_text (stmt, 7);
+    int decision = sqlite3_column_int (stmt, 8);
     wyl_id_t parsed_id;
 
     if (id == NULL || wyl_id_parse (id, &parsed_id) != WYRELOG_E_OK
@@ -2515,7 +2540,7 @@ wyl_policy_store_foreach_audit_event (wyl_policy_store_t *store,
       return WYRELOG_E_POLICY;
     }
     rc = cb (id, created_at_us, subject_id, action, resource_id, deny_reason,
-        deny_origin, (wyl_decision_t) decision, user_data);
+        deny_origin, request_id, (wyl_decision_t) decision, user_data);
     if (rc != WYRELOG_E_OK) {
       sqlite3_finalize (stmt);
       return rc;

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -1087,7 +1087,8 @@ wyrelog_error_t
     const gchar * audit_id, gint64 audit_created_at_us,
     const gchar * audit_subject_id, const gchar * audit_action,
     const gchar * audit_resource_id, const gchar * audit_deny_reason,
-    const gchar * audit_deny_origin, wyl_decision_t audit_decision)
+    const gchar * audit_deny_origin, const gchar * audit_request_id,
+    wyl_decision_t audit_decision)
 {
   if (store == NULL || store->db == NULL || subject_id == NULL
       || perm_id == NULL || scope == NULL)
@@ -1120,10 +1121,11 @@ wyrelog_error_t
         perm_id, scope, insert ? "grant" : "revoke");
   }
   if (rc == WYRELOG_E_OK && audit_id != NULL) {
-    rc = wyl_policy_store_append_audit_event (store, audit_id,
+    gboolean inserted = FALSE;
+    rc = wyl_policy_store_append_audit_event_full (store, audit_id,
         audit_created_at_us, audit_subject_id, audit_action,
         audit_resource_id, audit_deny_reason, audit_deny_origin,
-        audit_decision);
+        audit_request_id, audit_decision, &inserted);
   }
   if (rc == WYRELOG_E_OK)
     rc = wyl_policy_store_validate_snapshot (store);
@@ -1147,7 +1149,7 @@ wyl_policy_store_apply_direct_permission_mutation (wyl_policy_store_t *store,
 {
   return wyl_policy_store_apply_direct_permission_mutation_with_audit (store,
       subject_id, perm_id, scope, insert, NULL, 0, NULL, NULL, NULL, NULL, NULL,
-      WYL_DECISION_DENY);
+      NULL, WYL_DECISION_DENY);
 }
 
 wyrelog_error_t
@@ -1533,7 +1535,7 @@ wyrelog_error_t
     gint64 audit_created_at_us, const gchar * audit_subject_id,
     const gchar * audit_action, const gchar * audit_resource_id,
     const gchar * audit_deny_reason, const gchar * audit_deny_origin,
-    wyl_decision_t audit_decision)
+    const gchar * audit_request_id, wyl_decision_t audit_decision)
 {
   if (out_event_id != NULL)
     *out_event_id = -1;
@@ -1581,10 +1583,11 @@ wyrelog_error_t
         perm_id, scope, event, from_state_name, to_state_name, &event_id);
   }
   if (rc == WYRELOG_E_OK && audit_id != NULL) {
-    rc = wyl_policy_store_append_audit_event (store, audit_id,
+    gboolean inserted = FALSE;
+    rc = wyl_policy_store_append_audit_event_full (store, audit_id,
         audit_created_at_us, audit_subject_id, audit_action,
         audit_resource_id, audit_deny_reason, audit_deny_origin,
-        audit_decision);
+        audit_request_id, audit_decision, &inserted);
   }
   if (rc == WYRELOG_E_OK)
     rc = wyl_policy_store_validate_snapshot (store);
@@ -1610,7 +1613,7 @@ wyl_policy_store_apply_permission_state_transition (wyl_policy_store_t *store,
 {
   return wyl_policy_store_apply_permission_state_transition_with_audit (store,
       subject_id, perm_id, scope, event, out_event_id, NULL, 0, NULL, NULL,
-      NULL, NULL, NULL, WYL_DECISION_DENY);
+      NULL, NULL, NULL, NULL, WYL_DECISION_DENY);
 }
 
 wyrelog_error_t
@@ -2203,7 +2206,8 @@ wyrelog_error_t
     const gchar * audit_id, gint64 audit_created_at_us,
     const gchar * audit_subject_id, const gchar * audit_action,
     const gchar * audit_resource_id, const gchar * audit_deny_reason,
-    const gchar * audit_deny_origin, wyl_decision_t audit_decision)
+    const gchar * audit_deny_origin, const gchar * audit_request_id,
+    wyl_decision_t audit_decision)
 {
   if (store == NULL || store->db == NULL || subject_id == NULL
       || role_id == NULL || scope == NULL)
@@ -2223,10 +2227,11 @@ wyrelog_error_t
         role_id, scope, insert ? "grant" : "revoke");
   }
   if (rc == WYRELOG_E_OK && audit_id != NULL) {
-    rc = wyl_policy_store_append_audit_event (store, audit_id,
+    gboolean inserted = FALSE;
+    rc = wyl_policy_store_append_audit_event_full (store, audit_id,
         audit_created_at_us, audit_subject_id, audit_action,
         audit_resource_id, audit_deny_reason, audit_deny_origin,
-        audit_decision);
+        audit_request_id, audit_decision, &inserted);
   }
   if (rc == WYRELOG_E_OK)
     rc = wyl_policy_store_validate_snapshot (store);
@@ -2250,7 +2255,7 @@ wyl_policy_store_apply_role_membership_mutation (wyl_policy_store_t *store,
 {
   return wyl_policy_store_apply_role_membership_mutation_with_audit (store,
       subject_id, role_id, scope, insert, NULL, 0, NULL, NULL, NULL, NULL, NULL,
-      WYL_DECISION_DENY);
+      NULL, WYL_DECISION_DENY);
 }
 
 wyrelog_error_t

--- a/wyrelog/wyl-handle-private.h
+++ b/wyrelog/wyl-handle-private.h
@@ -298,7 +298,7 @@ wyrelog_error_t wyl_handle_insert_audit_fact (WylHandle * self,
     const gchar * id, gint64 created_at_us, const gchar * subject_id,
     const gchar * action, const gchar * resource_id,
     const gchar * deny_reason, const gchar * deny_origin,
-    wyl_decision_t decision);
+    const gchar * request_id, wyl_decision_t decision);
 
 /*
  * Probes the read engine for an exact snapshot-visible row match. Rejected

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -535,13 +535,15 @@ wyl_handle_get_audit_conn (WylHandle *self)
 static wyrelog_error_t
 insert_policy_store_audit_event (const gchar *id, gint64 created_at_us,
     const gchar *subject_id, const gchar *action, const gchar *resource_id,
-    const gchar *deny_reason, const gchar *deny_origin,
+    const gchar *deny_reason, const gchar *deny_origin, const gchar *request_id,
     wyl_decision_t decision, gpointer user_data)
 {
   WylHandle *self = user_data;
+  gboolean inserted = FALSE;
 
-  return wyl_audit_conn_insert_event (self->audit_conn, id, created_at_us,
-      subject_id, action, resource_id, deny_reason, deny_origin, decision);
+  return wyl_audit_conn_insert_event_full (self->audit_conn, id, created_at_us,
+      subject_id, action, resource_id, deny_reason, deny_origin, request_id,
+      decision, &inserted);
 }
 
 wyrelog_error_t
@@ -1477,19 +1479,19 @@ insert_audit_attr_fact (WylHandle *self, WylAuditAttrFact *attr,
 static wyrelog_error_t
 insert_policy_store_audit_fact (const gchar *id, gint64 created_at_us,
     const gchar *subject_id, const gchar *action, const gchar *resource_id,
-    const gchar *deny_reason, const gchar *deny_origin,
+    const gchar *deny_reason, const gchar *deny_origin, const gchar *request_id,
     wyl_decision_t decision, gpointer user_data)
 {
   WylHandle *self = user_data;
   return wyl_handle_insert_audit_fact (self, id, created_at_us, subject_id,
-      action, resource_id, deny_reason, deny_origin, decision);
+      action, resource_id, deny_reason, deny_origin, request_id, decision);
 }
 
 wyrelog_error_t
 wyl_handle_insert_audit_fact (WylHandle *self, const gchar *id,
     gint64 created_at_us, const gchar *subject_id, const gchar *action,
     const gchar *resource_id, const gchar *deny_reason,
-    const gchar *deny_origin, wyl_decision_t decision)
+    const gchar *deny_origin, const gchar *request_id, wyl_decision_t decision)
 {
   if (self == NULL || !WYL_IS_HANDLE (self))
     return WYRELOG_E_INVALID;
@@ -1510,6 +1512,7 @@ wyl_handle_insert_audit_fact (WylHandle *self, const gchar *id,
     {.relation = "audit_event_resource_input"},
     {.relation = "audit_event_deny_reason_input"},
     {.relation = "audit_event_deny_origin_input"},
+    {.relation = "audit_event_request_id_input"},
   };
 
   wyrelog_error_t rc =
@@ -1531,6 +1534,7 @@ wyl_handle_insert_audit_fact (WylHandle *self, const gchar *id,
     resource_id,
     deny_reason,
     deny_origin,
+    request_id,
   };
   for (gsize i = 0; i < G_N_ELEMENTS (attrs); i++) {
     rc = insert_audit_attr_fact (self, &attrs[i], audit_event[0], values[i]);

--- a/wyrelog/wyl-perm.c
+++ b/wyrelog/wyl-perm.c
@@ -433,6 +433,7 @@ update_direct_permission_store (WylHandle *handle, const gchar *subject_id,
       wyl_audit_event_get_resource_id (audit_event),
       wyl_audit_event_get_deny_reason (audit_event),
       wyl_audit_event_get_deny_origin (audit_event),
+      wyl_audit_event_get_request_id (audit_event),
       wyl_audit_event_get_decision (audit_event));
 }
 
@@ -462,6 +463,7 @@ update_role_membership_store (WylHandle *handle, const gchar *subject_id,
       wyl_audit_event_get_resource_id (audit_event),
       wyl_audit_event_get_deny_reason (audit_event),
       wyl_audit_event_get_deny_origin (audit_event),
+      wyl_audit_event_get_request_id (audit_event),
       wyl_audit_event_get_decision (audit_event));
 }
 
@@ -495,6 +497,7 @@ wyl_handle_apply_permission_state_transition (WylHandle *handle,
         wyl_audit_event_get_resource_id (audit_event),
         wyl_audit_event_get_deny_reason (audit_event),
         wyl_audit_event_get_deny_origin (audit_event),
+        wyl_audit_event_get_request_id (audit_event),
         wyl_audit_event_get_decision (audit_event));
   }
   if (rc != WYRELOG_E_OK)

--- a/wyrelog/wyl-perm.c
+++ b/wyrelog/wyl-perm.c
@@ -17,6 +17,7 @@ struct _wyl_grant_req
   gchar *action;
   gchar *resource_id;
   gchar *actor_id;
+  gchar *request_id;
 };
 
 struct _wyl_revoke_req
@@ -25,6 +26,7 @@ struct _wyl_revoke_req
   gchar *action;
   gchar *resource_id;
   gchar *actor_id;
+  gchar *request_id;
 };
 
 struct _wyl_role_grant_req
@@ -33,6 +35,7 @@ struct _wyl_role_grant_req
   gchar *role_id;
   gchar *scope;
   gchar *actor_id;
+  gchar *request_id;
 };
 
 struct _wyl_role_revoke_req
@@ -41,6 +44,7 @@ struct _wyl_role_revoke_req
   gchar *role_id;
   gchar *scope;
   gchar *actor_id;
+  gchar *request_id;
 };
 
 static wyrelog_error_t finish_policy_mutation (WylHandle * handle,
@@ -105,6 +109,7 @@ wyl_grant_req_free (wyl_grant_req_t *req)
   g_free (req->action);
   g_free (req->resource_id);
   g_free (req->actor_id);
+  g_free (req->request_id);
   g_free (req);
 }
 
@@ -168,6 +173,21 @@ wyl_grant_req_get_actor_id (const wyl_grant_req_t *req)
   return req->actor_id;
 }
 
+void
+wyl_grant_req_set_request_id (wyl_grant_req_t *req, const gchar *request_id)
+{
+  g_return_if_fail (req != NULL);
+  g_free (req->request_id);
+  req->request_id = g_strdup (request_id);
+}
+
+const gchar *
+wyl_grant_req_get_request_id (const wyl_grant_req_t *req)
+{
+  g_return_val_if_fail (req != NULL, NULL);
+  return req->request_id;
+}
+
 wyl_revoke_req_t *
 wyl_revoke_req_new (void)
 {
@@ -183,6 +203,7 @@ wyl_revoke_req_free (wyl_revoke_req_t *req)
   g_free (req->action);
   g_free (req->resource_id);
   g_free (req->actor_id);
+  g_free (req->request_id);
   g_free (req);
 }
 
@@ -246,6 +267,21 @@ wyl_revoke_req_get_actor_id (const wyl_revoke_req_t *req)
   return req->actor_id;
 }
 
+void
+wyl_revoke_req_set_request_id (wyl_revoke_req_t *req, const gchar *request_id)
+{
+  g_return_if_fail (req != NULL);
+  g_free (req->request_id);
+  req->request_id = g_strdup (request_id);
+}
+
+const gchar *
+wyl_revoke_req_get_request_id (const wyl_revoke_req_t *req)
+{
+  g_return_val_if_fail (req != NULL, NULL);
+  return req->request_id;
+}
+
 wyl_role_grant_req_t *
 wyl_role_grant_req_new (void)
 {
@@ -261,6 +297,7 @@ wyl_role_grant_req_free (wyl_role_grant_req_t *req)
   g_free (req->role_id);
   g_free (req->scope);
   g_free (req->actor_id);
+  g_free (req->request_id);
   g_free (req);
 }
 
@@ -326,6 +363,22 @@ wyl_role_grant_req_get_actor_id (const wyl_role_grant_req_t *req)
   return req->actor_id;
 }
 
+void
+wyl_role_grant_req_set_request_id (wyl_role_grant_req_t *req,
+    const gchar *request_id)
+{
+  g_return_if_fail (req != NULL);
+  g_free (req->request_id);
+  req->request_id = g_strdup (request_id);
+}
+
+const gchar *
+wyl_role_grant_req_get_request_id (const wyl_role_grant_req_t *req)
+{
+  g_return_val_if_fail (req != NULL, NULL);
+  return req->request_id;
+}
+
 wyl_role_revoke_req_t *
 wyl_role_revoke_req_new (void)
 {
@@ -341,6 +394,7 @@ wyl_role_revoke_req_free (wyl_role_revoke_req_t *req)
   g_free (req->role_id);
   g_free (req->scope);
   g_free (req->actor_id);
+  g_free (req->request_id);
   g_free (req);
 }
 
@@ -405,6 +459,22 @@ wyl_role_revoke_req_get_actor_id (const wyl_role_revoke_req_t *req)
 {
   g_return_val_if_fail (req != NULL, NULL);
   return req->actor_id;
+}
+
+void
+wyl_role_revoke_req_set_request_id (wyl_role_revoke_req_t *req,
+    const gchar *request_id)
+{
+  g_return_if_fail (req != NULL);
+  g_free (req->request_id);
+  req->request_id = g_strdup (request_id);
+}
+
+const gchar *
+wyl_role_revoke_req_get_request_id (const wyl_role_revoke_req_t *req)
+{
+  g_return_val_if_fail (req != NULL, NULL);
+  return req->request_id;
 }
 
 static wyrelog_error_t
@@ -553,6 +623,7 @@ wyl_perm_grant (WylHandle *handle, const wyl_grant_req_t *req)
   wyl_audit_event_set_action (ev, "permission_grant");
   wyl_audit_event_set_resource_id (ev, wyl_grant_req_get_resource_id (req));
   wyl_audit_event_set_deny_origin (ev, wyl_grant_req_get_action (req));
+  wyl_audit_event_set_request_id (ev, wyl_grant_req_get_request_id (req));
   wyl_audit_event_set_decision (ev, WYL_DECISION_ALLOW);
 #else
   WylAuditEvent *ev = NULL;
@@ -585,6 +656,7 @@ wyl_perm_revoke (WylHandle *handle, const wyl_revoke_req_t *req)
   wyl_audit_event_set_action (ev, "permission_revoke");
   wyl_audit_event_set_resource_id (ev, wyl_revoke_req_get_resource_id (req));
   wyl_audit_event_set_deny_origin (ev, wyl_revoke_req_get_action (req));
+  wyl_audit_event_set_request_id (ev, wyl_revoke_req_get_request_id (req));
   wyl_audit_event_set_decision (ev, WYL_DECISION_ALLOW);
 #else
   WylAuditEvent *ev = NULL;
@@ -617,6 +689,7 @@ wyl_role_grant (WylHandle *handle, const wyl_role_grant_req_t *req)
   wyl_audit_event_set_action (ev, "role_grant");
   wyl_audit_event_set_resource_id (ev, wyl_role_grant_req_get_scope (req));
   wyl_audit_event_set_deny_origin (ev, wyl_role_grant_req_get_role_id (req));
+  wyl_audit_event_set_request_id (ev, wyl_role_grant_req_get_request_id (req));
   wyl_audit_event_set_decision (ev, WYL_DECISION_ALLOW);
 #else
   WylAuditEvent *ev = NULL;
@@ -650,6 +723,7 @@ wyl_role_revoke (WylHandle *handle, const wyl_role_revoke_req_t *req)
   wyl_audit_event_set_action (ev, "role_revoke");
   wyl_audit_event_set_resource_id (ev, wyl_role_revoke_req_get_scope (req));
   wyl_audit_event_set_deny_origin (ev, wyl_role_revoke_req_get_role_id (req));
+  wyl_audit_event_set_request_id (ev, wyl_role_revoke_req_get_request_id (req));
   wyl_audit_event_set_decision (ev, WYL_DECISION_ALLOW);
 #else
   WylAuditEvent *ev = NULL;


### PR DESCRIPTION
## Summary
- add optional request IDs to audit events and audit storage
- project request IDs through runtime query JSON and wirelog audit facts
- bind daemon-generated request IDs to HTTP policy mutation audit rows

## Tests
- meson test -C builddir-ci-pr id audit-event audit-conn policy-store audit-emit handle-engine-pair login-projection client-smoke daemon-checks daemon-http-decide daemon-delta access-decision --print-errorlogs
- hooks/pre-commit.hook
- git diff --check
