### PR TITLE
audit: propagate request ids through decision and login events

### DIFF
--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -31,6 +31,8 @@ typedef struct
   const gchar *deny_reason;
   const gchar *deny_origin;
   const gchar *request_id;
+  gboolean check_decision;
+  wyl_decision_t decision;
   guint matches;
 } AuditEventProbe;
 
@@ -505,10 +507,12 @@ check_raw_decide_contract (WylHandle *handle, const gchar *base_url)
 }
 
 static gint
-send_raw_login (SoupSession *session, const gchar *method,
+send_raw_login_full (SoupSession *session, const gchar *method,
     const gchar *base_url, const gchar *query, guint *out_status,
-    gchar **out_body)
+    gchar **out_body, gchar **out_request_id)
 {
+  if (out_request_id != NULL)
+    *out_request_id = NULL;
   g_autofree gchar *root = g_strdup (base_url);
   while (root[0] != '\0' && g_str_has_suffix (root, "/"))
     root[strlen (root) - 1] = '\0';
@@ -534,7 +538,21 @@ send_raw_login (SoupSession *session, const gchar *method,
   const gchar *data = g_bytes_get_data (bytes, &size);
   *out_status = soup_message_get_status (msg);
   *out_body = g_strndup (data, size);
+  if (out_request_id != NULL) {
+    const gchar *request_id = soup_message_headers_get_one
+        (soup_message_get_response_headers (msg), "X-Wyrelog-Request-Id");
+    *out_request_id = g_strdup (request_id);
+  }
   return 0;
+}
+
+static gint
+send_raw_login (SoupSession *session, const gchar *method,
+    const gchar *base_url, const gchar *query, guint *out_status,
+    gchar **out_body)
+{
+  return send_raw_login_full (session, method, base_url, query, out_status,
+      out_body, NULL);
 }
 
 static gchar *
@@ -769,12 +787,31 @@ check_raw_login_contract (SoupServer *server, WylHandle *handle,
     return 472;
   g_clear_pointer (&body, g_free);
 
-  rc = send_raw_login (session, "POST", base_url,
-      "username=login-user&skip_mfa=true", &status, &body);
+  g_autofree gchar *denied_skip_request_id = NULL;
+  rc = send_raw_login_full (session, "POST", base_url,
+      "username=login-user&skip_mfa=true", &status, &body,
+      &denied_skip_request_id);
   if (rc != 0)
     return rc;
   if (status != 403 || strstr (body, "\"login_denied\"") == NULL)
     return 473;
+#ifdef WYL_HAS_AUDIT
+  AuditEventProbe denied_skip_audit = {
+    .subject_id = "login-user",
+    .action = "login_skip_mfa",
+    .resource_id = "principal_state",
+    .deny_reason = "skip_mfa_not_allowed",
+    .deny_origin = "login_ingress",
+    .request_id = denied_skip_request_id,
+    .check_decision = TRUE,
+    .decision = WYL_DECISION_DENY,
+  };
+  if (wyl_policy_store_foreach_audit_event (wyl_handle_get_policy_store
+          (handle), audit_event_probe_cb, &denied_skip_audit) != WYRELOG_E_OK)
+    return 1812;
+  if (denied_skip_audit.matches != 1)
+    return 1813;
+#endif
   g_clear_pointer (&body, g_free);
 
   if (wyl_policy_store_grant_direct_permission (wyl_handle_get_policy_store
@@ -784,8 +821,10 @@ check_raw_login_contract (SoupServer *server, WylHandle *handle,
   if (wyl_handle_reload_engine_pair (handle) != WYRELOG_E_OK)
     return 487;
 
-  rc = send_raw_login (session, "POST", base_url,
-      "username=login-user&skip_mfa=true", &status, &body);
+  g_autofree gchar *skip_success_request_id = NULL;
+  rc = send_raw_login_full (session, "POST", base_url,
+      "username=login-user&skip_mfa=true", &status, &body,
+      &skip_success_request_id);
   if (rc != 0)
     return rc;
   if (status != 200 ||
@@ -796,6 +835,38 @@ check_raw_login_contract (SoupServer *server, WylHandle *handle,
       extract_json_string (body, "session_token");
   if (authenticated_session_token == NULL)
     return 486;
+#ifdef WYL_HAS_AUDIT
+  AuditEventProbe principal_skip_audit = {
+    .subject_id = "login-user",
+    .action = "principal_state",
+    .resource_id = "authenticated",
+    .deny_reason = "login_skip_mfa",
+    .deny_origin = "unverified",
+    .request_id = skip_success_request_id,
+    .check_decision = TRUE,
+    .decision = WYL_DECISION_ALLOW,
+  };
+  if (wyl_policy_store_foreach_audit_event (wyl_handle_get_policy_store
+          (handle), audit_event_probe_cb, &principal_skip_audit)
+      != WYRELOG_E_OK)
+    return 1814;
+  if (principal_skip_audit.matches != 1)
+    return 1815;
+  AuditEventProbe session_skip_audit = {
+    .subject_id = authenticated_session_token,
+    .action = "session_state",
+    .resource_id = "active",
+    .deny_origin = "idle",
+    .request_id = skip_success_request_id,
+    .check_decision = TRUE,
+    .decision = WYL_DECISION_ALLOW,
+  };
+  if (wyl_policy_store_foreach_audit_event (wyl_handle_get_policy_store
+          (handle), audit_event_probe_cb, &session_skip_audit) != WYRELOG_E_OK)
+    return 1816;
+  if (session_skip_audit.matches != 1)
+    return 1817;
+#endif
   rc = verify_login_access_token (body, authenticated_session_token,
       "login-user", "authenticated", server);
   if (rc != 0)
@@ -1230,7 +1301,7 @@ audit_event_probe_cb (const gchar *id, gint64 created_at_us,
   (void) created_at_us;
   AuditEventProbe *probe = user_data;
 
-  if (decision == WYL_DECISION_ALLOW
+  if ((!probe->check_decision || decision == probe->decision)
       && g_strcmp0 (subject_id, probe->subject_id) == 0
       && g_strcmp0 (action, probe->action) == 0
       && g_strcmp0 (resource_id, probe->resource_id) == 0

--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -46,6 +46,14 @@ typedef struct
   guint matches;
 } PermissionStateProbe;
 
+#ifdef WYL_HAS_AUDIT
+static wyrelog_error_t audit_event_probe_cb (const gchar * id,
+    gint64 created_at_us, const gchar * subject_id, const gchar * action,
+    const gchar * resource_id, const gchar * deny_reason,
+    const gchar * deny_origin, const gchar * request_id,
+    wyl_decision_t decision, gpointer user_data);
+#endif
+
 static gboolean
 is_request_id_shape (const gchar *request_id)
 {
@@ -241,15 +249,17 @@ build_decide_uri (const gchar *base_url, const gchar *user, const gchar *perm,
 }
 
 static gint
-send_raw_decide (SoupSession *session, const gchar *method,
+send_raw_decide_full (SoupSession *session, const gchar *method,
     const gchar *base_url, const gchar *user, const gchar *perm,
     const gchar *scope, const gchar *extra_query, guint *out_status,
-    gchar **out_body)
+    gchar **out_body, gchar **out_request_id)
 {
   if (out_status == NULL || out_body == NULL)
     return 30;
   *out_status = 0;
   *out_body = NULL;
+  if (out_request_id != NULL)
+    *out_request_id = NULL;
 
   g_autofree gchar *uri =
       build_decide_uri (base_url, user, perm, scope, extra_query);
@@ -270,7 +280,22 @@ send_raw_decide (SoupSession *session, const gchar *method,
   const gchar *body_data = g_bytes_get_data (body, &body_size);
   *out_status = soup_message_get_status (msg);
   *out_body = g_strndup (body_data, body_size);
+  if (out_request_id != NULL) {
+    const gchar *request_id = soup_message_headers_get_one
+        (soup_message_get_response_headers (msg), "X-Wyrelog-Request-Id");
+    *out_request_id = g_strdup (request_id);
+  }
   return 0;
+}
+
+static gint
+send_raw_decide (SoupSession *session, const gchar *method,
+    const gchar *base_url, const gchar *user, const gchar *perm,
+    const gchar *scope, const gchar *extra_query, guint *out_status,
+    gchar **out_body)
+{
+  return send_raw_decide_full (session, method, base_url, user, perm, scope,
+      extra_query, out_status, out_body, NULL);
 }
 
 static gint
@@ -355,7 +380,7 @@ check_request_id_header_contract (const gchar *base_url)
 }
 
 static gint
-check_raw_decide_contract (const gchar *base_url)
+check_raw_decide_contract (WylHandle *handle, const gchar *base_url)
 {
   g_autoptr (SoupSession) session = soup_session_new ();
   guint status = 0;
@@ -394,10 +419,11 @@ check_raw_decide_contract (const gchar *base_url)
     return 39;
 
   g_clear_pointer (&body, g_free);
-  rc = send_raw_decide (session, "POST", base_url, "http-guard-user",
+  g_autofree gchar *allow_request_id = NULL;
+  rc = send_raw_decide_full (session, "POST", base_url, "http-guard-user",
       "wr.audit.read", "http-guard-scope",
       "guard_timestamp=123&guard_loc_class=public&guard_risk=69",
-      &status, &body);
+      &status, &body, &allow_request_id);
   if (rc != 0)
     return rc;
   if (status != 200)
@@ -408,6 +434,21 @@ check_raw_decide_contract (const gchar *base_url)
     return 42;
   if (strstr (body, "\"deny_origin\":null") == NULL)
     return 43;
+#ifdef WYL_HAS_AUDIT
+  AuditEventProbe allow_audit = {
+    .subject_id = "http-guard-user",
+    .action = "wr.audit.read",
+    .resource_id = "http-guard-scope",
+    .request_id = allow_request_id,
+  };
+  if (wyl_policy_store_foreach_audit_event (wyl_handle_get_policy_store
+          (handle), audit_event_probe_cb, &allow_audit) != WYRELOG_E_OK)
+    return 1810;
+  if (allow_audit.matches != 1)
+    return 1811;
+#else
+  (void) handle;
+#endif
 
   g_clear_pointer (&body, g_free);
   rc = send_raw_decide (session, "POST", base_url, "http-guard-user",
@@ -2142,7 +2183,7 @@ main (void)
   if (request_id_rc != 0)
     return request_id_rc;
 
-  gint raw_rc = check_raw_decide_contract (base_url);
+  gint raw_rc = check_raw_decide_contract (handle, base_url);
   if (raw_rc != 0)
     return raw_rc;
   gint decision = -1;

--- a/tests/test-decide-req.c
+++ b/tests/test-decide-req.c
@@ -21,6 +21,8 @@ check_defaults_are_null (void)
     return 13;
   if (wyl_decide_req_has_guard_context (req))
     return 14;
+  if (wyl_decide_req_get_request_id (req) != NULL)
+    return 15;
   return 0;
 }
 
@@ -51,6 +53,19 @@ check_resource_round_trip (void)
   wyl_decide_req_set_resource_id (req, "doc/42");
   if (g_strcmp0 (wyl_decide_req_get_resource_id (req), "doc/42") != 0)
     return 40;
+  return 0;
+}
+
+static gint
+check_request_id_round_trip (void)
+{
+  g_autoptr (wyl_decide_req_t) req = wyl_decide_req_new ();
+  wyl_decide_req_set_request_id (req, "req-123");
+  if (g_strcmp0 (wyl_decide_req_get_request_id (req), "req-123") != 0)
+    return 45;
+  wyl_decide_req_set_request_id (req, NULL);
+  if (wyl_decide_req_get_request_id (req) != NULL)
+    return 46;
   return 0;
 }
 
@@ -116,6 +131,8 @@ check_get_null_request (void)
     return 91;
   if (wyl_decide_req_get_resource_id (NULL) != NULL)
     return 92;
+  if (wyl_decide_req_get_request_id (NULL) != NULL)
+    return 93;
   return 0;
 }
 
@@ -235,6 +252,8 @@ main (void)
   if ((rc = check_action_round_trip ()) != 0)
     return rc;
   if ((rc = check_resource_round_trip ()) != 0)
+    return rc;
+  if ((rc = check_request_id_round_trip ()) != 0)
     return rc;
   if ((rc = check_caller_buffer_is_copied ()) != 0)
     return rc;

--- a/tests/test-login-req.c
+++ b/tests/test-login-req.c
@@ -14,6 +14,8 @@ check_default_username_is_null (void)
     return 11;
   if (wyl_login_req_get_skip_mfa (req))
     return 12;
+  if (wyl_login_req_get_request_id (req) != NULL)
+    return 13;
   return 0;
 }
 
@@ -76,6 +78,8 @@ check_get_null_request (void)
 {
   if (wyl_login_req_get_username (NULL) != NULL)
     return 60;
+  if (wyl_login_req_get_request_id (NULL) != NULL)
+    return 61;
   return 0;
 }
 
@@ -107,6 +111,19 @@ check_skip_mfa_null_request (void)
   return 0;
 }
 
+static gint
+check_request_id_set_then_get (void)
+{
+  g_autoptr (wyl_login_req_t) req = wyl_login_req_new ();
+  wyl_login_req_set_request_id (req, "req-login");
+  if (g_strcmp0 (wyl_login_req_get_request_id (req), "req-login") != 0)
+    return 100;
+  wyl_login_req_set_request_id (req, NULL);
+  if (wyl_login_req_get_request_id (req) != NULL)
+    return 101;
+  return 0;
+}
+
 int
 main (void)
 {
@@ -129,6 +146,8 @@ main (void)
   if ((rc = check_skip_mfa_set_then_get ()) != 0)
     return rc;
   if ((rc = check_skip_mfa_null_request ()) != 0)
+    return rc;
+  if ((rc = check_request_id_set_then_get ()) != 0)
     return rc;
 
   return 0;

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -929,6 +929,7 @@ login_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
   g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
   wyl_login_req_set_username (login, username);
   wyl_login_req_set_skip_mfa (login, skip_mfa_requested);
+  wyl_login_req_set_request_id (login, ensure_request_id_header (msg));
 
   g_autoptr (WylSession) session = NULL;
   wyrelog_error_t rc = wyl_session_login (handle, login, &session);

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -1090,6 +1090,7 @@ decide_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
   wyl_decide_req_set_subject_id (req, user);
   wyl_decide_req_set_action (req, perm);
   wyl_decide_req_set_resource_id (req, session_token);
+  wyl_decide_req_set_request_id (req, ensure_request_id_header (msg));
   if (has_guard_context) {
     gint64 timestamp = 0;
     gint64 risk = 0;

--- a/wyrelog/decide.h
+++ b/wyrelog/decide.h
@@ -55,6 +55,10 @@ void wyl_decide_req_set_resource_id (wyl_decide_req_t * req,
     const gchar * resource_id);
 const gchar *wyl_decide_req_get_resource_id (const wyl_decide_req_t * req);
 
+void wyl_decide_req_set_request_id (wyl_decide_req_t * req,
+    const gchar * request_id);
+const gchar *wyl_decide_req_get_request_id (const wyl_decide_req_t * req);
+
 /*
  * Sets or clears request-time attributes used by guarded catalogue
  * permissions. When no guard context is set, guarded permissions remain

--- a/wyrelog/session.h
+++ b/wyrelog/session.h
@@ -64,6 +64,9 @@ const gchar *wyl_login_req_get_username (const wyl_login_req_t * req);
  */
 void wyl_login_req_set_skip_mfa (wyl_login_req_t * req, gboolean skip_mfa);
 gboolean wyl_login_req_get_skip_mfa (const wyl_login_req_t * req);
+void wyl_login_req_set_request_id (wyl_login_req_t * req,
+    const gchar * request_id);
+const gchar *wyl_login_req_get_request_id (const wyl_login_req_t * req);
 
 wyrelog_error_t wyl_session_login (WylHandle * handle,
     const wyl_login_req_t * req, WylSession ** out_session);

--- a/wyrelog/wyl-decide.c
+++ b/wyrelog/wyl-decide.c
@@ -13,6 +13,7 @@ struct _wyl_decide_req
   gchar *subject_id;
   gchar *action;
   gchar *resource_id;
+  gchar *request_id;
   gboolean has_guard_context;
   gint64 guard_timestamp;
   gchar *guard_loc_class;
@@ -60,6 +61,7 @@ wyl_decide_req_free (wyl_decide_req_t *req)
   g_free (req->subject_id);
   g_free (req->action);
   g_free (req->resource_id);
+  g_free (req->request_id);
   g_free (req->guard_loc_class);
   g_free (req);
 }
@@ -107,6 +109,21 @@ wyl_decide_req_get_resource_id (const wyl_decide_req_t *req)
 {
   g_return_val_if_fail (req != NULL, NULL);
   return req->resource_id;
+}
+
+void
+wyl_decide_req_set_request_id (wyl_decide_req_t *req, const gchar *request_id)
+{
+  g_return_if_fail (req != NULL);
+  g_free (req->request_id);
+  req->request_id = g_strdup (request_id);
+}
+
+const gchar *
+wyl_decide_req_get_request_id (const wyl_decide_req_t *req)
+{
+  g_return_val_if_fail (req != NULL, NULL);
+  return req->request_id;
 }
 
 void
@@ -619,6 +636,7 @@ emit_audit:
   wyl_audit_event_set_resource_id (ev, wyl_decide_req_get_resource_id (req));
   wyl_audit_event_set_deny_reason (ev, deny_reason);
   wyl_audit_event_set_deny_origin (ev, deny_origin);
+  wyl_audit_event_set_request_id (ev, wyl_decide_req_get_request_id (req));
   wyl_audit_event_set_decision (ev, wyl_decide_resp_get_decision (resp));
   if (wyl_audit_emit (handle, ev) != WYRELOG_E_OK)
     fail_closed_for_audit (resp);

--- a/wyrelog/wyl-perm.c
+++ b/wyrelog/wyl-perm.c
@@ -8,6 +8,7 @@
 struct _wyl_login_req
 {
   gchar *username;
+  gchar *request_id;
   gboolean skip_mfa;
 };
 
@@ -62,6 +63,7 @@ wyl_login_req_free (wyl_login_req_t *req)
   if (req == NULL)
     return;
   g_free (req->username);
+  g_free (req->request_id);
   g_free (req);
 }
 
@@ -92,6 +94,21 @@ wyl_login_req_get_skip_mfa (const wyl_login_req_t *req)
 {
   g_return_val_if_fail (req != NULL, FALSE);
   return req->skip_mfa;
+}
+
+void
+wyl_login_req_set_request_id (wyl_login_req_t *req, const gchar *request_id)
+{
+  g_return_if_fail (req != NULL);
+  g_free (req->request_id);
+  req->request_id = g_strdup (request_id);
+}
+
+const gchar *
+wyl_login_req_get_request_id (const wyl_login_req_t *req)
+{
+  g_return_val_if_fail (req != NULL, NULL);
+  return req->request_id;
 }
 
 wyl_grant_req_t *

--- a/wyrelog/wyl-session.c
+++ b/wyrelog/wyl-session.c
@@ -106,7 +106,7 @@ login_skip_mfa_allowed (WylHandle *handle, const wyl_login_req_t *req,
 
 #ifdef WYL_HAS_AUDIT
 static WylAuditEvent *
-new_login_skip_mfa_denied_audit (const gchar *username)
+new_login_skip_mfa_denied_audit (const gchar *username, const gchar *request_id)
 {
   WylAuditEvent *ev = wyl_audit_event_new ();
   wyl_audit_event_set_subject_id (ev, username);
@@ -114,20 +114,24 @@ new_login_skip_mfa_denied_audit (const gchar *username)
   wyl_audit_event_set_resource_id (ev, "principal_state");
   wyl_audit_event_set_deny_reason (ev, "skip_mfa_not_allowed");
   wyl_audit_event_set_deny_origin (ev, "login_ingress");
+  wyl_audit_event_set_request_id (ev, request_id);
   wyl_audit_event_set_decision (ev, WYL_DECISION_DENY);
   return ev;
 }
 
 static wyrelog_error_t
-emit_login_skip_mfa_denied_audit (WylHandle *handle, const gchar *username)
+emit_login_skip_mfa_denied_audit (WylHandle *handle, const gchar *username,
+    const gchar *request_id)
 {
-  g_autoptr (WylAuditEvent) ev = new_login_skip_mfa_denied_audit (username);
+  g_autoptr (WylAuditEvent) ev =
+      new_login_skip_mfa_denied_audit (username, request_id);
   return wyl_audit_emit (handle, ev);
 }
 
 static WylAuditEvent *
 new_principal_state_audit (const gchar *username,
-    const gchar *old_state, const gchar *new_state, const gchar *event)
+    const gchar *old_state, const gchar *new_state, const gchar *event,
+    const gchar *request_id)
 {
   WylAuditEvent *ev = wyl_audit_event_new ();
   wyl_audit_event_set_subject_id (ev, username);
@@ -135,10 +139,28 @@ new_principal_state_audit (const gchar *username,
   wyl_audit_event_set_resource_id (ev, new_state);
   wyl_audit_event_set_deny_reason (ev, event);
   wyl_audit_event_set_deny_origin (ev, old_state);
+  wyl_audit_event_set_request_id (ev, request_id);
   wyl_audit_event_set_decision (ev, WYL_DECISION_ALLOW);
   return ev;
 }
 #endif
+
+static wyrelog_error_t
+append_policy_audit_event (wyl_policy_store_t *store, const gchar *audit_id,
+    const WylAuditEvent *event)
+{
+  gboolean inserted = FALSE;
+
+  return wyl_policy_store_append_audit_event_full (store, audit_id,
+      wyl_audit_event_get_created_at_us (event),
+      wyl_audit_event_get_subject_id (event),
+      wyl_audit_event_get_action (event),
+      wyl_audit_event_get_resource_id (event),
+      wyl_audit_event_get_deny_reason (event),
+      wyl_audit_event_get_deny_origin (event),
+      wyl_audit_event_get_request_id (event),
+      wyl_audit_event_get_decision (event), &inserted);
+}
 
 static wyrelog_error_t
 insert_principal_event_fact (WylHandle *handle, gint64 event_id,
@@ -219,14 +241,7 @@ apply_principal_state_mutation (WylHandle *handle, const gchar *username,
         event_name, old_state_name, new_state_name, &event_id);
   }
   if (rc == WYRELOG_E_OK && audit_event != NULL) {
-    rc = wyl_policy_store_append_audit_event (store, audit_id,
-        wyl_audit_event_get_created_at_us (audit_event),
-        wyl_audit_event_get_subject_id (audit_event),
-        wyl_audit_event_get_action (audit_event),
-        wyl_audit_event_get_resource_id (audit_event),
-        wyl_audit_event_get_deny_reason (audit_event),
-        wyl_audit_event_get_deny_origin (audit_event),
-        wyl_audit_event_get_decision (audit_event));
+    rc = append_policy_audit_event (store, audit_id, audit_event);
   }
   if (rc == WYRELOG_E_OK)
     rc = wyl_policy_store_commit_mutation (store);
@@ -270,7 +285,8 @@ transition_principal_state (WylHandle *handle, const gchar *username,
 #ifdef WYL_HAS_AUDIT
   g_autoptr (WylAuditEvent) ev = new_principal_state_audit (username,
       old_state_name,
-      new_state_name, wyl_principal_event_name (WYL_PRINCIPAL_EVENT_MFA_OK));
+      new_state_name, wyl_principal_event_name (WYL_PRINCIPAL_EVENT_MFA_OK),
+      NULL);
 #else
   WylAuditEvent *ev = NULL;
 #endif
@@ -289,13 +305,14 @@ transition_principal_state (WylHandle *handle, const gchar *username,
 #ifdef WYL_HAS_AUDIT
 static WylAuditEvent *
 new_session_state_audit (const gchar *session_id,
-    const gchar *old_state, const gchar *new_state)
+    const gchar *old_state, const gchar *new_state, const gchar *request_id)
 {
   WylAuditEvent *ev = wyl_audit_event_new ();
   wyl_audit_event_set_subject_id (ev, session_id);
   wyl_audit_event_set_action (ev, "session_state");
   wyl_audit_event_set_resource_id (ev, new_state);
   wyl_audit_event_set_deny_origin (ev, old_state);
+  wyl_audit_event_set_request_id (ev, request_id);
   wyl_audit_event_set_decision (ev, WYL_DECISION_ALLOW);
   return ev;
 }
@@ -380,14 +397,7 @@ apply_session_state_mutation (WylHandle *handle, const gchar *session_id,
         event_name, old_state_name, new_state_name, &event_id);
   }
   if (rc == WYRELOG_E_OK && audit_event != NULL) {
-    rc = wyl_policy_store_append_audit_event (store, audit_id,
-        wyl_audit_event_get_created_at_us (audit_event),
-        wyl_audit_event_get_subject_id (audit_event),
-        wyl_audit_event_get_action (audit_event),
-        wyl_audit_event_get_resource_id (audit_event),
-        wyl_audit_event_get_deny_reason (audit_event),
-        wyl_audit_event_get_deny_origin (audit_event),
-        wyl_audit_event_get_decision (audit_event));
+    rc = append_policy_audit_event (store, audit_id, audit_event);
   }
   if (rc == WYRELOG_E_OK)
     rc = wyl_policy_store_commit_mutation (store);
@@ -475,14 +485,8 @@ apply_login_state_mutation (WylHandle *handle, const gchar *username,
         &principal_event_id);
   }
   if (rc == WYRELOG_E_OK && principal_audit_event != NULL) {
-    rc = wyl_policy_store_append_audit_event (store, principal_audit_id,
-        wyl_audit_event_get_created_at_us (principal_audit_event),
-        wyl_audit_event_get_subject_id (principal_audit_event),
-        wyl_audit_event_get_action (principal_audit_event),
-        wyl_audit_event_get_resource_id (principal_audit_event),
-        wyl_audit_event_get_deny_reason (principal_audit_event),
-        wyl_audit_event_get_deny_origin (principal_audit_event),
-        wyl_audit_event_get_decision (principal_audit_event));
+    rc = append_policy_audit_event (store, principal_audit_id,
+        principal_audit_event);
   }
   if (rc == WYRELOG_E_OK)
     rc = wyl_policy_store_set_session_state (store, session_id,
@@ -493,14 +497,8 @@ apply_login_state_mutation (WylHandle *handle, const gchar *username,
         &session_event_id);
   }
   if (rc == WYRELOG_E_OK && session_audit_event != NULL) {
-    rc = wyl_policy_store_append_audit_event (store, session_audit_id,
-        wyl_audit_event_get_created_at_us (session_audit_event),
-        wyl_audit_event_get_subject_id (session_audit_event),
-        wyl_audit_event_get_action (session_audit_event),
-        wyl_audit_event_get_resource_id (session_audit_event),
-        wyl_audit_event_get_deny_reason (session_audit_event),
-        wyl_audit_event_get_deny_origin (session_audit_event),
-        wyl_audit_event_get_decision (session_audit_event));
+    rc = append_policy_audit_event (store, session_audit_id,
+        session_audit_event);
   }
   if (rc == WYRELOG_E_OK)
     rc = wyl_policy_store_commit_mutation (store);
@@ -528,7 +526,7 @@ transition_session_state (WylHandle *handle, WylSession *session,
 
 #ifdef WYL_HAS_AUDIT
   g_autoptr (WylAuditEvent) ev = new_session_state_audit (session_id,
-      old_state_name, new_state_name);
+      old_state_name, new_state_name, NULL);
 #else
   WylAuditEvent *ev = NULL;
 #endif
@@ -567,7 +565,7 @@ wyl_session_login (WylHandle *handle, const wyl_login_req_t *req,
     if (!skip_mfa_allowed) {
 #ifdef WYL_HAS_AUDIT
       wyrelog_error_t audit_rc = emit_login_skip_mfa_denied_audit (handle,
-          wyl_login_req_get_username (req));
+          wyl_login_req_get_username (req), wyl_login_req_get_request_id (req));
       if (audit_rc != WYRELOG_E_OK)
         return audit_rc;
 #endif
@@ -601,10 +599,12 @@ wyl_session_login (WylHandle *handle, const wyl_login_req_t *req,
     g_autoptr (WylAuditEvent) principal_ev =
         new_principal_state_audit (username,
         wyl_principal_state_name (WYL_PRINCIPAL_STATE_UNVERIFIED),
-        wyl_principal_state_name (state), wyl_principal_event_name (event));
+        wyl_principal_state_name (state), wyl_principal_event_name (event),
+        wyl_login_req_get_request_id (req));
     g_autoptr (WylAuditEvent) session_ev =
         new_session_state_audit (session_id,
-        wyl_session_state_name (session->state), "active");
+        wyl_session_state_name (session->state), "active",
+        wyl_login_req_get_request_id (req));
 #else
     WylAuditEvent *principal_ev = NULL;
     WylAuditEvent *session_ev = NULL;
@@ -648,7 +648,8 @@ wyl_session_login (WylHandle *handle, const wyl_login_req_t *req,
   }
 #ifdef WYL_HAS_AUDIT
   g_autoptr (WylAuditEvent) ev = new_session_state_audit (session_id,
-      wyl_session_state_name (session->state), "active");
+      wyl_session_state_name (session->state), "active",
+      req != NULL ? wyl_login_req_get_request_id (req) : NULL);
 #else
   WylAuditEvent *ev = NULL;
 #endif


### PR DESCRIPTION
## Summary
- carry HTTP request IDs through decision request carriers and audit events
- carry HTTP request IDs through login request carriers and lifecycle audit rows
- cover decision, skip-MFA denial, and skip-MFA success audit correlation

## Tests
- meson test -C builddir-ci-pr decide decide-req login-req session-username daemon-http-decide audit-emit client-smoke handle-engine-pair login-projection audit-event audit-conn policy-store --print-errorlogs
- hooks/pre-commit.hook
- git diff --check
