### PR TITLE
access: guard audit schema and bootstrap drift

### DIFF
--- a/templates/access/duckdb-schema.sql
+++ b/templates/access/duckdb-schema.sql
@@ -79,6 +79,12 @@ CREATE INDEX IF NOT EXISTS idx_audit_events_decision
 CREATE INDEX IF NOT EXISTS idx_audit_events_deny_reason
     ON audit_events (deny_reason);
 
+CREATE INDEX IF NOT EXISTS idx_audit_events_deny_origin
+    ON audit_events (deny_origin);
+
+CREATE INDEX IF NOT EXISTS idx_audit_events_request_id
+    ON audit_events (request_id);
+
 -- ---------------------------------------------------------------------------
 -- Table: cache
 -- In-process LRU decision cache. Invalidated on policy change.

--- a/templates/access/sqlite-schema.sql
+++ b/templates/access/sqlite-schema.sql
@@ -304,6 +304,12 @@ CREATE INDEX IF NOT EXISTS idx_audit_events_decision
 CREATE INDEX IF NOT EXISTS idx_audit_events_deny_reason
     ON audit_events (deny_reason);
 
+CREATE INDEX IF NOT EXISTS idx_audit_events_deny_origin
+    ON audit_events (deny_origin);
+
+CREATE INDEX IF NOT EXISTS idx_audit_events_request_id
+    ON audit_events (request_id);
+
 -- ---------------------------------------------------------------------------
 -- Table: policy_signatures
 -- Ed25519 signatures over policy snapshots, authored by security_officer.

--- a/tests/test-template-tree.c
+++ b/tests/test-template-tree.c
@@ -220,6 +220,53 @@ check_permission_scope_relation_contract (void)
       G_N_ELEMENTS (snippets), 130);
 }
 
+static gint
+check_audit_schema_contract (const gchar *relative_path, gint error_base)
+{
+  static const gchar *const snippets[] = {
+    "CREATE TABLE IF NOT EXISTS audit_events (",
+    "id            ",
+    "created_at_us ",
+    "subject_id    ",
+    "action        ",
+    "resource_id   ",
+    "deny_reason   ",
+    "deny_origin   ",
+    "request_id    ",
+    "decision      ",
+    "CREATE INDEX IF NOT EXISTS idx_audit_events_created_at_us\n"
+        "    ON audit_events (created_at_us);",
+    "CREATE INDEX IF NOT EXISTS idx_audit_events_subject_id\n"
+        "    ON audit_events (subject_id);",
+    "CREATE INDEX IF NOT EXISTS idx_audit_events_action\n"
+        "    ON audit_events (action);",
+    "CREATE INDEX IF NOT EXISTS idx_audit_events_decision\n"
+        "    ON audit_events (decision);",
+    "CREATE INDEX IF NOT EXISTS idx_audit_events_deny_reason\n"
+        "    ON audit_events (deny_reason);",
+    "CREATE INDEX IF NOT EXISTS idx_audit_events_deny_origin\n"
+        "    ON audit_events (deny_origin);",
+    "CREATE INDEX IF NOT EXISTS idx_audit_events_request_id\n"
+        "    ON audit_events (request_id);",
+  };
+  g_autofree gchar *contents = NULL;
+  gsize len = 0;
+  gint rc = read_template_file (relative_path, &contents, &len);
+  if (rc != 0)
+    return rc;
+  return check_required_snippets (contents, len, snippets,
+      G_N_ELEMENTS (snippets), error_base);
+}
+
+static gint
+check_audit_schema_contracts (void)
+{
+  gint rc = check_audit_schema_contract ("sqlite-schema.sql", 150);
+  if (rc != 0)
+    return rc;
+  return check_audit_schema_contract ("duckdb-schema.sql", 180);
+}
+
 int
 main (void)
 {
@@ -231,5 +278,8 @@ main (void)
   rc = check_decision_template_relation_contract ();
   if (rc != 0)
     return rc;
-  return check_permission_scope_relation_contract ();
+  rc = check_permission_scope_relation_contract ();
+  if (rc != 0)
+    return rc;
+  return check_audit_schema_contracts ();
 }

--- a/tests/test-template-tree.c
+++ b/tests/test-template-tree.c
@@ -86,6 +86,48 @@ check_seed_list (GHashTable *template_ids, gsize count,
 }
 
 static gint
+check_bootstrap_seed_contract (const gchar *contents, gsize len)
+{
+  static const gchar *const snippets[] = {
+    ".decl role(name: symbol)",
+    ".decl permission(name: symbol)",
+    ".decl role_permission(role: symbol, perm: symbol)",
+    ".decl inherits(child: symbol, parent: symbol)",
+    ".decl direct_permission(user: symbol, perm: symbol, scope: symbol)",
+    ".decl member_of(user: symbol, role: symbol, scope: symbol)",
+    ".decl effective_member(user: symbol, role: symbol, scope: symbol)",
+    ".decl effective_permission(role: symbol, perm: symbol)",
+    ".decl has_permission(user: symbol, perm: symbol, scope: symbol)",
+    ".decl login_skip_mfa_authz(user: symbol)",
+    "permission(\"wr.policy.read\").",
+    "permission(\"wr.policy.write\").",
+    "permission(\"wr.policy.grant_role\").",
+    "permission(\"wr.audit.read\").",
+    "permission(\"wr.audit.write\").",
+    "role_permission(\"wr.system_admin\", \"wr.policy.write\").",
+    "role_permission(\"wr.service_admin\", \"wr.policy.write\").",
+    "role_permission(\"wr.auditor\", \"wr.audit.read\").",
+    "role_permission(\"wr.system_agent\", \"wr.audit.write\").",
+    "effective_permission(R, P) :- role_permission(R, P).",
+    "has_permission(U, P, S) :- effective_member(U, R, S), effective_permission(R, P).",
+    "has_permission(U, P, S) :- direct_permission(U, P, S).",
+    "can_read_audit(U) :- has_permission(U, \"wr.audit.read\", _).",
+  };
+
+  for (gsize i = 0; i < G_N_ELEMENTS (snippets); i++) {
+    if (g_strstr_len (contents, (gssize) len, snippets[i]) == NULL)
+      return (gint) (80 + i);
+  }
+  if (count_substring (contents, "permission(\"wr.login.skip_mfa\").") != 1)
+    return 103;
+  if (count_substring (contents, "role_permission(\"wr.login.skip_mfa\"") != 0)
+    return 104;
+  if (count_substring (contents, ", \"wr.login.skip_mfa\")") != 0)
+    return 105;
+  return 0;
+}
+
+static gint
 check_bootstrap_seed_consistency (void)
 {
   g_autofree gchar *path =
@@ -98,13 +140,16 @@ check_bootstrap_seed_consistency (void)
     return 30;
   if (count_substring (contents, "\"wr.login.skip_mfa\"") != 1)
     return 33;
+  gint rc = check_bootstrap_seed_contract (contents, len);
+  if (rc != 0)
+    return rc;
 
   g_autoptr (GHashTable) roles = g_hash_table_new_full (g_str_hash,
       g_str_equal, g_free, NULL);
   g_autoptr (GHashTable) permissions = g_hash_table_new_full (g_str_hash,
       g_str_equal, g_free, NULL);
 
-  gint rc = collect_template_facts (contents, "role(", roles);
+  rc = collect_template_facts (contents, "role(", roles);
   if (rc != 0)
     return 31;
   rc = collect_template_facts (contents, "permission(", permissions);

--- a/wyrelog/audit/conn.c
+++ b/wyrelog/audit/conn.c
@@ -201,7 +201,9 @@ wyl_audit_conn_create_schema (wyl_audit_conn_t *conn)
       "CREATE INDEX IF NOT EXISTS idx_audit_events_decision "
       "  ON audit_events (decision);"
       "CREATE INDEX IF NOT EXISTS idx_audit_events_deny_reason "
-      "  ON audit_events (deny_reason);";
+      "  ON audit_events (deny_reason);"
+      "CREATE INDEX IF NOT EXISTS idx_audit_events_deny_origin "
+      "  ON audit_events (deny_origin);";
 
   if (conn == NULL)
     return WYRELOG_E_INVALID;
@@ -212,7 +214,18 @@ wyl_audit_conn_create_schema (wyl_audit_conn_t *conn)
     return WYRELOG_E_IO;
   }
   duckdb_destroy_result (&result);
-  return ensure_audit_events_request_id_column (conn);
+  wyrelog_error_t rc = ensure_audit_events_request_id_column (conn);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  if (duckdb_query (conn->conn,
+          "CREATE INDEX IF NOT EXISTS idx_audit_events_request_id "
+          "ON audit_events (request_id);", &result) != DuckDBSuccess) {
+    duckdb_destroy_result (&result);
+    return WYRELOG_E_IO;
+  }
+  duckdb_destroy_result (&result);
+  return WYRELOG_E_OK;
 }
 
 wyrelog_error_t

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -649,6 +649,8 @@ wyl_policy_store_create_schema (wyl_policy_store_t *store)
       "  ON audit_events (decision);"
       "CREATE INDEX IF NOT EXISTS idx_audit_events_deny_reason "
       "  ON audit_events (deny_reason);"
+      "CREATE INDEX IF NOT EXISTS idx_audit_events_deny_origin "
+      "  ON audit_events (deny_origin);"
       "CREATE TABLE IF NOT EXISTS policy_signatures ("
       "  policy_version INTEGER PRIMARY KEY,"
       "  policy_hash BLOB NOT NULL,"
@@ -679,6 +681,11 @@ wyl_policy_store_create_schema (wyl_policy_store_t *store)
     if (rc != WYRELOG_E_OK)
       return rc;
   }
+  rc = exec_sql (store->db,
+      "CREATE INDEX IF NOT EXISTS idx_audit_events_request_id "
+      "ON audit_events (request_id);");
+  if (rc != WYRELOG_E_OK)
+    return rc;
   return seed_builtin_catalog (store->db);
 }
 


### PR DESCRIPTION
## Summary

- add deny-origin and request-id indexes for audit query filters across
  SQLite and DuckDB audit schemas
- keep request-id index creation behind the existing request-id column
  migration path for older stores
- guard audit schema and bootstrap seed contracts in template-tree tests

## Validation

- meson test -C builddir-ci-pr template-tree audit-conn policy-store \
  audit-emit handle-engine-pair daemon-checks session-username \
  --print-errorlogs
- meson test -C builddir-audit template-tree audit-conn policy-store \
  audit-emit handle-engine-pair daemon-checks session-username \
  --print-errorlogs
- hooks/pre-commit.hook
- git diff --check
