### PR TITLE
daemon: verify skip-mfa readiness override path

### DIFF
--- a/tests/test-daemon-checks.c
+++ b/tests/test-daemon-checks.c
@@ -152,12 +152,19 @@ check_login_skip_mfa_ready_allows_development_path (void)
   if (!count_duckdb_rows (conn,
           "SELECT COUNT(*) FROM audit_events "
           "WHERE action = 'principal_state' "
-          "AND subject_id = 'wyrelogd-skip-mfa-user' "
+          "AND subject_id = 'wyrelogd-skip-mfa-override-user' "
           "AND deny_reason = 'login_skip_mfa' "
           "AND resource_id = 'authenticated' " "AND decision = 1;", &count))
     return 33;
   if (count != 1)
     return 34;
+  if (wyl_handle_get_login_skip_mfa_override_allowed (handle))
+    return 35;
+  if (wyl_policy_store_set_deployment_mode (wyl_handle_get_policy_store
+          (handle), "production") != WYRELOG_E_OK)
+    return 36;
+  if (wyl_handle_get_login_skip_mfa_allowed (handle))
+    return 37;
   return 0;
 }
 

--- a/wyrelog/daemon/checks.c
+++ b/wyrelog/daemon/checks.c
@@ -190,6 +190,26 @@ wyl_daemon_check_audit_sink_ready (WylHandle *handle)
   return WYRELOG_E_OK;
 }
 
+static wyrelog_error_t
+check_login_skip_mfa_override_ready (WylHandle *handle, gboolean restore)
+{
+  wyl_handle_set_login_skip_mfa_allowed (handle, TRUE);
+  g_autoptr (wyl_login_req_t) override_login = wyl_login_req_new ();
+  g_autoptr (WylSession) override_session = NULL;
+  wyl_login_req_set_username (override_login,
+      "wyrelogd-skip-mfa-override-user");
+  wyl_login_req_set_skip_mfa (override_login, TRUE);
+  wyrelog_error_t rc =
+      wyl_session_login (handle, override_login, &override_session);
+  wyl_handle_set_login_skip_mfa_allowed (handle, restore);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if (override_session == NULL)
+    return WYRELOG_E_POLICY;
+
+  return WYRELOG_E_OK;
+}
+
 wyrelog_error_t
 wyl_daemon_check_login_skip_mfa_ready (WylHandle *handle)
 {
@@ -200,9 +220,11 @@ wyl_daemon_check_login_skip_mfa_ready (WylHandle *handle)
   wyl_login_req_set_skip_mfa (login, TRUE);
 
   gboolean allowed = wyl_handle_get_login_skip_mfa_allowed (handle);
+  gboolean override_allowed =
+      wyl_handle_get_login_skip_mfa_override_allowed (handle);
   wyrelog_error_t rc = wyl_session_login (handle, login, &session);
   if (!allowed && rc == WYRELOG_E_POLICY)
-    return WYRELOG_E_OK;
+    return check_login_skip_mfa_override_ready (handle, override_allowed);
   if (rc != WYRELOG_E_OK)
     return rc;
   if (session == NULL)
@@ -232,7 +254,7 @@ wyl_daemon_check_login_skip_mfa_ready (WylHandle *handle)
   if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_ALLOW)
     return WYRELOG_E_POLICY;
 
-  return WYRELOG_E_OK;
+  return check_login_skip_mfa_override_ready (handle, override_allowed);
 }
 
 static wyrelog_error_t

--- a/wyrelog/wyl-handle-private.h
+++ b/wyrelog/wyl-handle-private.h
@@ -63,6 +63,7 @@ wyl_policy_store_t *wyl_handle_get_policy_store (WylHandle * self);
  * non-production modes and rejects it for production or unreadable config.
  */
 void wyl_handle_set_login_skip_mfa_allowed (WylHandle * self, gboolean allowed);
+gboolean wyl_handle_get_login_skip_mfa_override_allowed (WylHandle * self);
 gboolean wyl_handle_get_login_skip_mfa_allowed (WylHandle * self);
 
 /*

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -511,6 +511,13 @@ wyl_handle_set_login_skip_mfa_allowed (WylHandle *self, gboolean allowed)
 }
 
 gboolean
+wyl_handle_get_login_skip_mfa_override_allowed (WylHandle *self)
+{
+  g_return_val_if_fail (WYL_IS_HANDLE (self), FALSE);
+  return self->login_skip_mfa_allowed;
+}
+
+gboolean
 wyl_handle_get_login_skip_mfa_allowed (WylHandle *self)
 {
   g_return_val_if_fail (WYL_IS_HANDLE (self), FALSE);


### PR DESCRIPTION
## Summary
- exercise the explicit skip-MFA host override during daemon readiness
- restore the raw override flag after readiness probes
- cover development-to-production fallback so readiness cannot leak override state

## Tests
- meson test -C builddir --print-errorlogs
- meson test -C builddir-ci-pr --print-errorlogs
