### PR TITLE
access: align permission-state contract

### DIFF
--- a/templates/access/fsm/permission_scope.dl
+++ b/templates/access/fsm/permission_scope.dl
@@ -4,13 +4,14 @@
 // Copyright (C) 2026 wyrelog authors. Also available under a separate
 // commercial license; see LICENSE.md at the project root.
 //
-// Stateless armed/3 derivation. The version-0 perm-scope is a pure
-// IDB rule set with no transition lifecycle: the host must inject
-// perm_state(user, perm, scope, "armed") for unguarded permissions
-// that are ready to participate in allow/3. Guarded permissions are
-// armed only when the host injects a payload-bearing request-local
-// context_now/3 compound, guard_context/6, and eval_guard/4 bridge
-// facts for a satisfied guard expression.
+// Stateful armed/3 derivation. The version-0 perm-scope keeps the
+// durable permission-state lifecycle in the host policy store, then
+// replays the current snapshot as perm_state/4 and the transition
+// ledger as perm_state_event/7. Unguarded permissions participate in
+// allow/3 only when the current state is "armed". Guarded permissions
+// still require a payload-bearing request-local context_now/3
+// compound, guard_context/6, and eval_guard/4 bridge facts for a
+// satisfied guard expression.
 //
 // v0 defines the permission-state transition surface for host mutation
 // code and downstream tooling. The transition table is intentionally
@@ -19,7 +20,10 @@
 // events move them.
 //
 // EDB schemas (host-populated, no clauses below):
-//   perm_state(user, perm, scope, state)        -- v0 row count = 0
+//   perm_state(user, perm, scope, state)        -- current durable
+//                                                   lifecycle state
+//   perm_state_event(event_id, user, perm,     -- append-only durable
+//       scope, event, from_state, to_state)        transition ledger
 //   has_permission(user, perm, scope)            -- declared in
 //                                                   bootstrap.dl
 //   perm_arm_rule(perm, guard_handle)            -- guard(root) side

--- a/tests/test-fsm-bisim.c
+++ b/tests/test-fsm-bisim.c
@@ -12,11 +12,12 @@
  * agree on the destination, undefined transitions agree on the
  * rejection.
  *
- * permission_scope is intentionally NOT bisimulated: the v0
- * permission scope is stateless armed/3 derivation, not a
- * Mealy-style transition table. The guard expression depth/atom
- * limits and the perm_arm_rule mirror oracle already cover its
- * semantics in earlier test files.
+ * permission_scope is covered by tests/test-fsm-permission-scope.c.
+ * That suite compares the Datalog transition rows against the C
+ * reference table and checks armed/3 projection from current
+ * perm_state/4 rows plus request-local guard context. Keeping it out
+ * of this bisimulation harness avoids mixing table-driven FSM tests
+ * with permission-scope projection tests.
  */
 #include <glib.h>
 #include <glib/gstdio.h>

--- a/tests/test-perm.c
+++ b/tests/test-perm.c
@@ -10,10 +10,12 @@
 
 /*
  * v0 contract for wyl_perm_grant / wyl_perm_revoke: validate
- * arguments, persist direct permission authority rows, mirror direct
- * permission plus armed-state facts into any attached policy engine
- * pair, record the admin operation in the audit log when audit is
- * enabled, and return WYRELOG_E_OK.
+ * arguments, persist direct permission authority rows, project those
+ * rows into any attached policy engine pair, record the admin
+ * operation in the audit log when audit is enabled, and return
+ * WYRELOG_E_OK. The permission-state lifecycle remains a separate
+ * contract; unguarded direct permissions keep a compatibility
+ * projection path until callers migrate to explicit transitions.
  */
 
 typedef struct
@@ -291,7 +293,7 @@ check_role_grant_requires_existing_role (void)
 }
 
 static gint
-check_grant_allows_engine_decide (void)
+check_direct_grant_compat_allows_engine_decide (void)
 {
   g_autoptr (WylHandle) handle = NULL;
   if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
@@ -341,7 +343,7 @@ check_grant_allows_engine_decide (void)
 }
 
 static gint
-check_role_grant_allows_engine_decide (void)
+check_role_grant_with_armed_state_allows_engine_decide (void)
 {
   g_autoptr (WylHandle) handle = NULL;
   if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
@@ -747,9 +749,9 @@ main (void)
     return rc;
   if ((rc = check_role_grant_requires_existing_role ()) != 0)
     return rc;
-  if ((rc = check_grant_allows_engine_decide ()) != 0)
+  if ((rc = check_direct_grant_compat_allows_engine_decide ()) != 0)
     return rc;
-  if ((rc = check_role_grant_allows_engine_decide ()) != 0)
+  if ((rc = check_role_grant_with_armed_state_allows_engine_decide ()) != 0)
     return rc;
   if ((rc = check_gated_grant_is_rejected_by_engine_path ()) != 0)
     return rc;

--- a/wyrelog/daemon/checks.c
+++ b/wyrelog/daemon/checks.c
@@ -295,6 +295,11 @@ wyl_daemon_check_policy_snapshot_reload_ready (WylHandle *handle)
 wyrelog_error_t
 wyl_daemon_check_direct_permission_grant_ready (WylHandle *handle)
 {
+  /*
+   * This readiness probe covers direct permission mutation, audit, reload,
+   * and the unguarded compatibility projection. The canonical stateful
+   * lifecycle probe is wyl_daemon_check_permission_state_transition_ready().
+   */
   g_autoptr (WylSession) session = NULL;
   wyrelog_error_t rc =
       login_check_principal (handle, "wyrelogd-direct-grant-user", &session);


### PR DESCRIPTION
## Summary

- describe permission-scope arming as a durable permission-state lifecycle
- distinguish direct grant compatibility behavior from explicit transitions


## Tests
- meson test -C builddir-ci-pr --print-errorlogs
- meson test -C builddir-ci-pr fsm-permission-scope fsm-bisim perm daemon-checks --print-errorlogs
