### PR TITLE
audit: probe request_id column via pragma_table_info

### DIFF
--- a/wyrelog/audit/conn.c
+++ b/wyrelog/audit/conn.c
@@ -148,9 +148,15 @@ static wyrelog_error_t
 ensure_audit_events_request_id_column (wyl_audit_conn_t *conn)
 {
   duckdb_result result = { 0 };
+  /* DuckDB v1.5.1's information_schema.columns view binds an internal
+   * "system" catalog that is not resolvable on an open in-memory database,
+   * surfacing as a Binder Error and breaking init for every caller that
+   * runs the audit schema migration. pragma_table_info is the portable
+   * column-existence probe in DuckDB and matches the SQLite migration in
+   * wyl_policy_store_create_schema. */
   static const gchar *probe_sql =
-      "SELECT COUNT(*) FROM information_schema.columns "
-      "WHERE table_name = 'audit_events' AND column_name = 'request_id';";
+      "SELECT COUNT(*) FROM pragma_table_info('audit_events') "
+      "WHERE name = 'request_id';";
 
   if (duckdb_query (conn->conn, probe_sql, &result) != DuckDBSuccess) {
     duckdb_destroy_result (&result);


### PR DESCRIPTION
## Summary

- `wyl_audit_conn_create_schema` started failing with `WYRELOG_E_IO` after the recent audit-request-id work landed (`c230084` and following), so every `wyl_init` / `wyrelogd --check` / unit test that touches the audit sink now bails at init with `wyrelogd: init failed: i/o error`. CI Main has been red on every push since.
- Root cause: `ensure_audit_events_request_id_column` probes for the new column with a query against `information_schema.columns`. DuckDB v1.5.1 (the vendored amalgamated build) implements that view in a way that binds an internal `system` catalog whose absence on a freshly opened in-memory database surfaces as `Binder Error: Referenced table "system" not found!`. `information_schema.tables` happens to bind without it, which is why the older `wyl_audit_conn_table_exists` probe was unaffected and only the new column probe regressed.
- Fix swaps the probe to `pragma_table_info('audit_events')`, which is the portable column-existence query in DuckDB and matches the `PRAGMA table_info` migration `wyl_policy_store_create_schema` already uses for the SQLite policy store. The `ALTER TABLE ... ADD COLUMN` migration arm is unchanged, so persistent DuckDB stores written before `request_id` was added still upgrade in place.

Reproducer (current `main`, before this patch):

```c
duckdb_open(NULL, &db); duckdb_connect(db, &conn);
duckdb_query(conn, "CREATE TABLE audit_events (id VARCHAR, request_id VARCHAR);", &r);
duckdb_query(conn,
  "SELECT COUNT(*) FROM information_schema.columns "
  "WHERE table_name='audit_events' AND column_name='request_id';", &r);
// -> Binder Error: Referenced table "system" not found!

duckdb_query(conn,
  "SELECT COUNT(*) FROM pragma_table_info('audit_events') "
  "WHERE name='request_id';", &r);
// -> OK, count=1
```

## Test plan

- [x] `meson compile -C builddir` clean.
- [x] `wyrelogd --template-dir=... --policy-db=... --audit-db=... --check` exits 0 (was exit 1 with `init failed: i/o error`).
- [x] `meson test -C builddir`: 51/56 pass, no `init failed: i/o error` rows in `testlog.txt` (was 6+ before). The four remaining failures (`wyrelogd-healthz`, `client-audit-daemon`, `handle-engine-pair`, `session-username`) are pre-existing local-environment-only items (5 s poll window in two driver scripts; two slow tests that exceed the 30 s default meson timeout under ASAN load). They were already failing on `main` before the audit-request-id series and are out of scope here.
- [ ] CI Main green on the resulting commit.