### PR TITLE
Stabilize LoBAC permission-state replay

### DIFF
--- a/tests/test-audit-emit.c
+++ b/tests/test-audit-emit.c
@@ -1408,7 +1408,7 @@ check_login_survives_runtime_audit_failure (void)
   gint64 count = -1;
   if (!policy_count_rows (store,
           "SELECT COUNT(*) FROM audit_events "
-          "WHERE action = 'principal_state';", &count)) {
+          "WHERE action = 'login_skip_mfa';", &count)) {
     g_object_unref (handle);
     return 250;
   }
@@ -1694,7 +1694,7 @@ check_login_principal_state_emits_audit_row (void)
 }
 
 static gint
-check_login_skip_mfa_emits_principal_state_audit_row (void)
+check_login_skip_mfa_emits_canonical_audit_row (void)
 {
   WylHandle *handle = NULL;
   if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
@@ -1716,7 +1716,7 @@ check_login_skip_mfa_emits_principal_state_audit_row (void)
   if (duckdb_query (conn,
           "SELECT subject_id, action, resource_id, deny_reason, "
           "deny_origin, decision "
-          "FROM audit_events WHERE action = 'principal_state';", &result)
+          "FROM audit_events WHERE action = 'login_skip_mfa';", &result)
       != DuckDBSuccess) {
     duckdb_destroy_result (&result);
     g_object_unref (handle);
@@ -1732,18 +1732,18 @@ check_login_skip_mfa_emits_principal_state_audit_row (void)
   const gchar *subject = duckdb_value_varchar (&result, 0, 0);
   const gchar *action = duckdb_value_varchar (&result, 1, 0);
   const gchar *resource = duckdb_value_varchar (&result, 2, 0);
-  const gchar *event = duckdb_value_varchar (&result, 3, 0);
-  const gchar *old_state = duckdb_value_varchar (&result, 4, 0);
+  gboolean reason_is_null = duckdb_value_is_null (&result, 3, 0);
+  gboolean origin_is_null = duckdb_value_is_null (&result, 4, 0);
   gint16 decision = (gint16) duckdb_value_int64 (&result, 5, 0);
   if (g_strcmp0 (subject, "audit-skip-mfa-user") != 0)
     rc = 104;
-  else if (g_strcmp0 (action, "principal_state") != 0)
+  else if (g_strcmp0 (action, "login_skip_mfa") != 0)
     rc = 105;
-  else if (g_strcmp0 (resource, "authenticated") != 0)
+  else if (g_strcmp0 (resource, "principal_state") != 0)
     rc = 106;
-  else if (g_strcmp0 (event, "login_skip_mfa") != 0)
+  else if (!reason_is_null)
     rc = 107;
-  else if (g_strcmp0 (old_state, "unverified") != 0)
+  else if (!origin_is_null)
     rc = 108;
   else if (decision != WYL_DECISION_ALLOW)
     rc = 109;
@@ -1751,8 +1751,6 @@ check_login_skip_mfa_emits_principal_state_audit_row (void)
   duckdb_free ((void *) subject);
   duckdb_free ((void *) action);
   duckdb_free ((void *) resource);
-  duckdb_free ((void *) event);
-  duckdb_free ((void *) old_state);
   duckdb_destroy_result (&result);
   g_object_unref (handle);
   return rc;
@@ -1879,7 +1877,7 @@ check_allowed_login_skip_mfa_rolls_back_on_store_audit_failure (void)
   wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
   if (sqlite3_exec (wyl_policy_store_get_db (store),
           "CREATE TRIGGER fail_skip_mfa_principal_audit "
-          "BEFORE INSERT ON audit_events WHEN NEW.action = 'principal_state' "
+          "BEFORE INSERT ON audit_events WHEN NEW.action = 'login_skip_mfa' "
           "BEGIN SELECT RAISE(ABORT, 'fail audit'); END;",
           NULL, NULL, NULL) != SQLITE_OK) {
     g_object_unref (handle);
@@ -2891,7 +2889,7 @@ main (void)
     return rc;
   if ((rc = check_login_principal_state_emits_audit_row ()) != 0)
     return rc;
-  if ((rc = check_login_skip_mfa_emits_principal_state_audit_row ()) != 0)
+  if ((rc = check_login_skip_mfa_emits_canonical_audit_row ()) != 0)
     return rc;
   if ((rc = check_denied_login_skip_mfa_emits_audit_row ()) != 0)
     return rc;

--- a/tests/test-daemon-checks.c
+++ b/tests/test-daemon-checks.c
@@ -151,10 +151,10 @@ check_login_skip_mfa_ready_allows_development_path (void)
       wyl_audit_conn_get_connection (wyl_handle_get_audit_conn (handle));
   if (!count_duckdb_rows (conn,
           "SELECT COUNT(*) FROM audit_events "
-          "WHERE action = 'principal_state' "
+          "WHERE action = 'login_skip_mfa' "
           "AND subject_id = 'wyrelogd-skip-mfa-override-user' "
-          "AND deny_reason = 'login_skip_mfa' "
-          "AND resource_id = 'authenticated' " "AND decision = 1;", &count))
+          "AND deny_reason IS NULL "
+          "AND resource_id = 'principal_state' " "AND decision = 1;", &count))
     return 33;
   if (count != 1)
     return 34;
@@ -193,10 +193,10 @@ check_login_skip_mfa_ready_allows_policy_path (void)
       wyl_audit_conn_get_connection (wyl_handle_get_audit_conn (handle));
   if (!count_duckdb_rows (conn,
           "SELECT COUNT(*) FROM audit_events "
-          "WHERE action = 'principal_state' "
+          "WHERE action = 'login_skip_mfa' "
           "AND subject_id = 'wyrelogd-skip-mfa-user' "
-          "AND deny_reason = 'login_skip_mfa' "
-          "AND resource_id = 'authenticated' AND decision = 1;", &count))
+          "AND deny_reason IS NULL "
+          "AND resource_id = 'principal_state' AND decision = 1;", &count))
     return 43;
   if (count != 1)
     return 44;
@@ -242,10 +242,10 @@ check_login_skip_mfa_ready_allows_role_policy_path (void)
       wyl_audit_conn_get_connection (wyl_handle_get_audit_conn (handle));
   if (!count_duckdb_rows (conn,
           "SELECT COUNT(*) FROM audit_events "
-          "WHERE action = 'principal_state' "
+          "WHERE action = 'login_skip_mfa' "
           "AND subject_id = 'wyrelogd-skip-mfa-user' "
-          "AND deny_reason = 'login_skip_mfa' "
-          "AND resource_id = 'authenticated' AND decision = 1;", &count))
+          "AND deny_reason IS NULL "
+          "AND resource_id = 'principal_state' AND decision = 1;", &count))
     return 62;
   if (count != 1)
     return 63;

--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -955,10 +955,8 @@ check_raw_login_contract (SoupServer *server, WylHandle *handle,
 #ifdef WYL_HAS_AUDIT
   AuditEventProbe principal_skip_audit = {
     .subject_id = "login-user",
-    .action = "principal_state",
-    .resource_id = "authenticated",
-    .deny_reason = "login_skip_mfa",
-    .deny_origin = "unverified",
+    .action = "login_skip_mfa",
+    .resource_id = "principal_state",
     .request_id = skip_success_request_id,
     .check_decision = TRUE,
     .decision = WYL_DECISION_ALLOW,

--- a/tests/test-decide.c
+++ b/tests/test-decide.c
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #include <glib.h>
+#include <glib/gstdio.h>
 
 #include "wyrelog/wyrelog.h"
 #include "wyrelog/policy/store-private.h"
@@ -726,7 +727,7 @@ check_decide_denies_guarded_permission_on_context_miss (void)
 }
 
 static gint
-check_policy_store_replay_synthesizes_legacy_direct_grant_state (void)
+check_policy_store_replay_requires_durable_permission_state (void)
 {
   g_autoptr (WylHandle) handle = NULL;
   if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
@@ -745,19 +746,19 @@ check_policy_store_replay_synthesizes_legacy_direct_grant_state (void)
     return 126;
 
   gboolean contains = TRUE;
-  gint64 synthesized_row[4];
-  if (intern_symbol (handle, "replay-legacy-user", &synthesized_row[0])
+  gint64 armed_row[4];
+  if (intern_symbol (handle, "replay-legacy-user", &armed_row[0])
       != WYRELOG_E_OK)
     return 150;
-  if (intern_symbol (handle, "site.replay.read", &synthesized_row[1])
+  if (intern_symbol (handle, "site.replay.read", &armed_row[1])
       != WYRELOG_E_OK)
     return 151;
-  if (intern_symbol (handle, "tenant/replay", &synthesized_row[2])
+  if (intern_symbol (handle, "tenant/replay", &armed_row[2])
       != WYRELOG_E_OK)
     return 152;
-  if (intern_symbol (handle, "armed", &synthesized_row[3]) != WYRELOG_E_OK)
+  if (intern_symbol (handle, "armed", &armed_row[3]) != WYRELOG_E_OK)
     return 153;
-  if (wyl_handle_engine_contains (handle, "perm_state", synthesized_row, 4,
+  if (wyl_handle_engine_contains (handle, "perm_state", armed_row, 4,
           &contains) != WYRELOG_E_OK)
     return 154;
   if (contains)
@@ -767,10 +768,12 @@ check_policy_store_replay_synthesizes_legacy_direct_grant_state (void)
   if (decide_policy_store_fixture (handle, "replay-legacy-user",
           "site.replay.read", "tenant/replay", resp) != WYRELOG_E_OK)
     return 127;
-  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_ALLOW)
+  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_DENY)
     return 128;
-  if (wyl_decide_resp_get_deny_reason (resp) != NULL)
+  if (g_strcmp0 (wyl_decide_resp_get_deny_reason (resp), "not_armed") != 0)
     return 129;
+  if (g_strcmp0 (wyl_decide_resp_get_deny_origin (resp), "perm_state") != 0)
+    return 156;
   return 0;
 }
 
@@ -835,6 +838,129 @@ check_policy_store_replay_preserves_armed_permission_state (void)
     return 139;
   if (wyl_decide_resp_get_deny_reason (resp) != NULL)
     return 140;
+  return 0;
+}
+
+static gint
+check_persistent_permission_state_authority_matrix (void)
+{
+  g_autoptr (GError) error = NULL;
+  g_autofree gchar *dir = g_dir_make_tmp ("wyrelog-decide-XXXXXX", &error);
+  if (dir == NULL)
+    return 157;
+
+  g_autofree gchar *policy_path = g_build_filename (dir, "policy.sqlite", NULL);
+#ifdef WYL_HAS_AUDIT
+  g_autofree gchar *audit_path = g_build_filename (dir, "audit.duckdb", NULL);
+#endif
+
+  {
+    g_autoptr (WylHandle) handle = NULL;
+    WylHandleOpenOptions opts = {
+      .template_dir = WYL_TEST_TEMPLATE_DIR,
+      .policy_store_path = policy_path,
+#ifdef WYL_HAS_AUDIT
+      .audit_store_path = audit_path,
+#endif
+    };
+    if (wyl_handle_open_with_options (&opts, &handle) != WYRELOG_E_OK)
+      return 158;
+    if (seed_policy_store_decide_fixture (handle, "matrix-direct-user",
+            "site.matrix.read", "tenant/matrix", NULL) != WYRELOG_E_OK)
+      return 159;
+
+    g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
+    if (decide_policy_store_fixture (handle, "matrix-direct-user",
+            "site.matrix.read", "tenant/matrix", resp) != WYRELOG_E_OK)
+      return 160;
+    if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_DENY)
+      return 161;
+    if (g_strcmp0 (wyl_decide_resp_get_deny_reason (resp), "not_armed") != 0)
+      return 162;
+
+    if (wyl_handle_reload_engine_pair (handle) != WYRELOG_E_OK)
+      return 163;
+    g_autoptr (wyl_decide_resp_t) reload_resp = wyl_decide_resp_new ();
+    if (decide_policy_store_fixture (handle, "matrix-direct-user",
+            "site.matrix.read", "tenant/matrix", reload_resp)
+        != WYRELOG_E_OK)
+      return 164;
+    if (wyl_decide_resp_get_decision (reload_resp) != WYL_DECISION_DENY)
+      return 165;
+    if (g_strcmp0 (wyl_decide_resp_get_deny_reason (reload_resp),
+            "not_armed") != 0)
+      return 166;
+  }
+
+  {
+    g_autoptr (WylHandle) handle = NULL;
+    WylHandleOpenOptions opts = {
+      .template_dir = WYL_TEST_TEMPLATE_DIR,
+      .policy_store_path = policy_path,
+#ifdef WYL_HAS_AUDIT
+      .audit_store_path = audit_path,
+#endif
+    };
+    if (wyl_handle_open_with_options (&opts, &handle) != WYRELOG_E_OK)
+      return 167;
+
+    g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
+    if (decide_policy_store_fixture (handle, "matrix-direct-user",
+            "site.matrix.read", "tenant/matrix", resp) != WYRELOG_E_OK)
+      return 168;
+    if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_DENY)
+      return 169;
+    if (g_strcmp0 (wyl_decide_resp_get_deny_reason (resp), "not_armed") != 0)
+      return 170;
+
+    wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+    if (wyl_policy_store_set_permission_state (store, "matrix-direct-user",
+            "site.matrix.read", "tenant/matrix", "armed") != WYRELOG_E_OK)
+      return 171;
+    if (wyl_handle_reload_engine_pair (handle) != WYRELOG_E_OK)
+      return 172;
+    g_clear_pointer (&resp, wyl_decide_resp_free);
+    resp = wyl_decide_resp_new ();
+    if (decide_policy_store_fixture (handle, "matrix-direct-user",
+            "site.matrix.read", "tenant/matrix", resp) != WYRELOG_E_OK)
+      return 173;
+    if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_ALLOW)
+      return 174;
+    if (wyl_decide_resp_get_deny_reason (resp) != NULL)
+      return 175;
+
+    if (wyl_policy_store_upsert_permission (store, "site.matrix.transition",
+            "transition only", "basic") != WYRELOG_E_OK)
+      return 176;
+    if (wyl_policy_store_set_principal_state (store, "matrix-transition-user",
+            "authenticated") != WYRELOG_E_OK)
+      return 177;
+    if (wyl_policy_store_set_session_state (store, "tenant/matrix-transition",
+            "active") != WYRELOG_E_OK)
+      return 178;
+    if (wyl_policy_store_set_permission_state (store, "matrix-transition-user",
+            "site.matrix.transition", "tenant/matrix-transition", "armed")
+        != WYRELOG_E_OK)
+      return 179;
+    if (wyl_handle_reload_engine_pair (handle) != WYRELOG_E_OK)
+      return 180;
+    g_clear_pointer (&resp, wyl_decide_resp_free);
+    resp = wyl_decide_resp_new ();
+    if (decide_policy_store_fixture (handle, "matrix-transition-user",
+            "site.matrix.transition", "tenant/matrix-transition", resp)
+        != WYRELOG_E_OK)
+      return 181;
+    if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_DENY)
+      return 182;
+    if (wyl_decide_resp_get_deny_reason (resp) != NULL)
+      return 183;
+  }
+
+#ifdef WYL_HAS_AUDIT
+  g_remove (audit_path);
+#endif
+  g_remove (policy_path);
+  g_rmdir (dir);
   return 0;
 }
 
@@ -1147,7 +1273,7 @@ main (void)
     return rc;
   if ((rc = check_decide_denies_guarded_permission_on_context_miss ()) != 0)
     return rc;
-  if ((rc = check_policy_store_replay_synthesizes_legacy_direct_grant_state ())
+  if ((rc = check_policy_store_replay_requires_durable_permission_state ())
       != 0)
     return rc;
   if ((rc = check_policy_store_replay_preserves_dormant_permission_state ())
@@ -1155,6 +1281,8 @@ main (void)
     return rc;
   if ((rc = check_policy_store_replay_preserves_armed_permission_state ())
       != 0)
+    return rc;
+  if ((rc = check_persistent_permission_state_authority_matrix ()) != 0)
     return rc;
   if ((rc = check_decide_cleans_guard_facts_after_guarded_deny ()) != 0)
     return rc;

--- a/tests/test-handle-engine-pair.c
+++ b/tests/test-handle-engine-pair.c
@@ -3107,7 +3107,7 @@ check_policy_store_role_memberships_require_engine_pair (void)
 }
 
 static gint
-check_policy_store_direct_permissions_autoload_on_open (void)
+check_policy_store_direct_permissions_autoload_without_auto_arm (void)
 {
   g_autoptr (WylHandle) handle = NULL;
 
@@ -3138,12 +3138,18 @@ check_policy_store_direct_permissions_autoload_on_open (void)
   if (intern3 (handle, "direct-load-user", "site.direct.autoload",
           "direct-load-scope", decision_row) != WYRELOG_E_OK)
     return 357;
+  gboolean found = FALSE;
+  if (wyl_handle_engine_contains (handle, "has_permission", decision_row, 3,
+          &found) != WYRELOG_E_OK)
+    return 359;
+  if (!found)
+    return 363;
   gboolean allowed = FALSE;
   if (wyl_handle_engine_decide (handle, decision_row, &allowed)
       != WYRELOG_E_OK)
     return 358;
-  if (!allowed)
-    return 359;
+  if (allowed)
+    return 364;
   return 0;
 }
 
@@ -4942,7 +4948,8 @@ main (void)
     return rc;
   if ((rc = check_policy_store_role_memberships_require_engine_pair ()) != 0)
     return rc;
-  if ((rc = check_policy_store_direct_permissions_autoload_on_open ()) != 0)
+  if ((rc = check_policy_store_direct_permissions_autoload_without_auto_arm ())
+      != 0)
     return rc;
   if ((rc = check_policy_store_guarded_direct_permissions_do_not_auto_arm ())
       != 0)

--- a/tests/test-login-projection.c
+++ b/tests/test-login-projection.c
@@ -519,10 +519,10 @@ check_skip_mfa_login_projects_authority_state (void)
   if (!policy_count_rows (store,
           "SELECT COUNT(*) FROM audit_events "
           "WHERE subject_id = 'projection-skip-mfa-user' "
-          "AND action = 'principal_state' "
-          "AND resource_id = 'authenticated' "
-          "AND deny_reason = 'login_skip_mfa' "
-          "AND deny_origin = 'unverified' AND decision = 1;", &count))
+          "AND action = 'login_skip_mfa' "
+          "AND resource_id = 'principal_state' "
+          "AND deny_reason IS NULL "
+          "AND deny_origin IS NULL AND decision = 1;", &count))
     return 62;
   if (count != 1)
     return 63;
@@ -556,11 +556,10 @@ check_skip_mfa_login_projects_authority_state (void)
   if (!policy_select_text_params (store,
           "SELECT id FROM audit_events "
           "WHERE subject_id = 'projection-skip-mfa-user' "
-          "AND action = 'principal_state' "
-          "AND resource_id = 'authenticated' "
-          "AND deny_reason = 'login_skip_mfa' "
-          "AND deny_origin = 'unverified' AND decision = 1;",
-          NULL, 0, &audit_id))
+          "AND action = 'login_skip_mfa' "
+          "AND resource_id = 'principal_state' "
+          "AND deny_reason IS NULL "
+          "AND deny_origin IS NULL AND decision = 1;", NULL, 0, &audit_id))
     return 68;
   gint64 audit_created_at_us = -1;
   const gchar *audit_param[] = { audit_id };
@@ -598,15 +597,15 @@ check_skip_mfa_login_projects_authority_state (void)
           username))
     return 77;
   if (!engine_contains_audit_attr (handle, "audit_event_action", audit_id,
-          "principal_state"))
+          "login_skip_mfa"))
     return 78;
   if (!engine_contains_audit_attr (handle, "audit_event_resource", audit_id,
-          "authenticated"))
+          "principal_state"))
     return 79;
-  if (!engine_contains_audit_attr (handle, "audit_event_deny_reason",
+  if (engine_contains_audit_attr (handle, "audit_event_deny_reason",
           audit_id, "login_skip_mfa"))
     return 80;
-  if (!engine_contains_audit_attr (handle, "audit_event_deny_origin",
+  if (engine_contains_audit_attr (handle, "audit_event_deny_origin",
           audit_id, "unverified"))
     return 81;
 
@@ -686,9 +685,9 @@ check_handle_reopens_persistent_policy_and_audit_paths (void)
 
     if (!policy_select_text_params (store,
             "SELECT id FROM audit_events "
-            "WHERE subject_id = ? AND action = 'principal_state' "
-            "AND resource_id = 'authenticated' "
-            "AND deny_reason = 'login_skip_mfa';", &username, 1, &audit_id))
+            "WHERE subject_id = ? AND action = 'login_skip_mfa' "
+            "AND resource_id = 'principal_state' "
+            "AND deny_reason IS NULL;", &username, 1, &audit_id))
       return 119;
     const gchar *audit_param[] = { audit_id };
     if (!policy_select_int64_params (store,
@@ -699,7 +698,7 @@ check_handle_reopens_persistent_policy_and_audit_paths (void)
     gint64 runtime_count = -1;
     if (!runtime_count_rows (handle,
             "SELECT COUNT(*) FROM audit_events "
-            "WHERE action = 'principal_state' "
+            "WHERE action = 'login_skip_mfa' "
             "AND subject_id = 'projection-persistent-user';", &runtime_count))
       return 121;
     if (runtime_count != 1)
@@ -737,13 +736,13 @@ check_handle_reopens_persistent_policy_and_audit_paths (void)
             username))
       return 128;
     if (!engine_contains_audit_attr (handle, "audit_event_action", audit_id,
-            "principal_state"))
+            "login_skip_mfa"))
       return 129;
 
     gint64 runtime_count = -1;
     if (!runtime_count_rows (handle,
             "SELECT COUNT(*) FROM audit_events "
-            "WHERE action = 'principal_state' "
+            "WHERE action = 'login_skip_mfa' "
             "AND subject_id = 'projection-persistent-user';", &runtime_count))
       return 130;
     if (runtime_count != 1)

--- a/tests/test-login-projection.c
+++ b/tests/test-login-projection.c
@@ -575,8 +575,13 @@ check_skip_mfa_login_projects_authority_state (void)
   if (wyl_policy_store_grant_direct_permission (store, username, perm_id,
           session_id) != WYRELOG_E_OK)
     return 71;
+  if (wyl_policy_store_set_permission_state (store, username, perm_id,
+          session_id, "armed") != WYRELOG_E_OK)
+    return 87;
   if (wyl_handle_load_policy_store_direct_permissions (handle) != WYRELOG_E_OK)
     return 72;
+  if (wyl_handle_load_policy_store_permission_states (handle) != WYRELOG_E_OK)
+    return 88;
   if (!decide_allows (handle, username, perm_id, session_id))
     return 73;
   if (!engine_contains_event_row5 (handle, "principal_fired",
@@ -671,6 +676,9 @@ check_handle_reopens_persistent_policy_and_audit_paths (void)
     if (wyl_policy_store_grant_direct_permission (store, username, perm_id,
             session_id) != WYRELOG_E_OK)
       return 116;
+    if (wyl_policy_store_set_permission_state (store, username, perm_id,
+            session_id, "armed") != WYRELOG_E_OK)
+      return 133;
     if (wyl_handle_reload_engine_pair (handle) != WYRELOG_E_OK)
       return 117;
     if (!decide_allows (handle, username, perm_id, session_id))

--- a/tests/test-perm.c
+++ b/tests/test-perm.c
@@ -14,8 +14,7 @@
  * rows into any attached policy engine pair, record the admin
  * operation in the audit log when audit is enabled, and return
  * WYRELOG_E_OK. The permission-state lifecycle remains a separate
- * contract; unguarded direct permissions keep a compatibility
- * projection path until callers migrate to explicit transitions.
+ * contract and must provide the arming fact required for ALLOW.
  */
 
 typedef struct
@@ -316,7 +315,7 @@ check_role_grant_requires_existing_role (void)
 }
 
 static gint
-check_direct_grant_compat_allows_engine_decide (void)
+check_direct_grant_requires_permission_state (void)
 {
   g_autoptr (WylHandle) handle = NULL;
   if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
@@ -360,8 +359,12 @@ check_direct_grant_compat_allows_engine_decide (void)
   g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
   if (wyl_decide (handle, decide, resp) != WYRELOG_E_OK)
     return 57;
-  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_ALLOW)
+  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_DENY)
     return 58;
+  if (g_strcmp0 (wyl_decide_resp_get_deny_reason (resp), "not_armed") != 0)
+    return 60;
+  if (g_strcmp0 (wyl_decide_resp_get_deny_origin (resp), "perm_state") != 0)
+    return 61;
   return 0;
 }
 
@@ -834,7 +837,7 @@ main (void)
     return rc;
   if ((rc = check_role_grant_requires_existing_role ()) != 0)
     return rc;
-  if ((rc = check_direct_grant_compat_allows_engine_decide ()) != 0)
+  if ((rc = check_direct_grant_requires_permission_state ()) != 0)
     return rc;
   if ((rc = check_direct_grant_preserves_dormant_permission_state ()) != 0)
     return rc;

--- a/tests/test-session-username.c
+++ b/tests/test-session-username.c
@@ -465,6 +465,10 @@ check_mfa_verify_authenticates_engine_principal (void)
   if (grant_direct (handle, "login-user", "site.login-permission",
           "login-scope") != WYRELOG_E_OK)
     return 82;
+  if (wyl_handle_apply_permission_state_transition (handle, "login-user",
+          "site.login-permission", "login-scope", "grant", NULL, NULL)
+      != WYRELOG_E_OK)
+    return 231;
 
   g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
   wyl_login_req_set_username (login, "login-user");
@@ -702,6 +706,10 @@ check_login_session_id_is_active_decision_scope (void)
   if (grant_direct (handle, "session-id-user", "site.session-id-permission",
           session_id) != WYRELOG_E_OK)
     return 145;
+  if (wyl_handle_apply_permission_state_transition (handle, "session-id-user",
+          "site.session-id-permission", session_id, "grant", NULL, NULL)
+      != WYRELOG_E_OK)
+    return 233;
 
   g_autoptr (wyl_decide_req_t) decide = wyl_decide_req_new ();
   wyl_decide_req_set_subject_id (decide, "session-id-user");
@@ -758,6 +766,10 @@ check_mfa_verify_with_proof_requires_validator (void)
   if (grant_direct (handle, "mfa-proof-user", "site.mfa-proof-permission",
           "mfa-proof-scope") != WYRELOG_E_OK)
     return 102;
+  if (wyl_handle_apply_permission_state_transition (handle, "mfa-proof-user",
+          "site.mfa-proof-permission", "mfa-proof-scope", "grant", NULL, NULL)
+      != WYRELOG_E_OK)
+    return 234;
 
   g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
   wyl_login_req_set_username (login, "mfa-proof-user");
@@ -872,6 +884,10 @@ check_login_skip_mfa_authenticates_principal (void)
   if (grant_direct (handle, "skip-mfa-user", "site.skip-mfa-permission",
           "skip-mfa-scope") != WYRELOG_E_OK)
     return 152;
+  if (wyl_handle_apply_permission_state_transition (handle, "skip-mfa-user",
+          "site.skip-mfa-permission", "skip-mfa-scope", "grant", NULL, NULL)
+      != WYRELOG_E_OK)
+    return 232;
 
   g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
   wyl_login_req_set_username (login, "skip-mfa-user");
@@ -1252,6 +1268,10 @@ check_session_close_deactivates_decision_scope (void)
   if (grant_direct (handle, "close-user", "site.close-permission",
           session_id) != WYRELOG_E_OK)
     return 174;
+  if (wyl_handle_apply_permission_state_transition (handle, "close-user",
+          "site.close-permission", session_id, "grant", NULL, NULL)
+      != WYRELOG_E_OK)
+    return 241;
 
   if (wyl_session_close (handle, session) != WYRELOG_E_OK)
     return 176;
@@ -1404,6 +1424,10 @@ check_elevated_session_remains_active_decision_scope (void)
   if (grant_direct (handle, "elevate-user", "site.elevate-permission",
           session_id) != WYRELOG_E_OK)
     return 225;
+  if (wyl_handle_apply_permission_state_transition (handle, "elevate-user",
+          "site.elevate-permission", session_id, "grant", NULL, NULL)
+      != WYRELOG_E_OK)
+    return 242;
 
   g_autoptr (wyl_decide_req_t) decide = wyl_decide_req_new ();
   wyl_decide_req_set_subject_id (decide, "elevate-user");
@@ -1440,6 +1464,10 @@ check_elevated_session_close_deactivates_decision_scope (void)
   if (grant_direct (handle, "elevated-close-user",
           "site.elevated-close-permission", session_id) != WYRELOG_E_OK)
     return 235;
+  if (wyl_handle_apply_permission_state_transition (handle,
+          "elevated-close-user", "site.elevated-close-permission", session_id,
+          "grant", NULL, NULL) != WYRELOG_E_OK)
+    return 242;
 
   if (wyl_session_close (handle, session) != WYRELOG_E_OK)
     return 237;
@@ -1510,6 +1538,10 @@ check_idle_session_deactivates_decision_scope (void)
   if (grant_direct (handle, "idle-user", "site.idle-permission",
           session_id) != WYRELOG_E_OK)
     return 274;
+  if (wyl_handle_apply_permission_state_transition (handle, "idle-user",
+          "site.idle-permission", session_id, "grant", NULL, NULL)
+      != WYRELOG_E_OK)
+    return 286;
 
   if (wyl_session_idle_timeout (handle, session) != WYRELOG_E_OK)
     return 276;
@@ -1552,6 +1584,10 @@ check_elevated_session_idle_timeout_deactivates_scope (void)
   if (grant_direct (handle, "elevated-idle-user",
           "site.elevated-idle-permission", session_id) != WYRELOG_E_OK)
     return 285;
+  if (wyl_handle_apply_permission_state_transition (handle,
+          "elevated-idle-user", "site.elevated-idle-permission", session_id,
+          "grant", NULL, NULL) != WYRELOG_E_OK)
+    return 286;
 
   if (wyl_session_idle_timeout (handle, session) != WYRELOG_E_OK)
     return 287;
@@ -1622,6 +1658,10 @@ check_expiring_session_deactivates_decision_scope (void)
   if (grant_direct (handle, "expiry-user", "site.expiry-permission",
           session_id) != WYRELOG_E_OK)
     return 314;
+  if (wyl_handle_apply_permission_state_transition (handle, "expiry-user",
+          "site.expiry-permission", session_id, "grant", NULL, NULL)
+      != WYRELOG_E_OK)
+    return 320;
 
   if (wyl_session_expire (handle, session) != WYRELOG_E_OK)
     return 316;

--- a/wyrelog/daemon/checks.c
+++ b/wyrelog/daemon/checks.c
@@ -223,6 +223,12 @@ wyl_daemon_check_login_skip_mfa_ready (WylHandle *handle)
   if (rc != WYRELOG_E_OK)
     return rc;
 
+  rc = wyl_handle_apply_permission_state_transition (handle,
+      "wyrelogd-skip-mfa-user", "wyrelogd.skip_mfa.ready", session_id, "grant",
+      NULL, NULL);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
   g_autoptr (wyl_decide_req_t) decide = wyl_decide_req_new ();
   wyl_decide_req_set_subject_id (decide, "wyrelogd-skip-mfa-user");
   wyl_decide_req_set_action (decide, "wyrelogd.skip_mfa.ready");
@@ -282,6 +288,12 @@ wyl_daemon_check_policy_snapshot_reload_ready (WylHandle *handle)
   if (rc != WYRELOG_E_OK)
     return rc;
 
+  rc = wyl_handle_apply_permission_state_transition (handle,
+      "wyrelogd-snapshot-user", "wyrelogd.snapshot.read", session_id, "grant",
+      NULL, NULL);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
   g_autoptr (wyl_decide_req_t) decide = wyl_decide_req_new ();
   wyl_decide_req_set_subject_id (decide, "wyrelogd-snapshot-user");
   wyl_decide_req_set_action (decide, "wyrelogd.snapshot.read");
@@ -300,8 +312,9 @@ wyl_daemon_check_direct_permission_grant_ready (WylHandle *handle)
 {
   /*
    * This readiness probe covers direct permission mutation, audit, reload,
-   * and the unguarded compatibility projection. The canonical stateful
-   * lifecycle probe is wyl_daemon_check_permission_state_transition_ready().
+   * and the decision path that requires durable permission-state arming.
+   * The canonical stateful transition lifecycle probe is
+   * wyl_daemon_check_permission_state_transition_ready().
    */
   g_autoptr (WylSession) session = NULL;
   wyrelog_error_t rc =
@@ -329,6 +342,12 @@ wyl_daemon_check_direct_permission_grant_ready (WylHandle *handle)
     return rc;
   if (!found)
     return WYRELOG_E_POLICY;
+
+  rc = wyl_handle_apply_permission_state_transition (handle,
+      "wyrelogd-direct-grant-user", "wyrelogd.direct_grant.read", session_id,
+      "grant", NULL, NULL);
+  if (rc != WYRELOG_E_OK)
+    return rc;
 
   g_autoptr (wyl_decide_req_t) decide = wyl_decide_req_new ();
   wyl_decide_req_set_subject_id (decide, "wyrelogd-direct-grant-user");

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -1451,40 +1451,6 @@ wyl_handle_load_policy_store_role_memberships (WylHandle *self)
 }
 
 static wyrelog_error_t
-direct_permission_should_synthesize_armed_state (WylHandle *self,
-    const gchar *subject_id, const gchar *perm_id, const gchar *scope,
-    gboolean *out_synthesize)
-{
-  if (out_synthesize != NULL)
-    *out_synthesize = FALSE;
-  if (self == NULL || !WYL_IS_HANDLE (self) || out_synthesize == NULL)
-    return WYRELOG_E_INVALID;
-  if (self->policy_store == NULL)
-    return WYRELOG_E_INVALID;
-
-  /*
-   * Direct permissions grant authority membership. Unguarded legacy
-   * decisions also need an armed lifecycle fact, but only as a replay
-   * compatibility projection when the durable Policy Store has no
-   * permission_states row for this tuple.
-   *
-   * Guarded permissions never use persisted perm_state as their arming
-   * source; they are armed by request-local guard evidence instead.
-   */
-  if (wyl_perm_arm_rule_lookup (perm_id) != NULL)
-    return WYRELOG_E_OK;
-
-  gboolean has_durable_state = FALSE;
-  wyrelog_error_t rc = wyl_policy_store_permission_state_exists
-      (self->policy_store, subject_id, perm_id, scope, &has_durable_state);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-
-  *out_synthesize = !has_durable_state;
-  return WYRELOG_E_OK;
-}
-
-static wyrelog_error_t
 insert_policy_store_direct_permission (const gchar *subject_id,
     const gchar *perm_id, const gchar *scope, gpointer user_data)
 {
@@ -1509,23 +1475,7 @@ insert_policy_store_direct_permission (const gchar *subject_id,
   rc = insert_login_skip_mfa_authz_if_allowed (self, subject_id, scope);
   if (rc != WYRELOG_E_OK)
     return rc;
-
-  gboolean synthesize_armed = FALSE;
-  rc = direct_permission_should_synthesize_armed_state (self, subject_id,
-      perm_id, scope, &synthesize_armed);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  if (!synthesize_armed)
-    return WYRELOG_E_OK;
-
-  gint64 state_row[4];
-  state_row[0] = row[0];
-  state_row[1] = row[1];
-  state_row[2] = row[2];
-  rc = wyl_handle_intern_engine_symbol (self, "armed", &state_row[3]);
-  if (rc != WYRELOG_E_OK)
-    return rc;
-  return wyl_handle_engine_insert (self, "perm_state", state_row, 4);
+  return WYRELOG_E_OK;
 }
 
 wyrelog_error_t
@@ -1981,11 +1931,7 @@ wyl_handle_engine_contains (WylHandle *self, const gchar *relation,
    * the template mirror while preserving the handle-level relation name. */
   if (g_strcmp0 (relation, "principal_state") == 0)
     snapshot_relation = "principal_state_observed";
-  /*
-   * perm_state probes are the public replay-observation path. Actual
-   * engine-local arming input may also include legacy synthesized rows,
-   * which must not be reported as durable replay.
-   */
+  /* perm_state probes are the public durable replay-observation path. */
   else if (g_strcmp0 (relation, "perm_state") == 0)
     snapshot_relation = "perm_state_observed";
   else if (g_strcmp0 (relation, "login_skip_mfa_authz") == 0)

--- a/wyrelog/wyl-session.c
+++ b/wyrelog/wyl-session.c
@@ -119,6 +119,19 @@ new_login_skip_mfa_denied_audit (const gchar *username, const gchar *request_id)
   return ev;
 }
 
+static WylAuditEvent *
+new_login_skip_mfa_allowed_audit (const gchar *username,
+    const gchar *request_id)
+{
+  WylAuditEvent *ev = wyl_audit_event_new ();
+  wyl_audit_event_set_subject_id (ev, username);
+  wyl_audit_event_set_action (ev, "login_skip_mfa");
+  wyl_audit_event_set_resource_id (ev, "principal_state");
+  wyl_audit_event_set_request_id (ev, request_id);
+  wyl_audit_event_set_decision (ev, WYL_DECISION_ALLOW);
+  return ev;
+}
+
 static wyrelog_error_t
 emit_login_skip_mfa_denied_audit (WylHandle *handle, const gchar *username,
     const gchar *request_id)
@@ -596,11 +609,15 @@ wyl_session_login (WylHandle *handle, const wyl_login_req_t *req,
       return (rc == WYRELOG_E_OK) ? WYRELOG_E_INTERNAL : rc;
     }
 #ifdef WYL_HAS_AUDIT
-    g_autoptr (WylAuditEvent) principal_ev =
-        new_principal_state_audit (username,
-        wyl_principal_state_name (WYL_PRINCIPAL_STATE_UNVERIFIED),
-        wyl_principal_state_name (state), wyl_principal_event_name (event),
-        wyl_login_req_get_request_id (req));
+    g_autoptr (WylAuditEvent) principal_ev = NULL;
+    if (req != NULL && wyl_login_req_get_skip_mfa (req))
+      principal_ev = new_login_skip_mfa_allowed_audit (username,
+          wyl_login_req_get_request_id (req));
+    else
+      principal_ev = new_principal_state_audit (username,
+          wyl_principal_state_name (WYL_PRINCIPAL_STATE_UNVERIFIED),
+          wyl_principal_state_name (state), wyl_principal_event_name (event),
+          wyl_login_req_get_request_id (req));
     g_autoptr (WylAuditEvent) session_ev =
         new_session_state_audit (session_id,
         wyl_session_state_name (session->state), "active",


### PR DESCRIPTION
## Summary
- require durable permission-state rows for unguarded ALLOW decisions
- update daemon readiness and session tests to use explicit state transitions
- canonicalize successful skip-MFA audit rows under the login_skip_mfa action

## Tests
- meson test -C builddir --print-errorlogs
- meson test -C builddir-audit --print-errorlogs
- git diff --check
