### PR TITLE
daemon: surface runtime readiness degradation

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -92,6 +92,7 @@ if build_client
   test_daemon_http_decide = executable('test-daemon-http-decide',
     'test-daemon-http-decide.c',
     '../wyrelog/daemon/http.c',
+    '../wyrelog/daemon/delta.c',
     c_args : test_daemon_http_decide_c_args,
     include_directories : [wyrelog_inc, include_directories('../wyrelog')],
     dependencies : test_daemon_http_decide_deps,

--- a/tests/test-daemon-delta.c
+++ b/tests/test-daemon-delta.c
@@ -242,7 +242,7 @@ check_delta_callback_ignores_runtime_projection_failure (void)
   runtime.handle = handle;
   if (wyl_daemon_start_delta_callbacks (handle, &runtime) != WYRELOG_E_OK)
     return 11;
-  if (!runtime.delta_session_live)
+  if (!g_atomic_int_get (&runtime.delta_session_live))
     return 26;
   if (malform_audit_events_table (handle) != WYRELOG_E_OK)
     return 12;
@@ -258,7 +258,7 @@ check_delta_callback_ignores_runtime_projection_failure (void)
     return 27;
   if (runtime.audit_errors != 0)
     return 16;
-  if (runtime.audit_degraded)
+  if (g_atomic_int_get (&runtime.audit_degraded))
     return 28;
   if (runtime.last_audit_error != WYRELOG_E_OK)
     return 17;
@@ -307,7 +307,7 @@ check_perm_state_delta_persists_audit_rows (void)
   runtime.handle = handle;
   if (wyl_daemon_start_delta_callbacks (handle, &runtime) != WYRELOG_E_OK)
     return 51;
-  if (!runtime.delta_session_live)
+  if (!g_atomic_int_get (&runtime.delta_session_live))
     return 64;
   if (intern_perm_event7 (handle, 701, "daemon-delta-perm-user",
           "site.daemon-delta.perm", "daemon-delta-perm-scope", "grant",
@@ -323,7 +323,7 @@ check_perm_state_delta_persists_audit_rows (void)
     return 65;
   if (runtime.audit_errors != 0)
     return 55;
-  if (runtime.audit_degraded)
+  if (g_atomic_int_get (&runtime.audit_degraded))
     return 66;
 
   if (wyl_handle_engine_remove (handle, "perm_state_event", event_row, 7)
@@ -335,7 +335,7 @@ check_perm_state_delta_persists_audit_rows (void)
     return 67;
   if (runtime.audit_errors != 0)
     return 58;
-  if (runtime.audit_degraded)
+  if (g_atomic_int_get (&runtime.audit_degraded))
     return 68;
 
   g_autofree gchar *insert_id = NULL;
@@ -381,7 +381,7 @@ check_invalid_perm_state_delta_skips_audit_rows (void)
   runtime.handle = handle;
   if (wyl_daemon_start_delta_callbacks (handle, &runtime) != WYRELOG_E_OK)
     return 71;
-  if (!runtime.delta_session_live)
+  if (!g_atomic_int_get (&runtime.delta_session_live))
     return 79;
   if (intern_perm_event7 (handle, 702, "daemon-delta-invalid-user",
           "site.daemon-delta.invalid", "daemon-delta-invalid-scope", "grant",
@@ -397,7 +397,7 @@ check_invalid_perm_state_delta_skips_audit_rows (void)
     return 80;
   if (runtime.audit_errors != 0)
     return 75;
-  if (runtime.audit_degraded)
+  if (g_atomic_int_get (&runtime.audit_degraded))
     return 81;
 
   guint matches = 0;

--- a/tests/test-daemon-delta.c
+++ b/tests/test-daemon-delta.c
@@ -242,6 +242,8 @@ check_delta_callback_ignores_runtime_projection_failure (void)
   runtime.handle = handle;
   if (wyl_daemon_start_delta_callbacks (handle, &runtime) != WYRELOG_E_OK)
     return 11;
+  if (!runtime.delta_session_live)
+    return 26;
   if (malform_audit_events_table (handle) != WYRELOG_E_OK)
     return 12;
   if (intern3 (handle, "daemon-delta-audit-user", "wr.viewer",
@@ -252,8 +254,12 @@ check_delta_callback_ignores_runtime_projection_failure (void)
     return 14;
   if (runtime.inserted == 0)
     return 15;
+  if (runtime.delta_events_seen == 0 || runtime.last_delta_event_us <= 0)
+    return 27;
   if (runtime.audit_errors != 0)
     return 16;
+  if (runtime.audit_degraded)
+    return 28;
   if (runtime.last_audit_error != WYRELOG_E_OK)
     return 17;
 
@@ -301,6 +307,8 @@ check_perm_state_delta_persists_audit_rows (void)
   runtime.handle = handle;
   if (wyl_daemon_start_delta_callbacks (handle, &runtime) != WYRELOG_E_OK)
     return 51;
+  if (!runtime.delta_session_live)
+    return 64;
   if (intern_perm_event7 (handle, 701, "daemon-delta-perm-user",
           "site.daemon-delta.perm", "daemon-delta-perm-scope", "grant",
           "dormant", "armed", event_row) != WYRELOG_E_OK)
@@ -311,16 +319,24 @@ check_perm_state_delta_persists_audit_rows (void)
     return 53;
   if (runtime.inserted == 0)
     return 54;
+  if (runtime.delta_events_seen == 0 || runtime.last_delta_event_us <= 0)
+    return 65;
   if (runtime.audit_errors != 0)
     return 55;
+  if (runtime.audit_degraded)
+    return 66;
 
   if (wyl_handle_engine_remove (handle, "perm_state_event", event_row, 7)
       != WYRELOG_E_OK)
     return 56;
   if (runtime.removed == 0)
     return 57;
+  if (runtime.delta_events_seen < 2)
+    return 67;
   if (runtime.audit_errors != 0)
     return 58;
+  if (runtime.audit_degraded)
+    return 68;
 
   g_autofree gchar *insert_id = NULL;
   gint64 insert_created_at_us = -1;
@@ -365,6 +381,8 @@ check_invalid_perm_state_delta_skips_audit_rows (void)
   runtime.handle = handle;
   if (wyl_daemon_start_delta_callbacks (handle, &runtime) != WYRELOG_E_OK)
     return 71;
+  if (!runtime.delta_session_live)
+    return 79;
   if (intern_perm_event7 (handle, 702, "daemon-delta-invalid-user",
           "site.daemon-delta.invalid", "daemon-delta-invalid-scope", "grant",
           "armed", "dormant", event_row) != WYRELOG_E_OK)
@@ -375,8 +393,12 @@ check_invalid_perm_state_delta_skips_audit_rows (void)
     return 73;
   if (runtime.inserted != 0 || runtime.removed != 0)
     return 74;
+  if (runtime.delta_events_seen != 0 || runtime.last_delta_event_us != 0)
+    return 80;
   if (runtime.audit_errors != 0)
     return 75;
+  if (runtime.audit_degraded)
+    return 81;
 
   guint matches = 0;
   if (!count_policy_audit_rows (handle, "perm_state_fired_delta_insert",

--- a/tests/test-daemon-delta.c
+++ b/tests/test-daemon-delta.c
@@ -231,7 +231,7 @@ malform_audit_events_table (WylHandle *handle)
 }
 
 static gint
-check_delta_callback_ignores_runtime_projection_failure (void)
+check_delta_callback_records_runtime_projection_failure (void)
 {
   g_autoptr (WylHandle) handle = NULL;
   gint64 row[3];
@@ -256,11 +256,11 @@ check_delta_callback_ignores_runtime_projection_failure (void)
     return 15;
   if (runtime.delta_events_seen == 0 || runtime.last_delta_event_us <= 0)
     return 27;
-  if (runtime.audit_errors != 0)
+  if (runtime.audit_errors == 0)
     return 16;
-  if (g_atomic_int_get (&runtime.audit_degraded))
+  if (!g_atomic_int_get (&runtime.audit_degraded))
     return 28;
-  if (runtime.last_audit_error != WYRELOG_E_OK)
+  if (runtime.last_audit_error == WYRELOG_E_OK)
     return 17;
 
   g_autofree gchar *id = NULL;
@@ -447,7 +447,7 @@ main (void)
 {
   gint rc;
 
-  if ((rc = check_delta_callback_ignores_runtime_projection_failure ()) != 0)
+  if ((rc = check_delta_callback_records_runtime_projection_failure ()) != 0)
     return rc;
   if ((rc = check_perm_state_delta_persists_audit_rows ()) != 0)
     return rc;

--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -2510,6 +2510,56 @@ drop_runtime_audit_events_table (WylHandle *handle)
   return WYRELOG_E_OK;
 }
 
+static wyrelog_error_t
+malform_runtime_audit_events_table (WylHandle *handle)
+{
+  wyrelog_error_t rc = drop_runtime_audit_events_table (handle);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  duckdb_connection conn =
+      wyl_audit_conn_get_connection (wyl_handle_get_audit_conn (handle));
+  duckdb_result result = { 0 };
+  if (duckdb_query (conn,
+          "CREATE TABLE audit_events (id VARCHAR PRIMARY KEY);", &result)
+      != DuckDBSuccess) {
+    duckdb_destroy_result (&result);
+    return WYRELOG_E_IO;
+  }
+
+  duckdb_destroy_result (&result);
+  return WYRELOG_E_OK;
+}
+
+static gint
+check_readyz_malformed_audit_projection_contract (WylHandle *handle,
+    const gchar *base_url)
+{
+  g_autoptr (SoupSession) session = soup_session_new ();
+  guint status = 0;
+  g_autofree gchar *body = NULL;
+
+  if (malform_runtime_audit_events_table (handle) != WYRELOG_E_OK)
+    return 1914;
+  if (send_raw_path (session, "GET", base_url, "/readyz", &status, &body)
+      != 0)
+    return 1915;
+  if (status != 503 || strstr (body, "\"not_ready\"") == NULL)
+    return 1916;
+
+  if (drop_runtime_audit_events_table (handle) != WYRELOG_E_OK)
+    return 1917;
+  if (wyl_audit_conn_create_schema (wyl_handle_get_audit_conn (handle))
+      != WYRELOG_E_OK)
+    return 1918;
+
+  g_clear_pointer (&body, g_free);
+  if (send_raw_path (session, "GET", base_url, "/readyz", &status, &body)
+      != 0)
+    return 1919;
+  return status == 200 ? 0 : 1920;
+}
+
 static gint
 check_audit_event_present (WylClient *client, const gchar *filter,
     const gchar *subject, const gchar *action, const gchar *resource,
@@ -2586,6 +2636,13 @@ main (void)
   gint readyz_rc = check_readyz_runtime_liveness_contract (base_url, &runtime);
   if (readyz_rc != 0)
     return readyz_rc;
+
+#ifdef WYL_HAS_AUDIT
+  readyz_rc = check_readyz_malformed_audit_projection_contract (handle,
+      base_url);
+  if (readyz_rc != 0)
+    return readyz_rc;
+#endif
 
   gint request_id_rc = check_request_id_header_contract (base_url);
   if (request_id_rc != 0)

--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -6,6 +6,7 @@
 #include <duckdb.h>
 #endif
 
+#include "daemon/delta.h"
 #include "daemon/http.h"
 #include "wyrelog/auth/jwt-private.h"
 #include "wyrelog/client.h"
@@ -248,6 +249,86 @@ build_decide_uri (const gchar *base_url, const gchar *user, const gchar *perm,
   return g_strdup_printf ("%s/decide?user=%s&perm=%s&session_token=%s%s%s",
       base, escaped_user, escaped_perm, escaped_scope,
       extra_query != NULL ? "&" : "", extra_query != NULL ? extra_query : "");
+}
+
+static gint
+send_raw_path (SoupSession *session, const gchar *method,
+    const gchar *base_url, const gchar *path, guint *out_status,
+    gchar **out_body)
+{
+  if (out_status == NULL || out_body == NULL)
+    return 1900;
+  *out_status = 0;
+  *out_body = NULL;
+
+  g_autofree gchar *root = g_strdup (base_url);
+  while (root[0] != '\0' && g_str_has_suffix (root, "/"))
+    root[strlen (root) - 1] = '\0';
+  g_autofree gchar *uri = g_strdup_printf ("%s%s", root, path);
+  g_autoptr (SoupMessage) msg = soup_message_new (method, uri);
+  if (msg == NULL)
+    return 1901;
+
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GBytes) bytes = soup_session_send_and_read (session, msg, NULL,
+      &error);
+  if (bytes == NULL)
+    return 1902;
+  gint rc = check_response_request_id_header (msg, 1903);
+  if (rc != 0)
+    return rc;
+
+  gsize body_size = 0;
+  const gchar *body_data = g_bytes_get_data (bytes, &body_size);
+  *out_status = soup_message_get_status (msg);
+  *out_body = g_strndup (body_data, body_size);
+  return 0;
+}
+
+static gint
+check_readyz_runtime_liveness_contract (const gchar *base_url,
+    WylDaemonRuntime *runtime)
+{
+  g_autoptr (SoupSession) session = soup_session_new ();
+  guint status = 0;
+  g_autofree gchar *body = NULL;
+
+  if (send_raw_path (session, "GET", base_url, "/healthz", &status, &body)
+      != 0)
+    return 1904;
+  if (status != 200 || strstr (body, "ok") == NULL)
+    return 1905;
+
+  g_clear_pointer (&body, g_free);
+  if (send_raw_path (session, "GET", base_url, "/readyz", &status, &body)
+      != 0)
+    return 1906;
+  if (status != 200 || strstr (body, "ready") == NULL)
+    return 1907;
+
+  g_atomic_int_set (&runtime->delta_session_live, FALSE);
+  g_clear_pointer (&body, g_free);
+  if (send_raw_path (session, "GET", base_url, "/readyz", &status, &body)
+      != 0)
+    return 1908;
+  if (status != 503 || strstr (body, "\"delta_not_ready\"") == NULL)
+    return 1909;
+
+  g_atomic_int_set (&runtime->delta_session_live, TRUE);
+  g_atomic_int_set (&runtime->audit_degraded, TRUE);
+  g_clear_pointer (&body, g_free);
+  if (send_raw_path (session, "GET", base_url, "/readyz", &status, &body)
+      != 0)
+    return 1910;
+  if (status != 503 || strstr (body, "\"audit_degraded\"") == NULL)
+    return 1911;
+
+  g_atomic_int_set (&runtime->audit_degraded, FALSE);
+  g_clear_pointer (&body, g_free);
+  if (send_raw_path (session, "GET", base_url, "/readyz", &status, &body)
+      != 0)
+    return 1912;
+  return status == 200 ? 0 : 1913;
 }
 
 static gint
@@ -2477,10 +2558,16 @@ main (void)
     .template_dir = WYL_TEST_TEMPLATE_DIR,
     .listen_port = 0,
   };
+  WylDaemonRuntime runtime = {
+    .handle = handle,
+  };
+  if (wyl_daemon_start_delta_callbacks (handle, &runtime) != WYRELOG_E_OK)
+    return 14;
   TestHttpServer http = { 0 };
   http.loop = g_main_loop_new (NULL, FALSE);
   g_autoptr (GError) error = NULL;
-  http.server = wyl_daemon_start_http_server (&opts, handle, &error);
+  http.server = wyl_daemon_start_http_server_with_runtime (&opts, handle,
+      &runtime, &error);
   if (http.server == NULL)
     return 3;
   GThread *thread = g_thread_new ("daemon-http-decide",
@@ -2495,6 +2582,10 @@ main (void)
   g_autoptr (WylClient) client = NULL;
   if (wyl_client_new (base_url, &client) != WYRELOG_E_OK)
     return 5;
+
+  gint readyz_rc = check_readyz_runtime_liveness_contract (base_url, &runtime);
+  if (readyz_rc != 0)
+    return readyz_rc;
 
   gint request_id_rc = check_request_id_header_contract (base_url);
   if (request_id_rc != 0)

--- a/wyrelog/daemon/delta.c
+++ b/wyrelog/daemon/delta.c
@@ -13,7 +13,7 @@ record_daemon_audit_result (WylDaemonRuntime *runtime, wyrelog_error_t rc)
   if (runtime == NULL || rc == WYRELOG_E_OK)
     return;
 
-  runtime->audit_degraded = TRUE;
+  g_atomic_int_set (&runtime->audit_degraded, TRUE);
   runtime->audit_errors++;
   runtime->last_audit_error = rc;
 }
@@ -381,7 +381,7 @@ wyl_daemon_start_delta_callbacks (WylHandle *handle, WylDaemonRuntime *runtime)
   wyrelog_error_t rc =
       wyl_handle_engine_set_delta_callback (handle, daemon_delta_cb, runtime);
   runtime->last_delta_error = rc;
-  runtime->delta_session_live = rc == WYRELOG_E_OK;
+  g_atomic_int_set (&runtime->delta_session_live, rc == WYRELOG_E_OK);
   return rc;
 }
 

--- a/wyrelog/daemon/delta.c
+++ b/wyrelog/daemon/delta.c
@@ -13,6 +13,7 @@ record_daemon_audit_result (WylDaemonRuntime *runtime, wyrelog_error_t rc)
   if (runtime == NULL || rc == WYRELOG_E_OK)
     return;
 
+  runtime->audit_degraded = TRUE;
   runtime->audit_errors++;
   runtime->last_audit_error = rc;
 }
@@ -279,6 +280,10 @@ daemon_delta_cb (const gchar *relation, const gint64 *row, guint ncols,
 
   if (runtime == NULL)
     return;
+
+  runtime->delta_events_seen++;
+  runtime->last_delta_event_us = g_get_real_time ();
+
   if (kind == WYL_DELTA_INSERT) {
     runtime->inserted++;
   } else if (kind == WYL_DELTA_REMOVE) {
@@ -370,8 +375,14 @@ perm_state_fired_relation:
 wyrelog_error_t
 wyl_daemon_start_delta_callbacks (WylHandle *handle, WylDaemonRuntime *runtime)
 {
-  return wyl_handle_engine_set_delta_callback (handle, daemon_delta_cb,
-      runtime);
+  if (runtime == NULL)
+    return WYRELOG_E_INVALID;
+
+  wyrelog_error_t rc =
+      wyl_handle_engine_set_delta_callback (handle, daemon_delta_cb, runtime);
+  runtime->last_delta_error = rc;
+  runtime->delta_session_live = rc == WYRELOG_E_OK;
+  return rc;
 }
 
 wyrelog_error_t

--- a/wyrelog/daemon/delta.c
+++ b/wyrelog/daemon/delta.c
@@ -67,10 +67,10 @@ persist_daemon_audit_event (WylDaemonRuntime *runtime, const WylAuditEvent *ev)
 
   rc = wyl_audit_conn_create_schema (audit_conn);
   if (rc != WYRELOG_E_OK)
-    return WYRELOG_E_OK;
+    return rc;
 
   gboolean audit_inserted = FALSE;
-  (void) wyl_audit_conn_insert_event_full (audit_conn, id,
+  rc = wyl_audit_conn_insert_event_full (audit_conn, id,
       wyl_audit_event_get_created_at_us (ev),
       wyl_audit_event_get_subject_id (ev), wyl_audit_event_get_action (ev),
       wyl_audit_event_get_resource_id (ev),
@@ -78,7 +78,7 @@ persist_daemon_audit_event (WylDaemonRuntime *runtime, const WylAuditEvent *ev)
       wyl_audit_event_get_deny_origin (ev),
       wyl_audit_event_get_request_id (ev), wyl_audit_event_get_decision (ev),
       &audit_inserted);
-  return WYRELOG_E_OK;
+  return rc;
 }
 
 static void

--- a/wyrelog/daemon/delta.h
+++ b/wyrelog/daemon/delta.h
@@ -6,10 +6,10 @@
 typedef struct
 {
   WylHandle *handle;
-  gboolean delta_session_live;
+  gint delta_session_live;
   guint64 delta_events_seen;
   gint64 last_delta_event_us;
-  gboolean audit_degraded;
+  gint audit_degraded;
   guint64 inserted;
   guint64 removed;
   guint64 audit_errors;

--- a/wyrelog/daemon/delta.h
+++ b/wyrelog/daemon/delta.h
@@ -6,10 +6,15 @@
 typedef struct
 {
   WylHandle *handle;
+  gboolean delta_session_live;
+  guint64 delta_events_seen;
+  gint64 last_delta_event_us;
+  gboolean audit_degraded;
   guint64 inserted;
   guint64 removed;
   guint64 audit_errors;
   wyrelog_error_t last_audit_error;
+  wyrelog_error_t last_delta_error;
   gboolean expect_effective_member;
   gint64 expected_row[3];
   gboolean matched_expected_insert;

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -6,6 +6,7 @@
 #include <sodium.h>
 #include <string.h>
 
+#include "daemon/delta.h"
 #include "wyrelog/wyrelog.h"
 #include "wyrelog/auth/jwt-private.h"
 #include "wyrelog/wyl-handle-private.h"
@@ -24,6 +25,7 @@
 typedef struct
 {
   WylHandle *handle;
+  WylDaemonRuntime *runtime;
   guint8 access_token_secret[WYL_DAEMON_JWT_KEY_LEN];
   gboolean access_token_secret_ready;
   GHashTable *sessions_by_token;
@@ -49,11 +51,12 @@ wyl_daemon_http_context_free (gpointer data)
 }
 
 static WylDaemonHttpContext *
-wyl_daemon_http_context_new (WylHandle *handle)
+wyl_daemon_http_context_new (WylHandle *handle, WylDaemonRuntime *runtime)
 {
   WylDaemonHttpContext *ctx = g_new0 (WylDaemonHttpContext, 1);
 
   ctx->handle = handle;
+  ctx->runtime = runtime;
   if (sodium_init () >= 0) {
     randombytes_buf (ctx->access_token_secret, sizeof ctx->access_token_secret);
     ctx->access_token_secret_ready = TRUE;
@@ -492,6 +495,21 @@ check_runtime_ready (WylHandle *handle)
   return WYRELOG_E_OK;
 }
 
+static const gchar *
+check_runtime_liveness_ready (WylDaemonRuntime *runtime)
+{
+  if (runtime == NULL)
+    return NULL;
+  if (!g_atomic_int_get (&runtime->delta_session_live))
+    return "delta_not_ready";
+  if (runtime->last_delta_error != WYRELOG_E_OK)
+    return "delta_not_ready";
+  if (g_atomic_int_get (&runtime->audit_degraded))
+    return "audit_degraded";
+
+  return NULL;
+}
+
 static void
 readyz_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
     GHashTable *query, gpointer user_data)
@@ -501,6 +519,12 @@ readyz_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
   (void) query;
 
   WylDaemonHttpContext *ctx = user_data;
+  const gchar *liveness_error = check_runtime_liveness_ready (ctx->runtime);
+  if (liveness_error != NULL) {
+    set_json_error (msg, 503, liveness_error);
+    return;
+  }
+
   wyrelog_error_t rc = check_runtime_ready (ctx->handle);
   if (rc != WYRELOG_E_OK) {
     set_json_error (msg, 503, "not_ready");
@@ -1212,8 +1236,8 @@ decide_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
 }
 
 SoupServer *
-wyl_daemon_start_http_server (const WylDaemonOptions *opts, WylHandle *handle,
-    GError **error)
+wyl_daemon_start_http_server_with_runtime (const WylDaemonOptions *opts,
+    WylHandle *handle, WylDaemonRuntime *runtime, GError **error)
 {
   g_return_val_if_fail (opts != NULL, NULL);
   g_return_val_if_fail (WYL_IS_HANDLE (handle), NULL);
@@ -1225,7 +1249,7 @@ wyl_daemon_start_http_server (const WylDaemonOptions *opts, WylHandle *handle,
   }
 
   SoupServer *server = soup_server_new (NULL, NULL);
-  WylDaemonHttpContext *ctx = wyl_daemon_http_context_new (handle);
+  WylDaemonHttpContext *ctx = wyl_daemon_http_context_new (handle, runtime);
   g_object_set_data_full (G_OBJECT (server), "wyl-daemon-http-context", ctx,
       wyl_daemon_http_context_free);
   soup_server_add_handler (server, "/healthz", healthz_handler, NULL, NULL);
@@ -1251,5 +1275,12 @@ wyl_daemon_start_http_server (const WylDaemonOptions *opts, WylHandle *handle,
   }
 
   return server;
+}
+
+SoupServer *
+wyl_daemon_start_http_server (const WylDaemonOptions *opts, WylHandle *handle,
+    GError **error)
+{
+  return wyl_daemon_start_http_server_with_runtime (opts, handle, NULL, error);
 }
 #endif

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -490,6 +490,11 @@ check_runtime_ready (WylHandle *handle)
     return rc;
   if (!found)
     return WYRELOG_E_IO;
+
+  g_autofree gchar *json = NULL;
+  rc = wyl_audit_conn_query_events_json (conn, NULL, &json);
+  if (rc != WYRELOG_E_OK)
+    return rc;
 #endif
 
   return WYRELOG_E_OK;

--- a/wyrelog/daemon/http.h
+++ b/wyrelog/daemon/http.h
@@ -9,8 +9,13 @@
 #ifdef WYL_HAS_DAEMON_HTTP
 #include <libsoup/soup.h>
 
+#include "daemon/delta.h"
+
 SoupServer *wyl_daemon_start_http_server (const WylDaemonOptions * opts,
     WylHandle * handle, GError ** error);
+SoupServer *wyl_daemon_start_http_server_with_runtime
+    (const WylDaemonOptions * opts, WylHandle * handle,
+    WylDaemonRuntime * runtime, GError ** error);
 WylSession *wyl_daemon_http_ref_session (SoupServer * server,
     const gchar * session_token);
 #ifdef WYL_TEST_DAEMON_HTTP

--- a/wyrelog/daemon/runtime.c
+++ b/wyrelog/daemon/runtime.c
@@ -108,7 +108,8 @@ wyl_daemon_run_runtime (const WylDaemonOptions *opts)
   g_autoptr (GMainLoop) loop = g_main_loop_new (NULL, FALSE);
 #ifdef WYL_HAS_DAEMON_HTTP
   g_autoptr (SoupServer) server =
-      wyl_daemon_start_http_server (opts, handle, &error);
+      wyl_daemon_start_http_server_with_runtime (opts, handle, &runtime,
+      &error);
   if (server == NULL) {
     g_printerr ("wyrelogd: listen failed: %s\n", error->message);
     return 1;


### PR DESCRIPTION
## Summary

- track daemon delta callback liveness and audit degradation state
- gate `/readyz` on runtime delta readiness and audit query readiness
- keep `/healthz` scoped to process liveness while preserving the legacy HTTP server constructor

## Tests

- `git diff --check main..HEAD`
- `meson test -C builddir --print-errorlogs wyrelog:daemon-http-decide`
- `meson test -C builddir-audit --print-errorlogs wyrelog:daemon-http-decide wyrelog:daemon-delta wyrelog:daemon-checks wyrelog:wyrelogd-healthz`
