### PR TITLE
engine: stabilize handle-owned engine pairs

### DIFF
--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -6,6 +6,7 @@
 #include "wyrelog/policy/store-private.h"
 #include "wyrelog/wyl-handle-compound-private.h"
 #include "wyrelog/wyl-handle-private.h"
+#include "wyrelog/wyl-engine-private.h"
 #include "wyrelog/wyl-permission-scope-private.h"
 
 #ifndef WYL_TEST_TEMPLATE_DIR
@@ -527,7 +528,7 @@ intern3 (WylHandle *handle, const gchar *a, const gchar *b, const gchar *c,
 static wyrelog_error_t
 intern_read_symbol (WylHandle *handle, const gchar *symbol, gint64 *out_id)
 {
-  return wyl_engine_intern_symbol (wyl_handle_get_read_engine (handle),
+  return wyl_engine_owned_intern_symbol (wyl_handle_get_read_engine (handle),
       symbol, out_id);
 }
 
@@ -856,6 +857,92 @@ check_open_pair_creates_distinct_engines (void)
 }
 
 static gint
+check_owned_read_engine_rejects_public_mutation (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  gint64 row[3];
+  gint64 symbol_id = 0;
+  gint64 compound_id = 0;
+  wirelog_compound_arg_t args[1] = {
+    {WIRELOG_TYPE_STRING, 1},
+  };
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 560;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 561;
+  if (intern3 (handle, "owned-read-user", "wr.viewer", "owned-read-scope",
+          row) != WYRELOG_E_OK)
+    return 562;
+
+  WylEngine *read_engine = wyl_handle_get_read_engine (handle);
+  if (wyl_engine_step (read_engine) != WYRELOG_E_INVALID)
+    return 563;
+  if (wyl_engine_insert (read_engine, "member_of", row, 3)
+      != WYRELOG_E_INVALID)
+    return 564;
+  if (wyl_engine_remove (read_engine, "member_of", row, 3)
+      != WYRELOG_E_INVALID)
+    return 565;
+  if (wyl_engine_set_delta_callback (read_engine, delta_expect_cb, NULL)
+      != WYRELOG_E_INVALID)
+    return 566;
+  if (wyl_engine_intern_symbol (read_engine, "owned-read-extra", &symbol_id)
+      != WYRELOG_E_INVALID)
+    return 576;
+  if (wyl_engine_make_compound (read_engine, "scope", args, G_N_ELEMENTS (args),
+          &compound_id) != WYRELOG_E_INVALID)
+    return 577;
+  return 0;
+}
+
+static gint
+check_owned_delta_engine_rejects_public_probe_and_mutation (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  gint64 row[3];
+  gint64 symbol_id = 0;
+  gint64 compound_id = 0;
+  guint seen = 0;
+  wirelog_compound_arg_t args[1] = {
+    {WIRELOG_TYPE_STRING, 1},
+  };
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 567;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 568;
+  if (intern3 (handle, "owned-delta-user", "wr.viewer", "owned-delta-scope",
+          row) != WYRELOG_E_OK)
+    return 569;
+
+  WylEngine *delta_engine = wyl_handle_get_delta_engine (handle);
+  if (wyl_engine_snapshot (delta_engine, "member_of", snapshot_count_cb, &seen)
+      != WYRELOG_E_INVALID)
+    return 570;
+  if (wyl_engine_step (delta_engine) != WYRELOG_E_INVALID)
+    return 571;
+  if (wyl_engine_insert (delta_engine, "member_of", row, 3)
+      != WYRELOG_E_INVALID)
+    return 572;
+  if (wyl_engine_remove (delta_engine, "member_of", row, 3)
+      != WYRELOG_E_INVALID)
+    return 573;
+  if (wyl_engine_set_delta_callback (delta_engine, delta_expect_cb, NULL)
+      != WYRELOG_E_INVALID)
+    return 574;
+  if (wyl_engine_intern_symbol (delta_engine, "owned-delta-extra", &symbol_id)
+      != WYRELOG_E_INVALID)
+    return 578;
+  if (wyl_engine_make_compound (delta_engine, "scope", args,
+          G_N_ELEMENTS (args), &compound_id) != WYRELOG_E_INVALID)
+    return 579;
+  return wyl_handle_engine_step_delta (handle) == WYRELOG_E_OK ? 0 : 575;
+}
+
+static gint
 check_init_config_opens_engine_pair (void)
 {
   g_autoptr (WylHandle) handle = NULL;
@@ -1019,11 +1106,11 @@ check_symbol_intern_reaches_both_engines (void)
     return 62;
   if (pair_id < 0)
     return 63;
-  if (wyl_engine_intern_symbol (wyl_handle_get_read_engine (handle),
-          "pair-symbol-a", &read_id) != WYRELOG_E_OK)
+  if (wyl_handle_intern_engine_symbol (handle, "pair-symbol-a", &read_id)
+      != WYRELOG_E_OK)
     return 64;
-  if (wyl_engine_intern_symbol (wyl_handle_get_delta_engine (handle),
-          "pair-symbol-a", &delta_id) != WYRELOG_E_OK)
+  if (wyl_handle_intern_engine_symbol (handle, "pair-symbol-a", &delta_id)
+      != WYRELOG_E_OK)
     return 65;
   if (pair_id != read_id)
     return 66;
@@ -4725,6 +4812,10 @@ main (void)
   if ((rc = check_init_keeps_engines_absent ()) != 0)
     return rc;
   if ((rc = check_open_pair_creates_distinct_engines ()) != 0)
+    return rc;
+  if ((rc = check_owned_read_engine_rejects_public_mutation ()) != 0)
+    return rc;
+  if ((rc = check_owned_delta_engine_rejects_public_probe_and_mutation ()) != 0)
     return rc;
   if ((rc = check_init_config_opens_engine_pair ()) != 0)
     return rc;

--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -1803,6 +1803,241 @@ check_session_event_fanout_derives_delta (void)
 }
 
 static gint
+check_insert_fanout_delta_insert_failure_repairs_pair (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  gint64 event_row[5];
+  gint64 fired_row[5];
+  RelationSnapshotExpect fired_expect = {
+    .expected_relation = "session_fired",
+    .expected_row = fired_row,
+    .ncols = 5,
+  };
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 156;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 157;
+  if (intern_event5 (handle, 231, "delta-insert-fail-session",
+          "elevate_grant", "active", "elevated", event_row) != WYRELOG_E_OK)
+    return 158;
+
+  wyl_handle_set_engine_delta_insert_fault_once (handle, "session_event",
+      WYRELOG_E_IO);
+  if (wyl_handle_engine_insert (handle, "session_event", event_row, 5)
+      != WYRELOG_E_IO)
+    return 159;
+
+  if (intern_event5 (handle, 231, "delta-insert-fail-session", "active",
+          "elevate_grant", "elevated", fired_row) != WYRELOG_E_OK)
+    return 160;
+  if (wyl_engine_snapshot (wyl_handle_get_read_engine (handle),
+          "session_fired", relation_snapshot_expect_cb, &fired_expect)
+      != WYRELOG_E_OK)
+    return 161;
+  return fired_expect.seen == 0 ? 0 : 162;
+}
+
+static gint
+check_insert_fanout_delta_step_failure_repairs_pair (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  gint64 event_row[5];
+  gint64 fired_row[5];
+  RelationSnapshotExpect fired_expect = {
+    .expected_relation = "session_fired",
+    .expected_row = fired_row,
+    .ncols = 5,
+  };
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 163;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 164;
+  if (intern_event5 (handle, 232, "delta-step-fail-session", "elevate_grant",
+          "active", "elevated", event_row) != WYRELOG_E_OK)
+    return 165;
+
+  wyl_handle_set_engine_delta_step_fault_once (handle, "session_event",
+      WYRELOG_E_IO);
+  if (wyl_handle_engine_insert (handle, "session_event", event_row, 5)
+      != WYRELOG_E_IO)
+    return 166;
+
+  if (intern_event5 (handle, 232, "delta-step-fail-session", "active",
+          "elevate_grant", "elevated", fired_row) != WYRELOG_E_OK)
+    return 167;
+  if (wyl_engine_snapshot (wyl_handle_get_read_engine (handle),
+          "session_fired", relation_snapshot_expect_cb, &fired_expect)
+      != WYRELOG_E_OK)
+    return 168;
+  return fired_expect.seen == 0 ? 0 : 169;
+}
+
+static gint
+check_insert_fanout_delta_step_failure_suppresses_callback (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  gint64 event_row[5];
+  guint deltas = 0;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 230;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 231;
+  if (intern_event5 (handle, 234, "delta-step-callback-session",
+          "elevate_grant", "active", "elevated", event_row) != WYRELOG_E_OK)
+    return 232;
+  if (wyl_handle_engine_set_delta_callback (handle, delta_count_cb, &deltas)
+      != WYRELOG_E_OK)
+    return 233;
+
+  wyl_handle_set_engine_delta_step_fault_once (handle, "session_event",
+      WYRELOG_E_IO);
+  if (wyl_handle_engine_insert (handle, "session_event", event_row, 5)
+      != WYRELOG_E_IO)
+    return 234;
+  return deltas == 0 ? 0 : 235;
+}
+
+static gint
+check_remove_fanout_delta_remove_failure_repairs_pair (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  gint64 event_row[5];
+  gint64 next_event_row[5];
+  guint deltas = 0;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 236;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 237;
+  if (intern_event5 (handle, 235, "delta-remove-fail-session",
+          "elevate_grant", "active", "elevated", event_row) != WYRELOG_E_OK)
+    return 238;
+  if (wyl_handle_engine_insert (handle, "session_event", event_row, 5)
+      != WYRELOG_E_OK)
+    return 239;
+
+  wyl_handle_set_engine_delta_remove_fault_once (handle, "session_event",
+      WYRELOG_E_IO);
+  if (wyl_handle_engine_remove (handle, "session_event", event_row, 5)
+      != WYRELOG_E_IO)
+    return 240;
+
+  if (intern_event5 (handle, 236, "delta-remove-fail-session",
+          "idle_timeout", "active", "idle", next_event_row) != WYRELOG_E_OK)
+    return 241;
+  if (wyl_handle_engine_set_delta_callback (handle, delta_count_cb, &deltas)
+      != WYRELOG_E_OK)
+    return 242;
+  if (wyl_handle_engine_insert (handle, "session_event", next_event_row, 5)
+      != WYRELOG_E_OK)
+    return 243;
+  return deltas > 0 ? 0 : 244;
+}
+
+static gint
+check_remove_fanout_delta_step_failure_suppresses_callback (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  gint64 event_row[5];
+  guint deltas = 0;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 245;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 246;
+  if (intern_event5 (handle, 237, "delta-remove-step-session",
+          "elevate_grant", "active", "elevated", event_row) != WYRELOG_E_OK)
+    return 247;
+  if (wyl_handle_engine_insert (handle, "session_event", event_row, 5)
+      != WYRELOG_E_OK)
+    return 248;
+  if (wyl_handle_engine_set_delta_callback (handle, delta_count_cb, &deltas)
+      != WYRELOG_E_OK)
+    return 249;
+
+  wyl_handle_set_engine_delta_step_fault_once (handle, "session_event",
+      WYRELOG_E_IO);
+  if (wyl_handle_engine_remove (handle, "session_event", event_row, 5)
+      != WYRELOG_E_IO)
+    return 250;
+  return deltas == 0 ? 0 : 251;
+}
+
+static gint
+check_insert_fanout_repair_failure_poisons_pair (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  gint64 event_row[5];
+  gint64 fired_row[5];
+  gboolean found = TRUE;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 170;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 171;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (wyl_policy_store_append_session_event (store, "poison-reload-session",
+          "missing", "active", "idle", NULL) != WYRELOG_E_OK)
+    return 172;
+  if (intern_event5 (handle, 233, "poison-live-session", "elevate_grant",
+          "active", "elevated", event_row) != WYRELOG_E_OK)
+    return 173;
+
+  wyl_handle_set_engine_delta_step_fault_once (handle, "session_event",
+      WYRELOG_E_IO);
+  if (wyl_handle_engine_insert (handle, "session_event", event_row, 5)
+      != WYRELOG_E_POLICY)
+    return 174;
+  if (wyl_handle_get_read_engine (handle) != NULL)
+    return 175;
+  if (wyl_handle_get_delta_engine (handle) != NULL)
+    return 176;
+  if (intern_event5 (handle, 233, "poison-live-session", "active",
+          "elevate_grant", "elevated", fired_row) == WYRELOG_E_OK)
+    return 177;
+  return wyl_handle_engine_contains (handle, "session_fired", fired_row, 5,
+      &found) == WYRELOG_E_INVALID ? 0 : 178;
+}
+
+static gint
+check_durable_session_event_fanout_failure_reloads_committed_event (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  g_autoptr (wyl_login_req_t) login = NULL;
+  WylSession *session = NULL;
+  guint seen = 0;
+
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 179;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 180;
+
+  login = wyl_login_req_new ();
+  wyl_login_req_set_username (login, "durable-fanout-fail-user");
+  wyl_handle_set_engine_delta_step_fault_once (handle, "session_event",
+      WYRELOG_E_IO);
+  if (wyl_session_login (handle, login, &session) != WYRELOG_E_IO)
+    return 181;
+  if (session != NULL)
+    return 182;
+  if (wyl_engine_snapshot (wyl_handle_get_read_engine (handle),
+          "session_fired", snapshot_count_cb, &seen) != WYRELOG_E_OK)
+    return 183;
+  return seen > 0 ? 0 : 184;
+}
+
+static gint
 check_delta_callback_survives_reload (void)
 {
   g_autoptr (WylHandle) handle = NULL;
@@ -4542,6 +4777,24 @@ main (void)
   if ((rc = check_principal_event_fanout_derives_delta ()) != 0)
     return rc;
   if ((rc = check_session_event_fanout_derives_delta ()) != 0)
+    return rc;
+  if ((rc = check_insert_fanout_delta_insert_failure_repairs_pair ()) != 0)
+    return rc;
+  if ((rc = check_insert_fanout_delta_step_failure_repairs_pair ()) != 0)
+    return rc;
+  if ((rc = check_insert_fanout_delta_step_failure_suppresses_callback ())
+      != 0)
+    return rc;
+  if ((rc = check_remove_fanout_delta_remove_failure_repairs_pair ()) != 0)
+    return rc;
+  if ((rc = check_remove_fanout_delta_step_failure_suppresses_callback ())
+      != 0)
+    return rc;
+  if ((rc = check_insert_fanout_repair_failure_poisons_pair ()) != 0)
+    return rc;
+  if ((rc =
+          check_durable_session_event_fanout_failure_reloads_committed_event ())
+      != 0)
     return rc;
   if ((rc = check_delta_callback_survives_reload ()) != 0)
     return rc;

--- a/wyrelog/wyl-engine-private.h
+++ b/wyrelog/wyl-engine-private.h
@@ -21,6 +21,13 @@ typedef enum
   WYL_ENGINE_MODE_SNAPSHOT,
 } wyl_engine_mode_t;
 
+typedef enum
+{
+  WYL_ENGINE_OWNER_STANDALONE = 0,
+  WYL_ENGINE_OWNER_READ,
+  WYL_ENGINE_OWNER_DELTA,
+} wyl_engine_owner_t;
+
 typedef struct _WylDeltaCookie WylDeltaCookie;
 
 struct _WylEngine
@@ -30,6 +37,7 @@ struct _WylEngine
   /* Logical path strings for diagnostic logging only; freed in finalize. */
   gchar *dl_src_logical_paths[WYL_ENGINE_TEMPLATE_COUNT];
   wyl_engine_mode_t mode;       /* Latched at first step or snapshot. */
+  wyl_engine_owner_t owner;     /* Handle pair role, or standalone. */
   WylDeltaCookie *delta_cookie; /* Heap-owned, NULL when no cb. */
 };
 
@@ -83,5 +91,19 @@ wyrelog_error_t wyl_engine_load_templates (const gchar * template_dir,
 wyrelog_error_t wyl_engine_make_compound (WylEngine * self,
     const gchar * functor, const wirelog_compound_arg_t * args, gsize nargs,
     gint64 * out_id);
+
+void wyl_engine_set_owner (WylEngine * self, wyl_engine_owner_t owner);
+wyrelog_error_t wyl_engine_owned_intern_symbol (WylEngine * self,
+    const gchar * symbol, gint64 * out_id);
+wyrelog_error_t wyl_engine_owned_make_compound (WylEngine * self,
+    const gchar * functor, const wirelog_compound_arg_t * args, gsize nargs,
+    gint64 * out_id);
+wyrelog_error_t wyl_engine_owned_insert (WylEngine * self,
+    const gchar * relation, const gint64 * row, gsize ncols);
+wyrelog_error_t wyl_engine_owned_remove (WylEngine * self,
+    const gchar * relation, const gint64 * row, gsize ncols);
+wyrelog_error_t wyl_engine_owned_step (WylEngine * self);
+wyrelog_error_t wyl_engine_owned_set_delta_callback (WylEngine * self,
+    WylDeltaCallback cb, gpointer user_data);
 
 G_END_DECLS;

--- a/wyrelog/wyl-engine.c
+++ b/wyrelog/wyl-engine.c
@@ -89,6 +89,14 @@ wyl_engine_delta_trampoline (const char *relation, const int64_t *row,
 
 G_DEFINE_FINAL_TYPE (WylEngine, wyl_engine, G_TYPE_OBJECT);
 
+void
+wyl_engine_set_owner (WylEngine *self, wyl_engine_owner_t owner)
+{
+  g_return_if_fail (WYL_IS_ENGINE (self));
+
+  self->owner = owner;
+}
+
 static void
 wyl_engine_finalize (GObject *object)
 {
@@ -280,8 +288,9 @@ wyl_engine_close (WylEngine *engine)
   g_object_unref (engine);
 }
 
-wyrelog_error_t
-wyl_engine_intern_symbol (WylEngine *self, const gchar *symbol, gint64 *out_id)
+static wyrelog_error_t
+wyl_engine_intern_symbol_unchecked (WylEngine *self, const gchar *symbol,
+    gint64 *out_id)
 {
   if (self == NULL || !WYL_IS_ENGINE (self))
     return WYRELOG_E_INVALID;
@@ -303,7 +312,25 @@ wyl_engine_intern_symbol (WylEngine *self, const gchar *symbol, gint64 *out_id)
 }
 
 wyrelog_error_t
-wyl_engine_make_compound (WylEngine *self, const gchar *functor,
+wyl_engine_intern_symbol (WylEngine *self, const gchar *symbol, gint64 *out_id)
+{
+  if (self == NULL || !WYL_IS_ENGINE (self))
+    return WYRELOG_E_INVALID;
+  if (self->owner != WYL_ENGINE_OWNER_STANDALONE)
+    return WYRELOG_E_INVALID;
+
+  return wyl_engine_intern_symbol_unchecked (self, symbol, out_id);
+}
+
+wyrelog_error_t
+wyl_engine_owned_intern_symbol (WylEngine *self, const gchar *symbol,
+    gint64 *out_id)
+{
+  return wyl_engine_intern_symbol_unchecked (self, symbol, out_id);
+}
+
+static wyrelog_error_t
+wyl_engine_make_compound_unchecked (WylEngine *self, const gchar *functor,
     const wirelog_compound_arg_t *args, gsize nargs, gint64 *out_id)
 {
   if (out_id != NULL)
@@ -341,8 +368,29 @@ wyl_engine_make_compound (WylEngine *self, const gchar *functor,
 }
 
 wyrelog_error_t
-wyl_engine_insert (WylEngine *self, const gchar *relation, const gint64 *row,
-    gsize ncols)
+wyl_engine_make_compound (WylEngine *self, const gchar *functor,
+    const wirelog_compound_arg_t *args, gsize nargs, gint64 *out_id)
+{
+  if (self == NULL || !WYL_IS_ENGINE (self))
+    return WYRELOG_E_INVALID;
+  if (self->owner != WYL_ENGINE_OWNER_STANDALONE)
+    return WYRELOG_E_INVALID;
+
+  return wyl_engine_make_compound_unchecked (self, functor, args, nargs,
+      out_id);
+}
+
+wyrelog_error_t
+wyl_engine_owned_make_compound (WylEngine *self, const gchar *functor,
+    const wirelog_compound_arg_t *args, gsize nargs, gint64 *out_id)
+{
+  return wyl_engine_make_compound_unchecked (self, functor, args, nargs,
+      out_id);
+}
+
+static wyrelog_error_t
+wyl_engine_insert_unchecked (WylEngine *self, const gchar *relation,
+    const gint64 *row, gsize ncols)
 {
   if (self == NULL || !WYL_IS_ENGINE (self))
     return WYRELOG_E_INVALID;
@@ -367,7 +415,26 @@ wyl_engine_insert (WylEngine *self, const gchar *relation, const gint64 *row,
 }
 
 wyrelog_error_t
-wyl_engine_step (WylEngine *self)
+wyl_engine_insert (WylEngine *self, const gchar *relation, const gint64 *row,
+    gsize ncols)
+{
+  if (self == NULL || !WYL_IS_ENGINE (self))
+    return WYRELOG_E_INVALID;
+  if (self->owner != WYL_ENGINE_OWNER_STANDALONE)
+    return WYRELOG_E_INVALID;
+
+  return wyl_engine_insert_unchecked (self, relation, row, ncols);
+}
+
+wyrelog_error_t
+wyl_engine_owned_insert (WylEngine *self, const gchar *relation,
+    const gint64 *row, gsize ncols)
+{
+  return wyl_engine_insert_unchecked (self, relation, row, ncols);
+}
+
+static wyrelog_error_t
+wyl_engine_step_unchecked (WylEngine *self)
 {
   if (self == NULL || !WYL_IS_ENGINE (self))
     return WYRELOG_E_INVALID;
@@ -389,6 +456,23 @@ wyl_engine_step (WylEngine *self)
 }
 
 wyrelog_error_t
+wyl_engine_step (WylEngine *self)
+{
+  if (self == NULL || !WYL_IS_ENGINE (self))
+    return WYRELOG_E_INVALID;
+  if (self->owner != WYL_ENGINE_OWNER_STANDALONE)
+    return WYRELOG_E_INVALID;
+
+  return wyl_engine_step_unchecked (self);
+}
+
+wyrelog_error_t
+wyl_engine_owned_step (WylEngine *self)
+{
+  return wyl_engine_step_unchecked (self);
+}
+
+wyrelog_error_t
 wyl_engine_snapshot (WylEngine *self, const gchar *relation,
     WylTupleCallback cb, gpointer user_data)
 {
@@ -397,6 +481,8 @@ wyl_engine_snapshot (WylEngine *self, const gchar *relation,
   if (relation == NULL || cb == NULL)
     return WYRELOG_E_INVALID;
   if (self->session == NULL)
+    return WYRELOG_E_INVALID;
+  if (self->owner == WYL_ENGINE_OWNER_DELTA)
     return WYRELOG_E_INVALID;
   if (self->mode == WYL_ENGINE_MODE_STEP)
     return WYRELOG_E_INVALID;
@@ -417,8 +503,8 @@ wyl_engine_snapshot (WylEngine *self, const gchar *relation,
   return rc;
 }
 
-wyrelog_error_t
-wyl_engine_set_delta_callback (WylEngine *self, WylDeltaCallback cb,
+static wyrelog_error_t
+wyl_engine_set_delta_callback_unchecked (WylEngine *self, WylDeltaCallback cb,
     gpointer user_data)
 {
   if (self == NULL || !WYL_IS_ENGINE (self))
@@ -465,8 +551,27 @@ wyl_engine_set_delta_callback (WylEngine *self, WylDeltaCallback cb,
 }
 
 wyrelog_error_t
-wyl_engine_remove (WylEngine *self, const gchar *relation, const gint64 *row,
-    gsize ncols)
+wyl_engine_set_delta_callback (WylEngine *self, WylDeltaCallback cb,
+    gpointer user_data)
+{
+  if (self == NULL || !WYL_IS_ENGINE (self))
+    return WYRELOG_E_INVALID;
+  if (self->owner != WYL_ENGINE_OWNER_STANDALONE)
+    return WYRELOG_E_INVALID;
+
+  return wyl_engine_set_delta_callback_unchecked (self, cb, user_data);
+}
+
+wyrelog_error_t
+wyl_engine_owned_set_delta_callback (WylEngine *self, WylDeltaCallback cb,
+    gpointer user_data)
+{
+  return wyl_engine_set_delta_callback_unchecked (self, cb, user_data);
+}
+
+static wyrelog_error_t
+wyl_engine_remove_unchecked (WylEngine *self, const gchar *relation,
+    const gint64 *row, gsize ncols)
 {
   if (self == NULL || !WYL_IS_ENGINE (self))
     return WYRELOG_E_INVALID;
@@ -488,4 +593,23 @@ wyl_engine_remove (WylEngine *self, const gchar *relation, const gint64 *row,
   }
 
   return rc;
+}
+
+wyrelog_error_t
+wyl_engine_remove (WylEngine *self, const gchar *relation, const gint64 *row,
+    gsize ncols)
+{
+  if (self == NULL || !WYL_IS_ENGINE (self))
+    return WYRELOG_E_INVALID;
+  if (self->owner != WYL_ENGINE_OWNER_STANDALONE)
+    return WYRELOG_E_INVALID;
+
+  return wyl_engine_remove_unchecked (self, relation, row, ncols);
+}
+
+wyrelog_error_t
+wyl_engine_owned_remove (WylEngine *self, const gchar *relation,
+    const gint64 *row, gsize ncols)
+{
+  return wyl_engine_remove_unchecked (self, relation, row, ncols);
 }

--- a/wyrelog/wyl-handle-private.h
+++ b/wyrelog/wyl-handle-private.h
@@ -120,6 +120,9 @@ typedef struct
 
 typedef WylHandleEngineFaultOnce WylHandleEngineInsertFaultOnce;
 typedef WylHandleEngineFaultOnce WylHandleEngineRemoveFaultOnce;
+typedef WylHandleEngineFaultOnce WylHandleEngineDeltaInsertFaultOnce;
+typedef WylHandleEngineFaultOnce WylHandleEngineDeltaRemoveFaultOnce;
+typedef WylHandleEngineFaultOnce WylHandleEngineDeltaStepFaultOnce;
 
 static inline void
 wyl_handle_engine_fault_once_free (gpointer data)
@@ -142,6 +145,24 @@ static inline GQuark
 wyl_handle_engine_remove_fault_once_quark (void)
 {
   return g_quark_from_static_string ("wyrelog-handle-engine-remove-fault-once");
+}
+
+static inline GQuark
+wyl_handle_engine_delta_insert_fault_once_quark (void)
+{
+  return g_quark_from_static_string ("wyl-delta-insert-fault-once");
+}
+
+static inline GQuark
+wyl_handle_engine_delta_remove_fault_once_quark (void)
+{
+  return g_quark_from_static_string ("wyl-delta-remove-fault-once");
+}
+
+static inline GQuark
+wyl_handle_engine_delta_step_fault_once_quark (void)
+{
+  return g_quark_from_static_string ("wyl-delta-step-fault-once");
 }
 
 static inline void
@@ -196,6 +217,72 @@ wyl_handle_set_engine_remove_fault_once (WylHandle *self,
   g_object_set_qdata_full (G_OBJECT (self),
       wyl_handle_engine_remove_fault_once_quark (), fault,
       wyl_handle_engine_remove_fault_once_free);
+}
+
+/*
+ * Test-only hook for fanout coverage. The next delta-engine insert for
+ * @relation fails after the read engine has accepted the row.
+ */
+static inline void
+wyl_handle_set_engine_delta_insert_fault_once (WylHandle *self,
+    const gchar *relation, wyrelog_error_t rc)
+{
+  WylHandleEngineDeltaInsertFaultOnce *fault;
+
+  g_return_if_fail (WYL_IS_HANDLE (self));
+  g_return_if_fail (relation != NULL);
+  g_return_if_fail (rc != WYRELOG_E_OK);
+
+  fault = g_new0 (WylHandleEngineDeltaInsertFaultOnce, 1);
+  fault->relation = g_strdup (relation);
+  fault->rc = rc;
+  g_object_set_qdata_full (G_OBJECT (self),
+      wyl_handle_engine_delta_insert_fault_once_quark (), fault,
+      wyl_handle_engine_fault_once_free);
+}
+
+/*
+ * Test-only hook for fanout coverage. The next delta-engine remove for
+ * @relation fails after the read engine has accepted the removal.
+ */
+static inline void
+wyl_handle_set_engine_delta_remove_fault_once (WylHandle *self,
+    const gchar *relation, wyrelog_error_t rc)
+{
+  WylHandleEngineDeltaRemoveFaultOnce *fault;
+
+  g_return_if_fail (WYL_IS_HANDLE (self));
+  g_return_if_fail (relation != NULL);
+  g_return_if_fail (rc != WYRELOG_E_OK);
+
+  fault = g_new0 (WylHandleEngineDeltaRemoveFaultOnce, 1);
+  fault->relation = g_strdup (relation);
+  fault->rc = rc;
+  g_object_set_qdata_full (G_OBJECT (self),
+      wyl_handle_engine_delta_remove_fault_once_quark (), fault,
+      wyl_handle_engine_fault_once_free);
+}
+
+/*
+ * Test-only hook for fanout coverage. The next delta-engine step for
+ * @relation fails after both engines have accepted the row.
+ */
+static inline void
+wyl_handle_set_engine_delta_step_fault_once (WylHandle *self,
+    const gchar *relation, wyrelog_error_t rc)
+{
+  WylHandleEngineDeltaStepFaultOnce *fault;
+
+  g_return_if_fail (WYL_IS_HANDLE (self));
+  g_return_if_fail (relation != NULL);
+  g_return_if_fail (rc != WYRELOG_E_OK);
+
+  fault = g_new0 (WylHandleEngineDeltaStepFaultOnce, 1);
+  fault->relation = g_strdup (relation);
+  fault->rc = rc;
+  g_object_set_qdata_full (G_OBJECT (self),
+      wyl_handle_engine_delta_step_fault_once_quark (), fault,
+      wyl_handle_engine_fault_once_free);
 }
 
 /*

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -22,6 +22,14 @@
 #include "audit/conn-private.h"
 #endif
 
+typedef struct
+{
+  gchar *relation;
+  gint64 *row;
+  guint ncols;
+  WylDeltaKind kind;
+} WylPendingDelta;
+
 struct _WylHandle
 {
   GObject parent_instance;
@@ -33,14 +41,67 @@ struct _WylHandle
   gchar *template_dir;
   WylDeltaCallback delta_callback;
   gpointer delta_callback_user_data;
+  GPtrArray *pending_deltas;
   wyl_policy_store_t *policy_store;
   gboolean login_skip_mfa_allowed;
+  gboolean engine_pair_poisoned;
 #ifdef WYL_HAS_AUDIT
   wyl_audit_conn_t *audit_conn;
 #endif
 };
 
 G_DEFINE_FINAL_TYPE (WylHandle, wyl_handle, G_TYPE_OBJECT);
+
+static void
+wyl_pending_delta_free (gpointer data)
+{
+  WylPendingDelta *delta = data;
+
+  if (delta == NULL)
+    return;
+  g_free (delta->relation);
+  g_free (delta->row);
+  g_free (delta);
+}
+
+static void
+clear_pending_deltas (WylHandle *self)
+{
+  if (self->pending_deltas != NULL)
+    g_ptr_array_set_size (self->pending_deltas, 0);
+}
+
+static void
+wyl_handle_buffer_delta_cb (const gchar *relation, const gint64 *row,
+    guint ncols, WylDeltaKind kind, gpointer user_data)
+{
+  WylHandle *self = WYL_HANDLE (user_data);
+  WylPendingDelta *delta = g_new0 (WylPendingDelta, 1);
+
+  delta->relation = g_strdup (relation);
+  delta->row = g_memdup2 (row, sizeof (gint64) * ncols);
+  delta->ncols = ncols;
+  delta->kind = kind;
+  g_ptr_array_add (self->pending_deltas, delta);
+}
+
+static void
+flush_pending_deltas (WylHandle *self)
+{
+  WylDeltaCallback cb = self->delta_callback;
+  gpointer user_data = self->delta_callback_user_data;
+
+  if (cb == NULL) {
+    clear_pending_deltas (self);
+    return;
+  }
+
+  for (guint i = 0; i < self->pending_deltas->len; i++) {
+    WylPendingDelta *delta = g_ptr_array_index (self->pending_deltas, i);
+    cb (delta->relation, delta->row, delta->ncols, delta->kind, user_data);
+  }
+  clear_pending_deltas (self);
+}
 
 static void
 wyl_handle_finalize (GObject *object)
@@ -51,6 +112,7 @@ wyl_handle_finalize (GObject *object)
   g_clear_object (&self->delta_engine);
   g_clear_pointer (&self->engine_symbols_by_id, g_hash_table_unref);
   g_clear_pointer (&self->template_dir, g_free);
+  g_clear_pointer (&self->pending_deltas, g_ptr_array_unref);
   g_clear_pointer (&self->policy_store, wyl_policy_store_close);
 #ifdef WYL_HAS_AUDIT
   /* NULL-safe: if wyl_shutdown already closed the conn the pointer
@@ -84,6 +146,8 @@ wyl_handle_init (WylHandle *self)
   self->created_at_us = g_get_real_time ();
   self->engine_symbols_by_id =
       g_hash_table_new_full (g_int64_hash, g_int64_equal, g_free, g_free);
+  self->pending_deltas =
+      g_ptr_array_new_with_free_func (wyl_pending_delta_free);
 }
 
 static wyrelog_error_t wyl_handle_make_guard_expr_node_compound (WylHandle *
@@ -405,9 +469,17 @@ wyl_shutdown (WylHandle *handle)
   g_clear_pointer (&handle->policy_store, wyl_policy_store_close);
   g_clear_object (&handle->read_engine);
   g_clear_object (&handle->delta_engine);
+  handle->engine_pair_poisoned = FALSE;
+  clear_pending_deltas (handle);
   g_clear_pointer (&handle->template_dir, g_free);
   g_object_set_qdata (G_OBJECT (handle),
       wyl_handle_engine_remove_fault_once_quark (), NULL);
+  g_object_set_qdata (G_OBJECT (handle),
+      wyl_handle_engine_delta_insert_fault_once_quark (), NULL);
+  g_object_set_qdata (G_OBJECT (handle),
+      wyl_handle_engine_delta_remove_fault_once_quark (), NULL);
+  g_object_set_qdata (G_OBJECT (handle),
+      wyl_handle_engine_delta_step_fault_once_quark (), NULL);
   g_hash_table_remove_all (handle->engine_symbols_by_id);
 }
 
@@ -836,7 +908,7 @@ replace_engine_pair (WylHandle *self, const gchar *template_dir)
   }
   if (self->delta_callback != NULL) {
     rc = wyl_engine_set_delta_callback (self->delta_engine,
-        self->delta_callback, self->delta_callback_user_data);
+        wyl_handle_buffer_delta_cb, self);
     if (rc != WYRELOG_E_OK) {
       g_clear_object (&self->read_engine);
       g_clear_object (&self->delta_engine);
@@ -858,6 +930,23 @@ replace_engine_pair (WylHandle *self, const gchar *template_dir)
   return WYRELOG_E_OK;
 }
 
+static void
+poison_engine_pair (WylHandle *self)
+{
+  clear_pending_deltas (self);
+  g_clear_object (&self->read_engine);
+  g_clear_object (&self->delta_engine);
+  g_hash_table_remove_all (self->engine_symbols_by_id);
+  self->engine_pair_poisoned = TRUE;
+}
+
+static gboolean
+engine_pair_unavailable (WylHandle *self)
+{
+  return self->engine_pair_poisoned || self->read_engine == NULL
+      || self->delta_engine == NULL;
+}
+
 wyrelog_error_t
 wyl_handle_open_engine_pair (WylHandle *self, const gchar *template_dir)
 {
@@ -868,7 +957,10 @@ wyl_handle_open_engine_pair (WylHandle *self, const gchar *template_dir)
   if (self->read_engine != NULL || self->delta_engine != NULL)
     return WYRELOG_E_INVALID;
 
-  return replace_engine_pair (self, template_dir);
+  wyrelog_error_t rc = replace_engine_pair (self, template_dir);
+  if (rc == WYRELOG_E_OK)
+    self->engine_pair_poisoned = FALSE;
+  return rc;
 }
 
 wyrelog_error_t
@@ -880,7 +972,10 @@ wyl_handle_reload_engine_pair (WylHandle *self)
     return WYRELOG_E_INVALID;
 
   g_autofree gchar *template_dir = g_strdup (self->template_dir);
-  return replace_engine_pair (self, template_dir);
+  wyrelog_error_t rc = replace_engine_pair (self, template_dir);
+  if (rc == WYRELOG_E_OK)
+    self->engine_pair_poisoned = FALSE;
+  return rc;
 }
 
 wyrelog_error_t
@@ -891,7 +986,7 @@ wyl_handle_intern_engine_symbol (WylHandle *self, const gchar *symbol,
     return WYRELOG_E_INVALID;
   if (symbol == NULL || out_id == NULL)
     return WYRELOG_E_INVALID;
-  if (self->read_engine == NULL || self->delta_engine == NULL)
+  if (engine_pair_unavailable (self))
     return WYRELOG_E_INVALID;
 
   gint64 read_id = -1;
@@ -943,7 +1038,7 @@ wyl_handle_make_engine_compound (WylHandle *self, const gchar *functor,
     return WYRELOG_E_INVALID;
   if (nargs == 0 || nargs > G_MAXUINT32)
     return WYRELOG_E_INVALID;
-  if (self->read_engine == NULL || self->delta_engine == NULL)
+  if (engine_pair_unavailable (self))
     return WYRELOG_E_INVALID;
 
   gint64 read_id = 0;
@@ -977,7 +1072,7 @@ wyl_handle_make_read_engine_compound (WylHandle *self, const gchar *functor,
     return WYRELOG_E_INVALID;
   if (nargs == 0 || nargs > G_MAXUINT32)
     return WYRELOG_E_INVALID;
-  if (self->read_engine == NULL || self->delta_engine == NULL)
+  if (engine_pair_unavailable (self))
     return WYRELOG_E_INVALID;
 
   gint64 functor_id = 0;
@@ -1007,7 +1102,7 @@ wyl_handle_make_guard_context_compound (WylHandle *self, gint64 timestamp,
 
   if (self == NULL || !WYL_IS_HANDLE (self) || out_id == NULL)
     return WYRELOG_E_INVALID;
-  if (self->read_engine == NULL || self->delta_engine == NULL)
+  if (engine_pair_unavailable (self))
     return WYRELOG_E_INVALID;
 
   wirelog_compound_arg_t metadata_args[3] = {
@@ -1066,13 +1161,56 @@ relation_fans_out_to_delta (const gchar *relation)
       || g_strcmp0 (relation, "session_event") == 0;
 }
 
+static gboolean
+take_engine_fault_once (WylHandle *self, GQuark quark, const gchar *relation,
+    wyrelog_error_t *out_rc)
+{
+  WylHandleEngineFaultOnce *fault = g_object_get_qdata (G_OBJECT (self), quark);
+  if (fault == NULL || g_strcmp0 (fault->relation, relation) != 0)
+    return FALSE;
+
+  if (out_rc != NULL)
+    *out_rc = fault->rc;
+  g_object_steal_qdata (G_OBJECT (self), quark);
+  wyl_handle_engine_fault_once_free (fault);
+  return TRUE;
+}
+
+static wyrelog_error_t
+repair_engine_pair_after_projection_failure (WylHandle *self)
+{
+  if (self->template_dir == NULL)
+    return WYRELOG_E_INVALID;
+
+  clear_pending_deltas (self);
+  g_autofree gchar *template_dir = g_strdup (self->template_dir);
+  wyrelog_error_t rc = replace_engine_pair (self, template_dir);
+  if (rc != WYRELOG_E_OK)
+    poison_engine_pair (self);
+  return rc;
+}
+
+static wyrelog_error_t
+step_delta_engine_and_flush (WylHandle *self)
+{
+  clear_pending_deltas (self);
+  wyrelog_error_t rc = wyl_engine_step (self->delta_engine);
+  if (rc != WYRELOG_E_OK) {
+    clear_pending_deltas (self);
+    return rc;
+  }
+
+  flush_pending_deltas (self);
+  return WYRELOG_E_OK;
+}
+
 wyrelog_error_t
 wyl_handle_engine_insert (WylHandle *self, const gchar *relation,
     const gint64 *row, gsize ncols)
 {
   if (self == NULL || !WYL_IS_HANDLE (self))
     return WYRELOG_E_INVALID;
-  if (self->read_engine == NULL || self->delta_engine == NULL)
+  if (engine_pair_unavailable (self))
     return WYRELOG_E_INVALID;
 
   WylHandleEngineInsertFaultOnce *fault = g_object_get_qdata (G_OBJECT (self),
@@ -1092,10 +1230,36 @@ wyl_handle_engine_insert (WylHandle *self, const gchar *relation,
 
   if (!relation_fans_out_to_delta (relation))
     return WYRELOG_E_OK;
+  wyrelog_error_t fault_rc = WYRELOG_E_OK;
+  if (take_engine_fault_once (self,
+          wyl_handle_engine_delta_insert_fault_once_quark (), relation,
+          &fault_rc)) {
+    wyrelog_error_t repair_rc =
+        repair_engine_pair_after_projection_failure (self);
+    return repair_rc == WYRELOG_E_OK ? fault_rc : repair_rc;
+  }
   rc = wyl_engine_insert (self->delta_engine, relation, row, ncols);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  return wyl_engine_step (self->delta_engine);
+  if (rc != WYRELOG_E_OK) {
+    wyrelog_error_t repair_rc =
+        repair_engine_pair_after_projection_failure (self);
+    return repair_rc == WYRELOG_E_OK ? rc : repair_rc;
+  }
+  if (take_engine_fault_once (self,
+          wyl_handle_engine_delta_step_fault_once_quark (), relation,
+          &fault_rc)) {
+    wyl_handle_buffer_delta_cb (relation, row, (guint) ncols,
+        WYL_DELTA_INSERT, self);
+    wyrelog_error_t repair_rc =
+        repair_engine_pair_after_projection_failure (self);
+    return repair_rc == WYRELOG_E_OK ? fault_rc : repair_rc;
+  }
+  rc = step_delta_engine_and_flush (self);
+  if (rc != WYRELOG_E_OK) {
+    wyrelog_error_t repair_rc =
+        repair_engine_pair_after_projection_failure (self);
+    return repair_rc == WYRELOG_E_OK ? rc : repair_rc;
+  }
+  return WYRELOG_E_OK;
 }
 
 wyrelog_error_t
@@ -1104,7 +1268,7 @@ wyl_handle_engine_remove (WylHandle *self, const gchar *relation,
 {
   if (self == NULL || !WYL_IS_HANDLE (self))
     return WYRELOG_E_INVALID;
-  if (self->read_engine == NULL || self->delta_engine == NULL)
+  if (engine_pair_unavailable (self))
     return WYRELOG_E_INVALID;
 
   WylHandleEngineRemoveFaultOnce *fault = g_object_get_qdata (G_OBJECT (self),
@@ -1125,12 +1289,35 @@ wyl_handle_engine_remove (WylHandle *self, const gchar *relation,
 
   if (!relation_fans_out_to_delta (relation))
     return fault_matches ? fault_rc : WYRELOG_E_OK;
+  wyrelog_error_t delta_fault_rc = WYRELOG_E_OK;
+  if (take_engine_fault_once (self,
+          wyl_handle_engine_delta_remove_fault_once_quark (), relation,
+          &delta_fault_rc)) {
+    wyrelog_error_t repair_rc =
+        repair_engine_pair_after_projection_failure (self);
+    return repair_rc == WYRELOG_E_OK ? delta_fault_rc : repair_rc;
+  }
   rc = wyl_engine_remove (self->delta_engine, relation, row, ncols);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  rc = wyl_engine_step (self->delta_engine);
-  if (rc != WYRELOG_E_OK)
-    return rc;
+  if (rc != WYRELOG_E_OK) {
+    wyrelog_error_t repair_rc =
+        repair_engine_pair_after_projection_failure (self);
+    return repair_rc == WYRELOG_E_OK ? rc : repair_rc;
+  }
+  if (take_engine_fault_once (self,
+          wyl_handle_engine_delta_step_fault_once_quark (), relation,
+          &delta_fault_rc)) {
+    wyl_handle_buffer_delta_cb (relation, row, (guint) ncols,
+        WYL_DELTA_REMOVE, self);
+    wyrelog_error_t repair_rc =
+        repair_engine_pair_after_projection_failure (self);
+    return repair_rc == WYRELOG_E_OK ? delta_fault_rc : repair_rc;
+  }
+  rc = step_delta_engine_and_flush (self);
+  if (rc != WYRELOG_E_OK) {
+    wyrelog_error_t repair_rc =
+        repair_engine_pair_after_projection_failure (self);
+    return repair_rc == WYRELOG_E_OK ? rc : repair_rc;
+  }
   return fault_matches ? fault_rc : WYRELOG_E_OK;
 }
 
@@ -1139,10 +1326,10 @@ wyl_handle_engine_step_delta (WylHandle *self)
 {
   if (self == NULL || !WYL_IS_HANDLE (self))
     return WYRELOG_E_INVALID;
-  if (self->delta_engine == NULL)
+  if (self->engine_pair_poisoned || self->delta_engine == NULL)
     return WYRELOG_E_INVALID;
 
-  return wyl_engine_step (self->delta_engine);
+  return step_delta_engine_and_flush (self);
 }
 
 wyrelog_error_t
@@ -1151,14 +1338,18 @@ wyl_handle_engine_set_delta_callback (WylHandle *self, WylDeltaCallback cb,
 {
   if (self == NULL || !WYL_IS_HANDLE (self))
     return WYRELOG_E_INVALID;
-  if (self->delta_engine == NULL)
+  if (self->engine_pair_poisoned || self->delta_engine == NULL)
     return WYRELOG_E_INVALID;
 
-  wyrelog_error_t rc =
-      wyl_engine_set_delta_callback (self->delta_engine, cb, user_data);
+  WylDeltaCallback engine_cb = cb == NULL ? NULL : wyl_handle_buffer_delta_cb;
+  gpointer engine_user_data = cb == NULL ? NULL : self;
+  wyrelog_error_t rc = wyl_engine_set_delta_callback (self->delta_engine,
+      engine_cb, engine_user_data);
   if (rc != WYRELOG_E_OK)
     return rc;
 
+  if (cb == NULL)
+    clear_pending_deltas (self);
   self->delta_callback = cb;
   self->delta_callback_user_data = user_data;
   return WYRELOG_E_OK;
@@ -1681,7 +1872,7 @@ wyl_handle_insert_audit_fact (WylHandle *self, const gchar *id,
     return WYRELOG_E_INVALID;
   if (id == NULL || created_at_us < 0)
     return WYRELOG_E_INVALID;
-  if (self->read_engine == NULL || self->delta_engine == NULL)
+  if (engine_pair_unavailable (self))
     return WYRELOG_E_OK;
 
   const gchar *decision_name = decision_symbol (decision);
@@ -1779,7 +1970,7 @@ wyl_handle_engine_contains (WylHandle *self, const gchar *relation,
     return WYRELOG_E_INVALID;
   if (relation == NULL || row == NULL || ncols == 0 || out_contains == NULL)
     return WYRELOG_E_INVALID;
-  if (self->read_engine == NULL || self->delta_engine == NULL)
+  if (engine_pair_unavailable (self))
     return WYRELOG_E_INVALID;
 
   const gchar *snapshot_relation = relation;
@@ -1815,7 +2006,7 @@ wyl_handle_engine_decide (WylHandle *self, const gint64 row[3],
     return WYRELOG_E_INVALID;
   if (row == NULL || out_allowed == NULL)
     return WYRELOG_E_INVALID;
-  if (self->read_engine == NULL || self->delta_engine == NULL)
+  if (engine_pair_unavailable (self))
     return WYRELOG_E_INVALID;
 
   return wyl_handle_engine_contains (self, "allow_bool", row, 3, out_allowed);
@@ -1825,6 +2016,8 @@ WylEngine *
 wyl_handle_get_read_engine (WylHandle *self)
 {
   g_return_val_if_fail (WYL_IS_HANDLE (self), NULL);
+  if (self->engine_pair_poisoned)
+    return NULL;
   return self->read_engine;
 }
 
@@ -1832,6 +2025,8 @@ WylEngine *
 wyl_handle_get_delta_engine (WylHandle *self)
 {
   g_return_val_if_fail (WYL_IS_HANDLE (self), NULL);
+  if (self->engine_pair_poisoned)
+    return NULL;
   return self->delta_engine;
 }
 
@@ -1843,7 +2038,7 @@ wyl_handle_replay_delta_insert (WylHandle *self, const gchar *relation,
     return WYRELOG_E_INVALID;
   if (relation == NULL || row == NULL || ncols == 0)
     return WYRELOG_E_INVALID;
-  if (self->delta_engine == NULL)
+  if (self->engine_pair_poisoned || self->delta_engine == NULL)
     return WYRELOG_E_INVALID;
 
   if (self->delta_callback == NULL)

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -5,6 +5,7 @@
 
 #include "access/decision-private.h"
 #include "wyrelog/engine.h"
+#include "wyl-engine-private.h"
 #include "wyl-fsm-permission-scope-private.h"
 #include "wyl-fsm-principal-private.h"
 #include "wyl-fsm-session-private.h"
@@ -162,7 +163,7 @@ wyl_handle_intern_symbol_on_engine (WylHandle *self, WylEngine *engine,
   if (engine == NULL || symbol == NULL || out_id == NULL)
     return WYRELOG_E_INVALID;
 
-  wyrelog_error_t rc = wyl_engine_intern_symbol (engine, symbol, out_id);
+  wyrelog_error_t rc = wyl_engine_owned_intern_symbol (engine, symbol, out_id);
   if (rc != WYRELOG_E_OK)
     return rc;
 
@@ -211,7 +212,7 @@ wyl_handle_make_guard_cmp_compound (WylHandle *self,
     {WIRELOG_TYPE_STRING, op_id},
     {WIRELOG_TYPE_STRING, value_id},
   };
-  return wyl_engine_make_compound (engine, "guard_cmp", args,
+  return wyl_engine_owned_make_compound (engine, "guard_cmp", args,
       G_N_ELEMENTS (args), out_id);
 }
 
@@ -228,7 +229,7 @@ wyl_handle_make_guard_tag_compound (WylHandle *self,
   wirelog_compound_arg_t args[1] = {
     {WIRELOG_TYPE_STRING, atom_id},
   };
-  return wyl_engine_make_compound (engine, "guard_tag", args,
+  return wyl_engine_owned_make_compound (engine, "guard_tag", args,
       G_N_ELEMENTS (args), out_id);
 }
 
@@ -246,8 +247,8 @@ wyl_handle_make_guard_unary_compound (WylHandle *self, WylEngine *engine,
   wirelog_compound_arg_t args[1] = {
     {WIRELOG_TYPE_INT64, child_id},
   };
-  return wyl_engine_make_compound (engine, functor, args, G_N_ELEMENTS (args),
-      out_id);
+  return wyl_engine_owned_make_compound (engine, functor, args,
+      G_N_ELEMENTS (args), out_id);
 }
 
 static wyrelog_error_t
@@ -271,8 +272,8 @@ wyl_handle_make_guard_binary_compound (WylHandle *self, WylEngine *engine,
     {WIRELOG_TYPE_INT64, left_id},
     {WIRELOG_TYPE_INT64, right_id},
   };
-  return wyl_engine_make_compound (engine, functor, args, G_N_ELEMENTS (args),
-      out_id);
+  return wyl_engine_owned_make_compound (engine, functor, args,
+      G_N_ELEMENTS (args), out_id);
 }
 
 static wyrelog_error_t
@@ -317,8 +318,8 @@ wyl_handle_make_guard_expr_compound (WylHandle *self, WylEngine *engine,
   wirelog_compound_arg_t args[1] = {
     {WIRELOG_TYPE_INT64, root_id},
   };
-  return wyl_engine_make_compound (engine, "guard", args, G_N_ELEMENTS (args),
-      out_id);
+  return wyl_engine_owned_make_compound (engine, "guard", args,
+      G_N_ELEMENTS (args), out_id);
 }
 
 static wyrelog_error_t
@@ -335,11 +336,11 @@ wyl_handle_seed_perm_arm_rule_on_engine (WylHandle *self, WylEngine *engine,
   if (rc != WYRELOG_E_OK)
     return rc;
 
-  rc = wyl_engine_insert (engine, "perm_arm_rule", row, 2);
+  rc = wyl_engine_owned_insert (engine, "perm_arm_rule", row, 2);
   if (rc != WYRELOG_E_OK)
     return rc;
   if (engine == self->delta_engine)
-    return wyl_engine_step (engine);
+    return wyl_engine_owned_step (engine);
   return WYRELOG_E_OK;
 }
 
@@ -888,6 +889,8 @@ replace_engine_pair (WylHandle *self, const gchar *template_dir)
     g_object_unref (new_read_engine);
     return rc;
   }
+  wyl_engine_set_owner (new_read_engine, WYL_ENGINE_OWNER_READ);
+  wyl_engine_set_owner (new_delta_engine, WYL_ENGINE_OWNER_DELTA);
 
   self->read_engine = new_read_engine;
   self->delta_engine = new_delta_engine;
@@ -907,7 +910,7 @@ replace_engine_pair (WylHandle *self, const gchar *template_dir)
     return rc;
   }
   if (self->delta_callback != NULL) {
-    rc = wyl_engine_set_delta_callback (self->delta_engine,
+    rc = wyl_engine_owned_set_delta_callback (self->delta_engine,
         wyl_handle_buffer_delta_cb, self);
     if (rc != WYRELOG_E_OK) {
       g_clear_object (&self->read_engine);
@@ -991,12 +994,12 @@ wyl_handle_intern_engine_symbol (WylHandle *self, const gchar *symbol,
 
   gint64 read_id = -1;
   wyrelog_error_t rc =
-      wyl_engine_intern_symbol (self->read_engine, symbol, &read_id);
+      wyl_engine_owned_intern_symbol (self->read_engine, symbol, &read_id);
   if (rc != WYRELOG_E_OK)
     return rc;
 
   gint64 delta_id = -1;
-  rc = wyl_engine_intern_symbol (self->delta_engine, symbol, &delta_id);
+  rc = wyl_engine_owned_intern_symbol (self->delta_engine, symbol, &delta_id);
   if (rc != WYRELOG_E_OK)
     return rc;
 
@@ -1042,13 +1045,13 @@ wyl_handle_make_engine_compound (WylHandle *self, const gchar *functor,
     return WYRELOG_E_INVALID;
 
   gint64 read_id = 0;
-  wyrelog_error_t rc = wyl_engine_make_compound (self->read_engine,
+  wyrelog_error_t rc = wyl_engine_owned_make_compound (self->read_engine,
       functor, args, nargs, &read_id);
   if (rc != WYRELOG_E_OK)
     return rc;
 
   gint64 delta_id = 0;
-  rc = wyl_engine_make_compound (self->delta_engine, functor, args, nargs,
+  rc = wyl_engine_owned_make_compound (self->delta_engine, functor, args, nargs,
       &delta_id);
   if (rc != WYRELOG_E_OK)
     return rc;
@@ -1081,7 +1084,7 @@ wyl_handle_make_read_engine_compound (WylHandle *self, const gchar *functor,
   if (rc != WYRELOG_E_OK)
     return rc;
 
-  rc = wyl_engine_make_compound (self->read_engine, functor, args, nargs,
+  rc = wyl_engine_owned_make_compound (self->read_engine, functor, args, nargs,
       out_id);
   if (rc != WYRELOG_E_OK)
     return rc;
@@ -1089,8 +1092,8 @@ wyl_handle_make_read_engine_compound (WylHandle *self, const gchar *functor,
   /* Keep the handle-owned engines' intern and side-arena streams aligned.
    * The returned handle remains read-engine-local and request-scoped. */
   gint64 delta_id = 0;
-  return wyl_engine_make_compound (self->delta_engine, functor, args, nargs,
-      &delta_id);
+  return wyl_engine_owned_make_compound (self->delta_engine, functor, args,
+      nargs, &delta_id);
 }
 
 wyrelog_error_t
@@ -1120,13 +1123,13 @@ wyl_handle_make_guard_context_compound (WylHandle *self, gint64 timestamp,
     return rc;
 
   gint64 read_metadata_id = 0;
-  rc = wyl_engine_make_compound (self->read_engine, "metadata",
+  rc = wyl_engine_owned_make_compound (self->read_engine, "metadata",
       metadata_args, G_N_ELEMENTS (metadata_args), &read_metadata_id);
   if (rc != WYRELOG_E_OK)
     return rc;
 
   gint64 delta_metadata_id = 0;
-  rc = wyl_engine_make_compound (self->delta_engine, "metadata",
+  rc = wyl_engine_owned_make_compound (self->delta_engine, "metadata",
       metadata_args, G_N_ELEMENTS (metadata_args), &delta_metadata_id);
   if (rc != WYRELOG_E_OK)
     return rc;
@@ -1135,7 +1138,7 @@ wyl_handle_make_guard_context_compound (WylHandle *self, gint64 timestamp,
     {WIRELOG_TYPE_INT64, read_metadata_id},
     {WIRELOG_TYPE_STRING, scope_id},
   };
-  rc = wyl_engine_make_compound (self->read_engine, "scope",
+  rc = wyl_engine_owned_make_compound (self->read_engine, "scope",
       read_scope_args, G_N_ELEMENTS (read_scope_args), out_id);
   if (rc != WYRELOG_E_OK)
     return rc;
@@ -1145,7 +1148,7 @@ wyl_handle_make_guard_context_compound (WylHandle *self, gint64 timestamp,
     {WIRELOG_TYPE_STRING, scope_id},
   };
   gint64 delta_scope_id = 0;
-  return wyl_engine_make_compound (self->delta_engine, "scope",
+  return wyl_engine_owned_make_compound (self->delta_engine, "scope",
       delta_scope_args, G_N_ELEMENTS (delta_scope_args), &delta_scope_id);
 }
 
@@ -1194,7 +1197,7 @@ static wyrelog_error_t
 step_delta_engine_and_flush (WylHandle *self)
 {
   clear_pending_deltas (self);
-  wyrelog_error_t rc = wyl_engine_step (self->delta_engine);
+  wyrelog_error_t rc = wyl_engine_owned_step (self->delta_engine);
   if (rc != WYRELOG_E_OK) {
     clear_pending_deltas (self);
     return rc;
@@ -1224,7 +1227,7 @@ wyl_handle_engine_insert (WylHandle *self, const gchar *relation,
   }
 
   wyrelog_error_t rc =
-      wyl_engine_insert (self->read_engine, relation, row, ncols);
+      wyl_engine_owned_insert (self->read_engine, relation, row, ncols);
   if (rc != WYRELOG_E_OK)
     return rc;
 
@@ -1238,7 +1241,7 @@ wyl_handle_engine_insert (WylHandle *self, const gchar *relation,
         repair_engine_pair_after_projection_failure (self);
     return repair_rc == WYRELOG_E_OK ? fault_rc : repair_rc;
   }
-  rc = wyl_engine_insert (self->delta_engine, relation, row, ncols);
+  rc = wyl_engine_owned_insert (self->delta_engine, relation, row, ncols);
   if (rc != WYRELOG_E_OK) {
     wyrelog_error_t repair_rc =
         repair_engine_pair_after_projection_failure (self);
@@ -1283,7 +1286,7 @@ wyl_handle_engine_remove (WylHandle *self, const gchar *relation,
   }
 
   wyrelog_error_t rc =
-      wyl_engine_remove (self->read_engine, relation, row, ncols);
+      wyl_engine_owned_remove (self->read_engine, relation, row, ncols);
   if (rc != WYRELOG_E_OK)
     return rc;
 
@@ -1297,7 +1300,7 @@ wyl_handle_engine_remove (WylHandle *self, const gchar *relation,
         repair_engine_pair_after_projection_failure (self);
     return repair_rc == WYRELOG_E_OK ? delta_fault_rc : repair_rc;
   }
-  rc = wyl_engine_remove (self->delta_engine, relation, row, ncols);
+  rc = wyl_engine_owned_remove (self->delta_engine, relation, row, ncols);
   if (rc != WYRELOG_E_OK) {
     wyrelog_error_t repair_rc =
         repair_engine_pair_after_projection_failure (self);
@@ -1343,7 +1346,7 @@ wyl_handle_engine_set_delta_callback (WylHandle *self, WylDeltaCallback cb,
 
   WylDeltaCallback engine_cb = cb == NULL ? NULL : wyl_handle_buffer_delta_cb;
   gpointer engine_user_data = cb == NULL ? NULL : self;
-  wyrelog_error_t rc = wyl_engine_set_delta_callback (self->delta_engine,
+  wyrelog_error_t rc = wyl_engine_owned_set_delta_callback (self->delta_engine,
       engine_cb, engine_user_data);
   if (rc != WYRELOG_E_OK)
     return rc;


### PR DESCRIPTION
## Summary

- repair handle-owned read/delta engine pairs from the policy store when
  fanout projection fails after one side has accepted a change
- buffer delta callbacks until the delta engine step succeeds so failed
  projections do not emit external deltas
- reject public mutation, symbol interning, compound allocation, step, and
  callback APIs on borrowed handle-owned engines

## Validation

- meson test -C builddir --print-errorlogs
- meson test -C builddir-audit --print-errorlogs wyrelog:handle-engine-pair wyrelog:session-username wyrelog:daemon-delta wyrelog:login-projection
- git diff --check main...HEAD
