### PR TITLE
LoBAC: cover permission-state wirelog deltas

### DIFF
--- a/tests/test-daemon-delta.c
+++ b/tests/test-daemon-delta.c
@@ -34,6 +34,30 @@ intern3 (WylHandle *handle, const gchar *a, const gchar *b, const gchar *c,
 }
 
 static wyrelog_error_t
+intern_perm_event7 (WylHandle *handle, gint64 event_id, const gchar *subject,
+    const gchar *perm, const gchar *scope, const gchar *event,
+    const gchar *from_state, const gchar *to_state, gint64 row[7])
+{
+  row[0] = event_id;
+  wyrelog_error_t rc = intern_symbol (handle, subject, &row[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = intern_symbol (handle, perm, &row[2]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = intern_symbol (handle, scope, &row[3]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = intern_symbol (handle, event, &row[4]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = intern_symbol (handle, from_state, &row[5]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return intern_symbol (handle, to_state, &row[6]);
+}
+
+static wyrelog_error_t
 contains_audit_event_fact (WylHandle *handle, const gchar *id,
     gint64 created_at_us, gboolean *out_contains)
 {
@@ -221,6 +245,70 @@ check_delta_callback_ignores_runtime_projection_failure (void)
 }
 
 static gint
+check_perm_state_delta_persists_audit_rows (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  gint64 event_row[7];
+  WylDaemonRuntime runtime = { 0 };
+
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 50;
+  runtime.handle = handle;
+  if (wyl_daemon_start_delta_callbacks (handle, &runtime) != WYRELOG_E_OK)
+    return 51;
+  if (intern_perm_event7 (handle, 701, "daemon-delta-perm-user",
+          "site.daemon-delta.perm", "daemon-delta-perm-scope", "grant",
+          "dormant", "armed", event_row) != WYRELOG_E_OK)
+    return 52;
+
+  if (wyl_handle_engine_insert (handle, "perm_state_event", event_row, 7)
+      != WYRELOG_E_OK)
+    return 53;
+  if (runtime.inserted == 0)
+    return 54;
+  if (runtime.audit_errors != 0)
+    return 55;
+
+  if (wyl_handle_engine_remove (handle, "perm_state_event", event_row, 7)
+      != WYRELOG_E_OK)
+    return 56;
+  if (runtime.removed == 0)
+    return 57;
+  if (runtime.audit_errors != 0)
+    return 58;
+
+  g_autofree gchar *insert_id = NULL;
+  gint64 insert_created_at_us = -1;
+  if (!lookup_policy_audit_row (handle, "perm_state_fired_delta_insert",
+          "daemon-delta-perm-user", "site.daemon-delta.perm",
+          "dormant:grant:armed", "daemon-delta-perm-scope", &insert_id,
+          &insert_created_at_us))
+    return 59;
+  g_autofree gchar *remove_id = NULL;
+  gint64 remove_created_at_us = -1;
+  if (!lookup_policy_audit_row (handle, "perm_state_fired_delta_remove",
+          "daemon-delta-perm-user", "site.daemon-delta.perm",
+          "dormant:grant:armed", "daemon-delta-perm-scope", &remove_id,
+          &remove_created_at_us))
+    return 60;
+
+  gboolean contains = FALSE;
+  if (contains_audit_event_attr_fact (handle, "audit_event_action", insert_id,
+          "perm_state_fired_delta_insert", &contains) != WYRELOG_E_OK
+      || !contains)
+    return 61;
+  if (contains_audit_event_attr_fact (handle, "audit_event_action", remove_id,
+          "perm_state_fired_delta_remove", &contains) != WYRELOG_E_OK
+      || !contains)
+    return 62;
+
+  if (wyl_handle_engine_set_delta_callback (handle, NULL, NULL)
+      != WYRELOG_E_OK)
+    return 63;
+  return 0;
+}
+
+static gint
 check_delta_readiness_recovers_audit_table_loss (void)
 {
   g_autoptr (WylHandle) handle = NULL;
@@ -254,6 +342,8 @@ main (void)
   gint rc;
 
   if ((rc = check_delta_callback_ignores_runtime_projection_failure ()) != 0)
+    return rc;
+  if ((rc = check_perm_state_delta_persists_audit_rows ()) != 0)
     return rc;
   if ((rc = check_delta_readiness_recovers_audit_table_loss ()) != 0)
     return rc;

--- a/tests/test-daemon-delta.c
+++ b/tests/test-daemon-delta.c
@@ -99,6 +99,8 @@ typedef struct
   guint matches;
 } AuditRowLookup;
 
+typedef AuditRowLookup AuditRowCount;
+
 static wyrelog_error_t
 lookup_audit_row_cb (const gchar *id, gint64 created_at_us,
     const gchar *subject_id, const gchar *action, const gchar *resource_id,
@@ -120,6 +122,27 @@ lookup_audit_row_cb (const gchar *id, gint64 created_at_us,
   g_free (lookup->id);
   lookup->id = g_strdup (id);
   lookup->created_at_us = created_at_us;
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+count_audit_row_cb (const gchar *id, gint64 created_at_us,
+    const gchar *subject_id, const gchar *action, const gchar *resource_id,
+    const gchar *deny_reason, const gchar *deny_origin,
+    const gchar *request_id, wyl_decision_t decision, gpointer user_data)
+{
+  (void) id;
+  (void) created_at_us;
+  (void) request_id;
+  AuditRowCount *count = user_data;
+
+  if (decision == WYL_DECISION_ALLOW
+      && g_strcmp0 (action, count->action) == 0
+      && g_strcmp0 (subject_id, count->subject) == 0
+      && g_strcmp0 (resource_id, count->resource) == 0
+      && g_strcmp0 (deny_reason, count->reason) == 0
+      && g_strcmp0 (deny_origin, count->origin) == 0)
+    count->matches++;
   return WYRELOG_E_OK;
 }
 
@@ -146,6 +169,28 @@ lookup_policy_audit_row (WylHandle *handle, const gchar *action,
 
   *out_id = g_steal_pointer (&lookup.id);
   *out_created_at_us = lookup.created_at_us;
+  return TRUE;
+}
+
+static gboolean
+count_policy_audit_rows (WylHandle *handle, const gchar *action,
+    const gchar *subject, const gchar *resource, const gchar *reason,
+    const gchar *origin, guint *out_matches)
+{
+  AuditRowCount count = {
+    .action = action,
+    .subject = subject,
+    .resource = resource,
+    .reason = reason,
+    .origin = origin,
+  };
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  wyrelog_error_t rc = wyl_policy_store_foreach_audit_event (store,
+      count_audit_row_cb, &count);
+  if (rc != WYRELOG_E_OK)
+    return FALSE;
+
+  *out_matches = count.matches;
   return TRUE;
 }
 
@@ -309,6 +354,45 @@ check_perm_state_delta_persists_audit_rows (void)
 }
 
 static gint
+check_invalid_perm_state_delta_skips_audit_rows (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  gint64 event_row[7];
+  WylDaemonRuntime runtime = { 0 };
+
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 70;
+  runtime.handle = handle;
+  if (wyl_daemon_start_delta_callbacks (handle, &runtime) != WYRELOG_E_OK)
+    return 71;
+  if (intern_perm_event7 (handle, 702, "daemon-delta-invalid-user",
+          "site.daemon-delta.invalid", "daemon-delta-invalid-scope", "grant",
+          "armed", "dormant", event_row) != WYRELOG_E_OK)
+    return 72;
+
+  if (wyl_handle_engine_insert (handle, "perm_state_event", event_row, 7)
+      != WYRELOG_E_OK)
+    return 73;
+  if (runtime.inserted != 0 || runtime.removed != 0)
+    return 74;
+  if (runtime.audit_errors != 0)
+    return 75;
+
+  guint matches = 0;
+  if (!count_policy_audit_rows (handle, "perm_state_fired_delta_insert",
+          "daemon-delta-invalid-user", "site.daemon-delta.invalid",
+          "armed:grant:dormant", "daemon-delta-invalid-scope", &matches))
+    return 76;
+  if (matches != 0)
+    return 77;
+
+  if (wyl_handle_engine_set_delta_callback (handle, NULL, NULL)
+      != WYRELOG_E_OK)
+    return 78;
+  return 0;
+}
+
+static gint
 check_delta_readiness_recovers_audit_table_loss (void)
 {
   g_autoptr (WylHandle) handle = NULL;
@@ -344,6 +428,8 @@ main (void)
   if ((rc = check_delta_callback_ignores_runtime_projection_failure ()) != 0)
     return rc;
   if ((rc = check_perm_state_delta_persists_audit_rows ()) != 0)
+    return rc;
+  if ((rc = check_invalid_perm_state_delta_skips_audit_rows ()) != 0)
     return rc;
   if ((rc = check_delta_readiness_recovers_audit_table_loss ()) != 0)
     return rc;

--- a/wyrelog/daemon/delta.c
+++ b/wyrelog/daemon/delta.c
@@ -139,6 +139,44 @@ emit_wirelog_fsm_fired_audit (WylDaemonRuntime *runtime, const gchar *relation,
           ev));
 }
 
+static void
+emit_wirelog_perm_state_fired_audit (WylDaemonRuntime *runtime,
+    const gint64 row[7], WylDeltaKind kind)
+{
+  if (runtime == NULL || runtime->handle == NULL)
+    return;
+
+  g_autofree gchar *subject =
+      wyl_handle_dup_engine_symbol (runtime->handle, row[1]);
+  g_autofree gchar *perm =
+      wyl_handle_dup_engine_symbol (runtime->handle, row[2]);
+  g_autofree gchar *scope =
+      wyl_handle_dup_engine_symbol (runtime->handle, row[3]);
+  g_autofree gchar *from_state =
+      wyl_handle_dup_engine_symbol (runtime->handle, row[4]);
+  g_autofree gchar *event =
+      wyl_handle_dup_engine_symbol (runtime->handle, row[5]);
+  g_autofree gchar *to_state =
+      wyl_handle_dup_engine_symbol (runtime->handle, row[6]);
+  if (subject == NULL || perm == NULL || scope == NULL || from_state == NULL
+      || event == NULL || to_state == NULL)
+    return;
+
+  g_autofree gchar *transition =
+      g_strdup_printf ("%s:%s:%s", from_state, event, to_state);
+  g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
+  wyl_audit_event_set_subject_id (ev, subject);
+  wyl_audit_event_set_action (ev,
+      kind == WYL_DELTA_INSERT ? "perm_state_fired_delta_insert" :
+      "perm_state_fired_delta_remove");
+  wyl_audit_event_set_resource_id (ev, perm);
+  wyl_audit_event_set_deny_reason (ev, transition);
+  wyl_audit_event_set_deny_origin (ev, scope);
+  wyl_audit_event_set_decision (ev, WYL_DECISION_ALLOW);
+  record_daemon_audit_result (runtime, persist_daemon_audit_event (runtime,
+          ev));
+}
+
 static wyrelog_error_t
 check_wirelog_delta_audit_rows (WylHandle *handle)
 {
@@ -201,6 +239,18 @@ check_wirelog_fsm_audit_rows (WylHandle *handle)
           "AND resource_id = 'elevated' "
           "AND deny_reason = 'elevate_grant' "
           "AND deny_origin = 'active' "
+          "AND decision = 1), "
+          "COUNT(*) FILTER (WHERE action = 'perm_state_fired_delta_insert' "
+          "AND subject_id = 'wyrelogd-perm-state-user' "
+          "AND resource_id = 'wyrelogd.perm_state.read' "
+          "AND deny_reason = 'dormant:grant:armed' "
+          "AND deny_origin = 'wyrelogd-perm-state-scope' "
+          "AND decision = 1), "
+          "COUNT(*) FILTER (WHERE action = 'perm_state_fired_delta_remove' "
+          "AND subject_id = 'wyrelogd-perm-state-user' "
+          "AND resource_id = 'wyrelogd.perm_state.read' "
+          "AND deny_reason = 'dormant:grant:armed' "
+          "AND deny_origin = 'wyrelogd-perm-state-scope' "
           "AND decision = 1) " "FROM audit_events;", &result)
       != DuckDBSuccess) {
     duckdb_destroy_result (&result);
@@ -211,9 +261,12 @@ check_wirelog_fsm_audit_rows (WylHandle *handle)
   gint64 session_inserts = duckdb_value_int64 (&result, 1, 0);
   gint64 principal_removes = duckdb_value_int64 (&result, 2, 0);
   gint64 session_removes = duckdb_value_int64 (&result, 3, 0);
+  gint64 perm_state_inserts = duckdb_value_int64 (&result, 4, 0);
+  gint64 perm_state_removes = duckdb_value_int64 (&result, 5, 0);
   duckdb_destroy_result (&result);
   return principal_inserts == 1 && session_inserts == 1
-      && principal_removes == 1 && session_removes == 1 ?
+      && principal_removes == 1 && session_removes == 1
+      && perm_state_inserts == 1 && perm_state_removes == 1 ?
       WYRELOG_E_OK : WYRELOG_E_POLICY;
 }
 #endif
@@ -257,7 +310,7 @@ fsm_relations:
   if ((g_strcmp0 (relation, "principal_fired") != 0
           && g_strcmp0 (relation, "session_fired") != 0)
       || (kind != WYL_DELTA_INSERT && kind != WYL_DELTA_REMOVE) || ncols != 5)
-    return;
+    goto perm_state_fired_relation;
 
 #ifdef WYL_HAS_AUDIT
   emit_wirelog_fsm_fired_audit (runtime, relation, row, kind);
@@ -287,6 +340,31 @@ fsm_relations:
     else if (kind == WYL_DELTA_REMOVE)
       runtime->matched_session_fired_remove = TRUE;
   }
+  return;
+
+perm_state_fired_relation:
+  if (g_strcmp0 (relation, "perm_state_fired") != 0
+      || (kind != WYL_DELTA_INSERT && kind != WYL_DELTA_REMOVE) || ncols != 7)
+    return;
+
+#ifdef WYL_HAS_AUDIT
+  emit_wirelog_perm_state_fired_audit (runtime, row, kind);
+#endif
+
+  if (!runtime->expect_perm_state_fired)
+    return;
+  if (row[0] == runtime->expected_perm_state_fired[0]
+      && row[1] == runtime->expected_perm_state_fired[1]
+      && row[2] == runtime->expected_perm_state_fired[2]
+      && row[3] == runtime->expected_perm_state_fired[3]
+      && row[4] == runtime->expected_perm_state_fired[4]
+      && row[5] == runtime->expected_perm_state_fired[5]
+      && row[6] == runtime->expected_perm_state_fired[6]) {
+    if (kind == WYL_DELTA_INSERT)
+      runtime->matched_perm_state_fired_insert = TRUE;
+    else if (kind == WYL_DELTA_REMOVE)
+      runtime->matched_perm_state_fired_remove = TRUE;
+  }
 }
 
 wyrelog_error_t
@@ -304,6 +382,7 @@ wyl_daemon_check_delta_ready (WylHandle *handle)
     .expect_effective_member = TRUE,
     .expect_principal_fired = TRUE,
     .expect_session_fired = TRUE,
+    .expect_perm_state_fired = TRUE,
   };
 
   wyrelog_error_t rc =
@@ -353,6 +432,31 @@ wyl_daemon_check_delta_ready (WylHandle *handle)
       &runtime.expected_session_fired[4]);
   if (rc != WYRELOG_E_OK)
     return rc;
+  runtime.expected_perm_state_fired[0] = 3;
+  rc = wyl_handle_intern_engine_symbol (handle, "wyrelogd-perm-state-user",
+      &runtime.expected_perm_state_fired[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, "wyrelogd.perm_state.read",
+      &runtime.expected_perm_state_fired[2]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, "wyrelogd-perm-state-scope",
+      &runtime.expected_perm_state_fired[3]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, "dormant",
+      &runtime.expected_perm_state_fired[4]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, "grant",
+      &runtime.expected_perm_state_fired[5]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_handle_intern_engine_symbol (handle, "armed",
+      &runtime.expected_perm_state_fired[6]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
 
   rc = wyl_daemon_start_delta_callbacks (handle, &runtime);
   if (rc != WYRELOG_E_OK)
@@ -371,6 +475,15 @@ wyl_daemon_check_delta_ready (WylHandle *handle)
     runtime.expected_session_fired[3],
     runtime.expected_session_fired[2],
     runtime.expected_session_fired[4],
+  };
+  gint64 perm_state_event[7] = {
+    runtime.expected_perm_state_fired[0],
+    runtime.expected_perm_state_fired[1],
+    runtime.expected_perm_state_fired[2],
+    runtime.expected_perm_state_fired[3],
+    runtime.expected_perm_state_fired[5],
+    runtime.expected_perm_state_fired[4],
+    runtime.expected_perm_state_fired[6],
   };
 
   rc = wyl_handle_engine_insert (handle, "member_of", runtime.expected_row, 3);
@@ -397,6 +510,15 @@ wyl_daemon_check_delta_ready (WylHandle *handle)
     goto cleanup;
   }
 
+  rc = wyl_handle_engine_insert (handle, "perm_state_event",
+      perm_state_event, 7);
+  if (rc != WYRELOG_E_OK)
+    goto cleanup;
+  if (!runtime.matched_perm_state_fired_insert) {
+    rc = WYRELOG_E_POLICY;
+    goto cleanup;
+  }
+
   rc = wyl_handle_engine_remove (handle, "principal_event", principal_event, 5);
   if (rc != WYRELOG_E_OK)
     goto cleanup;
@@ -409,6 +531,15 @@ wyl_daemon_check_delta_ready (WylHandle *handle)
   if (rc != WYRELOG_E_OK)
     goto cleanup;
   if (!runtime.matched_session_fired_remove) {
+    rc = WYRELOG_E_POLICY;
+    goto cleanup;
+  }
+
+  rc = wyl_handle_engine_remove (handle, "perm_state_event",
+      perm_state_event, 7);
+  if (rc != WYRELOG_E_OK)
+    goto cleanup;
+  if (!runtime.matched_perm_state_fired_remove) {
     rc = WYRELOG_E_POLICY;
     goto cleanup;
   }

--- a/wyrelog/daemon/delta.h
+++ b/wyrelog/daemon/delta.h
@@ -16,12 +16,16 @@ typedef struct
   gboolean matched_expected_remove;
   gboolean expect_principal_fired;
   gboolean expect_session_fired;
+  gboolean expect_perm_state_fired;
   gint64 expected_principal_fired[5];
   gint64 expected_session_fired[5];
+  gint64 expected_perm_state_fired[7];
   gboolean matched_principal_fired_insert;
   gboolean matched_session_fired_insert;
+  gboolean matched_perm_state_fired_insert;
   gboolean matched_principal_fired_remove;
   gboolean matched_session_fired_remove;
+  gboolean matched_perm_state_fired_remove;
 } WylDaemonRuntime;
 
 wyrelog_error_t wyl_daemon_start_delta_callbacks (WylHandle * handle,


### PR DESCRIPTION
## Summary

- handle `perm_state_fired` rows in the daemon delta callback path
- record permission-state fired insert and remove observations in audit
- extend daemon delta readiness to cover permission-state lifecycle deltas
- add invalid-transition coverage so malformed lifecycle edges do not emit
  fired delta audit rows

## Tests

- `meson test -C builddir-ci-pr daemon-delta daemon-checks handle-engine-pair fsm-permission-scope --print-errorlogs`
- `meson test -C builddir-ci-pr --print-errorlogs`
