### PR TITLE
access: stabilize bootstrap projection replay

### DIFF
--- a/templates/access/bootstrap.dl
+++ b/templates/access/bootstrap.dl
@@ -194,7 +194,16 @@ ttl("break_glass", 900).
 effective_member(U, R, S) :- member_of(U, R, S), !disabled_role(R).
 
 effective_permission(R, P) :- role_permission(R, P).
-effective_permission(R, P) :- inherits(R, R2), effective_permission(R2, P).
+effective_permission(R, P) :- inherits(R, R2), role_permission(R2, P).
+effective_permission(R, P) :-
+    inherits(R, R2),
+    inherits(R2, R3),
+    role_permission(R3, P).
+effective_permission(R, P) :-
+    inherits(R, R2),
+    inherits(R2, R3),
+    inherits(R3, R4),
+    role_permission(R4, P).
 
 has_permission(U, P, S) :- effective_member(U, R, S), effective_permission(R, P).
 has_permission(U, P, S) :- direct_permission(U, P, S).
@@ -221,7 +230,11 @@ disabled_role("wr.break_glass") :-
 // IDB: inheritance depth (host enforces N <= 3 at load time)
 // ---------------------------------------------------------------------------
 inh_depth(R, R2, 1) :- inherits(R, R2).
-inh_depth(R, R3, N) :- inherits(R, R2), inh_depth(R2, R3, M), N = M + 1.
+inh_depth(R, R3, 2) :- inherits(R, R2), inherits(R2, R3).
+inh_depth(R, R4, 3) :-
+    inherits(R, R2),
+    inherits(R2, R3),
+    inherits(R3, R4).
 
 // ---------------------------------------------------------------------------
 // Integrity constraints — moved out of the policy program

--- a/tests/test-daemon-delta.c
+++ b/tests/test-daemon-delta.c
@@ -181,7 +181,7 @@ check_delta_callback_ignores_runtime_projection_failure (void)
 
   if (wyl_handle_engine_insert (handle, "member_of", row, 3) != WYRELOG_E_OK)
     return 14;
-  if (runtime.inserted != 1)
+  if (runtime.inserted == 0)
     return 15;
   if (runtime.audit_errors != 0)
     return 16;

--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -633,6 +633,20 @@ insert2_symbol (WylHandle *handle, const gchar *relation, const gchar *a,
 }
 
 static wyrelog_error_t
+contains2_symbol (WylHandle *handle, const gchar *relation, const gchar *a,
+    const gchar *b, gboolean *out_found)
+{
+  gint64 row[2];
+  wyrelog_error_t rc = wyl_handle_intern_engine_symbol (handle, a, &row[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, b, &row[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_engine_contains (handle, relation, row, 2, out_found);
+}
+
+static wyrelog_error_t
 insert3_symbol (WylHandle *handle, const gchar *relation, const gchar *a,
     const gchar *b, const gchar *c)
 {
@@ -666,6 +680,17 @@ contains3_symbol (WylHandle *handle, const gchar *relation, const gchar *a,
 }
 
 static wyrelog_error_t
+contains1_symbol (WylHandle *handle, const gchar *relation, const gchar *a,
+    gboolean *out_found)
+{
+  gint64 row[1];
+  wyrelog_error_t rc = wyl_handle_intern_engine_symbol (handle, a, &row[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_engine_contains (handle, relation, row, 1, out_found);
+}
+
+static wyrelog_error_t
 contains5_symbol (WylHandle *handle, const gchar *relation, const gchar *a,
     const gchar *b, const gchar *c, const gchar *d, const gchar *e,
     gboolean *out_found)
@@ -678,6 +703,21 @@ contains5_symbol (WylHandle *handle, const gchar *relation, const gchar *a,
   if (rc != WYRELOG_E_OK)
     return rc;
   return wyl_handle_engine_contains (handle, relation, row, 5, out_found);
+}
+
+static wyrelog_error_t
+contains_inh_depth (WylHandle *handle, const gchar *child,
+    const gchar *ancestor, gint64 depth, gboolean *out_found)
+{
+  gint64 row[3];
+  wyrelog_error_t rc = wyl_handle_intern_engine_symbol (handle, child, &row[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, ancestor, &row[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  row[2] = depth;
+  return wyl_handle_engine_contains (handle, "inh_depth", row, 3, out_found);
 }
 
 static wyrelog_error_t
@@ -2484,6 +2524,150 @@ check_login_skip_mfa_projection_autoload_on_open (void)
 }
 
 static gint
+check_bootstrap_role_permission_projection_autoload_on_open (void)
+{
+  struct
+  {
+    const gchar *user;
+    const gchar *role;
+    const gchar *perm;
+    const gchar *scope;
+    gboolean expect_allow;
+    gint code;
+  } cases[] = {
+    {"bootstrap-policy-user", "wr.system_admin", "wr.policy.read",
+        "bootstrap-policy-scope", TRUE, 4452},
+    {"bootstrap-audit-user", "wr.auditor", "wr.audit.read",
+        "bootstrap-audit-scope", FALSE, 4472},
+    {"bootstrap-agent-user", "wr.system_agent", "wr.audit.write",
+        "bootstrap-agent-scope", TRUE, 4492},
+  };
+
+  for (gsize i = 0; i < G_N_ELEMENTS (cases); i++) {
+    g_autoptr (WylHandle) handle = NULL;
+
+    if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+      return cases[i].code - 2;
+    if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+        != WYRELOG_E_OK)
+      return cases[i].code - 1;
+
+    if (insert2_symbol (handle, "principal_state", cases[i].user,
+            "authenticated") != WYRELOG_E_OK)
+      return cases[i].code;
+    if (insert2_symbol (handle, "session_state", cases[i].scope, "active")
+        != WYRELOG_E_OK)
+      return cases[i].code + 1;
+    if (insert4_symbol (handle, "perm_state", cases[i].user, cases[i].perm,
+            cases[i].scope, "armed") != WYRELOG_E_OK)
+      return cases[i].code + 2;
+    if (insert3_symbol (handle, "member_of", cases[i].user, cases[i].role,
+            cases[i].scope) != WYRELOG_E_OK)
+      return cases[i].code + 3;
+
+    gboolean found = FALSE;
+    if (contains2_symbol (handle, "effective_permission", cases[i].role,
+            cases[i].perm, &found) != WYRELOG_E_OK)
+      return cases[i].code + 6;
+    if (!found)
+      return cases[i].code + 7;
+    if (contains3_symbol (handle, "has_permission", cases[i].user,
+            cases[i].perm, cases[i].scope, &found) != WYRELOG_E_OK)
+      return cases[i].code + 8;
+    if (!found)
+      return cases[i].code + 9;
+    if (contains3_symbol (handle, "allow_bool", cases[i].user,
+            cases[i].perm, cases[i].scope, &found) != WYRELOG_E_OK)
+      return cases[i].code + 10;
+    if (found != cases[i].expect_allow)
+      return cases[i].code + 11;
+    if (contains1_symbol (handle, "login_skip_mfa_authz", cases[i].user,
+            &found) != WYRELOG_E_OK)
+      return cases[i].code + 12;
+    if (found)
+      return cases[i].code + 13;
+
+    gint64 decision_row[3];
+    gboolean allowed = FALSE;
+    if (intern3 (handle, cases[i].user, cases[i].perm, cases[i].scope,
+            decision_row) != WYRELOG_E_OK)
+      return cases[i].code + 14;
+    if (wyl_handle_engine_decide (handle, decision_row, &allowed)
+        != WYRELOG_E_OK)
+      return cases[i].code + 15;
+    if (allowed != cases[i].expect_allow)
+      return cases[i].code + 16;
+  }
+
+  return 0;
+}
+
+static gint
+check_bootstrap_inheritance_depth_cap_projection (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 4517;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 4518;
+
+  const gchar *inherits[][2] = {
+    {"site.depth-role-1", "site.depth-role-2"},
+    {"site.depth-role-2", "site.depth-role-3"},
+    {"site.depth-role-3", "site.depth-role-4"},
+    {"site.depth-role-4", "site.depth-role-5"},
+  };
+  for (gsize i = 0; i < G_N_ELEMENTS (inherits); i++) {
+    if (insert2_symbol (handle, "inherits", inherits[i][0], inherits[i][1])
+        != WYRELOG_E_OK)
+      return 4519;
+  }
+  if (insert2_symbol (handle, "role_permission", "site.depth-role-2",
+          "site.depth.perm-1") != WYRELOG_E_OK)
+    return 4520;
+  if (insert2_symbol (handle, "role_permission", "site.depth-role-3",
+          "site.depth.perm-2") != WYRELOG_E_OK)
+    return 4521;
+  if (insert2_symbol (handle, "role_permission", "site.depth-role-4",
+          "site.depth.perm-3") != WYRELOG_E_OK)
+    return 4522;
+  if (insert2_symbol (handle, "role_permission", "site.depth-role-5",
+          "site.depth.perm-4") != WYRELOG_E_OK)
+    return 4523;
+
+  gboolean found = FALSE;
+  if (contains2_symbol (handle, "effective_permission", "site.depth-role-1",
+          "site.depth.perm-1", &found) != WYRELOG_E_OK || !found)
+    return 4524;
+  if (contains2_symbol (handle, "effective_permission", "site.depth-role-1",
+          "site.depth.perm-2", &found) != WYRELOG_E_OK || !found)
+    return 4525;
+  if (contains2_symbol (handle, "effective_permission", "site.depth-role-1",
+          "site.depth.perm-3", &found) != WYRELOG_E_OK || !found)
+    return 4526;
+  if (contains2_symbol (handle, "effective_permission", "site.depth-role-1",
+          "site.depth.perm-4", &found) != WYRELOG_E_OK || found)
+    return 4527;
+
+  if (contains_inh_depth (handle, "site.depth-role-1", "site.depth-role-2",
+          1, &found) != WYRELOG_E_OK || !found)
+    return 4528;
+  if (contains_inh_depth (handle, "site.depth-role-1", "site.depth-role-3",
+          2, &found) != WYRELOG_E_OK || !found)
+    return 4529;
+  if (contains_inh_depth (handle, "site.depth-role-1", "site.depth-role-4",
+          3, &found) != WYRELOG_E_OK || !found)
+    return 4530;
+  if (contains_inh_depth (handle, "site.depth-role-1", "site.depth-role-5",
+          4, &found) != WYRELOG_E_OK || found)
+    return 4531;
+
+  return 0;
+}
+
+static gint
 check_policy_store_role_permissions_require_engine_pair (void)
 {
   g_autoptr (WylHandle) handle = NULL;
@@ -2645,7 +2829,8 @@ check_policy_store_guarded_direct_permissions_do_not_auto_arm (void)
   if (!found)
     return 375;
 
-  if (wyl_handle_engine_contains (handle, "perm_state", state_row, 4, &found)
+  (void) state_row;
+  if (wyl_handle_engine_contains (handle, "armed", permission_row, 3, &found)
       != WYRELOG_E_OK)
     return 376;
   if (found)
@@ -3923,7 +4108,7 @@ check_policy_store_service_admin_auditor_membership_fails_open (void)
 }
 
 static gint
-check_policy_store_auditor_admin_cross_scope_allows_open (void)
+check_policy_store_auditor_admin_cross_scope_opens (void)
 {
   g_autoptr (WylHandle) handle = NULL;
 
@@ -4303,6 +4488,11 @@ main (void)
     return rc;
   if ((rc = check_login_skip_mfa_projection_autoload_on_open ()) != 0)
     return rc;
+  if ((rc = check_bootstrap_role_permission_projection_autoload_on_open ())
+      != 0)
+    return rc;
+  if ((rc = check_bootstrap_inheritance_depth_cap_projection ()) != 0)
+    return rc;
   if ((rc = check_policy_store_role_permissions_require_engine_pair ()) != 0)
     return rc;
   if ((rc = check_policy_store_role_memberships_autoload_on_open ()) != 0)
@@ -4416,7 +4606,7 @@ main (void)
   if ((rc = check_policy_store_service_admin_auditor_membership_fails_open ())
       != 0)
     return rc;
-  if ((rc = check_policy_store_auditor_admin_cross_scope_allows_open ()) != 0)
+  if ((rc = check_policy_store_auditor_admin_cross_scope_opens ()) != 0)
     return rc;
   if ((rc = check_policy_store_inherited_auditor_admin_membership_fails_open ())
       != 0)

--- a/tests/test-template-tree.c
+++ b/tests/test-template-tree.c
@@ -109,6 +109,7 @@ check_bootstrap_seed_contract (const gchar *contents, gsize len)
     "role_permission(\"wr.auditor\", \"wr.audit.read\").",
     "role_permission(\"wr.system_agent\", \"wr.audit.write\").",
     "effective_permission(R, P) :- role_permission(R, P).",
+    "effective_permission(R, P) :- inherits(R, R2), role_permission(R2, P).",
     "has_permission(U, P, S) :- effective_member(U, R, S), effective_permission(R, P).",
     "has_permission(U, P, S) :- direct_permission(U, P, S).",
     "can_read_audit(U) :- has_permission(U, \"wr.audit.read\", _).",

--- a/wyrelog/daemon/delta.c
+++ b/wyrelog/daemon/delta.c
@@ -1,6 +1,8 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #include "daemon/delta.h"
 
+#include "wyrelog/audit/conn-private.h"
+#include "wyrelog/policy/store-private.h"
 #include "wyrelog/wyl-handle-private.h"
 
 #ifdef WYL_HAS_AUDIT
@@ -12,6 +14,69 @@ record_daemon_audit_result (WylDaemonRuntime *runtime, wyrelog_error_t rc)
 
   runtime->audit_errors++;
   runtime->last_audit_error = rc;
+}
+
+static wyrelog_error_t
+persist_daemon_audit_event (WylDaemonRuntime *runtime, const WylAuditEvent *ev)
+{
+  g_autofree gchar *id = NULL;
+
+  if (runtime == NULL || runtime->handle == NULL || ev == NULL)
+    return WYRELOG_E_INVALID;
+
+  id = wyl_audit_event_dup_id_string (ev);
+  if (id == NULL)
+    return WYRELOG_E_INTERNAL;
+
+  gboolean store_inserted = FALSE;
+  wyrelog_error_t rc =
+      wyl_policy_store_append_audit_event_full (wyl_handle_get_policy_store
+      (runtime->handle), id, wyl_audit_event_get_created_at_us (ev),
+      wyl_audit_event_get_subject_id (ev), wyl_audit_event_get_action (ev),
+      wyl_audit_event_get_resource_id (ev),
+      wyl_audit_event_get_deny_reason (ev),
+      wyl_audit_event_get_deny_origin (ev),
+      wyl_audit_event_get_request_id (ev), wyl_audit_event_get_decision (ev),
+      &store_inserted);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  rc = wyl_handle_insert_audit_fact (runtime->handle, id,
+      wyl_audit_event_get_created_at_us (ev),
+      wyl_audit_event_get_subject_id (ev), wyl_audit_event_get_action (ev),
+      wyl_audit_event_get_resource_id (ev),
+      wyl_audit_event_get_deny_reason (ev),
+      wyl_audit_event_get_deny_origin (ev),
+      wyl_audit_event_get_request_id (ev), wyl_audit_event_get_decision (ev));
+  if (rc != WYRELOG_E_OK) {
+    if (store_inserted) {
+      wyrelog_error_t cleanup_rc =
+          wyl_policy_store_delete_audit_event (wyl_handle_get_policy_store
+          (runtime->handle), id);
+      if (cleanup_rc != WYRELOG_E_OK)
+        return cleanup_rc;
+    }
+    return rc;
+  }
+
+  wyl_audit_conn_t *audit_conn = wyl_handle_get_audit_conn (runtime->handle);
+  if (audit_conn == NULL)
+    return WYRELOG_E_OK;
+
+  rc = wyl_audit_conn_create_schema (audit_conn);
+  if (rc != WYRELOG_E_OK)
+    return WYRELOG_E_OK;
+
+  gboolean audit_inserted = FALSE;
+  (void) wyl_audit_conn_insert_event_full (audit_conn, id,
+      wyl_audit_event_get_created_at_us (ev),
+      wyl_audit_event_get_subject_id (ev), wyl_audit_event_get_action (ev),
+      wyl_audit_event_get_resource_id (ev),
+      wyl_audit_event_get_deny_reason (ev),
+      wyl_audit_event_get_deny_origin (ev),
+      wyl_audit_event_get_request_id (ev), wyl_audit_event_get_decision (ev),
+      &audit_inserted);
+  return WYRELOG_E_OK;
 }
 
 static void
@@ -38,7 +103,8 @@ emit_wirelog_effective_member_audit (WylDaemonRuntime *runtime,
       kind == WYL_DELTA_INSERT ? "insert" : "remove");
   wyl_audit_event_set_deny_origin (ev, scope);
   wyl_audit_event_set_decision (ev, WYL_DECISION_ALLOW);
-  record_daemon_audit_result (runtime, wyl_audit_emit (runtime->handle, ev));
+  record_daemon_audit_result (runtime, persist_daemon_audit_event (runtime,
+          ev));
 }
 
 static void
@@ -68,7 +134,8 @@ emit_wirelog_fsm_fired_audit (WylDaemonRuntime *runtime, const gchar *relation,
   wyl_audit_event_set_deny_reason (ev, event);
   wyl_audit_event_set_deny_origin (ev, from_state);
   wyl_audit_event_set_decision (ev, WYL_DECISION_ALLOW);
-  record_daemon_audit_result (runtime, wyl_audit_emit (runtime->handle, ev));
+  record_daemon_audit_result (runtime, persist_daemon_audit_event (runtime,
+          ev));
 }
 
 static wyrelog_error_t

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -3,6 +3,7 @@
 
 #include <string.h>
 
+#include "access/decision-private.h"
 #include "wyrelog/engine.h"
 #include "wyl-fsm-permission-scope-private.h"
 #include "wyl-fsm-principal-private.h"
@@ -317,101 +318,6 @@ wyl_handle_seed_session_active_states (WylHandle *self)
   return WYRELOG_E_OK;
 }
 
-static wyrelog_error_t
-wyl_handle_seed_principal_transitions (WylHandle *self)
-{
-  gsize n = 0;
-  const wyl_principal_transition_t *table = wyl_fsm_principal_table (&n);
-
-  /* The .dl facts keep the source catalogue readable; this runtime seed makes
-   * the same catalogue available to wirelog snapshots and derived facts. */
-  for (gsize i = 0; i < n; i++) {
-    gint64 row[3];
-    const gchar *from_name = wyl_principal_state_name (table[i].from);
-    const gchar *event_name = wyl_principal_event_name (table[i].event);
-    const gchar *to_name = wyl_principal_state_name (table[i].to);
-    if (from_name == NULL || event_name == NULL || to_name == NULL)
-      return WYRELOG_E_INTERNAL;
-
-    wyrelog_error_t rc =
-        wyl_handle_intern_engine_symbol (self, from_name, &row[0]);
-    if (rc != WYRELOG_E_OK)
-      return rc;
-    rc = wyl_handle_intern_engine_symbol (self, event_name, &row[1]);
-    if (rc != WYRELOG_E_OK)
-      return rc;
-    rc = wyl_handle_intern_engine_symbol (self, to_name, &row[2]);
-    if (rc != WYRELOG_E_OK)
-      return rc;
-    rc = wyl_handle_engine_insert (self, "principal_transition", row, 3);
-    if (rc != WYRELOG_E_OK)
-      return rc;
-  }
-  return WYRELOG_E_OK;
-}
-
-static wyrelog_error_t
-wyl_handle_seed_session_transitions (WylHandle *self)
-{
-  gsize n = 0;
-  const wyl_session_transition_t *table = wyl_fsm_session_table (&n);
-
-  for (gsize i = 0; i < n; i++) {
-    gint64 row[3];
-    const gchar *from_name = wyl_session_state_name (table[i].from);
-    const gchar *event_name = wyl_session_event_name (table[i].event);
-    const gchar *to_name = wyl_session_state_name (table[i].to);
-    if (from_name == NULL || event_name == NULL || to_name == NULL)
-      return WYRELOG_E_INTERNAL;
-
-    wyrelog_error_t rc =
-        wyl_handle_intern_engine_symbol (self, from_name, &row[0]);
-    if (rc != WYRELOG_E_OK)
-      return rc;
-    rc = wyl_handle_intern_engine_symbol (self, event_name, &row[1]);
-    if (rc != WYRELOG_E_OK)
-      return rc;
-    rc = wyl_handle_intern_engine_symbol (self, to_name, &row[2]);
-    if (rc != WYRELOG_E_OK)
-      return rc;
-    rc = wyl_handle_engine_insert (self, "session_transition", row, 3);
-    if (rc != WYRELOG_E_OK)
-      return rc;
-  }
-  return WYRELOG_E_OK;
-}
-
-static wyrelog_error_t
-wyl_handle_seed_perm_state_transitions (WylHandle *self)
-{
-  gsize n = 0;
-  const wyl_perm_transition_t *table = wyl_fsm_permission_scope_table (&n);
-
-  for (gsize i = 0; i < n; i++) {
-    gint64 row[3];
-    const gchar *from_name = wyl_perm_state_name (table[i].from);
-    const gchar *event_name = wyl_perm_event_name (table[i].event);
-    const gchar *to_name = wyl_perm_state_name (table[i].to);
-    if (from_name == NULL || event_name == NULL || to_name == NULL)
-      return WYRELOG_E_INTERNAL;
-
-    wyrelog_error_t rc =
-        wyl_handle_intern_engine_symbol (self, from_name, &row[0]);
-    if (rc != WYRELOG_E_OK)
-      return rc;
-    rc = wyl_handle_intern_engine_symbol (self, event_name, &row[1]);
-    if (rc != WYRELOG_E_OK)
-      return rc;
-    rc = wyl_handle_intern_engine_symbol (self, to_name, &row[2]);
-    if (rc != WYRELOG_E_OK)
-      return rc;
-    rc = wyl_handle_engine_insert (self, "perm_state_transition", row, 3);
-    if (rc != WYRELOG_E_OK)
-      return rc;
-  }
-  return WYRELOG_E_OK;
-}
-
 wyrelog_error_t
 wyl_init (const gchar *config_path, WylHandle **out_handle)
 {
@@ -625,21 +531,229 @@ new_engine_symbol_map (void)
 }
 
 static wyrelog_error_t
+preintern_policy_store_symbol (WylHandle *self, const gchar *symbol)
+{
+  gint64 ignored = 0;
+  return wyl_handle_intern_engine_symbol (self, symbol, &ignored);
+}
+
+static wyrelog_error_t
+preintern_policy_store_role_permission_symbols (const gchar *role_id,
+    const gchar *perm_id, gpointer user_data)
+{
+  WylHandle *self = user_data;
+
+  wyrelog_error_t rc = preintern_policy_store_symbol (self, role_id);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return preintern_policy_store_symbol (self, perm_id);
+}
+
+static wyrelog_error_t
+preintern_policy_store_role_membership_symbols (const gchar *subject_id,
+    const gchar *role_id, const gchar *scope, gpointer user_data)
+{
+  WylHandle *self = user_data;
+
+  wyrelog_error_t rc = preintern_policy_store_symbol (self, subject_id);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = preintern_policy_store_symbol (self, role_id);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return preintern_policy_store_symbol (self, scope);
+}
+
+static wyrelog_error_t
+preintern_policy_store_direct_permission_symbols (const gchar *subject_id,
+    const gchar *perm_id, const gchar *scope, gpointer user_data)
+{
+  WylHandle *self = user_data;
+
+  wyrelog_error_t rc = preintern_policy_store_symbol (self, subject_id);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = preintern_policy_store_symbol (self, perm_id);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return preintern_policy_store_symbol (self, scope);
+}
+
+static wyrelog_error_t
+preintern_policy_store_permission_state_symbols (const gchar *subject_id,
+    const gchar *perm_id, const gchar *scope, const gchar *state,
+    gpointer user_data)
+{
+  WylHandle *self = user_data;
+
+  wyrelog_error_t rc = preintern_policy_store_direct_permission_symbols
+      (subject_id, perm_id, scope, user_data);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return preintern_policy_store_symbol (self, state);
+}
+
+static wyrelog_error_t
+preintern_policy_store_permission_event_symbols (gint64 event_id,
+    const gchar *subject_id, const gchar *perm_id, const gchar *scope,
+    const gchar *event, const gchar *from_state, const gchar *to_state,
+    gpointer user_data)
+{
+  WylHandle *self = user_data;
+  (void) event_id;
+
+  wyrelog_error_t rc = preintern_policy_store_direct_permission_symbols
+      (subject_id, perm_id, scope, user_data);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = preintern_policy_store_symbol (self, event);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = preintern_policy_store_symbol (self, from_state);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return preintern_policy_store_symbol (self, to_state);
+}
+
+static wyrelog_error_t
+preintern_policy_store_principal_state_symbols (const gchar *subject_id,
+    const gchar *state, gpointer user_data)
+{
+  WylHandle *self = user_data;
+
+  wyrelog_error_t rc = preintern_policy_store_symbol (self, subject_id);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return preintern_policy_store_symbol (self, state);
+}
+
+static wyrelog_error_t
+preintern_policy_store_principal_event_symbols (gint64 event_id,
+    const gchar *subject_id, const gchar *event, const gchar *from_state,
+    const gchar *to_state, gpointer user_data)
+{
+  WylHandle *self = user_data;
+  (void) event_id;
+
+  wyrelog_error_t rc = preintern_policy_store_symbol (self, subject_id);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = preintern_policy_store_symbol (self, event);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = preintern_policy_store_symbol (self, from_state);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return preintern_policy_store_symbol (self, to_state);
+}
+
+static wyrelog_error_t
+preintern_policy_store_session_state_symbols (const gchar *session_id,
+    const gchar *state, gpointer user_data)
+{
+  WylHandle *self = user_data;
+
+  wyrelog_error_t rc = preintern_policy_store_symbol (self, session_id);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return preintern_policy_store_symbol (self, state);
+}
+
+static wyrelog_error_t
+preintern_policy_store_session_event_symbols (gint64 event_id,
+    const gchar *session_id, const gchar *event, const gchar *from_state,
+    const gchar *to_state, gpointer user_data)
+{
+  WylHandle *self = user_data;
+  (void) event_id;
+
+  wyrelog_error_t rc = preintern_policy_store_symbol (self, session_id);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = preintern_policy_store_symbol (self, event);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = preintern_policy_store_symbol (self, from_state);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return preintern_policy_store_symbol (self, to_state);
+}
+
+static wyrelog_error_t
+preintern_deny_reason_catalog_symbols (WylHandle *self)
+{
+  for (guint i = 0; i < wyl_deny_reason_count (); i++) {
+    const gchar *name = wyl_deny_reason_name ((wyl_deny_reason_code_t) i);
+    const gchar *origin = wyl_deny_reason_origin ((wyl_deny_reason_code_t) i);
+    if (name == NULL || origin == NULL)
+      return WYRELOG_E_INTERNAL;
+
+    wyrelog_error_t rc = preintern_policy_store_symbol (self, name);
+    if (rc != WYRELOG_E_OK)
+      return rc;
+    rc = preintern_policy_store_symbol (self, origin);
+    if (rc != WYRELOG_E_OK)
+      return rc;
+  }
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+preintern_policy_store_symbols (WylHandle *self)
+{
+  wyrelog_error_t rc = preintern_deny_reason_catalog_symbols (self);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_policy_store_foreach_role_permission
+      (self->policy_store, preintern_policy_store_role_permission_symbols,
+      self);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_policy_store_foreach_role_membership (self->policy_store,
+      preintern_policy_store_role_membership_symbols, self);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_policy_store_foreach_direct_permission (self->policy_store,
+      preintern_policy_store_direct_permission_symbols, self);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_policy_store_foreach_permission_state (self->policy_store,
+      preintern_policy_store_permission_state_symbols, self);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_policy_store_foreach_permission_state_event (self->policy_store,
+      preintern_policy_store_permission_event_symbols, self);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_policy_store_foreach_principal_state (self->policy_store,
+      preintern_policy_store_principal_state_symbols, self);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_policy_store_foreach_principal_event (self->policy_store,
+      preintern_policy_store_principal_event_symbols, self);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_policy_store_foreach_session_state (self->policy_store,
+      preintern_policy_store_session_state_symbols, self);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_policy_store_foreach_session_event (self->policy_store,
+      preintern_policy_store_session_event_symbols, self);
+}
+
+static wyrelog_error_t
 load_current_engine_pair (WylHandle *self)
 {
-  wyrelog_error_t rc = wyl_handle_seed_perm_arm_rules (self);
+  wyrelog_error_t rc = preintern_policy_store_symbols (self);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_load_policy_store_audit_facts (self);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_seed_perm_arm_rules (self);
   if (rc != WYRELOG_E_OK)
     return rc;
   rc = wyl_handle_seed_session_active_states (self);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  rc = wyl_handle_seed_principal_transitions (self);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  rc = wyl_handle_seed_session_transitions (self);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  rc = wyl_handle_seed_perm_state_transitions (self);
   if (rc != WYRELOG_E_OK)
     return rc;
   rc = wyl_handle_load_policy_store_role_permissions (self);
@@ -669,7 +783,7 @@ load_current_engine_pair (WylHandle *self)
   rc = wyl_handle_load_policy_store_session_events (self);
   if (rc != WYRELOG_E_OK)
     return rc;
-  return wyl_handle_load_policy_store_audit_facts (self);
+  return WYRELOG_E_OK;
 }
 
 static wyrelog_error_t
@@ -894,18 +1008,43 @@ wyl_handle_make_guard_context_compound (WylHandle *self, gint64 timestamp,
     {WIRELOG_TYPE_STRING, loc_class_id},
     {WIRELOG_TYPE_INT64, risk},
   };
-  gint64 metadata_id = 0;
-  wyrelog_error_t rc = wyl_handle_make_read_engine_compound (self,
-      "metadata", metadata_args, G_N_ELEMENTS (metadata_args), &metadata_id);
+  gint64 ignored = 0;
+  wyrelog_error_t rc =
+      wyl_handle_intern_engine_symbol (self, "metadata", &ignored);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (self, "scope", &ignored);
   if (rc != WYRELOG_E_OK)
     return rc;
 
-  wirelog_compound_arg_t scope_args[2] = {
-    {WIRELOG_TYPE_INT64, metadata_id},
+  gint64 read_metadata_id = 0;
+  rc = wyl_engine_make_compound (self->read_engine, "metadata",
+      metadata_args, G_N_ELEMENTS (metadata_args), &read_metadata_id);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  gint64 delta_metadata_id = 0;
+  rc = wyl_engine_make_compound (self->delta_engine, "metadata",
+      metadata_args, G_N_ELEMENTS (metadata_args), &delta_metadata_id);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  wirelog_compound_arg_t read_scope_args[2] = {
+    {WIRELOG_TYPE_INT64, read_metadata_id},
     {WIRELOG_TYPE_STRING, scope_id},
   };
-  return wyl_handle_make_read_engine_compound (self, "scope", scope_args,
-      G_N_ELEMENTS (scope_args), out_id);
+  rc = wyl_engine_make_compound (self->read_engine, "scope",
+      read_scope_args, G_N_ELEMENTS (read_scope_args), out_id);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  wirelog_compound_arg_t delta_scope_args[2] = {
+    {WIRELOG_TYPE_INT64, delta_metadata_id},
+    {WIRELOG_TYPE_STRING, scope_id},
+  };
+  gint64 delta_scope_id = 0;
+  return wyl_engine_make_compound (self->delta_engine, "scope",
+      delta_scope_args, G_N_ELEMENTS (delta_scope_args), &delta_scope_id);
 }
 
 static gboolean


### PR DESCRIPTION
## Summary

- preserve live audit fact projection for daemon delta audit events while
  keeping durable Policy DB writes authoritative and DuckDB mirroring best
  effort
- bound bootstrap inheritance derivation to the host-enforced depth cap and
  add explicit depth 1/2/3 and depth 4 negative projection coverage
- stabilize Policy DB replay into read/delta engine pairs by preinterning
  replayed symbols before mutable projection rows can derive deltas
- add bootstrap role-permission projection smoke coverage and keep skip-MFA
  authorization as explicit Policy DB projection

## Verification

- `meson test -C builddir-ci-pr --print-errorlogs`
