### PR TITLE
access: add LoBAC template drift guards

### DIFF
--- a/tests/test-access-decision.c
+++ b/tests/test-access-decision.c
@@ -444,6 +444,77 @@ append_non_comment_lines (GString *out, const gchar *contents)
 }
 
 static gint
+paren_delta (const gchar *line)
+{
+  gint delta = 0;
+
+  for (const gchar * p = line; *p != '\0'; p++) {
+    if (*p == '(')
+      delta++;
+    else if (*p == ')')
+      delta--;
+  }
+  return delta;
+}
+
+static void
+append_declaration_blocks (GString *out, const gchar *contents)
+{
+  g_auto (GStrv) lines = g_strsplit (contents, "\n", -1);
+  gboolean in_decl = FALSE;
+  gint depth = 0;
+
+  for (gsize i = 0; lines[i] != NULL; i++) {
+    g_autofree gchar *line = g_strdup (lines[i]);
+    gchar *trimmed = g_strstrip (line);
+
+    if (trimmed[0] == '\0' || g_str_has_prefix (trimmed, "//"))
+      continue;
+    if (!in_decl && !g_str_has_prefix (trimmed, ".decl "))
+      continue;
+
+    g_string_append (out, trimmed);
+    g_string_append_c (out, '\n');
+    depth += paren_delta (trimmed);
+    in_decl = depth > 0;
+  }
+}
+
+static gint
+check_legacy_declarations_match_canonical (void)
+{
+  g_autofree gchar *canonical = NULL;
+  g_autofree gchar *legacy = NULL;
+  gsize canonical_len = 0;
+  gsize legacy_len = 0;
+  g_autoptr (GError) err = NULL;
+
+  if (!g_file_get_contents (WYL_TEST_ACCESS_DECISION_DL_PATH, &canonical,
+          &canonical_len, &err)) {
+    g_printerr ("cannot read %s: %s\n", WYL_TEST_ACCESS_DECISION_DL_PATH,
+        err ? err->message : "?");
+    return 173;
+  }
+
+  g_clear_error (&err);
+  if (!g_file_get_contents (WYL_TEST_ACCESS_DECISION_LEGACY_DL_PATH, &legacy,
+          &legacy_len, &err)) {
+    g_printerr ("cannot read %s: %s\n",
+        WYL_TEST_ACCESS_DECISION_LEGACY_DL_PATH, err ? err->message : "?");
+    return 174;
+  }
+
+  g_autoptr (GString) canonical_decls = g_string_new (NULL);
+  g_autoptr (GString) legacy_decls = g_string_new (NULL);
+  append_declaration_blocks (canonical_decls, canonical);
+  append_declaration_blocks (legacy_decls, legacy);
+
+  if (g_strcmp0 (canonical_decls->str, legacy_decls->str) != 0)
+    return 175;
+  return 0;
+}
+
+static gint
 check_legacy_template_matches_canonical (void)
 {
   g_autofree gchar *canonical = NULL;
@@ -494,6 +565,8 @@ main (void)
   if ((rc = check_audit_fact_declarations ()) != 0)
     return rc;
   if ((rc = check_decision_rule_bodies ()) != 0)
+    return rc;
+  if ((rc = check_legacy_declarations_match_canonical ()) != 0)
     return rc;
   if ((rc = check_legacy_template_matches_canonical ()) != 0)
     return rc;

--- a/tests/test-template-tree.c
+++ b/tests/test-template-tree.c
@@ -124,10 +124,103 @@ check_bootstrap_seed_consistency (void)
   return 0;
 }
 
+static gint
+read_template_file (const gchar *relative_path, gchar **out_contents,
+    gsize *out_len)
+{
+  g_autofree gchar *path =
+      g_build_filename (WYL_TEST_TEMPLATE_DIR, relative_path, NULL);
+  g_autoptr (GError) error = NULL;
+
+  if (!g_file_get_contents (path, out_contents, out_len, &error))
+    return 90;
+  return 0;
+}
+
+static gint
+check_required_snippets (const gchar *contents, gsize len,
+    const gchar *const *snippets, gsize n_snippets, gint error_base)
+{
+  for (gsize i = 0; i < n_snippets; i++) {
+    if (g_strstr_len (contents, (gssize) len, snippets[i]) == NULL)
+      return (gint) (error_base + i);
+  }
+  return 0;
+}
+
+static gint
+check_decision_template_relation_contract (void)
+{
+  static const gchar *const snippets[] = {
+    ".decl audit_event_input(id: symbol, created_at_us: int64, decision: symbol)",
+    ".decl audit_event_subject_input(id: symbol, subject: symbol)",
+    ".decl audit_event_action_input(id: symbol, action: symbol)",
+    ".decl audit_event_resource_input(id: symbol, resource: symbol)",
+    ".decl audit_event_deny_reason_input(id: symbol, reason: symbol)",
+    ".decl audit_event_deny_origin_input(id: symbol, origin: symbol)",
+    ".decl audit_event_request_id_input(id: symbol, request_id: symbol)",
+    ".decl audit_event(id: symbol, created_at_us: int64, decision: symbol)",
+    ".decl audit_event_subject(id: symbol, subject: symbol)",
+    ".decl audit_event_action(id: symbol, action: symbol)",
+    ".decl audit_event_resource(id: symbol, resource: symbol)",
+    ".decl audit_event_deny_reason(id: symbol, reason: symbol)",
+    ".decl audit_event_deny_origin(id: symbol, origin: symbol)",
+    ".decl audit_event_request_id(id: symbol, request_id: symbol)",
+    ".decl login_skip_mfa_authz_observed(user: symbol)",
+    ".decl allow_bool(user: symbol, perm: symbol, scope: symbol)",
+    ".decl deny_reason(user: symbol, perm: symbol, scope: symbol,\n"
+        "    code: symbol, origin: symbol)",
+    "audit_event_request_id(ID, RequestID) :-\n"
+        "    audit_event_request_id_input(ID, RequestID).",
+    "login_skip_mfa_authz_observed(U) :-\n" "    login_skip_mfa_authz(U).",
+  };
+  g_autofree gchar *contents = NULL;
+  gsize len = 0;
+  gint rc = read_template_file ("lobac/decision.dl", &contents, &len);
+  if (rc != 0)
+    return rc;
+  return check_required_snippets (contents, len, snippets,
+      G_N_ELEMENTS (snippets), 100);
+}
+
+static gint
+check_permission_scope_relation_contract (void)
+{
+  static const gchar *const snippets[] = {
+    ".decl perm_state_transition(from: symbol, event: symbol, to: symbol)",
+    ".decl perm_state_event(event_id: int64, user: symbol, perm: symbol,\n"
+        "    scope: symbol, event: symbol, from_state: symbol, to_state: symbol)",
+    ".decl perm_state_fired(event_id: int64, user: symbol, perm: symbol,\n"
+        "    scope: symbol, from_state: symbol, event: symbol, to_state: symbol)",
+    ".decl perm_arm_rule_observed(perm: symbol, guard_handle: int64)",
+    ".decl perm_window_guard_observed(perm: symbol, window: symbol)",
+    ".decl guard_context_timestamp(user: symbol, scope: symbol, timestamp: int64)",
+    ".decl guard_context_loc_class(user: symbol, scope: symbol, loc_class: symbol)",
+    ".decl guard_context_risk(user: symbol, scope: symbol, risk: int64)",
+    ".decl guard_context_in_window(user: symbol, scope: symbol, timestamp: int64,\n"
+        "    window: symbol)",
+    "perm_arm_rule_observed(P, G) :- perm_arm_rule(P, G).",
+    "perm_window_guard_observed(P, W) :- perm_window_guard(P, W).",
+  };
+  g_autofree gchar *contents = NULL;
+  gsize len = 0;
+  gint rc = read_template_file ("fsm/permission_scope.dl", &contents, &len);
+  if (rc != 0)
+    return rc;
+  return check_required_snippets (contents, len, snippets,
+      G_N_ELEMENTS (snippets), 130);
+}
+
 int
 main (void)
 {
   if (template_tree_has_backup (WYL_TEST_TEMPLATE_DIR))
     return 1;
-  return check_bootstrap_seed_consistency ();
+  gint rc = check_bootstrap_seed_consistency ();
+  if (rc != 0)
+    return rc;
+  rc = check_decision_template_relation_contract ();
+  if (rc != 0)
+    return rc;
+  return check_permission_scope_relation_contract ();
 }

--- a/tests/test-template-tree.c
+++ b/tests/test-template-tree.c
@@ -131,9 +131,18 @@ read_template_file (const gchar *relative_path, gchar **out_contents,
   g_autofree gchar *path =
       g_build_filename (WYL_TEST_TEMPLATE_DIR, relative_path, NULL);
   g_autoptr (GError) error = NULL;
+  g_autofree gchar *raw = NULL;
+  gsize raw_len = 0;
 
-  if (!g_file_get_contents (path, out_contents, out_len, &error))
+  if (!g_file_get_contents (path, &raw, &raw_len, &error))
     return 90;
+  g_autoptr (GString) normalized = g_string_sized_new (raw_len);
+  for (const gchar * p = raw; *p != '\0'; p++) {
+    if (*p != '\r')
+      g_string_append_c (normalized, *p);
+  }
+  *out_contents = g_string_free (g_steal_pointer (&normalized), FALSE);
+  *out_len = strlen (*out_contents);
   return 0;
 }
 


### PR DESCRIPTION
## Summary

- add static contract checks for LoBAC decision and permission-scope
  template relations
- verify canonical and legacy decision template declaration parity before
  the broader template parity check

## Validation

- meson test -C builddir-ci-pr template-tree access-decision \
  fsm-permission-scope guard-expr handle-engine-pair daemon-checks \
  session-username --print-errorlogs
- meson test -C builddir-audit template-tree access-decision \
  fsm-permission-scope daemon-checks session-username --print-errorlogs
- hooks/pre-commit.hook
- git diff --check
