### PR TITLE
Add durable audit intention reconciliation

### DIFF
--- a/templates/access/sqlite-schema.sql
+++ b/templates/access/sqlite-schema.sql
@@ -311,6 +311,42 @@ CREATE INDEX IF NOT EXISTS idx_audit_events_request_id
     ON audit_events (request_id);
 
 -- ---------------------------------------------------------------------------
+-- Table: audit_intentions
+-- Durable audit append lifecycle. SQLite is the source of truth; this ledger
+-- lets boot/query reconciliation distinguish pending runtime projection work
+-- from fully committed audit rows while reserving chain/anchor metadata hooks.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS audit_intentions (
+    audit_id        TEXT    PRIMARY KEY,
+    created_at_us   INTEGER NOT NULL,
+    subject_id      TEXT,
+    action          TEXT,
+    resource_id     TEXT,
+    deny_reason     TEXT,
+    deny_origin     TEXT,
+    request_id      TEXT,
+    decision        INTEGER NOT NULL CHECK (decision IN (0, 1)),
+    state           TEXT    NOT NULL CHECK
+        (state IN ('pending', 'committed', 'failed')),
+    created_at      INTEGER NOT NULL,
+    updated_at      INTEGER NOT NULL,
+    attempt_count   INTEGER NOT NULL DEFAULT 0,
+    last_error      TEXT,
+    chain_prev      TEXT,
+    chain_hash      TEXT,
+    anchor_batch_id TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_intentions_state
+    ON audit_intentions (state);
+
+CREATE INDEX IF NOT EXISTS idx_audit_intentions_action
+    ON audit_intentions (action);
+
+CREATE INDEX IF NOT EXISTS idx_audit_intentions_updated
+    ON audit_intentions (updated_at);
+
+-- ---------------------------------------------------------------------------
 -- Table: policy_signatures
 -- Ed25519 signatures over policy snapshots, authored by security_officer.
 -- Each policy version is immutably signed; versions are monotonically

--- a/tests/test-audit-emit.c
+++ b/tests/test-audit-emit.c
@@ -809,6 +809,72 @@ check_policy_store_audit_replay_loads_runtime_query (void)
 }
 
 static gint
+check_policy_store_audit_intention_reconciles_runtime_query (void)
+{
+  WylHandle *handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 508;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  static const gchar *id = "01890c10-2e3f-7000-8000-000000000013";
+  gboolean inserted = FALSE;
+  if (wyl_policy_store_record_audit_intention_full (store, id, 891,
+          "reconcile-user", "audit.reconcile", "reconcile-resource",
+          "not_armed", "perm_state", "req-reconcile", WYL_DECISION_DENY,
+          &inserted) != WYRELOG_E_OK) {
+    g_object_unref (handle);
+    return 509;
+  }
+  if (!inserted) {
+    g_object_unref (handle);
+    return 510;
+  }
+
+  gint64 count = -1;
+  if (!policy_count_audit_rows (handle, id, &count) || count != 0) {
+    g_object_unref (handle);
+    return 511;
+  }
+  if (wyl_handle_load_policy_store_audit_events (handle) != WYRELOG_E_OK) {
+    g_object_unref (handle);
+    return 512;
+  }
+  if (wyl_handle_load_policy_store_audit_events (handle) != WYRELOG_E_OK) {
+    g_object_unref (handle);
+    return 513;
+  }
+  if (!policy_count_audit_rows (handle, id, &count) || count != 1) {
+    g_object_unref (handle);
+    return 514;
+  }
+  if (!runtime_count_audit_rows (handle, id, &count) || count != 1) {
+    g_object_unref (handle);
+    return 515;
+  }
+
+  g_autofree gchar *state = NULL;
+  gint64 attempt_count = -1;
+  if (!policy_get_audit_intention_state (handle, id, &state, &attempt_count)) {
+    g_object_unref (handle);
+    return 516;
+  }
+  if (g_strcmp0 (state, "committed") != 0 || attempt_count != 0) {
+    g_object_unref (handle);
+    return 517;
+  }
+
+  gboolean contains = FALSE;
+  if (contains_audit_event_fact (handle, id, 891, "deny", &contains)
+      != WYRELOG_E_OK || !contains) {
+    g_object_unref (handle);
+    return 518;
+  }
+
+  g_object_unref (handle);
+  return 0;
+}
+
+static gint
 check_emit_replays_runtime_query_after_table_loss (void)
 {
   WylHandle *handle = NULL;
@@ -2916,6 +2982,9 @@ main (void)
   if ((rc = check_emit_mirrors_policy_store_row ()) != 0)
     return rc;
   if ((rc = check_policy_store_audit_replay_loads_runtime_query ()) != 0)
+    return rc;
+  if ((rc = check_policy_store_audit_intention_reconciles_runtime_query ())
+      != 0)
     return rc;
   if ((rc = check_emit_replays_runtime_query_after_table_loss ()) != 0)
     return rc;

--- a/tests/test-audit-emit.c
+++ b/tests/test-audit-emit.c
@@ -68,6 +68,32 @@ policy_count_audit_rows (WylHandle *handle, const gchar *id, gint64 *out_count)
 }
 
 static gboolean
+policy_get_audit_intention_state (WylHandle *handle, const gchar *id,
+    gchar **out_state, gint64 *out_attempt_count)
+{
+  sqlite3_stmt *stmt = NULL;
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+
+  if (sqlite3_prepare_v2 (wyl_policy_store_get_db (store),
+          "SELECT state, attempt_count FROM audit_intentions "
+          "WHERE audit_id = ?;", -1, &stmt, NULL) != SQLITE_OK)
+    return FALSE;
+  if (sqlite3_bind_text (stmt, 1, id, -1, SQLITE_TRANSIENT) != SQLITE_OK) {
+    sqlite3_finalize (stmt);
+    return FALSE;
+  }
+
+  gboolean ok = FALSE;
+  if (sqlite3_step (stmt) == SQLITE_ROW) {
+    *out_state = g_strdup ((const gchar *) sqlite3_column_text (stmt, 0));
+    *out_attempt_count = sqlite3_column_int64 (stmt, 1);
+    ok = TRUE;
+  }
+  sqlite3_finalize (stmt);
+  return ok;
+}
+
+static gboolean
 runtime_count_audit_rows (WylHandle *handle, const gchar *id, gint64 *out_count)
 {
   duckdb_connection conn =
@@ -652,6 +678,15 @@ check_emit_mirrors_policy_store_row (void)
     rc = 170;
 
   sqlite3_finalize (stmt);
+  if (rc == 0) {
+    g_autofree gchar *state = NULL;
+    gint64 attempt_count = -1;
+    if (!policy_get_audit_intention_state (handle, expected_id, &state,
+            &attempt_count))
+      rc = 500;
+    else if (g_strcmp0 (state, "committed") != 0 || attempt_count != 0)
+      rc = 501;
+  }
   g_object_unref (handle);
   return rc;
 }
@@ -1203,6 +1238,17 @@ check_decide_allows_when_runtime_audit_projection_fails (void)
     return 301;
   }
   sqlite3_finalize (stmt);
+
+  g_autofree gchar *state = NULL;
+  gint64 attempt_count = -1;
+  if (!policy_get_audit_intention_state (handle, id, &state, &attempt_count)) {
+    g_object_unref (handle);
+    return 506;
+  }
+  if (g_strcmp0 (state, "failed") != 0 || attempt_count != 1) {
+    g_object_unref (handle);
+    return 507;
+  }
 
   gboolean contains = FALSE;
   if (contains_audit_event_fact (handle, id, created_at_us, "allow",
@@ -2530,6 +2576,16 @@ check_emit_reports_live_projection_failure (void)
     g_object_unref (handle);
     return 226;
   }
+  g_autofree gchar *state = NULL;
+  gint64 attempt_count = -1;
+  if (!policy_get_audit_intention_state (handle, id, &state, &attempt_count)) {
+    g_object_unref (handle);
+    return 502;
+  }
+  if (g_strcmp0 (state, "failed") != 0 || attempt_count != 1) {
+    g_object_unref (handle);
+    return 503;
+  }
 
   g_object_unref (handle);
   return 0;
@@ -2570,6 +2626,16 @@ check_failed_duplicate_emit_keeps_durable_rows (void)
   if (!policy_count_audit_rows (handle, id, &count) || count != 1) {
     g_object_unref (handle);
     return 231;
+  }
+  g_autofree gchar *state = NULL;
+  gint64 attempt_count = -1;
+  if (!policy_get_audit_intention_state (handle, id, &state, &attempt_count)) {
+    g_object_unref (handle);
+    return 504;
+  }
+  if (g_strcmp0 (state, "committed") != 0 || attempt_count != 0) {
+    g_object_unref (handle);
+    return 505;
   }
   gboolean contains = FALSE;
   if (contains_audit_event_fact (handle, id, created_at_us, "allow",

--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -2542,7 +2542,7 @@ check_readyz_malformed_audit_projection_contract (WylHandle *handle,
   if (send_raw_path (session, "GET", base_url, "/readyz", &status, &body)
       != 0)
     return 1915;
-  if (status != 503 || strstr (body, "\"not_ready\"") == NULL)
+  if (status != 503 || strstr (body, "\"audit_degraded\"") == NULL)
     return 1916;
 
   if (drop_runtime_audit_events_table (handle) != WYRELOG_E_OK)

--- a/tests/test-policy-store.c
+++ b/tests/test-policy-store.c
@@ -677,6 +677,23 @@ typedef struct
   guint matches;
 } AuditEventExpect;
 
+typedef struct
+{
+  const gchar *id;
+  gint64 created_at_us;
+  const gchar *subject_id;
+  const gchar *action;
+  const gchar *resource_id;
+  const gchar *deny_reason;
+  const gchar *deny_origin;
+  const gchar *request_id;
+  wyl_decision_t decision;
+  const gchar *state;
+  gint64 attempt_count;
+  const gchar *last_error;
+  guint matches;
+} AuditIntentionExpect;
+
 static wyrelog_error_t
 role_permission_expect_cb (const gchar *role_id, const gchar *perm_id,
     gpointer user_data)
@@ -746,6 +763,31 @@ audit_event_expect_cb (const gchar *id, gint64 created_at_us,
       && g_strcmp0 (deny_origin, expect->deny_origin) == 0
       && g_strcmp0 (request_id, expect->request_id) == 0
       && decision == expect->decision)
+    expect->matches++;
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+audit_intention_expect_cb (const gchar *id, gint64 created_at_us,
+    const gchar *subject_id, const gchar *action, const gchar *resource_id,
+    const gchar *deny_reason, const gchar *deny_origin, const gchar *request_id,
+    wyl_decision_t decision, const gchar *state, gint64 attempt_count,
+    const gchar *last_error, gpointer user_data)
+{
+  AuditIntentionExpect *expect = user_data;
+
+  if (g_strcmp0 (id, expect->id) == 0
+      && created_at_us == expect->created_at_us
+      && g_strcmp0 (subject_id, expect->subject_id) == 0
+      && g_strcmp0 (action, expect->action) == 0
+      && g_strcmp0 (resource_id, expect->resource_id) == 0
+      && g_strcmp0 (deny_reason, expect->deny_reason) == 0
+      && g_strcmp0 (deny_origin, expect->deny_origin) == 0
+      && g_strcmp0 (request_id, expect->request_id) == 0
+      && decision == expect->decision
+      && g_strcmp0 (state, expect->state) == 0
+      && attempt_count == expect->attempt_count
+      && g_strcmp0 (last_error, expect->last_error) == 0)
     expect->matches++;
   return WYRELOG_E_OK;
 }
@@ -2058,6 +2100,240 @@ check_store_append_audit_event_is_idempotent (void)
 }
 
 static gint
+check_store_records_audit_intention (void)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+  static const gchar *id = "01890c10-2e3f-7000-8000-000000000006";
+
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 240;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 241;
+  gboolean inserted = FALSE;
+  if (wyl_policy_store_record_audit_intention_full (store, id, 1002,
+          "audit-user", "read", "doc/intent", "not_armed", "perm_state",
+          "req-intent", WYL_DECISION_DENY, &inserted) != WYRELOG_E_OK)
+    return 242;
+  if (!inserted)
+    return 243;
+
+  AuditIntentionExpect expect = {
+    .id = id,
+    .created_at_us = 1002,
+    .subject_id = "audit-user",
+    .action = "read",
+    .resource_id = "doc/intent",
+    .deny_reason = "not_armed",
+    .deny_origin = "perm_state",
+    .request_id = "req-intent",
+    .decision = WYL_DECISION_DENY,
+    .state = "pending",
+    .attempt_count = 0,
+  };
+  if (wyl_policy_store_foreach_audit_intention (store, "pending",
+          audit_intention_expect_cb, &expect) != WYRELOG_E_OK)
+    return 244;
+  if (expect.matches != 1)
+    return 245;
+
+  sqlite3_stmt *stmt = NULL;
+  static const gchar *sql =
+      "SELECT chain_prev, chain_hash, anchor_batch_id "
+      "FROM audit_intentions WHERE audit_id = ?;";
+  if (sqlite3_prepare_v2 (wyl_policy_store_get_db (store), sql, -1, &stmt,
+          NULL) != SQLITE_OK)
+    return 246;
+  if (sqlite3_bind_text (stmt, 1, id, -1, SQLITE_TRANSIENT) != SQLITE_OK) {
+    sqlite3_finalize (stmt);
+    return 247;
+  }
+
+  int step_rc = sqlite3_step (stmt);
+  gint rc = 0;
+  if (step_rc != SQLITE_ROW)
+    rc = 248;
+  else if (sqlite3_column_type (stmt, 0) != SQLITE_NULL
+      || sqlite3_column_type (stmt, 1) != SQLITE_NULL
+      || sqlite3_column_type (stmt, 2) != SQLITE_NULL)
+    rc = 249;
+
+  sqlite3_finalize (stmt);
+  return rc;
+}
+
+static gint
+check_store_audit_intention_is_idempotent (void)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+  static const gchar *id = "01890c10-2e3f-7000-8000-000000000007";
+
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 250;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 251;
+  gboolean inserted = FALSE;
+  if (wyl_policy_store_record_audit_intention_full (store, id, 1003,
+          "audit-user", "same.action", NULL, NULL, NULL, "req-same",
+          WYL_DECISION_ALLOW, &inserted) != WYRELOG_E_OK)
+    return 252;
+  if (!inserted)
+    return 253;
+  inserted = TRUE;
+  if (wyl_policy_store_record_audit_intention_full (store, id, 1003,
+          "audit-user", "same.action", NULL, NULL, NULL, "req-same",
+          WYL_DECISION_ALLOW, &inserted) != WYRELOG_E_OK)
+    return 254;
+  if (inserted)
+    return 255;
+  if (wyl_policy_store_record_audit_intention_full (store, id, 1003,
+          "audit-user", "different.action", NULL, NULL, NULL, "req-same",
+          WYL_DECISION_ALLOW, &inserted) != WYRELOG_E_POLICY)
+    return 256;
+
+  sqlite3_stmt *stmt = NULL;
+  static const gchar *sql =
+      "SELECT COUNT(*) FROM audit_intentions WHERE audit_id = ?;";
+  if (sqlite3_prepare_v2 (wyl_policy_store_get_db (store), sql, -1, &stmt,
+          NULL) != SQLITE_OK)
+    return 257;
+  if (sqlite3_bind_text (stmt, 1, id, -1, SQLITE_TRANSIENT) != SQLITE_OK) {
+    sqlite3_finalize (stmt);
+    return 258;
+  }
+
+  int step_rc = sqlite3_step (stmt);
+  gint rc = 0;
+  if (step_rc != SQLITE_ROW)
+    rc = 259;
+  else if (sqlite3_column_int64 (stmt, 0) != 1)
+    rc = 260;
+
+  sqlite3_finalize (stmt);
+  return rc;
+}
+
+static gint
+check_store_marks_audit_intention_states (void)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+  static const gchar *committed_id = "01890c10-2e3f-7000-8000-000000000008";
+  static const gchar *failed_id = "01890c10-2e3f-7000-8000-000000000009";
+
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 261;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 262;
+  gboolean inserted = FALSE;
+  if (wyl_policy_store_record_audit_intention_full (store, committed_id, 1004,
+          "audit-user", "commit.action", NULL, NULL, NULL, NULL,
+          WYL_DECISION_ALLOW, &inserted) != WYRELOG_E_OK)
+    return 263;
+  if (wyl_policy_store_record_audit_intention_full (store, failed_id, 1005,
+          "audit-user", "fail.action", NULL, NULL, NULL, NULL,
+          WYL_DECISION_DENY, &inserted) != WYRELOG_E_OK)
+    return 264;
+  if (wyl_policy_store_mark_audit_intention_committed (store, committed_id)
+      != WYRELOG_E_OK)
+    return 265;
+  if (wyl_policy_store_mark_audit_intention_committed (store, committed_id)
+      != WYRELOG_E_OK)
+    return 283;
+  if (wyl_policy_store_mark_audit_intention_failed (store, committed_id,
+          "late failure") != WYRELOG_E_POLICY)
+    return 284;
+  if (wyl_policy_store_mark_audit_intention_failed (store, failed_id,
+          "duckdb append failed") != WYRELOG_E_OK)
+    return 266;
+  if (wyl_policy_store_mark_audit_intention_committed (store, failed_id)
+      != WYRELOG_E_OK)
+    return 285;
+  if (wyl_policy_store_mark_audit_intention_failed (store, failed_id,
+          "late failure") != WYRELOG_E_POLICY)
+    return 286;
+
+  AuditIntentionExpect committed = {
+    .id = committed_id,
+    .created_at_us = 1004,
+    .subject_id = "audit-user",
+    .action = "commit.action",
+    .decision = WYL_DECISION_ALLOW,
+    .state = "committed",
+    .attempt_count = 0,
+  };
+  if (wyl_policy_store_foreach_audit_intention (store, "committed",
+          audit_intention_expect_cb, &committed) != WYRELOG_E_OK)
+    return 267;
+  if (committed.matches != 1)
+    return 268;
+
+  AuditIntentionExpect failed = {
+    .id = failed_id,
+    .created_at_us = 1005,
+    .subject_id = "audit-user",
+    .action = "fail.action",
+    .decision = WYL_DECISION_DENY,
+    .state = "committed",
+    .attempt_count = 1,
+  };
+  if (wyl_policy_store_foreach_audit_intention (store, "committed",
+          audit_intention_expect_cb, &failed) != WYRELOG_E_OK)
+    return 269;
+  if (failed.matches != 1)
+    return 270;
+  return 0;
+}
+
+static gint
+check_store_rejects_bad_audit_intentions (void)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+  gboolean inserted = FALSE;
+
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 271;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 272;
+  if (wyl_policy_store_record_audit_intention_full (NULL,
+          "01890c10-2e3f-7000-8000-000000000010", 1, NULL, NULL, NULL, NULL,
+          NULL, NULL, WYL_DECISION_ALLOW, &inserted) != WYRELOG_E_INVALID)
+    return 273;
+  if (wyl_policy_store_record_audit_intention_full (store, NULL, 1, NULL,
+          NULL, NULL, NULL, NULL, NULL, WYL_DECISION_ALLOW, &inserted)
+      != WYRELOG_E_INVALID)
+    return 274;
+  if (wyl_policy_store_record_audit_intention_full (store,
+          "01890c10-2e3f-7000-8000-000000000010", -1, NULL, NULL, NULL, NULL,
+          NULL, NULL, WYL_DECISION_ALLOW, &inserted) != WYRELOG_E_INVALID)
+    return 275;
+  if (wyl_policy_store_record_audit_intention_full (store, "not-a-uuid", 1,
+          NULL, NULL, NULL, NULL, NULL, NULL, WYL_DECISION_ALLOW, &inserted)
+      != WYRELOG_E_INVALID)
+    return 276;
+  if (wyl_policy_store_record_audit_intention_full (store,
+          "01890c10-2e3f-7000-8000-000000000010", 1, NULL, NULL, NULL, NULL,
+          NULL, NULL, (wyl_decision_t) 9, &inserted) != WYRELOG_E_INVALID)
+    return 277;
+  if (wyl_policy_store_record_audit_intention_full (store,
+          "01890c10-2e3f-7000-8000-000000000010", 1, NULL, NULL, NULL, NULL,
+          NULL, NULL, WYL_DECISION_ALLOW, NULL) != WYRELOG_E_INVALID)
+    return 278;
+  if (wyl_policy_store_foreach_audit_intention (store, "unknown",
+          audit_intention_expect_cb, NULL) != WYRELOG_E_INVALID)
+    return 279;
+  if (wyl_policy_store_foreach_audit_intention (store, NULL, NULL, NULL)
+      != WYRELOG_E_INVALID)
+    return 280;
+  if (wyl_policy_store_mark_audit_intention_committed (store,
+          "01890c10-2e3f-7000-8000-000000000010") != WYRELOG_E_POLICY)
+    return 281;
+  if (wyl_policy_store_mark_audit_intention_failed (store,
+          "01890c10-2e3f-7000-8000-000000000010", NULL)
+      != WYRELOG_E_INVALID)
+    return 282;
+  return 0;
+}
+
+static gint
 check_store_rejects_corrupt_audit_events (void)
 {
   g_autoptr (wyl_policy_store_t) store = NULL;
@@ -2360,6 +2636,14 @@ main (void)
   if ((rc = check_store_iterates_audit_event ()) != 0)
     return rc;
   if ((rc = check_store_append_audit_event_is_idempotent ()) != 0)
+    return rc;
+  if ((rc = check_store_records_audit_intention ()) != 0)
+    return rc;
+  if ((rc = check_store_audit_intention_is_idempotent ()) != 0)
+    return rc;
+  if ((rc = check_store_marks_audit_intention_states ()) != 0)
+    return rc;
+  if ((rc = check_store_rejects_bad_audit_intentions ()) != 0)
     return rc;
   if ((rc = check_store_rejects_corrupt_audit_events ()) != 0)
     return rc;

--- a/wyrelog/audit/event.c
+++ b/wyrelog/audit/event.c
@@ -278,7 +278,7 @@ wyl_audit_emit (WylHandle *handle, const WylAuditEvent *event)
     return WYRELOG_E_INTERNAL;
 
   wyrelog_error_t store_rc =
-      wyl_policy_store_append_audit_event_full (wyl_handle_get_policy_store
+      wyl_policy_store_record_audit_intention_full (wyl_handle_get_policy_store
       (handle), id_buf, event->created_at_us,
       event->subject_id, event->action, event->resource_id,
       event->deny_reason, event->deny_origin, event->request_id,
@@ -286,6 +286,20 @@ wyl_audit_emit (WylHandle *handle, const WylAuditEvent *event)
       &store_inserted);
   if (store_rc != WYRELOG_E_OK)
     return store_rc;
+
+  store_inserted = FALSE;
+  store_rc =
+      wyl_policy_store_append_audit_event_full (wyl_handle_get_policy_store
+      (handle), id_buf, event->created_at_us,
+      event->subject_id, event->action, event->resource_id,
+      event->deny_reason, event->deny_origin, event->request_id,
+      event->decision, &store_inserted);
+  if (store_rc != WYRELOG_E_OK) {
+    (void) wyl_policy_store_mark_audit_intention_failed
+        (wyl_handle_get_policy_store (handle), id_buf,
+        "sqlite audit append failed");
+    return store_rc;
+  }
 
   wyrelog_error_t rc = wyl_handle_insert_audit_fact (handle, id_buf,
       event->created_at_us,
@@ -300,22 +314,40 @@ wyl_audit_emit (WylHandle *handle, const WylAuditEvent *event)
       if (cleanup_rc != WYRELOG_E_OK)
         return cleanup_rc;
     }
+    (void) wyl_policy_store_mark_audit_intention_failed
+        (wyl_handle_get_policy_store (handle), id_buf,
+        "wirelog fact projection failed");
     return rc;
   }
 
   wyl_audit_conn_t *audit_conn = wyl_handle_get_audit_conn (handle);
-  if (audit_conn == NULL)
+  if (audit_conn == NULL) {
+    (void) wyl_policy_store_mark_audit_intention_committed
+        (wyl_handle_get_policy_store (handle), id_buf);
     return WYRELOG_E_OK;
+  }
 
   rc = wyl_audit_conn_create_schema (audit_conn);
-  if (rc != WYRELOG_E_OK)
+  if (rc != WYRELOG_E_OK) {
+    (void) wyl_policy_store_mark_audit_intention_failed
+        (wyl_handle_get_policy_store (handle), id_buf,
+        "duckdb schema unavailable");
     return WYRELOG_E_OK;
+  }
 
   gboolean inserted = FALSE;
-  (void) wyl_audit_conn_insert_event_full (audit_conn, id_buf,
+  rc = wyl_audit_conn_insert_event_full (audit_conn, id_buf,
       event->created_at_us, event->subject_id, event->action,
       event->resource_id, event->deny_reason, event->deny_origin,
       event->request_id, event->decision, &inserted);
+  if (rc != WYRELOG_E_OK) {
+    (void) wyl_policy_store_mark_audit_intention_failed
+        (wyl_handle_get_policy_store (handle), id_buf, "duckdb append failed");
+    return WYRELOG_E_OK;
+  }
+
+  (void) wyl_policy_store_mark_audit_intention_committed
+      (wyl_handle_get_policy_store (handle), id_buf);
 
   return WYRELOG_E_OK;
 #else

--- a/wyrelog/daemon/delta.c
+++ b/wyrelog/daemon/delta.c
@@ -32,7 +32,7 @@ persist_daemon_audit_event (WylDaemonRuntime *runtime, const WylAuditEvent *ev)
 
   gboolean store_inserted = FALSE;
   wyrelog_error_t rc =
-      wyl_policy_store_append_audit_event_full (wyl_handle_get_policy_store
+      wyl_policy_store_record_audit_intention_full (wyl_handle_get_policy_store
       (runtime->handle), id, wyl_audit_event_get_created_at_us (ev),
       wyl_audit_event_get_subject_id (ev), wyl_audit_event_get_action (ev),
       wyl_audit_event_get_resource_id (ev),
@@ -42,6 +42,22 @@ persist_daemon_audit_event (WylDaemonRuntime *runtime, const WylAuditEvent *ev)
       &store_inserted);
   if (rc != WYRELOG_E_OK)
     return rc;
+
+  store_inserted = FALSE;
+  rc = wyl_policy_store_append_audit_event_full (wyl_handle_get_policy_store
+      (runtime->handle), id, wyl_audit_event_get_created_at_us (ev),
+      wyl_audit_event_get_subject_id (ev), wyl_audit_event_get_action (ev),
+      wyl_audit_event_get_resource_id (ev),
+      wyl_audit_event_get_deny_reason (ev),
+      wyl_audit_event_get_deny_origin (ev),
+      wyl_audit_event_get_request_id (ev), wyl_audit_event_get_decision (ev),
+      &store_inserted);
+  if (rc != WYRELOG_E_OK) {
+    (void) wyl_policy_store_mark_audit_intention_failed
+        (wyl_handle_get_policy_store (runtime->handle), id,
+        "sqlite audit append failed");
+    return rc;
+  }
 
   rc = wyl_handle_insert_audit_fact (runtime->handle, id,
       wyl_audit_event_get_created_at_us (ev),
@@ -58,16 +74,26 @@ persist_daemon_audit_event (WylDaemonRuntime *runtime, const WylAuditEvent *ev)
       if (cleanup_rc != WYRELOG_E_OK)
         return cleanup_rc;
     }
+    (void) wyl_policy_store_mark_audit_intention_failed
+        (wyl_handle_get_policy_store (runtime->handle), id,
+        "wirelog fact projection failed");
     return rc;
   }
 
   wyl_audit_conn_t *audit_conn = wyl_handle_get_audit_conn (runtime->handle);
-  if (audit_conn == NULL)
+  if (audit_conn == NULL) {
+    (void) wyl_policy_store_mark_audit_intention_committed
+        (wyl_handle_get_policy_store (runtime->handle), id);
     return WYRELOG_E_OK;
+  }
 
   rc = wyl_audit_conn_create_schema (audit_conn);
-  if (rc != WYRELOG_E_OK)
+  if (rc != WYRELOG_E_OK) {
+    (void) wyl_policy_store_mark_audit_intention_failed
+        (wyl_handle_get_policy_store (runtime->handle), id,
+        "duckdb schema unavailable");
     return rc;
+  }
 
   gboolean audit_inserted = FALSE;
   rc = wyl_audit_conn_insert_event_full (audit_conn, id,
@@ -78,6 +104,14 @@ persist_daemon_audit_event (WylDaemonRuntime *runtime, const WylAuditEvent *ev)
       wyl_audit_event_get_deny_origin (ev),
       wyl_audit_event_get_request_id (ev), wyl_audit_event_get_decision (ev),
       &audit_inserted);
+  if (rc != WYRELOG_E_OK) {
+    (void) wyl_policy_store_mark_audit_intention_failed
+        (wyl_handle_get_policy_store (runtime->handle), id,
+        "duckdb append failed");
+    return rc;
+  }
+  (void) wyl_policy_store_mark_audit_intention_committed
+      (wyl_handle_get_policy_store (runtime->handle), id);
   return rc;
 }
 

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -454,9 +454,25 @@ healthz_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
       strlen (body));
 }
 
-static wyrelog_error_t
-check_runtime_ready (WylHandle *handle)
+#ifdef WYL_HAS_AUDIT
+static void
+mark_runtime_audit_degraded (WylDaemonRuntime *runtime, wyrelog_error_t rc)
 {
+  if (runtime == NULL || rc == WYRELOG_E_OK)
+    return;
+
+  g_atomic_int_set (&runtime->audit_degraded, TRUE);
+  runtime->audit_errors++;
+  runtime->last_audit_error = rc;
+}
+#endif
+
+static wyrelog_error_t
+check_runtime_ready (WylHandle *handle, const gchar **out_error)
+{
+  if (out_error != NULL)
+    *out_error = "not_ready";
+
   gint64 row[1];
   wyrelog_error_t rc =
       wyl_handle_intern_engine_symbol (handle, "wr.audit.read", &row[0]);
@@ -486,15 +502,24 @@ check_runtime_ready (WylHandle *handle)
   wyl_audit_conn_t *conn = wyl_handle_get_audit_conn (handle);
   gboolean found = FALSE;
   rc = wyl_audit_conn_table_exists (conn, "audit_events", &found);
-  if (rc != WYRELOG_E_OK)
+  if (rc != WYRELOG_E_OK) {
+    if (out_error != NULL)
+      *out_error = "audit_degraded";
     return rc;
-  if (!found)
+  }
+  if (!found) {
+    if (out_error != NULL)
+      *out_error = "audit_degraded";
     return WYRELOG_E_IO;
+  }
 
   g_autofree gchar *json = NULL;
   rc = wyl_audit_conn_query_events_json (conn, NULL, &json);
-  if (rc != WYRELOG_E_OK)
+  if (rc != WYRELOG_E_OK) {
+    if (out_error != NULL)
+      *out_error = "audit_degraded";
     return rc;
+  }
 #endif
 
   return WYRELOG_E_OK;
@@ -530,9 +555,10 @@ readyz_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
     return;
   }
 
-  wyrelog_error_t rc = check_runtime_ready (ctx->handle);
+  const gchar *readiness_error = "not_ready";
+  wyrelog_error_t rc = check_runtime_ready (ctx->handle, &readiness_error);
   if (rc != WYRELOG_E_OK) {
-    set_json_error (msg, 503, "not_ready");
+    set_json_error (msg, 503, readiness_error);
     return;
   }
 
@@ -680,6 +706,7 @@ audit_events_handler (SoupServer *server, SoupServerMessage *msg,
     return;
   }
   if (rc != WYRELOG_E_OK) {
+    mark_runtime_audit_degraded (ctx->runtime, rc);
     set_json_error (msg, 500, "audit_query_failed");
     return;
   }

--- a/wyrelog/policy/store-private.h
+++ b/wyrelog/policy/store-private.h
@@ -47,6 +47,12 @@ typedef wyrelog_error_t (*wyl_policy_audit_event_cb) (const gchar * id,
     const gchar * resource_id, const gchar * deny_reason,
     const gchar * deny_origin, const gchar * request_id,
     wyl_decision_t decision, gpointer user_data);
+typedef wyrelog_error_t (*wyl_policy_audit_intention_cb) (const gchar * id,
+    gint64 created_at_us, const gchar * subject_id, const gchar * action,
+    const gchar * resource_id, const gchar * deny_reason,
+    const gchar * deny_origin, const gchar * request_id,
+    wyl_decision_t decision, const gchar * state, gint64 attempt_count,
+    const gchar * last_error, gpointer user_data);
 
 /*
  * Policy authority store lifecycle wrapper.
@@ -220,6 +226,19 @@ wyrelog_error_t wyl_policy_store_append_audit_event_full (wyl_policy_store_t *
     const gchar * action, const gchar * resource_id,
     const gchar * deny_reason, const gchar * deny_origin,
     const gchar * request_id, wyl_decision_t decision, gboolean * out_inserted);
+wyrelog_error_t wyl_policy_store_record_audit_intention_full
+    (wyl_policy_store_t * store, const gchar * id, gint64 created_at_us,
+    const gchar * subject_id, const gchar * action,
+    const gchar * resource_id, const gchar * deny_reason,
+    const gchar * deny_origin, const gchar * request_id,
+    wyl_decision_t decision, gboolean * out_inserted);
+wyrelog_error_t wyl_policy_store_mark_audit_intention_committed
+    (wyl_policy_store_t * store, const gchar * id);
+wyrelog_error_t wyl_policy_store_mark_audit_intention_failed
+    (wyl_policy_store_t * store, const gchar * id, const gchar * last_error);
+wyrelog_error_t wyl_policy_store_foreach_audit_intention
+    (wyl_policy_store_t * store, const gchar * state,
+    wyl_policy_audit_intention_cb cb, gpointer user_data);
 wyrelog_error_t wyl_policy_store_delete_audit_event (wyl_policy_store_t *
     store, const gchar * id);
 wyrelog_error_t wyl_policy_store_foreach_audit_event (wyl_policy_store_t *

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -77,6 +77,7 @@ static const gchar *const required_tables[] = {
   "principal_states",
   "session_states",
   "session_events",
+  "audit_intentions",
   "audit_events",
   "policy_signatures",
 };
@@ -158,6 +159,14 @@ column_nullable_text_equal (sqlite3_stmt *stmt, int col, const gchar *expected)
     return expected == NULL;
   return g_strcmp0 ((const gchar *) sqlite3_column_text (stmt, col),
       expected) == 0;
+}
+
+static gboolean
+is_valid_audit_intention_state (const gchar *state)
+{
+  return g_strcmp0 (state, "pending") == 0
+      || g_strcmp0 (state, "committed") == 0
+      || g_strcmp0 (state, "failed") == 0;
 }
 
 static gboolean
@@ -671,6 +680,32 @@ wyl_policy_store_create_schema (wyl_policy_store_t *store)
       "  ON audit_events (deny_reason);"
       "CREATE INDEX IF NOT EXISTS idx_audit_events_deny_origin "
       "  ON audit_events (deny_origin);"
+      "CREATE TABLE IF NOT EXISTS audit_intentions ("
+      "  audit_id TEXT PRIMARY KEY,"
+      "  created_at_us INTEGER NOT NULL,"
+      "  subject_id TEXT,"
+      "  action TEXT,"
+      "  resource_id TEXT,"
+      "  deny_reason TEXT,"
+      "  deny_origin TEXT,"
+      "  request_id TEXT,"
+      "  decision INTEGER NOT NULL CHECK (decision IN (0, 1)),"
+      "  state TEXT NOT NULL CHECK "
+      "    (state IN ('pending', 'committed', 'failed')),"
+      "  created_at INTEGER NOT NULL,"
+      "  updated_at INTEGER NOT NULL,"
+      "  attempt_count INTEGER NOT NULL DEFAULT 0,"
+      "  last_error TEXT,"
+      "  chain_prev TEXT,"
+      "  chain_hash TEXT,"
+      "  anchor_batch_id TEXT"
+      ");"
+      "CREATE INDEX IF NOT EXISTS idx_audit_intentions_state "
+      "  ON audit_intentions (state);"
+      "CREATE INDEX IF NOT EXISTS idx_audit_intentions_action "
+      "  ON audit_intentions (action);"
+      "CREATE INDEX IF NOT EXISTS idx_audit_intentions_updated "
+      "  ON audit_intentions (updated_at);"
       "CREATE TABLE IF NOT EXISTS policy_signatures ("
       "  policy_version INTEGER PRIMARY KEY,"
       "  policy_hash BLOB NOT NULL,"
@@ -2561,6 +2596,208 @@ wyl_policy_store_append_audit_event (wyl_policy_store_t *store,
   return wyl_policy_store_append_audit_event_full (store, id, created_at_us,
       subject_id, action, resource_id, deny_reason, deny_origin, NULL, decision,
       &inserted);
+}
+
+wyrelog_error_t
+wyl_policy_store_record_audit_intention_full (wyl_policy_store_t *store,
+    const gchar *id, gint64 created_at_us, const gchar *subject_id,
+    const gchar *action, const gchar *resource_id, const gchar *deny_reason,
+    const gchar *deny_origin, const gchar *request_id,
+    wyl_decision_t decision, gboolean *out_inserted)
+{
+  sqlite3_stmt *stmt = NULL;
+  wyl_id_t parsed_id;
+
+  if (store == NULL || store->db == NULL || id == NULL || created_at_us < 0
+      || out_inserted == NULL)
+    return WYRELOG_E_INVALID;
+  *out_inserted = FALSE;
+  if (wyl_id_parse (id, &parsed_id) != WYRELOG_E_OK)
+    return WYRELOG_E_INVALID;
+  if (decision != WYL_DECISION_DENY && decision != WYL_DECISION_ALLOW)
+    return WYRELOG_E_INVALID;
+
+  static const gchar *select_sql =
+      "SELECT created_at_us, subject_id, action, resource_id, "
+      "deny_reason, deny_origin, request_id, decision "
+      "FROM audit_intentions WHERE audit_id = ?;";
+  wyrelog_error_t rc = prepare_stmt (store->db, select_sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if ((rc = bind_text (stmt, 1, id)) != WYRELOG_E_OK) {
+    sqlite3_finalize (stmt);
+    return rc;
+  }
+
+  int select_rc = sqlite3_step (stmt);
+  if (select_rc == SQLITE_ROW) {
+    gboolean equal =
+        sqlite3_column_int64 (stmt, 0) == created_at_us
+        && column_nullable_text_equal (stmt, 1, subject_id)
+        && column_nullable_text_equal (stmt, 2, action)
+        && column_nullable_text_equal (stmt, 3, resource_id)
+        && column_nullable_text_equal (stmt, 4, deny_reason)
+        && column_nullable_text_equal (stmt, 5, deny_origin)
+        && column_nullable_text_equal (stmt, 6, request_id)
+        && sqlite3_column_int (stmt, 7) == (int) decision;
+    sqlite3_finalize (stmt);
+    return equal ? WYRELOG_E_OK : WYRELOG_E_POLICY;
+  }
+  sqlite3_finalize (stmt);
+  stmt = NULL;
+  if (select_rc != SQLITE_DONE)
+    return WYRELOG_E_IO;
+
+  static const gchar *sql =
+      "INSERT INTO audit_intentions "
+      "  (audit_id, created_at_us, subject_id, action, resource_id, "
+      "   deny_reason, deny_origin, request_id, decision, state, "
+      "   created_at, updated_at) "
+      "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', unixepoch(), unixepoch());";
+  rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if ((rc = bind_text (stmt, 1, id)) != WYRELOG_E_OK
+      || sqlite3_bind_int64 (stmt, 2, created_at_us) != SQLITE_OK
+      || (rc = bind_nullable_text (stmt, 3, subject_id)) != WYRELOG_E_OK
+      || (rc = bind_nullable_text (stmt, 4, action)) != WYRELOG_E_OK
+      || (rc = bind_nullable_text (stmt, 5, resource_id)) != WYRELOG_E_OK
+      || (rc = bind_nullable_text (stmt, 6, deny_reason)) != WYRELOG_E_OK
+      || (rc = bind_nullable_text (stmt, 7, deny_origin)) != WYRELOG_E_OK
+      || (rc = bind_nullable_text (stmt, 8, request_id)) != WYRELOG_E_OK
+      || sqlite3_bind_int (stmt, 9, (int) decision) != SQLITE_OK) {
+    sqlite3_finalize (stmt);
+    return WYRELOG_E_IO;
+  }
+
+  int step_rc = sqlite3_step (stmt);
+  sqlite3_finalize (stmt);
+  if (step_rc != SQLITE_DONE)
+    return WYRELOG_E_IO;
+  *out_inserted = TRUE;
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+mark_audit_intention_state (wyl_policy_store_t *store, const gchar *id,
+    const gchar *state, const gchar *last_error)
+{
+  sqlite3_stmt *stmt = NULL;
+  wyl_id_t parsed_id;
+
+  if (store == NULL || store->db == NULL || id == NULL
+      || !is_valid_audit_intention_state (state))
+    return WYRELOG_E_INVALID;
+  if (g_strcmp0 (state, "failed") == 0 && last_error == NULL)
+    return WYRELOG_E_INVALID;
+  if (wyl_id_parse (id, &parsed_id) != WYRELOG_E_OK)
+    return WYRELOG_E_INVALID;
+
+  static const gchar *sql =
+      "UPDATE audit_intentions "
+      "SET state = ?, updated_at = unixepoch(), "
+      "    attempt_count = attempt_count + ?, last_error = ? "
+      "WHERE audit_id = ? AND (state != 'committed' OR ? = 'committed');";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if ((rc = bind_text (stmt, 1, state)) != WYRELOG_E_OK
+      || sqlite3_bind_int (stmt, 2,
+          g_strcmp0 (state, "failed") == 0 ? 1 : 0) != SQLITE_OK
+      || (rc = bind_nullable_text (stmt, 3, last_error)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 4, id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 5, state)) != WYRELOG_E_OK) {
+    sqlite3_finalize (stmt);
+    return WYRELOG_E_IO;
+  }
+
+  int step_rc = sqlite3_step (stmt);
+  sqlite3_finalize (stmt);
+  if (step_rc != SQLITE_DONE)
+    return WYRELOG_E_IO;
+  return sqlite3_changes (store->db) == 1 ? WYRELOG_E_OK : WYRELOG_E_POLICY;
+}
+
+wyrelog_error_t
+wyl_policy_store_mark_audit_intention_committed (wyl_policy_store_t *store,
+    const gchar *id)
+{
+  return mark_audit_intention_state (store, id, "committed", NULL);
+}
+
+wyrelog_error_t
+wyl_policy_store_mark_audit_intention_failed (wyl_policy_store_t *store,
+    const gchar *id, const gchar *last_error)
+{
+  return mark_audit_intention_state (store, id, "failed", last_error);
+}
+
+wyrelog_error_t
+wyl_policy_store_foreach_audit_intention (wyl_policy_store_t *store,
+    const gchar *state, wyl_policy_audit_intention_cb cb, gpointer user_data)
+{
+  sqlite3_stmt *stmt = NULL;
+
+  if (store == NULL || store->db == NULL || cb == NULL)
+    return WYRELOG_E_INVALID;
+  if (state != NULL && !is_valid_audit_intention_state (state))
+    return WYRELOG_E_INVALID;
+
+  static const gchar *all_sql =
+      "SELECT audit_id, created_at_us, subject_id, action, resource_id, "
+      "deny_reason, deny_origin, request_id, decision, state, "
+      "attempt_count, last_error "
+      "FROM audit_intentions ORDER BY created_at_us ASC, audit_id ASC;";
+  static const gchar *state_sql =
+      "SELECT audit_id, created_at_us, subject_id, action, resource_id, "
+      "deny_reason, deny_origin, request_id, decision, state, "
+      "attempt_count, last_error "
+      "FROM audit_intentions WHERE state = ? "
+      "ORDER BY created_at_us ASC, audit_id ASC;";
+  wyrelog_error_t rc = prepare_stmt (store->db,
+      state == NULL ? all_sql : state_sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if (state != NULL && (rc = bind_text (stmt, 1, state)) != WYRELOG_E_OK) {
+    sqlite3_finalize (stmt);
+    return rc;
+  }
+
+  int step_rc;
+  while ((step_rc = sqlite3_step (stmt)) == SQLITE_ROW) {
+    const gchar *id = (const gchar *) sqlite3_column_text (stmt, 0);
+    gint64 created_at_us = sqlite3_column_int64 (stmt, 1);
+    const gchar *subject_id = (const gchar *) sqlite3_column_text (stmt, 2);
+    const gchar *action = (const gchar *) sqlite3_column_text (stmt, 3);
+    const gchar *resource_id = (const gchar *) sqlite3_column_text (stmt, 4);
+    const gchar *deny_reason = (const gchar *) sqlite3_column_text (stmt, 5);
+    const gchar *deny_origin = (const gchar *) sqlite3_column_text (stmt, 6);
+    const gchar *request_id = (const gchar *) sqlite3_column_text (stmt, 7);
+    int decision = sqlite3_column_int (stmt, 8);
+    const gchar *row_state = (const gchar *) sqlite3_column_text (stmt, 9);
+    gint64 attempt_count = sqlite3_column_int64 (stmt, 10);
+    const gchar *last_error = (const gchar *) sqlite3_column_text (stmt, 11);
+    wyl_id_t parsed_id;
+
+    if (id == NULL || wyl_id_parse (id, &parsed_id) != WYRELOG_E_OK
+        || created_at_us < 0 || (decision != WYL_DECISION_DENY
+            && decision != WYL_DECISION_ALLOW)
+        || !is_valid_audit_intention_state (row_state)
+        || attempt_count < 0) {
+      sqlite3_finalize (stmt);
+      return WYRELOG_E_POLICY;
+    }
+    rc = cb (id, created_at_us, subject_id, action, resource_id, deny_reason,
+        deny_origin, request_id, (wyl_decision_t) decision, row_state,
+        attempt_count, last_error, user_data);
+    if (rc != WYRELOG_E_OK) {
+      sqlite3_finalize (stmt);
+      return rc;
+    }
+  }
+
+  sqlite3_finalize (stmt);
+  return (step_rc == SQLITE_DONE) ? WYRELOG_E_OK : WYRELOG_E_IO;
 }
 
 wyrelog_error_t

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -525,6 +525,80 @@ insert_policy_store_audit_event (const gchar *id, gint64 created_at_us,
       decision, &inserted);
 }
 
+typedef struct
+{
+  WylHandle *self;
+  GPtrArray *committed_ids;
+} WylAuditReconcileCtx;
+
+static wyrelog_error_t
+reconcile_policy_store_audit_intention (const gchar *id, gint64 created_at_us,
+    const gchar *subject_id, const gchar *action, const gchar *resource_id,
+    const gchar *deny_reason, const gchar *deny_origin, const gchar *request_id,
+    wyl_decision_t decision, const gchar *state, gint64 attempt_count,
+    const gchar *last_error, gpointer user_data)
+{
+  WylAuditReconcileCtx *ctx = user_data;
+  WylHandle *self = ctx->self;
+  gboolean inserted = FALSE;
+
+  (void) state;
+  (void) attempt_count;
+  (void) last_error;
+
+  wyrelog_error_t rc =
+      wyl_policy_store_append_audit_event_full (self->policy_store, id,
+      created_at_us, subject_id, action, resource_id, deny_reason, deny_origin,
+      request_id, decision, &inserted);
+  if (rc != WYRELOG_E_OK) {
+    (void) wyl_policy_store_mark_audit_intention_failed (self->policy_store,
+        id, "sqlite audit append failed");
+    return rc;
+  }
+
+  rc = wyl_handle_insert_audit_fact (self, id, created_at_us, subject_id,
+      action, resource_id, deny_reason, deny_origin, request_id, decision);
+  if (rc != WYRELOG_E_OK) {
+    if (inserted) {
+      wyrelog_error_t cleanup_rc =
+          wyl_policy_store_delete_audit_event (self->policy_store, id);
+      if (cleanup_rc != WYRELOG_E_OK)
+        return cleanup_rc;
+    }
+    (void) wyl_policy_store_mark_audit_intention_failed (self->policy_store,
+        id, "wirelog fact projection failed");
+    return rc;
+  }
+
+  rc = insert_policy_store_audit_event (id, created_at_us, subject_id, action,
+      resource_id, deny_reason, deny_origin, request_id, decision, self);
+  if (rc != WYRELOG_E_OK) {
+    (void) wyl_policy_store_mark_audit_intention_failed (self->policy_store,
+        id, "duckdb append failed");
+    return rc;
+  }
+
+  g_ptr_array_add (ctx->committed_ids, g_strdup (id));
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+reconcile_policy_store_audit_intentions (WylHandle *self,
+    GPtrArray *committed_ids)
+{
+  WylAuditReconcileCtx ctx = {
+    .self = self,
+    .committed_ids = committed_ids,
+  };
+  wyrelog_error_t rc =
+      wyl_policy_store_foreach_audit_intention (self->policy_store, "pending",
+      reconcile_policy_store_audit_intention, &ctx);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_policy_store_foreach_audit_intention (self->policy_store,
+      "failed", reconcile_policy_store_audit_intention, &ctx);
+}
+
 wyrelog_error_t
 wyl_handle_load_policy_store_audit_events (WylHandle *self)
 {
@@ -540,12 +614,21 @@ wyl_handle_load_policy_store_audit_events (WylHandle *self)
   duckdb_connection conn = wyl_audit_conn_get_connection (self->audit_conn);
   duckdb_result result;
   memset (&result, 0, sizeof (result));
+  g_autoptr (GPtrArray) committed_ids = g_ptr_array_new_with_free_func (g_free);
 
   if (duckdb_query (conn, "BEGIN TRANSACTION;", &result) != DuckDBSuccess) {
     duckdb_destroy_result (&result);
     return WYRELOG_E_IO;
   }
   duckdb_destroy_result (&result);
+
+  rc = reconcile_policy_store_audit_intentions (self, committed_ids);
+  if (rc != WYRELOG_E_OK) {
+    memset (&result, 0, sizeof (result));
+    duckdb_query (conn, "ROLLBACK;", &result);
+    duckdb_destroy_result (&result);
+    return rc;
+  }
 
   rc = wyl_policy_store_foreach_audit_event (self->policy_store,
       insert_policy_store_audit_event, self);
@@ -565,6 +648,13 @@ wyl_handle_load_policy_store_audit_events (WylHandle *self)
     return WYRELOG_E_IO;
   }
   duckdb_destroy_result (&result);
+  for (guint i = 0; i < committed_ids->len; i++) {
+    const gchar *id = g_ptr_array_index (committed_ids, i);
+    rc = wyl_policy_store_mark_audit_intention_committed (self->policy_store,
+        id);
+    if (rc != WYRELOG_E_OK)
+      return rc;
+  }
   return WYRELOG_E_OK;
 }
 #endif


### PR DESCRIPTION
## Summary

- add a private SQLite audit-intention ledger for durable audit append work
- route audit emission through pending, committed, and failed intention states
- reconcile pending and failed intentions during audit sink loading
- report runtime audit sink projection failures as audit_degraded readiness

## Verification

- meson test -C builddir --print-errorlogs
- meson test -C builddir-audit --print-errorlogs
- git diff --check HEAD~4..HEAD
