### PR TITLE
access: declare guard host surfaces

### DIFF
--- a/templates/access/fsm/permission_scope.dl
+++ b/templates/access/fsm/permission_scope.dl
@@ -38,6 +38,10 @@
 //   guard_context_risk(user, scope, risk)
 //   guard_context_in_window(user, scope, ts,     -- host-confirmed
 //       window)                                      timestamp window
+//   loc_class(loc_id, class)                      -- operator-maintained
+//                                                   location class map
+//   in_window(ts, window)                         -- host-confirmed
+//                                                   global time window
 //   eval_guard(user, perm, scope, ctx)           -- host guard result
 //
 // Derived schemas:
@@ -70,6 +74,8 @@
 .decl guard_context_risk(user: symbol, scope: symbol, risk: int64)
 .decl guard_context_in_window(user: symbol, scope: symbol, timestamp: int64,
     window: symbol)
+.decl loc_class(loc_id: symbol, class: symbol)
+.decl in_window(timestamp: int64, window: symbol)
 .decl eval_guard(user: symbol, perm: symbol, scope: symbol, ctx: scope/2 side)
 .decl perm_arm_rule_observed(perm: symbol, guard_handle: int64)
 .decl perm_window_guard_observed(perm: symbol, window: symbol)

--- a/tests/test-fsm-permission-scope.c
+++ b/tests/test-fsm-permission-scope.c
@@ -761,6 +761,22 @@ expect_engine_row_count (WylEngine *engine, const gchar *relation,
   return 0;
 }
 
+static gint
+check_host_context_relations_start_empty (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 220;
+  if (expect_engine_row_count (wyl_handle_get_read_engine (handle),
+          "loc_class", 0, 221) != 0)
+    return 221;
+  if (expect_engine_row_count (wyl_handle_get_read_engine (handle),
+          "in_window", 0, 223) != 0)
+    return 223;
+  return 0;
+}
+
 typedef struct
 {
   wyl_perm_state_t from;
@@ -1124,6 +1140,8 @@ main (void)
   if ((rc = check_argument_validation ()) != 0)
     return rc;
   if ((rc = check_template_static_fact_guards ()) != 0)
+    return rc;
+  if ((rc = check_host_context_relations_start_empty ()) != 0)
     return rc;
   if ((rc = check_perm_state_golden_trace ()) != 0)
     return rc;

--- a/tests/test-template-tree.c
+++ b/tests/test-template-tree.c
@@ -254,6 +254,8 @@ check_permission_scope_relation_contract (void)
     ".decl guard_context_risk(user: symbol, scope: symbol, risk: int64)",
     ".decl guard_context_in_window(user: symbol, scope: symbol, timestamp: int64,\n"
         "    window: symbol)",
+    ".decl loc_class(loc_id: symbol, class: symbol)",
+    ".decl in_window(timestamp: int64, window: symbol)",
     "perm_arm_rule_observed(P, G) :- perm_arm_rule(P, G).",
     "perm_window_guard_observed(P, W) :- perm_window_guard(P, W).",
   };


### PR DESCRIPTION
## Summary

- declare host-provided `loc_class/2` and `in_window/2` guard surfaces in
  the permission-scope template
- keep both surfaces unseeded by default so existing request-local guard
  evaluation remains unchanged
- cover the declarations in template-tree checks and assert fresh engines do
  not receive implicit rows

## Verification

- `meson test -C builddir-ci-pr --print-errorlogs`
