### PR TITLE
audit: complete HTTP request id lifecycle coverage

### DIFF
--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -1548,8 +1548,10 @@ check_policy_permission_mutation_contract (WylHandle *handle,
       g_strdup_printf ("subject=target&perm=site.policy.read&scope=tenant-a"
       "&session_token=%s&guard_timestamp=123&guard_loc_class=public"
       "&guard_risk=50", session_token);
-  rc = send_raw_policy_mutation (session, "POST", base_url,
-      "/policy/permissions/grant", guard_denied_query, &status, &body);
+  g_autofree gchar *guard_denied_request_id = NULL;
+  rc = send_raw_policy_mutation_full (session, "POST", base_url,
+      "/policy/permissions/grant", guard_denied_query, &status, &body,
+      &guard_denied_request_id);
   if (rc != 0)
     return rc;
   if (status != 403 || strstr (body, "\"policy_denied\"") == NULL)
@@ -1557,6 +1559,21 @@ check_policy_permission_mutation_contract (WylHandle *handle,
   if (direct_permission_exists (handle, "target", "site.policy.read",
           "tenant-a"))
     return 134;
+  AuditEventProbe guard_denied_audit = {
+    .subject_id = "http-policy-admin",
+    .action = "wr.policy.write",
+    .resource_id = "tenant-a",
+    .deny_reason = "not_armed",
+    .deny_origin = "perm_state",
+    .request_id = guard_denied_request_id,
+    .check_decision = TRUE,
+    .decision = WYL_DECISION_DENY,
+  };
+  if (wyl_policy_store_foreach_audit_event (store, audit_event_probe_cb,
+          &guard_denied_audit) != WYRELOG_E_OK)
+    return 200;
+  if (guard_denied_audit.matches != 1)
+    return 201;
   g_clear_pointer (&body, g_free);
 
   g_autofree gchar *transition_request_id = NULL;
@@ -1683,6 +1700,19 @@ check_policy_permission_mutation_contract (WylHandle *handle,
     return 196;
   if (grant_audit.matches != 1)
     return 197;
+  AuditEventProbe grant_auth_audit = {
+    .subject_id = "http-policy-admin",
+    .action = "wr.policy.write",
+    .resource_id = "tenant-a",
+    .request_id = grant_request_id,
+    .check_decision = TRUE,
+    .decision = WYL_DECISION_ALLOW,
+  };
+  if (wyl_policy_store_foreach_audit_event (store, audit_event_probe_cb,
+          &grant_auth_audit) != WYRELOG_E_OK)
+    return 202;
+  if (grant_auth_audit.matches != 1)
+    return 203;
   g_clear_pointer (&body, g_free);
 
   rc = send_raw_policy_mutation_bearer (session, "POST", base_url,

--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -655,14 +655,16 @@ sign_test_access_token (SoupServer *server, const gchar *session_id,
 #endif
 
 static gint
-send_raw_logout (SoupSession *session, const gchar *method,
+send_raw_logout_full (SoupSession *session, const gchar *method,
     const gchar *base_url, const gchar *query, guint *out_status,
-    gchar **out_body)
+    gchar **out_body, gchar **out_request_id)
 {
   if (out_status == NULL || out_body == NULL)
     return 484;
   *out_status = 0;
   *out_body = NULL;
+  if (out_request_id != NULL)
+    *out_request_id = NULL;
 
   g_autofree gchar *root = g_strdup (base_url);
   while (root[0] != '\0' && g_str_has_suffix (root, "/"))
@@ -683,6 +685,11 @@ send_raw_logout (SoupSession *session, const gchar *method,
   gint rc = check_response_request_id_header (msg, 514);
   if (rc != 0)
     return rc;
+  if (out_request_id != NULL) {
+    const gchar *request_id = soup_message_headers_get_one
+        (soup_message_get_response_headers (msg), "X-Wyrelog-Request-Id");
+    *out_request_id = g_strdup (request_id);
+  }
   gsize size = 0;
   const gchar *data = g_bytes_get_data (bytes, &size);
   *out_status = soup_message_get_status (msg);
@@ -691,14 +698,25 @@ send_raw_logout (SoupSession *session, const gchar *method,
 }
 
 static gint
-send_raw_logout_authorization (SoupSession *session, const gchar *method,
+send_raw_logout (SoupSession *session, const gchar *method,
+    const gchar *base_url, const gchar *query, guint *out_status,
+    gchar **out_body)
+{
+  return send_raw_logout_full (session, method, base_url, query, out_status,
+      out_body, NULL);
+}
+
+static gint
+send_raw_logout_authorization_full (SoupSession *session, const gchar *method,
     const gchar *base_url, const gchar *query, const gchar *authorization,
-    guint *out_status, gchar **out_body)
+    guint *out_status, gchar **out_body, gchar **out_request_id)
 {
   if (out_status == NULL || out_body == NULL)
     return 484;
   *out_status = 0;
   *out_body = NULL;
+  if (out_request_id != NULL)
+    *out_request_id = NULL;
 
   g_autofree gchar *root = g_strdup (base_url);
   while (root[0] != '\0' && g_str_has_suffix (root, "/"))
@@ -721,11 +739,25 @@ send_raw_logout_authorization (SoupSession *session, const gchar *method,
   gint rc = check_response_request_id_header (msg, 515);
   if (rc != 0)
     return rc;
+  if (out_request_id != NULL) {
+    const gchar *request_id = soup_message_headers_get_one
+        (soup_message_get_response_headers (msg), "X-Wyrelog-Request-Id");
+    *out_request_id = g_strdup (request_id);
+  }
   gsize size = 0;
   const gchar *data = g_bytes_get_data (bytes, &size);
   *out_status = soup_message_get_status (msg);
   *out_body = g_strndup (data, size);
   return 0;
+}
+
+static gint
+send_raw_logout_authorization (SoupSession *session, const gchar *method,
+    const gchar *base_url, const gchar *query, const gchar *authorization,
+    guint *out_status, gchar **out_body)
+{
+  return send_raw_logout_authorization_full (session, method, base_url, query,
+      authorization, out_status, out_body, NULL);
 }
 
 static gint send_raw_policy_mutation (SoupSession * session,
@@ -1009,8 +1041,9 @@ check_raw_login_contract (SoupServer *server, WylHandle *handle,
     return 494;
   g_clear_pointer (&body, g_free);
 
-  rc = send_raw_logout (session, "POST", base_url, logout_query, &status,
-      &body);
+  g_autofree gchar *logout_request_id = NULL;
+  rc = send_raw_logout_full (session, "POST", base_url, logout_query, &status,
+      &body, &logout_request_id);
   if (rc != 0)
     return rc;
   if (status != 200 || strstr (body, "\"ok\":true") == NULL)
@@ -1028,6 +1061,22 @@ check_raw_login_contract (SoupServer *server, WylHandle *handle,
     return 497;
   if (closed_expect.matches != 1)
     return 498;
+#ifdef WYL_HAS_AUDIT
+  AuditEventProbe close_audit = {
+    .subject_id = logout_session_token,
+    .action = "session_state",
+    .resource_id = "closed",
+    .deny_origin = "active",
+    .request_id = logout_request_id,
+    .check_decision = TRUE,
+    .decision = WYL_DECISION_ALLOW,
+  };
+  if (wyl_policy_store_foreach_audit_event (wyl_handle_get_policy_store
+          (handle), audit_event_probe_cb, &close_audit) != WYRELOG_E_OK)
+    return 1818;
+  if (close_audit.matches != 1)
+    return 1819;
+#endif
   g_clear_pointer (&body, g_free);
 
   g_autofree gchar *guarded_query = g_strdup_printf ("session_token=%s"
@@ -1099,8 +1148,9 @@ check_raw_login_contract (SoupServer *server, WylHandle *handle,
     return 507;
   g_clear_pointer (&body, g_free);
 
-  rc = send_raw_logout_authorization (session, "POST", base_url, NULL,
-      bearer_authorization, &status, &body);
+  g_autofree gchar *bearer_logout_request_id = NULL;
+  rc = send_raw_logout_authorization_full (session, "POST", base_url, NULL,
+      bearer_authorization, &status, &body, &bearer_logout_request_id);
   if (rc != 0)
     return rc;
   if (status != 200 || strstr (body, "\"ok\":true") == NULL)
@@ -1109,6 +1159,22 @@ check_raw_login_contract (SoupServer *server, WylHandle *handle,
       wyl_daemon_http_ref_session (server, bearer_logout_session_token);
   if (bearer_logged_out_session != NULL)
     return 509;
+#ifdef WYL_HAS_AUDIT
+  AuditEventProbe bearer_close_audit = {
+    .subject_id = bearer_logout_session_token,
+    .action = "session_state",
+    .resource_id = "closed",
+    .deny_origin = "active",
+    .request_id = bearer_logout_request_id,
+    .check_decision = TRUE,
+    .decision = WYL_DECISION_ALLOW,
+  };
+  if (wyl_policy_store_foreach_audit_event (wyl_handle_get_policy_store
+          (handle), audit_event_probe_cb, &bearer_close_audit) != WYRELOG_E_OK)
+    return 1820;
+  if (bearer_close_audit.matches != 1)
+    return 1821;
+#endif
   g_clear_pointer (&body, g_free);
 
   g_autofree gchar *bearer_guarded_query =

--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -2043,12 +2043,14 @@ send_raw_audit (SoupSession *session, const gchar *base_url,
 }
 
 static gint
-send_raw_audit_bearer (SoupSession *session, const gchar *base_url,
+send_raw_audit_bearer_full (SoupSession *session, const gchar *base_url,
     const gchar *query, const gchar *access_token, guint *out_status,
-    gchar **out_body)
+    gchar **out_body, gchar **out_request_id)
 {
   if (access_token == NULL)
     return 89;
+  if (out_request_id != NULL)
+    *out_request_id = NULL;
 
   g_autofree gchar *uri = build_audit_uri (base_url, query);
   g_autoptr (SoupMessage) msg = soup_message_new ("GET", uri);
@@ -2067,11 +2069,25 @@ send_raw_audit_bearer (SoupSession *session, const gchar *base_url,
   gint rc = check_response_request_id_header (msg, 111);
   if (rc != 0)
     return rc;
+  if (out_request_id != NULL) {
+    const gchar *request_id = soup_message_headers_get_one
+        (soup_message_get_response_headers (msg), "X-Wyrelog-Request-Id");
+    *out_request_id = g_strdup (request_id);
+  }
   gsize size = 0;
   const gchar *data = g_bytes_get_data (bytes, &size);
   *out_status = soup_message_get_status (msg);
   *out_body = g_strndup (data, size);
   return 0;
+}
+
+static gint
+send_raw_audit_bearer (SoupSession *session, const gchar *base_url,
+    const gchar *query, const gchar *access_token, guint *out_status,
+    gchar **out_body)
+{
+  return send_raw_audit_bearer_full (session, base_url, query, access_token,
+      out_status, out_body, NULL);
 }
 
 static gint
@@ -2155,12 +2171,32 @@ check_raw_audit_contract (SoupServer *server, WylHandle *handle,
   g_autofree gchar *bearer_allowed =
       g_strdup_printf ("guard_timestamp=123&guard_loc_class=public"
       "&guard_risk=69");
-  rc = send_raw_audit_bearer (session, base_url, bearer_allowed, access_token,
-      &status, &body);
+  g_autofree gchar *bearer_allowed_request_id = NULL;
+  rc = send_raw_audit_bearer_full (session, base_url, bearer_allowed,
+      access_token, &status, &body, &bearer_allowed_request_id);
   if (rc != 0)
     return rc;
   if (status != 200 || strstr (body, "[") == NULL)
     return 106;
+
+  g_clear_pointer (&body, g_free);
+  g_autofree gchar *request_filter =
+      g_strdup_printf ("request_id(\"%s\")", bearer_allowed_request_id);
+  g_autofree gchar *escaped_request_filter =
+      g_uri_escape_string (request_filter, NULL, TRUE);
+  g_autofree gchar *request_filter_query =
+      g_strdup_printf ("filter=%s&guard_timestamp=123"
+      "&guard_loc_class=public&guard_risk=69", escaped_request_filter);
+  rc = send_raw_audit_bearer (session, base_url, request_filter_query,
+      access_token, &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 200 ||
+      strstr (body, "\"subject_id\":\"http-audit-user\"") == NULL ||
+      strstr (body, "\"action\":\"wr.audit.read\"") == NULL ||
+      strstr (body, "\"request_id\":\"") == NULL ||
+      strstr (body, bearer_allowed_request_id) == NULL)
+    return 160;
 
   g_clear_pointer (&body, g_free);
   g_autofree gchar *mixed =

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -527,6 +527,7 @@ authorize_guarded_session_action (SoupServer *server, SoupServerMessage *msg,
   wyl_decide_req_set_resource_id (req,
       resource != NULL ? resource : auth_session_id);
   wyl_decide_req_set_guard_context (req, timestamp, guard_loc_class, risk);
+  wyl_decide_req_set_request_id (req, ensure_request_id_header (msg));
 
   wyrelog_error_t rc = wyl_decide (ctx->handle, req, resp);
   if (rc == WYRELOG_E_INVALID) {

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -1028,7 +1028,9 @@ logout_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
     return;
   }
 
-  wyrelog_error_t rc = wyl_session_close (ctx->handle, session);
+  const gchar *request_id = ensure_request_id_header (msg);
+  wyrelog_error_t rc =
+      wyl_session_close_with_request_id (ctx->handle, session, request_id);
   if (rc != WYRELOG_E_OK) {
     set_json_error (msg, 500, "logout_failed");
     return;

--- a/wyrelog/session.h
+++ b/wyrelog/session.h
@@ -94,6 +94,8 @@ wyrelog_error_t wyl_session_idle_timeout (WylHandle * handle,
     WylSession * session);
 wyrelog_error_t wyl_session_expire (WylHandle * handle, WylSession * session);
 wyrelog_error_t wyl_session_close (WylHandle * handle, WylSession * session);
+wyrelog_error_t wyl_session_close_with_request_id (WylHandle * handle,
+    WylSession * session, const gchar * request_id);
 wyrelog_error_t wyl_session_logout (WylHandle * handle, wyl_session_id_t sid);
 
 /*

--- a/wyrelog/wyl-session.c
+++ b/wyrelog/wyl-session.c
@@ -516,7 +516,7 @@ apply_login_state_mutation (WylHandle *handle, const gchar *username,
 static wyrelog_error_t
 transition_session_state (WylHandle *handle, WylSession *session,
     wyl_session_state_t old_state, wyl_session_event_t event,
-    wyl_session_state_t new_state)
+    wyl_session_state_t new_state, const gchar *request_id)
 {
   g_autofree gchar *session_id = wyl_session_dup_id_string (session);
   const gchar *old_state_name = wyl_session_state_name (old_state);
@@ -526,7 +526,7 @@ transition_session_state (WylHandle *handle, WylSession *session,
 
 #ifdef WYL_HAS_AUDIT
   g_autoptr (WylAuditEvent) ev = new_session_state_audit (session_id,
-      old_state_name, new_state_name, NULL);
+      old_state_name, new_state_name, request_id);
 #else
   WylAuditEvent *ev = NULL;
 #endif
@@ -721,7 +721,8 @@ wyl_session_mfa_verify_with_proof (WylHandle *handle, WylSession *session,
 }
 
 wyrelog_error_t
-wyl_session_close (WylHandle *handle, WylSession *session)
+wyl_session_close_with_request_id (WylHandle *handle, WylSession *session,
+    const gchar *request_id)
 {
   if (handle == NULL || session == NULL || !WYL_IS_SESSION (session))
     return WYRELOG_E_INVALID;
@@ -733,7 +734,13 @@ wyl_session_close (WylHandle *handle, WylSession *session)
     return (rc == WYRELOG_E_OK) ? WYRELOG_E_INTERNAL : rc;
 
   return transition_session_state (handle, session, session->state,
-      WYL_SESSION_EVENT_LOGOUT, state);
+      WYL_SESSION_EVENT_LOGOUT, state, request_id);
+}
+
+wyrelog_error_t
+wyl_session_close (WylHandle *handle, WylSession *session)
+{
+  return wyl_session_close_with_request_id (handle, session, NULL);
 }
 
 wyrelog_error_t
@@ -749,7 +756,7 @@ wyl_session_elevate (WylHandle *handle, WylSession *session)
     return (rc == WYRELOG_E_OK) ? WYRELOG_E_INTERNAL : rc;
 
   return transition_session_state (handle, session, session->state,
-      WYL_SESSION_EVENT_ELEVATE_GRANT, state);
+      WYL_SESSION_EVENT_ELEVATE_GRANT, state, NULL);
 }
 
 wyrelog_error_t
@@ -765,7 +772,7 @@ wyl_session_drop_elevation (WylHandle *handle, WylSession *session)
     return (rc == WYRELOG_E_OK) ? WYRELOG_E_INTERNAL : rc;
 
   return transition_session_state (handle, session, session->state,
-      WYL_SESSION_EVENT_ELEVATE_DROP, state);
+      WYL_SESSION_EVENT_ELEVATE_DROP, state, NULL);
 }
 
 wyrelog_error_t
@@ -781,7 +788,7 @@ wyl_session_idle_timeout (WylHandle *handle, WylSession *session)
     return (rc == WYRELOG_E_OK) ? WYRELOG_E_INTERNAL : rc;
 
   return transition_session_state (handle, session, session->state,
-      WYL_SESSION_EVENT_IDLE_TIMEOUT, state);
+      WYL_SESSION_EVENT_IDLE_TIMEOUT, state, NULL);
 }
 
 wyrelog_error_t
@@ -797,7 +804,7 @@ wyl_session_expire (WylHandle *handle, WylSession *session)
     return rc;
 
   return transition_session_state (handle, session, session->state,
-      WYL_SESSION_EVENT_EXPIRY, state);
+      WYL_SESSION_EVENT_EXPIRY, state, NULL);
 }
 
 wyrelog_error_t


### PR DESCRIPTION
## Summary

- Bind daemon request ids to guarded authorization decision audit rows.
- Bind HTTP logout close audit rows to their response request ids.
- Verify audit queries can filter by an HTTP-generated request id.

## Validation

- `meson test -C builddir-ci-pr daemon-http-decide session-username audit-emit daemon-checks client-smoke handle-engine-pair --print-errorlogs`
- `meson test -C builddir-audit daemon-http-decide audit-emit daemon-checks session-username --print-errorlogs`
- `hooks/pre-commit.hook`
- `git diff --check`
