### PR TITLE
policy: harden authority audit projection

### DIFF
--- a/tests/check-client-audit-daemon.sh
+++ b/tests/check-client-audit-daemon.sh
@@ -7,7 +7,14 @@ WYRELOGD=$1
 CLIENT_TEST=$2
 TEMPLATE_DIR=$3
 PYTHON=$4
-PORT=$((39000 + $$ % 20000))
+PORT=$("$PYTHON" - <<'PY'
+import socket
+
+with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+    sock.bind(("127.0.0.1", 0))
+    print(sock.getsockname()[1])
+PY
+)
 
 "$WYRELOGD" --template-dir "$TEMPLATE_DIR" --listen-port "$PORT" &
 PID=$!
@@ -26,7 +33,7 @@ port = sys.argv[1]
 url = f"http://127.0.0.1:{port}/healthz"
 last_error = None
 
-for _ in range(50):
+for _ in range(150):
     try:
         urllib.request.urlopen(url, timeout=1).read()
         sys.exit(0)

--- a/tests/check-wyrelogd-healthz.sh
+++ b/tests/check-wyrelogd-healthz.sh
@@ -7,7 +7,14 @@ WYRELOGD=$1
 TEMPLATE_DIR=$2
 PYTHON=$3
 EXPECT_AUDIT=${4:-0}
-PORT=$((39000 + $$ % 20000))
+PORT=$("$PYTHON" - <<'PY'
+import socket
+
+with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+    sock.bind(("127.0.0.1", 0))
+    print(sock.getsockname()[1])
+PY
+)
 TMPDIR=$(mktemp -d)
 POLICY_DB="$TMPDIR/policy.sqlite"
 AUDIT_DB="$TMPDIR/audit.duckdb"
@@ -97,7 +104,7 @@ def decide_denies_unseeded_user():
         and "deny_origin" in body
     )
 
-for _ in range(50):
+for _ in range(150):
     try:
         health = urllib.request.urlopen(f"{base}/healthz", timeout=1).read()
         if health != b"ok\n":

--- a/tests/check-wyrelogd-startup-readiness.sh
+++ b/tests/check-wyrelogd-startup-readiness.sh
@@ -6,7 +6,14 @@ set -eu
 WYRELOGD=$1
 TEMPLATE_DIR=$2
 PYTHON=$3
-PORT=$((20000 + $$ % 15000))
+PORT=$("$PYTHON" - <<'PY'
+import socket
+
+with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+    sock.bind(("127.0.0.1", 0))
+    print(sock.getsockname()[1])
+PY
+)
 TMPDIR=$(mktemp -d)
 PID=
 RC_FILE="$TMPDIR/daemon.rc"

--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -2489,6 +2489,12 @@ main (void)
       WYL_DECISION_ALLOW, NULL, "site.policy.read");
   if (audit_rc != 0)
     return audit_rc;
+  audit_rc = check_audit_event_present (client,
+      "action(\"permission_state.grant\")",
+      "http-policy-admin", "permission_state.grant", "site.policy.read",
+      WYL_DECISION_ALLOW, "grant", "tenant-a");
+  if (audit_rc != 0)
+    return audit_rc;
   audit_rc = check_audit_event_present (client, "action(\"role_grant\")",
       "http-policy-admin", "role_grant", "tenant-b",
       WYL_DECISION_ALLOW, NULL, "site.reader");

--- a/tests/test-policy-store.c
+++ b/tests/test-policy-store.c
@@ -19,33 +19,17 @@ check_store_creates_authority_schema (void)
   if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
     return 11;
 
-  const gchar *tables[] = {
-    "wyrelog_config",
-    "roles",
-    "permissions",
-    "role_permissions",
-    "role_inheritances",
-    "role_memberships",
-    "role_membership_events",
-    "direct_permissions",
-    "direct_permission_events",
-    "permission_states",
-    "permission_state_events",
-    "principal_events",
-    "principal_states",
-    "session_states",
-    "session_events",
-    "audit_events",
-    "policy_signatures",
-  };
-  for (gsize i = 0; i < G_N_ELEMENTS (tables); i++) {
+  for (gsize i = 0; i < wyl_policy_store_required_table_count (); i++) {
     gboolean exists = FALSE;
-    if (wyl_policy_store_table_exists (store, tables[i], &exists)
-        != WYRELOG_E_OK)
+    const gchar *table = wyl_policy_store_required_table_name (i);
+    if (wyl_policy_store_table_exists (store, table, &exists) != WYRELOG_E_OK)
       return 12;
     if (!exists)
       return 13;
   }
+  if (wyl_policy_store_required_table_name
+      (wyl_policy_store_required_table_count ()) != NULL)
+    return 14;
 
   return 0;
 }
@@ -70,29 +54,10 @@ check_template_schema_creates_state_tables (void)
     return 22;
   }
 
-  const gchar *tables[] = {
-    "wyrelog_config",
-    "roles",
-    "permissions",
-    "role_permissions",
-    "role_inheritances",
-    "role_memberships",
-    "role_membership_events",
-    "direct_permissions",
-    "direct_permission_events",
-    "permission_states",
-    "permission_state_events",
-    "principal_events",
-    "principal_states",
-    "session_states",
-    "session_events",
-    "audit_events",
-    "policy_signatures",
-  };
-  for (gsize i = 0; i < G_N_ELEMENTS (tables); i++) {
+  for (gsize i = 0; i < wyl_policy_store_required_table_count (); i++) {
     gboolean exists = FALSE;
-    if (wyl_policy_store_table_exists (store, tables[i], &exists)
-        != WYRELOG_E_OK)
+    const gchar *table = wyl_policy_store_required_table_name (i);
+    if (wyl_policy_store_table_exists (store, table, &exists) != WYRELOG_E_OK)
       return 23;
     if (!exists)
       return 24;

--- a/tests/test-policy-store.c
+++ b/tests/test-policy-store.c
@@ -1654,6 +1654,70 @@ check_store_permission_state_transition_rejects_invalid_audit (void)
 }
 
 static gint
+check_store_permission_state_transition_rolls_back_audit_conflict (void)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+  static const gchar *id = "01890c10-2e3f-7000-8000-000000000012";
+
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 294;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 295;
+  if (wyl_policy_store_append_audit_event (store, id, 1001,
+          "existing-audit-user", "existing.action", "existing-resource",
+          NULL, NULL, WYL_DECISION_ALLOW) != WYRELOG_E_OK)
+    return 296;
+
+  gint64 event_id = 102;
+  if (wyl_policy_store_apply_permission_state_transition_with_audit (store,
+          "perm-audit-conflict-user", "wr.perm.audit.conflict",
+          "perm-audit-conflict-scope", "grant", &event_id, id, 1001,
+          "perm-audit-conflict-user", "permission_state.grant",
+          "wr.perm.audit.conflict", "allowed", "permission_state",
+          NULL, WYL_DECISION_ALLOW) != WYRELOG_E_POLICY)
+    return 297;
+  if (event_id != -1)
+    return 298;
+
+  gboolean exists = TRUE;
+  if (wyl_policy_store_permission_state_exists (store,
+          "perm-audit-conflict-user", "wr.perm.audit.conflict",
+          "perm-audit-conflict-scope", &exists) != WYRELOG_E_OK)
+    return 299;
+  if (exists)
+    return 300;
+
+  PermissionStateEventExpect event_expect = {
+    .subject_id = "perm-audit-conflict-user",
+    .perm_id = "wr.perm.audit.conflict",
+    .scope = "perm-audit-conflict-scope",
+    .event = "grant",
+    .from_state = "dormant",
+    .to_state = "armed",
+  };
+  if (wyl_policy_store_foreach_permission_state_event (store,
+          permission_state_event_expect_cb, &event_expect) != WYRELOG_E_OK)
+    return 301;
+  if (event_expect.matches != 0)
+    return 302;
+
+  AuditEventExpect audit_expect = {
+    .id = id,
+    .created_at_us = 1001,
+    .subject_id = "existing-audit-user",
+    .action = "existing.action",
+    .resource_id = "existing-resource",
+    .decision = WYL_DECISION_ALLOW,
+  };
+  if (wyl_policy_store_foreach_audit_event (store, audit_event_expect_cb,
+          &audit_expect) != WYRELOG_E_OK)
+    return 303;
+  if (audit_expect.matches != 1)
+    return 304;
+  return 0;
+}
+
+static gint
 check_store_sets_principal_state (void)
 {
   g_autoptr (wyl_policy_store_t) store = NULL;
@@ -2275,6 +2339,10 @@ main (void)
       != 0)
     return rc;
   if ((rc = check_store_permission_state_transition_rejects_invalid_audit ())
+      != 0)
+    return rc;
+  if ((rc =
+          check_store_permission_state_transition_rolls_back_audit_conflict ())
       != 0)
     return rc;
   if ((rc = check_store_sets_principal_state ()) != 0)

--- a/wyrelog/daemon/checks.c
+++ b/wyrelog/daemon/checks.c
@@ -32,30 +32,11 @@ wyrelog_error_t
 wyl_daemon_check_policy_store_ready (WylHandle *handle)
 {
   wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
-  const gchar *tables[] = {
-    "wyrelog_config",
-    "roles",
-    "permissions",
-    "role_permissions",
-    "role_inheritances",
-    "role_memberships",
-    "role_membership_events",
-    "direct_permissions",
-    "direct_permission_events",
-    "permission_states",
-    "permission_state_events",
-    "principal_events",
-    "principal_states",
-    "session_states",
-    "session_events",
-    "audit_events",
-    "policy_signatures",
-  };
 
-  for (gsize i = 0; i < G_N_ELEMENTS (tables); i++) {
+  for (gsize i = 0; i < wyl_policy_store_required_table_count (); i++) {
     gboolean found = FALSE;
-    wyrelog_error_t rc =
-        wyl_policy_store_table_exists (store, tables[i], &found);
+    const gchar *table = wyl_policy_store_required_table_name (i);
+    wyrelog_error_t rc = wyl_policy_store_table_exists (store, table, &found);
     if (rc != WYRELOG_E_OK)
       return rc;
     if (!found)

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -465,29 +465,11 @@ check_runtime_ready (WylHandle *handle)
     return WYRELOG_E_POLICY;
 
   wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
-  const gchar *tables[] = {
-    "wyrelog_config",
-    "roles",
-    "permissions",
-    "role_permissions",
-    "role_inheritances",
-    "role_memberships",
-    "role_membership_events",
-    "direct_permissions",
-    "direct_permission_events",
-    "permission_states",
-    "permission_state_events",
-    "principal_events",
-    "principal_states",
-    "session_states",
-    "session_events",
-    "audit_events",
-    "policy_signatures",
-  };
 
-  for (gsize i = 0; i < G_N_ELEMENTS (tables); i++) {
+  for (gsize i = 0; i < wyl_policy_store_required_table_count (); i++) {
     gboolean found = FALSE;
-    rc = wyl_policy_store_table_exists (store, tables[i], &found);
+    const gchar *table = wyl_policy_store_required_table_name (i);
+    rc = wyl_policy_store_table_exists (store, table, &found);
     if (rc != WYRELOG_E_OK)
       return rc;
     if (!found)

--- a/wyrelog/policy/store-private.h
+++ b/wyrelog/policy/store-private.h
@@ -69,6 +69,8 @@ void wyl_policy_store_rollback_mutation (wyl_policy_store_t * store);
 
 wyrelog_error_t wyl_policy_store_create_schema (wyl_policy_store_t * store);
 wyrelog_error_t wyl_policy_store_validate_snapshot (wyl_policy_store_t * store);
+gsize wyl_policy_store_required_table_count (void);
+const gchar *wyl_policy_store_required_table_name (gsize idx);
 gsize wyl_policy_store_builtin_role_count (void);
 const gchar *wyl_policy_store_builtin_role_id (gsize idx);
 gsize wyl_policy_store_builtin_permission_count (void);

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -61,6 +61,26 @@ static const BuiltinPermission builtin_permissions[] = {
   {"wr.audit.write", "audit write", "critical"},
 };
 
+static const gchar *const required_tables[] = {
+  "wyrelog_config",
+  "roles",
+  "permissions",
+  "role_permissions",
+  "role_inheritances",
+  "role_memberships",
+  "role_membership_events",
+  "direct_permissions",
+  "direct_permission_events",
+  "permission_states",
+  "permission_state_events",
+  "principal_events",
+  "principal_states",
+  "session_states",
+  "session_events",
+  "audit_events",
+  "policy_signatures",
+};
+
 static const BuiltinRole *
 find_builtin_role (const gchar *role_id)
 {
@@ -687,6 +707,20 @@ wyl_policy_store_create_schema (wyl_policy_store_t *store)
   if (rc != WYRELOG_E_OK)
     return rc;
   return seed_builtin_catalog (store->db);
+}
+
+gsize
+wyl_policy_store_required_table_count (void)
+{
+  return G_N_ELEMENTS (required_tables);
+}
+
+const gchar *
+wyl_policy_store_required_table_name (gsize idx)
+{
+  if (idx >= G_N_ELEMENTS (required_tables))
+    return NULL;
+  return required_tables[idx];
 }
 
 gsize


### PR DESCRIPTION
## Summary
- centralize the private Policy Store authority table contract
- cover permission-state audit replay through daemon audit queries
- add rollback coverage for permission-state audit id conflicts
- stabilize daemon shell tests under parallel Meson execution

## Tests
- meson test -C builddir --print-errorlogs
- meson test -C builddir-ci-pr --print-errorlogs
