### PR TITLE
Harden daemon readiness and audit build boundaries

### DIFF
--- a/tests/check-wyrelogd-healthz.sh
+++ b/tests/check-wyrelogd-healthz.sh
@@ -102,6 +102,9 @@ for _ in range(50):
         health = urllib.request.urlopen(f"{base}/healthz", timeout=1).read()
         if health != b"ok\n":
             sys.exit(1)
+        ready = urllib.request.urlopen(f"{base}/readyz", timeout=1).read()
+        if ready != b"ready\n":
+            sys.exit(1)
         if expect_audit:
             if not audit_endpoint_requires_auth():
                 sys.exit(1)

--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -1625,6 +1625,7 @@ check_policy_permission_mutation_contract (WylHandle *handle,
   if (direct_permission_exists (handle, "target", "site.policy.read",
           "tenant-a"))
     return 134;
+#ifdef WYL_HAS_AUDIT
   AuditEventProbe guard_denied_audit = {
     .subject_id = "http-policy-admin",
     .action = "wr.policy.write",
@@ -1640,6 +1641,7 @@ check_policy_permission_mutation_contract (WylHandle *handle,
     return 200;
   if (guard_denied_audit.matches != 1)
     return 201;
+#endif
   g_clear_pointer (&body, g_free);
 
   g_autofree gchar *transition_request_id = NULL;
@@ -1754,6 +1756,7 @@ check_policy_permission_mutation_contract (WylHandle *handle,
   if (!direct_permission_exists (handle, "target", "site.policy.read",
           "tenant-a"))
     return 136;
+#ifdef WYL_HAS_AUDIT
   AuditEventProbe grant_audit = {
     .subject_id = "http-policy-admin",
     .action = "permission_grant",
@@ -1779,6 +1782,7 @@ check_policy_permission_mutation_contract (WylHandle *handle,
     return 202;
   if (grant_auth_audit.matches != 1)
     return 203;
+#endif
   g_clear_pointer (&body, g_free);
 
   rc = send_raw_policy_mutation_bearer (session, "POST", base_url,
@@ -1925,6 +1929,7 @@ check_policy_permission_mutation_contract (WylHandle *handle,
   if (!role_membership_exists (handle, "role-target", "site.reader",
           "tenant-b"))
     return 146;
+#ifdef WYL_HAS_AUDIT
   AuditEventProbe role_grant_audit = {
     .subject_id = "http-policy-admin",
     .action = "role_grant",
@@ -1937,6 +1942,7 @@ check_policy_permission_mutation_contract (WylHandle *handle,
     return 198;
   if (role_grant_audit.matches != 1)
     return 199;
+#endif
 
   g_autofree gchar *builtin_role_query =
       g_strdup_printf ("subject=builtin-role-target&role=wr.auditor"

--- a/wyrelog/daemon/delta.c
+++ b/wyrelog/daemon/delta.c
@@ -1,11 +1,12 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #include "daemon/delta.h"
 
-#include "wyrelog/audit/conn-private.h"
-#include "wyrelog/policy/store-private.h"
 #include "wyrelog/wyl-handle-private.h"
 
 #ifdef WYL_HAS_AUDIT
+#include "wyrelog/audit/conn-private.h"
+#include "wyrelog/policy/store-private.h"
+
 static void
 record_daemon_audit_result (WylDaemonRuntime *runtime, wyrelog_error_t rc)
 {

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -448,6 +448,87 @@ healthz_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
       strlen (body));
 }
 
+static wyrelog_error_t
+check_runtime_ready (WylHandle *handle)
+{
+  gint64 row[1];
+  wyrelog_error_t rc =
+      wyl_handle_intern_engine_symbol (handle, "wr.audit.read", &row[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  gboolean ready = FALSE;
+  rc = wyl_handle_engine_contains (handle, "guarded_perm", row, 1, &ready);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if (!ready)
+    return WYRELOG_E_POLICY;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  const gchar *tables[] = {
+    "wyrelog_config",
+    "roles",
+    "permissions",
+    "role_permissions",
+    "role_inheritances",
+    "role_memberships",
+    "role_membership_events",
+    "direct_permissions",
+    "direct_permission_events",
+    "permission_states",
+    "permission_state_events",
+    "principal_events",
+    "principal_states",
+    "session_states",
+    "session_events",
+    "audit_events",
+    "policy_signatures",
+  };
+
+  for (gsize i = 0; i < G_N_ELEMENTS (tables); i++) {
+    gboolean found = FALSE;
+    rc = wyl_policy_store_table_exists (store, tables[i], &found);
+    if (rc != WYRELOG_E_OK)
+      return rc;
+    if (!found)
+      return WYRELOG_E_POLICY;
+  }
+
+#ifdef WYL_HAS_AUDIT
+  wyl_audit_conn_t *conn = wyl_handle_get_audit_conn (handle);
+  gboolean found = FALSE;
+  rc = wyl_audit_conn_table_exists (conn, "audit_events", &found);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if (!found)
+    return WYRELOG_E_IO;
+#endif
+
+  return WYRELOG_E_OK;
+}
+
+static void
+readyz_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
+    GHashTable *query, gpointer user_data)
+{
+  (void) server;
+  (void) path;
+  (void) query;
+
+  WylDaemonHttpContext *ctx = user_data;
+  wyrelog_error_t rc = check_runtime_ready (ctx->handle);
+  if (rc != WYRELOG_E_OK) {
+    set_json_error (msg, 503, "not_ready");
+    return;
+  }
+
+  const gchar *body = "ready\n";
+  attach_request_id_header (msg);
+  soup_server_message_set_status (msg, 200, NULL);
+  soup_server_message_set_response (msg, "text/plain", SOUP_MEMORY_COPY, body,
+      strlen (body));
+}
+
 static gboolean
 authorize_guarded_session_action (SoupServer *server, SoupServerMessage *msg,
     GHashTable *query, WylDaemonHttpContext *ctx, const gchar *action,
@@ -1143,6 +1224,7 @@ wyl_daemon_start_http_server (const WylDaemonOptions *opts, WylHandle *handle,
   g_object_set_data_full (G_OBJECT (server), "wyl-daemon-http-context", ctx,
       wyl_daemon_http_context_free);
   soup_server_add_handler (server, "/healthz", healthz_handler, NULL, NULL);
+  soup_server_add_handler (server, "/readyz", readyz_handler, ctx, NULL);
   soup_server_add_handler (server, "/auth/login", login_handler, ctx, NULL);
   soup_server_add_handler (server, "/auth/logout", logout_handler, ctx, NULL);
   soup_server_add_handler (server, "/decide", decide_handler, ctx, NULL);


### PR DESCRIPTION
## Summary

- keep audit-disabled daemon builds free of DuckDB-only dependencies
- add a live /readyz probe for runtime policy and audit readiness


## Tests
- meson test -C builddir --print-errorlogs
- meson test -C builddir-ci-pr --print-errorlogs







