### PR TITLE
LoBAC: serialize daemon policy mutations

### DIFF
--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -1303,6 +1303,27 @@ send_raw_policy_mutation_bearer (SoupSession *session, const gchar *method,
   return 0;
 }
 
+typedef struct
+{
+  const gchar *base_url;
+  gchar *query;
+  gint rc;
+  guint status;
+  gchar *body;
+} ConcurrentPolicyMutation;
+
+static gpointer
+concurrent_permission_grant_thread (gpointer user_data)
+{
+  ConcurrentPolicyMutation *mutation = user_data;
+  g_autoptr (SoupSession) session = soup_session_new ();
+
+  mutation->rc = send_raw_policy_mutation (session, "POST",
+      mutation->base_url, "/policy/permissions/grant", mutation->query,
+      &mutation->status, &mutation->body);
+  return NULL;
+}
+
 static wyrelog_error_t
 grant_policy_write_authority (WylHandle *handle, const gchar *subject,
     const gchar *scope)
@@ -1422,6 +1443,81 @@ role_membership_exists (WylHandle *handle, const gchar *subject,
           &exists) != WYRELOG_E_OK)
     return FALSE;
   return exists;
+}
+
+static gint
+check_concurrent_permission_grants_serialize (WylHandle *handle,
+    const gchar *base_url, const gchar *session_token)
+{
+  static const guint n_threads = 4;
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+
+  if (wyl_policy_store_upsert_permission (store, "site.concurrent.read",
+          "site concurrent read", "basic") != WYRELOG_E_OK)
+    return 204;
+
+  ConcurrentPolicyMutation mutations[n_threads];
+  GThread *threads[n_threads];
+  gint result = 0;
+  memset (mutations, 0, sizeof mutations);
+  memset (threads, 0, sizeof threads);
+
+  for (guint i = 0; i < n_threads; i++) {
+    mutations[i].base_url = base_url;
+    mutations[i].query =
+        g_strdup_printf ("subject=concurrent-target"
+        "&perm=site.concurrent.read&scope=tenant-a"
+        "&session_token=%s&guard_timestamp=123"
+        "&guard_loc_class=public&guard_risk=49", session_token);
+    g_autofree gchar *name = g_strdup_printf ("policy-grant-%u", i);
+    threads[i] = g_thread_new (name, concurrent_permission_grant_thread,
+        &mutations[i]);
+  }
+
+  for (guint i = 0; i < n_threads; i++)
+    g_thread_join (threads[i]);
+
+  for (guint i = 0; i < n_threads; i++) {
+    if (mutations[i].rc != 0) {
+      result = 205;
+      goto cleanup;
+    }
+    if (mutations[i].status != 200
+        || strstr (mutations[i].body, "\"ok\":true") == NULL) {
+      result = 206;
+      goto cleanup;
+    }
+  }
+
+  if (!direct_permission_exists (handle, "concurrent-target",
+          "site.concurrent.read", "tenant-a")) {
+    result = 207;
+    goto cleanup;
+  }
+#ifdef WYL_HAS_AUDIT
+  AuditEventProbe grant_audit = {
+    .subject_id = "http-policy-admin",
+    .action = "permission_grant",
+    .resource_id = "tenant-a",
+    .deny_origin = "site.concurrent.read",
+  };
+  if (wyl_policy_store_foreach_audit_event (store, audit_event_probe_cb,
+          &grant_audit) != WYRELOG_E_OK) {
+    result = 208;
+    goto cleanup;
+  }
+  if (grant_audit.matches != n_threads) {
+    result = 209;
+    goto cleanup;
+  }
+#endif
+
+cleanup:
+  for (guint i = 0; i < n_threads; i++) {
+    g_free (mutations[i].query);
+    g_free (mutations[i].body);
+  }
+  return result;
 }
 
 static gint
@@ -1572,6 +1668,11 @@ check_policy_permission_mutation_contract (WylHandle *handle,
   if (grant_policy_write_authority (handle, "http-policy-admin",
           "tenant-a") != WYRELOG_E_OK)
     return 132;
+
+  gint concurrent_rc = check_concurrent_permission_grants_serialize (handle,
+      base_url, session_token);
+  if (concurrent_rc != 0)
+    return concurrent_rc;
 
   rc = send_raw_policy_mutation (session, "POST", base_url,
       "/policy/permissions/grant", missing_perm_grant_query, &status, &body);

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -784,8 +784,12 @@ direct_permission_mutation_handler (SoupServer *server, SoupServerMessage *msg,
           "invalid_policy_auth", "policy_denied", "policy_auth_failed", &actor))
     return;
 
-  if (!ensure_policy_permission_exists (msg, ctx, perm))
+  g_mutex_lock (&ctx->policy_mutation_lock);
+
+  if (!ensure_policy_permission_exists (msg, ctx, perm)) {
+    g_mutex_unlock (&ctx->policy_mutation_lock);
     return;
+  }
 
   wyrelog_error_t rc;
   if (grant) {
@@ -807,10 +811,12 @@ direct_permission_mutation_handler (SoupServer *server, SoupServerMessage *msg,
   }
   if (rc != WYRELOG_E_OK) {
     set_policy_mutation_error (msg, rc);
+    g_mutex_unlock (&ctx->policy_mutation_lock);
     return;
   }
 
   set_json_ok (msg);
+  g_mutex_unlock (&ctx->policy_mutation_lock);
 }
 
 static void
@@ -859,13 +865,19 @@ policy_permission_transition_handler (SoupServer *server,
           "invalid_policy_auth", "policy_denied", "policy_auth_failed", &actor))
     return;
 
-  if (!ensure_policy_permission_exists (msg, ctx, perm))
-    return;
+  g_mutex_lock (&ctx->policy_mutation_lock);
 
-  g_autoptr (WylAuditEvent) audit_event = wyl_audit_event_new ();
+  if (!ensure_policy_permission_exists (msg, ctx, perm)) {
+    g_mutex_unlock (&ctx->policy_mutation_lock);
+    return;
+  }
+
+  g_autoptr (WylAuditEvent) audit_event = NULL;
+  g_autofree gchar *audit_action = NULL;
+
+  audit_event = wyl_audit_event_new ();
   wyl_audit_event_set_subject_id (audit_event, actor);
-  g_autofree gchar *audit_action = g_strdup_printf ("permission_state.%s",
-      event);
+  audit_action = g_strdup_printf ("permission_state.%s", event);
   wyl_audit_event_set_action (audit_event, audit_action);
   wyl_audit_event_set_resource_id (audit_event, perm);
   wyl_audit_event_set_deny_reason (audit_event, event);
@@ -877,10 +889,12 @@ policy_permission_transition_handler (SoupServer *server,
       (ctx->handle, subject, perm, scope, event, audit_event, NULL);
   if (rc != WYRELOG_E_OK) {
     set_policy_transition_error (msg, rc);
+    g_mutex_unlock (&ctx->policy_mutation_lock);
     return;
   }
 
   set_json_ok (msg);
+  g_mutex_unlock (&ctx->policy_mutation_lock);
 }
 
 static void
@@ -909,8 +923,12 @@ role_membership_mutation_handler (SoupServer *server, SoupServerMessage *msg,
           "invalid_policy_auth", "policy_denied", "policy_auth_failed", &actor))
     return;
 
-  if (!ensure_policy_role_exists (msg, ctx, role))
+  g_mutex_lock (&ctx->policy_mutation_lock);
+
+  if (!ensure_policy_role_exists (msg, ctx, role)) {
+    g_mutex_unlock (&ctx->policy_mutation_lock);
     return;
+  }
 
   wyrelog_error_t rc;
   if (grant) {
@@ -932,10 +950,12 @@ role_membership_mutation_handler (SoupServer *server, SoupServerMessage *msg,
   }
   if (rc != WYRELOG_E_OK) {
     set_policy_mutation_error (msg, rc);
+    g_mutex_unlock (&ctx->policy_mutation_lock);
     return;
   }
 
   set_json_ok (msg);
+  g_mutex_unlock (&ctx->policy_mutation_lock);
 }
 
 static void

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -28,6 +28,7 @@ typedef struct
   gboolean access_token_secret_ready;
   GHashTable *sessions_by_token;
   GMutex lock;
+  GMutex policy_mutation_lock;
 } WylDaemonHttpContext;
 
 static WylDaemonHttpContext *wyl_daemon_http_get_context (SoupServer * server);
@@ -43,6 +44,7 @@ wyl_daemon_http_context_free (gpointer data)
   sodium_memzero (ctx->access_token_secret, sizeof ctx->access_token_secret);
   g_hash_table_unref (ctx->sessions_by_token);
   g_mutex_clear (&ctx->lock);
+  g_mutex_clear (&ctx->policy_mutation_lock);
   g_free (ctx);
 }
 
@@ -59,6 +61,7 @@ wyl_daemon_http_context_new (WylHandle *handle)
   ctx->sessions_by_token =
       g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_object_unref);
   g_mutex_init (&ctx->lock);
+  g_mutex_init (&ctx->policy_mutation_lock);
   return ctx;
 }
 


### PR DESCRIPTION
## Summary

- add a daemon HTTP policy mutation lock separate from session bookkeeping
- serialize permission grant, revoke, lifecycle transition, and role membership
  mutation handlers after policy authorization succeeds
- cover concurrent permission grants through the HTTP policy mutation endpoint
- verify accepted concurrent mutations leave durable authority and audit rows
  coherent

## Tests

- `meson test -C builddir-ci-pr daemon-http-decide daemon-checks daemon-delta --print-errorlogs`
- `meson test -C builddir-ci-pr --print-errorlogs`
