### PR TITLE
access: stabilize permission-state replay

### DIFF
--- a/templates/access/fsm/permission_scope.dl
+++ b/templates/access/fsm/permission_scope.dl
@@ -6,10 +6,12 @@
 //
 // Stateful armed/3 derivation. The version-0 perm-scope keeps the
 // durable permission-state lifecycle in the host policy store, then
-// replays the current snapshot as perm_state/4 and the transition
-// ledger as perm_state_event/7. Unguarded permissions participate in
-// allow/3 only when the current state is "armed". Guarded permissions
-// still require a payload-bearing request-local context_now/3
+// replays the current snapshot as perm_state/4 for arming and
+// perm_state_replayed/4 for durable replay observation. The transition
+// ledger is replayed as perm_state_event/7. Unguarded permissions
+// participate in allow/3 only when the current state is "armed".
+// Guarded permissions still require a payload-bearing request-local
+// context_now/3
 // compound, guard_context/6, and eval_guard/4 bridge facts for a
 // satisfied guard expression.
 //
@@ -20,8 +22,9 @@
 // events move them.
 //
 // EDB schemas (host-populated, no clauses below):
-//   perm_state(user, perm, scope, state)        -- current durable
-//                                                   lifecycle state
+//   perm_state(user, perm, scope, state)        -- current arming input
+//   perm_state_replayed(user, perm, scope,      -- durable snapshot replay
+//       state)                                      marker
 //   perm_state_event(event_id, user, perm,     -- append-only durable
 //       scope, event, from_state, to_state)        transition ledger
 //   has_permission(user, perm, scope)            -- declared in
@@ -59,6 +62,8 @@
 // facts are intentionally absent.
 
 .decl perm_state(user: symbol, perm: symbol, scope: symbol, state: symbol)
+.decl perm_state_replayed(user: symbol, perm: symbol, scope: symbol,
+    state: symbol)
 .decl perm_state_transition(from: symbol, event: symbol, to: symbol)
 .decl perm_state_step(from: symbol, event: symbol, to: symbol)
 .decl perm_state_event(event_id: int64, user: symbol, perm: symbol,
@@ -83,6 +88,8 @@
 .decl eval_guard(user: symbol, perm: symbol, scope: symbol, ctx: scope/2 side)
 .decl perm_arm_rule_observed(perm: symbol, guard_handle: int64)
 .decl perm_window_guard_observed(perm: symbol, window: symbol)
+.decl perm_state_observed(user: symbol, perm: symbol, scope: symbol,
+    state: symbol)
 .decl armed(user: symbol, perm: symbol, scope: symbol)
 
 // --- permission-state FSM schema -------------------------------------
@@ -95,6 +102,8 @@ perm_state_transition("cooldown", "reset",    "armed").
 perm_state_transition("cooldown", "expire",   "dormant").
 
 perm_state_step(From, Ev, To) :- perm_state_transition(From, Ev, To).
+
+perm_state_observed(U, P, S, State) :- perm_state_replayed(U, P, S, State).
 
 perm_state_fired(EventId, U, P, S, From, Ev, To) :-
     perm_state_event(EventId, U, P, S, Ev, From, To),

--- a/tests/test-daemon-checks.c
+++ b/tests/test-daemon-checks.c
@@ -180,6 +180,10 @@ check_login_skip_mfa_ready_allows_policy_path (void)
           (handle), "wyrelogd-skip-mfa-user", "wr.login.skip_mfa", "login")
       != WYRELOG_E_OK)
     return 41;
+  if (wyl_policy_store_set_permission_state (wyl_handle_get_policy_store
+          (handle), "wyrelogd-skip-mfa-user", "wr.login.skip_mfa", "login",
+          "armed") != WYRELOG_E_OK)
+    return 65;
   if (wyl_handle_reload_engine_pair (handle) != WYRELOG_E_OK)
     return 45;
   if (wyl_daemon_check_login_skip_mfa_ready (handle) != WYRELOG_E_OK)
@@ -219,6 +223,9 @@ check_login_skip_mfa_ready_allows_role_policy_path (void)
           "wyrelogd-skip-mfa-user", "wyrelogd-skip-mfa-role", "login")
       != WYRELOG_E_OK)
     return 49;
+  if (wyl_policy_store_set_permission_state (store, "wyrelogd-skip-mfa-user",
+          "wr.login.skip_mfa", "login", "armed") != WYRELOG_E_OK)
+    return 66;
   if (wyl_handle_reload_engine_pair (handle) != WYRELOG_E_OK)
     return 60;
 

--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -850,6 +850,10 @@ check_raw_login_contract (SoupServer *server, WylHandle *handle,
           (handle), "login-user", "wr.login.skip_mfa", "login")
       != WYRELOG_E_OK)
     return 484;
+  if (wyl_policy_store_set_permission_state (wyl_handle_get_policy_store
+          (handle), "login-user", "wr.login.skip_mfa", "login", "armed")
+      != WYRELOG_E_OK)
+    return 488;
   if (wyl_handle_reload_engine_pair (handle) != WYRELOG_E_OK)
     return 487;
 

--- a/tests/test-decide.c
+++ b/tests/test-decide.c
@@ -2,6 +2,7 @@
 #include <glib.h>
 
 #include "wyrelog/wyrelog.h"
+#include "wyrelog/policy/store-private.h"
 #include "wyrelog/wyl-handle-private.h"
 
 /*
@@ -127,6 +128,46 @@ insert_grant_fixture (WylHandle *handle, const gchar *subject,
     return rc;
   return insert_symbol_row3 (handle, "member_of", subject, "wr.decide-role",
       resource);
+}
+
+static wyrelog_error_t
+seed_policy_store_decide_fixture (WylHandle *handle, const gchar *subject,
+    const gchar *action, const gchar *resource, const gchar *perm_state)
+{
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+
+  wyrelog_error_t rc = wyl_policy_store_upsert_permission (store, action,
+      action, "basic");
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_policy_store_grant_direct_permission (store, subject, action,
+      resource);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_policy_store_set_principal_state (store, subject, "authenticated");
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_policy_store_set_session_state (store, resource, "active");
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if (perm_state != NULL) {
+    rc = wyl_policy_store_set_permission_state (store, subject, action,
+        resource, perm_state);
+    if (rc != WYRELOG_E_OK)
+      return rc;
+  }
+  return wyl_handle_reload_engine_pair (handle);
+}
+
+static wyrelog_error_t
+decide_policy_store_fixture (WylHandle *handle, const gchar *subject,
+    const gchar *action, const gchar *resource, wyl_decide_resp_t *resp)
+{
+  g_autoptr (wyl_decide_req_t) req = wyl_decide_req_new ();
+  wyl_decide_req_set_subject_id (req, subject);
+  wyl_decide_req_set_action (req, action);
+  wyl_decide_req_set_resource_id (req, resource);
+  return wyl_decide (handle, req, resp);
 }
 
 typedef struct
@@ -685,6 +726,119 @@ check_decide_denies_guarded_permission_on_context_miss (void)
 }
 
 static gint
+check_policy_store_replay_synthesizes_legacy_direct_grant_state (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 123;
+
+  if (seed_policy_store_decide_fixture (handle, "replay-legacy-user",
+          "site.replay.read", "tenant/replay", NULL) != WYRELOG_E_OK)
+    return 124;
+
+  gboolean has_durable_state = TRUE;
+  if (wyl_policy_store_permission_state_exists (wyl_handle_get_policy_store
+          (handle), "replay-legacy-user", "site.replay.read",
+          "tenant/replay", &has_durable_state) != WYRELOG_E_OK)
+    return 125;
+  if (has_durable_state)
+    return 126;
+
+  gboolean contains = TRUE;
+  gint64 synthesized_row[4];
+  if (intern_symbol (handle, "replay-legacy-user", &synthesized_row[0])
+      != WYRELOG_E_OK)
+    return 150;
+  if (intern_symbol (handle, "site.replay.read", &synthesized_row[1])
+      != WYRELOG_E_OK)
+    return 151;
+  if (intern_symbol (handle, "tenant/replay", &synthesized_row[2])
+      != WYRELOG_E_OK)
+    return 152;
+  if (intern_symbol (handle, "armed", &synthesized_row[3]) != WYRELOG_E_OK)
+    return 153;
+  if (wyl_handle_engine_contains (handle, "perm_state", synthesized_row, 4,
+          &contains) != WYRELOG_E_OK)
+    return 154;
+  if (contains)
+    return 155;
+
+  g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
+  if (decide_policy_store_fixture (handle, "replay-legacy-user",
+          "site.replay.read", "tenant/replay", resp) != WYRELOG_E_OK)
+    return 127;
+  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_ALLOW)
+    return 128;
+  if (wyl_decide_resp_get_deny_reason (resp) != NULL)
+    return 129;
+  return 0;
+}
+
+static gint
+check_policy_store_replay_preserves_dormant_permission_state (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 130;
+
+  if (seed_policy_store_decide_fixture (handle, "replay-dormant-user",
+          "site.replay.write", "tenant/replay", "dormant") != WYRELOG_E_OK)
+    return 131;
+  gboolean contains = FALSE;
+  gint64 dormant_row[4];
+  if (intern_symbol (handle, "replay-dormant-user", &dormant_row[0])
+      != WYRELOG_E_OK)
+    return 142;
+  if (intern_symbol (handle, "site.replay.write", &dormant_row[1])
+      != WYRELOG_E_OK)
+    return 143;
+  if (intern_symbol (handle, "tenant/replay", &dormant_row[2])
+      != WYRELOG_E_OK)
+    return 144;
+  if (intern_symbol (handle, "dormant", &dormant_row[3]) != WYRELOG_E_OK)
+    return 145;
+  if (wyl_handle_engine_contains (handle, "perm_state", dormant_row, 4,
+          &contains) != WYRELOG_E_OK)
+    return 146;
+  if (!contains)
+    return 147;
+
+  g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
+  if (decide_policy_store_fixture (handle, "replay-dormant-user",
+          "site.replay.write", "tenant/replay", resp) != WYRELOG_E_OK)
+    return 132;
+  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_DENY)
+    return 133;
+  if (g_strcmp0 (wyl_decide_resp_get_deny_reason (resp), "not_armed") != 0)
+    return 134;
+  if (g_strcmp0 (wyl_decide_resp_get_deny_origin (resp), "perm_state") != 0)
+    return 135;
+  return 0;
+}
+
+static gint
+check_policy_store_replay_preserves_armed_permission_state (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 136;
+
+  if (seed_policy_store_decide_fixture (handle, "replay-armed-user",
+          "site.replay.admin", "tenant/replay", "armed") != WYRELOG_E_OK)
+    return 137;
+
+  g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
+  if (decide_policy_store_fixture (handle, "replay-armed-user",
+          "site.replay.admin", "tenant/replay", resp) != WYRELOG_E_OK)
+    return 138;
+  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_ALLOW)
+    return 139;
+  if (wyl_decide_resp_get_deny_reason (resp) != NULL)
+    return 140;
+  return 0;
+}
+
+static gint
 check_decide_cleans_guard_facts_after_guarded_deny (void)
 {
   g_autoptr (WylHandle) handle = NULL;
@@ -992,6 +1146,15 @@ main (void)
   if ((rc = check_decide_allows_guarded_permission_with_context ()) != 0)
     return rc;
   if ((rc = check_decide_denies_guarded_permission_on_context_miss ()) != 0)
+    return rc;
+  if ((rc = check_policy_store_replay_synthesizes_legacy_direct_grant_state ())
+      != 0)
+    return rc;
+  if ((rc = check_policy_store_replay_preserves_dormant_permission_state ())
+      != 0)
+    return rc;
+  if ((rc = check_policy_store_replay_preserves_armed_permission_state ())
+      != 0)
     return rc;
   if ((rc = check_decide_cleans_guard_facts_after_guarded_deny ()) != 0)
     return rc;

--- a/tests/test-fsm-permission-scope.c
+++ b/tests/test-fsm-permission-scope.c
@@ -215,6 +215,9 @@ check_stratification (void)
   static const wyl_dl_body_atom_t perm_state_step_body[] = {
     {.predicate = "perm_state_transition",.negated = FALSE},
   };
+  static const wyl_dl_body_atom_t perm_state_observed_body[] = {
+    {.predicate = "perm_state_replayed",.negated = FALSE},
+  };
   static const wyl_dl_body_atom_t perm_state_fired_body[] = {
     {.predicate = "perm_state_event",.negated = FALSE},
     {.predicate = "perm_state_transition",.negated = FALSE},
@@ -257,6 +260,8 @@ check_stratification (void)
         .body_len = G_N_ELEMENTS (window_observed_body)},
     {.head = "perm_state_step",.body = perm_state_step_body,.body_len =
           G_N_ELEMENTS (perm_state_step_body)},
+    {.head = "perm_state_observed",.body = perm_state_observed_body,
+        .body_len = G_N_ELEMENTS (perm_state_observed_body)},
     {.head = "perm_state_fired",.body = perm_state_fired_body,.body_len =
           G_N_ELEMENTS (perm_state_fired_body)},
     {.head = "armed",.body = rule1_body,.body_len = G_N_ELEMENTS (rule1_body)},

--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -2476,6 +2476,9 @@ check_login_skip_mfa_projection_autoload_on_open (void)
           "skip-mfa-direct-user", "wr.login.skip_mfa", "login")
       != WYRELOG_E_OK)
     return 364;
+  if (wyl_policy_store_set_permission_state (store, "skip-mfa-direct-user",
+          "wr.login.skip_mfa", "login", "armed") != WYRELOG_E_OK)
+    return 396;
   if (wyl_policy_store_grant_direct_permission (store,
           "skip-mfa-wrong-scope-user", "wr.login.skip_mfa", "other")
       != WYRELOG_E_OK)
@@ -2489,6 +2492,9 @@ check_login_skip_mfa_projection_autoload_on_open (void)
   if (wyl_policy_store_grant_role_membership (store, "skip-mfa-role-user",
           "skip-mfa-role", "login") != WYRELOG_E_OK)
     return 368;
+  if (wyl_policy_store_set_permission_state (store, "skip-mfa-role-user",
+          "wr.login.skip_mfa", "login", "armed") != WYRELOG_E_OK)
+    return 397;
   if (wyl_policy_store_upsert_role (store, "skip-mfa-child-role",
           "skip mfa child role") != WYRELOG_E_OK)
     return 369;
@@ -2499,6 +2505,9 @@ check_login_skip_mfa_projection_autoload_on_open (void)
           "skip-mfa-inherited-user", "skip-mfa-child-role", "login")
       != WYRELOG_E_OK)
     return 371;
+  if (wyl_policy_store_set_permission_state (store, "skip-mfa-inherited-user",
+          "wr.login.skip_mfa", "login", "armed") != WYRELOG_E_OK)
+    return 398;
   if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
       != WYRELOG_E_OK)
     return 372;

--- a/tests/test-session-username.c
+++ b/tests/test-session-username.c
@@ -985,6 +985,10 @@ check_login_skip_mfa_uses_policy_permission (void)
   if (grant_direct (handle, "skip-mfa-policy-user", "wr.login.skip_mfa",
           "login") != WYRELOG_E_OK)
     return 174;
+  if (wyl_policy_store_set_permission_state (wyl_handle_get_policy_store
+          (handle), "skip-mfa-policy-user", "wr.login.skip_mfa", "login",
+          "armed") != WYRELOG_E_OK)
+    return 200;
 
   g_autoptr (WylSession) policy_session = NULL;
   if (login_skip_mfa_user (handle, "skip-mfa-policy-user", &policy_session)
@@ -1023,6 +1027,10 @@ check_login_skip_mfa_uses_policy_permission (void)
   if (grant_role_permission (handle, "skip-mfa-role-user",
           "site.skip-mfa-role", "wr.login.skip_mfa", "login") != WYRELOG_E_OK)
     return 184;
+  if (wyl_policy_store_set_permission_state (wyl_handle_get_policy_store
+          (handle), "skip-mfa-role-user", "wr.login.skip_mfa", "login",
+          "armed") != WYRELOG_E_OK)
+    return 201;
   g_autoptr (WylSession) role_session = NULL;
   if (login_skip_mfa_user (handle, "skip-mfa-role-user", &role_session)
       != WYRELOG_E_OK)
@@ -1056,7 +1064,7 @@ check_login_skip_mfa_does_not_use_state_without_permission (void)
 }
 
 static gint
-check_login_skip_mfa_policy_permission_ignores_state_lifecycle (void)
+check_login_skip_mfa_policy_permission_observes_state_lifecycle (void)
 {
   g_autoptr (WylHandle) handle = NULL;
   if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
@@ -1083,9 +1091,9 @@ check_login_skip_mfa_policy_permission_ignores_state_lifecycle (void)
 
   g_autoptr (WylSession) session = NULL;
   if (login_skip_mfa_user (handle, "skip-mfa-dormant-user", &session)
-      != WYRELOG_E_OK)
+      != WYRELOG_E_POLICY)
     return 198;
-  return session != NULL ? 0 : 199;
+  return session == NULL ? 0 : 199;
 }
 
 static gint
@@ -1800,7 +1808,7 @@ main (void)
   if ((rc = check_login_skip_mfa_does_not_use_state_without_permission ())
       != 0)
     return rc;
-  if ((rc = check_login_skip_mfa_policy_permission_ignores_state_lifecycle ())
+  if ((rc = check_login_skip_mfa_policy_permission_observes_state_lifecycle ())
       != 0)
     return rc;
   if ((rc = check_login_skip_mfa_inserts_wirelog_principal_fired ()) != 0)

--- a/tests/test-template-tree.c
+++ b/tests/test-template-tree.c
@@ -245,8 +245,12 @@ check_permission_scope_relation_contract (void)
     ".decl perm_state_transition(from: symbol, event: symbol, to: symbol)",
     ".decl perm_state_event(event_id: int64, user: symbol, perm: symbol,\n"
         "    scope: symbol, event: symbol, from_state: symbol, to_state: symbol)",
+    ".decl perm_state_replayed(user: symbol, perm: symbol, scope: symbol,\n"
+        "    state: symbol)",
     ".decl perm_state_fired(event_id: int64, user: symbol, perm: symbol,\n"
         "    scope: symbol, from_state: symbol, event: symbol, to_state: symbol)",
+    ".decl perm_state_observed(user: symbol, perm: symbol, scope: symbol,\n"
+        "    state: symbol)",
     ".decl perm_arm_rule_observed(perm: symbol, guard_handle: int64)",
     ".decl perm_window_guard_observed(perm: symbol, window: symbol)",
     ".decl guard_context_timestamp(user: symbol, scope: symbol, timestamp: int64)",
@@ -256,6 +260,8 @@ check_permission_scope_relation_contract (void)
         "    window: symbol)",
     ".decl loc_class(loc_id: symbol, class: symbol)",
     ".decl in_window(timestamp: int64, window: symbol)",
+    "perm_state_observed(U, P, S, State) :- "
+        "perm_state_replayed(U, P, S, State).",
     "perm_arm_rule_observed(P, G) :- perm_arm_rule(P, G).",
     "perm_window_guard_observed(P, W) :- perm_window_guard(P, W).",
   };

--- a/wyrelog/policy/store-private.h
+++ b/wyrelog/policy/store-private.h
@@ -168,6 +168,9 @@ wyrelog_error_t wyl_policy_store_set_permission_state (wyl_policy_store_t *
 wyrelog_error_t wyl_policy_store_permission_state_exists (wyl_policy_store_t *
     store, const gchar * subject_id, const gchar * perm_id, const gchar * scope,
     gboolean * out_exists);
+wyrelog_error_t wyl_policy_store_permission_state_is (wyl_policy_store_t *
+    store, const gchar * subject_id, const gchar * perm_id, const gchar * scope,
+    const gchar * state, gboolean * out_matches);
 wyrelog_error_t wyl_policy_store_foreach_permission_state (wyl_policy_store_t *
     store, wyl_policy_permission_state_cb cb, gpointer user_data);
 wyrelog_error_t wyl_policy_store_append_permission_state_event

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -1450,6 +1450,45 @@ wyl_policy_store_permission_state_exists (wyl_policy_store_t *store,
   return WYRELOG_E_OK;
 }
 
+wyrelog_error_t
+wyl_policy_store_permission_state_is (wyl_policy_store_t *store,
+    const gchar *subject_id, const gchar *perm_id, const gchar *scope,
+    const gchar *state, gboolean *out_matches)
+{
+  sqlite3_stmt *stmt = NULL;
+
+  if (store == NULL || store->db == NULL || subject_id == NULL
+      || perm_id == NULL || scope == NULL || state == NULL
+      || out_matches == NULL)
+    return WYRELOG_E_INVALID;
+
+  *out_matches = FALSE;
+  static const gchar *sql =
+      "SELECT 1 FROM permission_states "
+      "WHERE subject_id = ? AND perm_id = ? AND scope = ? AND state = ?;";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if ((rc = bind_text (stmt, 1, subject_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 2, perm_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 3, scope)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 4, state)) != WYRELOG_E_OK) {
+    sqlite3_finalize (stmt);
+    return rc;
+  }
+
+  int step_rc = sqlite3_step (stmt);
+  if (step_rc == SQLITE_ROW)
+    *out_matches = TRUE;
+  else if (step_rc != SQLITE_DONE) {
+    sqlite3_finalize (stmt);
+    return WYRELOG_E_IO;
+  }
+
+  sqlite3_finalize (stmt);
+  return WYRELOG_E_OK;
+}
+
 static wyrelog_error_t
 wyl_policy_store_get_permission_state (wyl_policy_store_t *store,
     const gchar *subject_id, const gchar *perm_id, const gchar *scope,

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -1178,6 +1178,12 @@ insert_login_skip_mfa_authz_if_allowed (WylHandle *self,
   if (rc != WYRELOG_E_OK || !allowed)
     return rc;
 
+  rc = wyl_policy_store_permission_state_is (self->policy_store, subject_id,
+      WYL_LOGIN_SKIP_MFA_PERMISSION, WYL_LOGIN_SKIP_MFA_SCOPE, "armed",
+      &allowed);
+  if (rc != WYRELOG_E_OK || !allowed)
+    return rc;
+
   gint64 row[1];
   rc = wyl_handle_intern_engine_symbol (self, subject_id, &row[0]);
   if (rc != WYRELOG_E_OK)

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -1371,7 +1371,10 @@ insert_policy_store_permission_state (const gchar *subject_id,
   rc = wyl_handle_intern_engine_symbol (self, state, &row[3]);
   if (rc != WYRELOG_E_OK)
     return rc;
-  return wyl_handle_engine_insert (self, "perm_state", row, 4);
+  rc = wyl_handle_engine_insert (self, "perm_state", row, 4);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_engine_insert (self, "perm_state_replayed", row, 4);
 }
 
 wyrelog_error_t
@@ -1784,6 +1787,13 @@ wyl_handle_engine_contains (WylHandle *self, const gchar *relation,
    * the template mirror while preserving the handle-level relation name. */
   if (g_strcmp0 (relation, "principal_state") == 0)
     snapshot_relation = "principal_state_observed";
+  /*
+   * perm_state probes are the public replay-observation path. Actual
+   * engine-local arming input may also include legacy synthesized rows,
+   * which must not be reported as durable replay.
+   */
+  else if (g_strcmp0 (relation, "perm_state") == 0)
+    snapshot_relation = "perm_state_observed";
   else if (g_strcmp0 (relation, "login_skip_mfa_authz") == 0)
     snapshot_relation = "login_skip_mfa_authz_observed";
 


### PR DESCRIPTION
## Scope
- require policy-derived skip-MFA authorization to be armed in the durable permission-state table
- expose durable permission-state replay through an observed template projection
- keep legacy synthesized arming out of durable replay observation
- cover legacy direct grants, dormant state, and armed state through policy-store replay tests

## Acceptance tests
- meson test -C builddir --print-errorlogs wyrelog:decide wyrelog:fsm-permission-scope wyrelog:template-tree wyrelog:handle-engine-pair wyrelog:check-no-derived-fsm-replay
- meson test -C builddir-audit --print-errorlogs wyrelog:daemon-checks wyrelog:login-projection wyrelog:audit-emit wyrelog:daemon-http-decide wyrelog:decide wyrelog:session-username wyrelog:handle-engine-pair wyrelog:fsm-permission-scope wyrelog:template-tree

## Review
- atomic commits reviewed
- architecture and critic meta-review approved
