### PR TITLE
codeql: scope to project sources only

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,5 @@
+# Copyright 2026 wyrelog authors
+name: Wyrelog CodeQL
+paths:
+  - tests
+  - wyrelog

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           languages: c-cpp
           build-mode: manual
+          config-file: .github/codeql/codeql-config.yml
 
       - name: Configure
         run: |
@@ -55,14 +56,6 @@ jobs:
         with:
           output: sarif-results
           upload: failure-only
-
-      - name: Filter vendored SARIF results
-        uses: advanced-security/filter-sarif@v1
-        with:
-          patterns: |
-            -subprojects/**/*
-          input: sarif-results/cpp.sarif
-          output: sarif-results/cpp.sarif
 
       - name: Upload CodeQL SARIF
         uses: github/codeql-action/upload-sarif@v4


### PR DESCRIPTION
## Scope statement
- Restrict CodeQL to wyrelog and tests sources only.
- Remove redundant vendored SARIF filter now that scope filtering is done in config.

## Depends on
- none

## Acceptance tests
- meson test -C builddir --print-errorlogs --suite wyrelog (CI)

## Notes
- PR is ready for review.
