### PR TITLE
LoBAC: harden permission replay authority

### DIFF
--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -1756,6 +1756,9 @@ check_policy_permission_mutation_contract (WylHandle *handle,
   if (!direct_permission_exists (handle, "target", "site.policy.read",
           "tenant-a"))
     return 136;
+  if (permission_state_exists (handle, "target", "site.policy.read",
+          "tenant-a"))
+    return 204;
 #ifdef WYL_HAS_AUDIT
   AuditEventProbe grant_audit = {
     .subject_id = "http-policy-admin",

--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -320,6 +320,19 @@ eval_guard_count_cb (const gchar *relation, const gint64 *row, guint ncols,
 }
 
 static void
+guard_context_field_count_cb (const gchar *relation, const gint64 *row,
+    guint ncols, gpointer user_data)
+{
+  GuardBridgeExpect *expect = user_data;
+
+  (void) relation;
+
+  if ((ncols == 3 || ncols == 4) && row[0] == expect->row[0]
+      && row[1] == expect->row[2])
+    expect->matches++;
+}
+
+static void
 seen_expect_cb (const gchar *relation, const gint64 *row, guint ncols,
     gpointer user_data)
 {
@@ -546,6 +559,22 @@ expect_guard_bridge_absent (WylHandle *handle, const gchar *subject,
     return base_code + 5;
   if (expect.matches != 0)
     return base_code + 6;
+
+  static const gchar *const field_relations[] = {
+    "guard_context_timestamp",
+    "guard_context_loc_class",
+    "guard_context_risk",
+    "guard_context_in_window",
+  };
+  for (gsize i = 0; i < G_N_ELEMENTS (field_relations); i++) {
+    expect.matches = 0;
+    if (wyl_engine_snapshot (wyl_handle_get_read_engine (handle),
+            field_relations[i], guard_context_field_count_cb, &expect)
+        != WYRELOG_E_OK)
+      return base_code + 7 + (gint) (i * 2);
+    if (expect.matches != 0)
+      return base_code + 8 + (gint) (i * 2);
+  }
 
   return 0;
 }
@@ -3204,20 +3233,81 @@ check_policy_store_guarded_permission_state_stays_guarded (void)
 }
 
 static gint
+check_policy_store_guarded_permission_state_needs_context (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 708;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (wyl_policy_store_grant_direct_permission (store,
+          "permstate-guard-context-user", "wr.audit.read",
+          "permstate-guard-context-scope") != WYRELOG_E_OK)
+    return 709;
+  if (wyl_policy_store_set_principal_state (store,
+          "permstate-guard-context-user", "authenticated") != WYRELOG_E_OK)
+    return 710;
+  if (wyl_policy_store_set_session_state (store,
+          "permstate-guard-context-scope", "active") != WYRELOG_E_OK)
+    return 711;
+  if (wyl_policy_store_set_permission_state (store,
+          "permstate-guard-context-user", "wr.audit.read",
+          "permstate-guard-context-scope", "armed") != WYRELOG_E_OK)
+    return 712;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 713;
+
+  g_autoptr (wyl_decide_req_t) req = wyl_decide_req_new ();
+  wyl_decide_req_set_subject_id (req, "permstate-guard-context-user");
+  wyl_decide_req_set_action (req, "wr.audit.read");
+  wyl_decide_req_set_resource_id (req, "permstate-guard-context-scope");
+
+  g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
+  if (wyl_decide (handle, req, resp) != WYRELOG_E_OK)
+    return 714;
+  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_DENY)
+    return 715;
+  if (g_strcmp0 (wyl_decide_resp_get_deny_reason (resp), "not_armed") != 0)
+    return 716;
+  if (g_strcmp0 (wyl_decide_resp_get_deny_origin (resp), "perm_state") != 0)
+    return 717;
+
+  wyl_decide_req_set_guard_context (req, 123, "public", 69);
+  wyl_decide_resp_set_decision (resp, WYL_DECISION_DENY);
+  if (wyl_decide (handle, req, resp) != WYRELOG_E_OK)
+    return 718;
+  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_ALLOW)
+    return 719;
+  if (wyl_decide_resp_get_deny_reason (resp) != NULL)
+    return 720;
+  if (wyl_decide_resp_get_deny_origin (resp) != NULL)
+    return 721;
+
+  gint residue = expect_guard_bridge_absent (handle,
+      "permstate-guard-context-user", "wr.audit.read",
+      "permstate-guard-context-scope", 722);
+  if (residue != 0)
+    return residue;
+  return 0;
+}
+
+static gint
 check_policy_store_permission_states_reject_unknown_state (void)
 {
   g_autoptr (WylHandle) handle = NULL;
 
   if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
-    return 705;
+    return 730;
 
   wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
   if (wyl_policy_store_set_permission_state (store, "permstate-bad-user",
           "wr.audit.read", "permstate-bad-scope", "missing") != WYRELOG_E_OK)
-    return 706;
+    return 731;
   if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
       != WYRELOG_E_POLICY)
-    return 707;
+    return 732;
   return 0;
 }
 
@@ -4529,6 +4619,8 @@ main (void)
   if ((rc = check_policy_store_permission_states_reject_non_armed ()) != 0)
     return rc;
   if ((rc = check_policy_store_guarded_permission_state_stays_guarded ()) != 0)
+    return rc;
+  if ((rc = check_policy_store_guarded_permission_state_needs_context ()) != 0)
     return rc;
   if ((rc = check_policy_store_permission_states_reject_unknown_state ()) != 0)
     return rc;

--- a/tests/test-perm.c
+++ b/tests/test-perm.c
@@ -36,6 +36,15 @@ typedef struct
   guint matches;
 } RoleMembershipEventExpect;
 
+typedef struct
+{
+  const gchar *subject_id;
+  const gchar *perm_id;
+  const gchar *scope;
+  const gchar *state;
+  guint matches;
+} PermissionStateExpect;
+
 static wyrelog_error_t
 direct_permission_event_expect_cb (const gchar *subject_id,
     const gchar *perm_id, const gchar *scope, const gchar *operation,
@@ -62,6 +71,20 @@ role_membership_event_expect_cb (const gchar *subject_id,
       && g_strcmp0 (role_id, expect->role_id) == 0
       && g_strcmp0 (scope, expect->scope) == 0
       && g_strcmp0 (operation, expect->operation) == 0)
+    expect->matches++;
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+permission_state_expect_cb (const gchar *subject_id, const gchar *perm_id,
+    const gchar *scope, const gchar *state, gpointer user_data)
+{
+  PermissionStateExpect *expect = user_data;
+
+  if (g_strcmp0 (subject_id, expect->subject_id) == 0
+      && g_strcmp0 (perm_id, expect->perm_id) == 0
+      && g_strcmp0 (scope, expect->scope) == 0
+      && g_strcmp0 (state, expect->state) == 0)
     expect->matches++;
   return WYRELOG_E_OK;
 }
@@ -339,6 +362,68 @@ check_direct_grant_compat_allows_engine_decide (void)
     return 57;
   if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_ALLOW)
     return 58;
+  return 0;
+}
+
+static gint
+check_direct_grant_preserves_dormant_permission_state (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 200;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (wyl_policy_store_set_principal_state (store, "grant-dormant-user",
+          "authenticated") != WYRELOG_E_OK)
+    return 201;
+  if (wyl_policy_store_set_session_state (store, "grant-dormant-scope",
+          "active") != WYRELOG_E_OK)
+    return 202;
+  if (wyl_policy_store_set_permission_state (store, "grant-dormant-user",
+          "site.grant-dormant", "grant-dormant-scope", "dormant")
+      != WYRELOG_E_OK)
+    return 203;
+
+  g_autoptr (wyl_grant_req_t) grant = wyl_grant_req_new ();
+  wyl_grant_req_set_subject_id (grant, "grant-dormant-user");
+  wyl_grant_req_set_action (grant, "site.grant-dormant");
+  wyl_grant_req_set_resource_id (grant, "grant-dormant-scope");
+  if (wyl_perm_grant (handle, grant) != WYRELOG_E_OK)
+    return 204;
+
+  gboolean exists = FALSE;
+  if (wyl_policy_store_direct_permission_exists (store,
+          "grant-dormant-user", "site.grant-dormant",
+          "grant-dormant-scope", &exists) != WYRELOG_E_OK)
+    return 205;
+  if (!exists)
+    return 206;
+
+  PermissionStateExpect expect = {
+    .subject_id = "grant-dormant-user",
+    .perm_id = "site.grant-dormant",
+    .scope = "grant-dormant-scope",
+    .state = "dormant",
+  };
+  if (wyl_policy_store_foreach_permission_state (store,
+          permission_state_expect_cb, &expect) != WYRELOG_E_OK)
+    return 207;
+  if (expect.matches != 1)
+    return 208;
+
+  g_autoptr (wyl_decide_req_t) decide = wyl_decide_req_new ();
+  wyl_decide_req_set_subject_id (decide, "grant-dormant-user");
+  wyl_decide_req_set_action (decide, "site.grant-dormant");
+  wyl_decide_req_set_resource_id (decide, "grant-dormant-scope");
+  g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
+  if (wyl_decide (handle, decide, resp) != WYRELOG_E_OK)
+    return 209;
+  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_DENY)
+    return 210;
+  if (g_strcmp0 (wyl_decide_resp_get_deny_reason (resp), "not_armed") != 0)
+    return 211;
+  if (g_strcmp0 (wyl_decide_resp_get_deny_origin (resp), "perm_state") != 0)
+    return 212;
   return 0;
 }
 
@@ -750,6 +835,8 @@ main (void)
   if ((rc = check_role_grant_requires_existing_role ()) != 0)
     return rc;
   if ((rc = check_direct_grant_compat_allows_engine_decide ()) != 0)
+    return rc;
+  if ((rc = check_direct_grant_preserves_dormant_permission_state ()) != 0)
     return rc;
   if ((rc = check_role_grant_with_armed_state_allows_engine_decide ()) != 0)
     return rc;

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -1251,6 +1251,40 @@ wyl_handle_load_policy_store_role_memberships (WylHandle *self)
 }
 
 static wyrelog_error_t
+direct_permission_should_synthesize_armed_state (WylHandle *self,
+    const gchar *subject_id, const gchar *perm_id, const gchar *scope,
+    gboolean *out_synthesize)
+{
+  if (out_synthesize != NULL)
+    *out_synthesize = FALSE;
+  if (self == NULL || !WYL_IS_HANDLE (self) || out_synthesize == NULL)
+    return WYRELOG_E_INVALID;
+  if (self->policy_store == NULL)
+    return WYRELOG_E_INVALID;
+
+  /*
+   * Direct permissions grant authority membership. Unguarded legacy
+   * decisions also need an armed lifecycle fact, but only as a replay
+   * compatibility projection when the durable Policy Store has no
+   * permission_states row for this tuple.
+   *
+   * Guarded permissions never use persisted perm_state as their arming
+   * source; they are armed by request-local guard evidence instead.
+   */
+  if (wyl_perm_arm_rule_lookup (perm_id) != NULL)
+    return WYRELOG_E_OK;
+
+  gboolean has_durable_state = FALSE;
+  wyrelog_error_t rc = wyl_policy_store_permission_state_exists
+      (self->policy_store, subject_id, perm_id, scope, &has_durable_state);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  *out_synthesize = !has_durable_state;
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
 insert_policy_store_direct_permission (const gchar *subject_id,
     const gchar *perm_id, const gchar *scope, gpointer user_data)
 {
@@ -1276,17 +1310,12 @@ insert_policy_store_direct_permission (const gchar *subject_id,
   if (rc != WYRELOG_E_OK)
     return rc;
 
-  /* Guarded permissions are granted membership only. Their armed state
-   * comes from request-local guard evaluation, not persisted perm_state. */
-  if (wyl_perm_arm_rule_lookup (perm_id) != NULL)
-    return WYRELOG_E_OK;
-
-  gboolean has_durable_state = FALSE;
-  rc = wyl_policy_store_permission_state_exists (self->policy_store, subject_id,
-      perm_id, scope, &has_durable_state);
+  gboolean synthesize_armed = FALSE;
+  rc = direct_permission_should_synthesize_armed_state (self, subject_id,
+      perm_id, scope, &synthesize_armed);
   if (rc != WYRELOG_E_OK)
     return rc;
-  if (has_durable_state)
+  if (!synthesize_armed)
     return WYRELOG_E_OK;
 
   gint64 state_row[4];


### PR DESCRIPTION
## Summary

- lock the public grant path so durable dormant permission-state remains
  authoritative over direct permission replay
- make direct permission armed-state synthesis explicit in the replay code
- cover guarded permissions so durable state cannot bypass request-local guard
  evidence
- assert the HTTP grant endpoint creates authority membership without durable
  permission-state lifecycle rows

## Tests

- `meson test -C builddir perm handle-engine-pair daemon-http-decide fsm-permission-scope --print-errorlogs`
- `meson test -C builddir --print-errorlogs`
- `meson test -C builddir-ci-pr perm handle-engine-pair daemon-http-decide fsm-permission-scope --print-errorlogs`
