### PR TITLE
Harden JWT access token binding

### DIFF
--- a/tests/test-client-smoke.c
+++ b/tests/test-client-smoke.c
@@ -243,7 +243,8 @@ main (void)
     return 510;
 
   http.body = "{\"session_token\":\"session-1\",\"username\":\"alice\","
-      "\"principal_state\":\"mfa_required\",\"session_state\":\"active\"}";
+      "\"tenant\":\"__wr_default\",\"principal_state\":\"mfa_required\","
+      "\"session_state\":\"active\"}";
   if (wyl_client_login (local_client, "alice", NULL) != WYRELOG_E_OK)
     return 42;
   if (g_strcmp0 (http.last_method, "POST") != 0)
@@ -261,6 +262,7 @@ main (void)
   g_autofree gchar *client_access_token =
       wyl_client_dup_access_token (local_client);
   g_autofree gchar *client_username = wyl_client_dup_username (local_client);
+  g_autofree gchar *client_tenant = wyl_client_dup_tenant (local_client);
   g_autofree gchar *client_principal_state =
       wyl_client_dup_principal_state (local_client);
   g_autofree gchar *client_session_state =
@@ -268,6 +270,7 @@ main (void)
   if (g_strcmp0 (client_session_token, "session-1") != 0 ||
       client_access_token != NULL ||
       g_strcmp0 (client_username, "alice") != 0 ||
+      g_strcmp0 (client_tenant, "__wr_default") != 0 ||
       g_strcmp0 (client_principal_state, "mfa_required") != 0 ||
       g_strcmp0 (client_session_state, "active") != 0)
     return 138;
@@ -294,8 +297,8 @@ main (void)
     return 175;
 
   http.body = "{\"session_token\":\"session-2\",\"username\":\"alice\","
-      "\"principal_state\":\"authenticated\",\"session_state\":\"active\","
-      "\"access_token\":\"access-2\"}";
+      "\"tenant\":\"__wr_default\",\"principal_state\":\"authenticated\","
+      "\"session_state\":\"active\",\"access_token\":\"access-2\"}";
   if (wyl_client_login_skip_mfa (local_client, "alice") != WYRELOG_E_OK)
     return 147;
   if (g_strcmp0 (http.last_method, "POST") != 0)
@@ -309,16 +312,19 @@ main (void)
   g_clear_pointer (&client_session_token, g_free);
   g_clear_pointer (&client_access_token, g_free);
   g_clear_pointer (&client_username, g_free);
+  g_clear_pointer (&client_tenant, g_free);
   g_clear_pointer (&client_principal_state, g_free);
   g_clear_pointer (&client_session_state, g_free);
   client_session_token = wyl_client_dup_session_token (local_client);
   client_access_token = wyl_client_dup_access_token (local_client);
   client_username = wyl_client_dup_username (local_client);
+  client_tenant = wyl_client_dup_tenant (local_client);
   client_principal_state = wyl_client_dup_principal_state (local_client);
   client_session_state = wyl_client_dup_session_state (local_client);
   if (g_strcmp0 (client_session_token, "session-2") != 0 ||
       g_strcmp0 (client_access_token, "access-2") != 0 ||
       g_strcmp0 (client_username, "alice") != 0 ||
+      g_strcmp0 (client_tenant, "__wr_default") != 0 ||
       g_strcmp0 (client_principal_state, "authenticated") != 0 ||
       g_strcmp0 (client_session_state, "active") != 0)
     return 152;
@@ -449,8 +455,8 @@ main (void)
     return 161;
 
   http.body = "{\"session_token\":\"session-3\",\"username\":\"alice\","
-      "\"principal_state\":\"authenticated\",\"session_state\":\"active\","
-      "\"access_token\":\"access-3\"}";
+      "\"tenant\":\"__wr_default\",\"principal_state\":\"authenticated\","
+      "\"session_state\":\"active\",\"access_token\":\"access-3\"}";
   if (wyl_client_login_skip_mfa (local_client, "alice") != WYRELOG_E_OK)
     return 162;
 
@@ -488,20 +494,21 @@ main (void)
     return 142;
 
   http.body = "{\"session_token\":\"session-bad\",\"username\":\"alice\","
-      "\"principal_state\":\"authenticated\",\"session_state\":\"active\","
-      "\"access_token\":\"\"}";
+      "\"tenant\":\"__wr_default\",\"principal_state\":\"authenticated\","
+      "\"session_state\":\"active\",\"access_token\":\"\"}";
   if (wyl_client_login_skip_mfa (local_client, "alice") != WYRELOG_E_IO)
     return 163;
 
   http.body = "{\"session_token\":\"session-bad\",\"username\":\"alice\","
-      "\"principal_state\":\"authenticated\",\"session_state\":\"active\","
-      "\"access_token\":null}";
+      "\"tenant\":\"__wr_default\",\"principal_state\":\"authenticated\","
+      "\"session_state\":\"active\",\"access_token\":null}";
   if (wyl_client_login_skip_mfa (local_client, "alice") != WYRELOG_E_IO)
     return 165;
 
   http.body = "{\"session_token\":\"session-bad\",\"username\":\"alice\","
-      "\"principal_state\":\"authenticated\",\"session_state\":\"active\","
-      "\"access_token\":\"access-a\",\"access_token\":\"access-b\"}";
+      "\"tenant\":\"__wr_default\",\"principal_state\":\"authenticated\","
+      "\"session_state\":\"active\",\"access_token\":\"access-a\","
+      "\"access_token\":\"access-b\"}";
   if (wyl_client_login_skip_mfa (local_client, "alice") != WYRELOG_E_IO)
     return 164;
 

--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -666,7 +666,8 @@ verify_login_access_token (const gchar *body, const gchar *session_token,
   g_autoptr (GBytes) payload = NULL;
   gint64 now = g_get_real_time () / G_USEC_PER_SEC;
   wyrelog_error_t rc = wyl_jwt_verify_hs256_access_token (access_token, secret,
-      sizeof secret, "wyrelogd", "wyrelog-client", now, &payload);
+      sizeof secret, "__wr_default_hs256", "wyrelogd", "wyrelog-client", now,
+      &payload);
   memset (secret, 0, sizeof secret);
   if (rc != WYRELOG_E_OK)
     return 532;
@@ -709,6 +710,7 @@ sign_test_access_token_with_jti (SoupServer *server, const gchar *jti,
     return rc;
 
   wyl_jwt_issue_input_t input = {
+    .key_id = "__wr_default_hs256",
     .jti = jti,
     .subject = subject,
     .issuer = issuer,

--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -682,9 +682,11 @@ verify_login_access_token (const gchar *body, const gchar *session_token,
       principal_state);
   g_autofree gchar *expected_session =
       g_strdup_printf ("\"session_id\":\"%s\"", session_token);
+  const gchar *expected_tenant = "\"tenant\":\"__wr_default\"";
   if (strstr (payload_text, expected_sub) == NULL ||
       strstr (payload_text, expected_state) == NULL ||
-      strstr (payload_text, expected_session) == NULL)
+      strstr (payload_text, expected_session) == NULL ||
+      strstr (payload_text, expected_tenant) == NULL)
     return 533;
   g_autofree gchar *jti = extract_json_string (payload_text, "jti");
   if (jti == NULL || g_strcmp0 (jti, session_token) == 0)
@@ -1041,6 +1043,14 @@ check_raw_login_contract (SoupServer *server, WylHandle *handle,
     return 478;
   g_clear_pointer (&body, g_free);
 
+  rc = send_raw_login (session, "POST", base_url,
+      "username=login-user&tenant=unknown", &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 400 || strstr (body, "\"invalid_login_request\"") == NULL)
+    return 484;
+  g_clear_pointer (&body, g_free);
+
   rc = send_raw_login (session, "POST", base_url, "username=login-user",
       &status, &body);
   if (rc != 0)
@@ -1048,6 +1058,7 @@ check_raw_login_contract (SoupServer *server, WylHandle *handle,
   if (status != 200 ||
       strstr (body, "\"session_token\":\"") == NULL ||
       strstr (body, "\"username\":\"login-user\"") == NULL ||
+      strstr (body, "\"tenant\":\"__wr_default\"") == NULL ||
       strstr (body, "\"principal_state\":\"mfa_required\"") == NULL ||
       strstr (body, "\"session_state\":\"active\"") == NULL)
     return 475;
@@ -1061,6 +1072,9 @@ check_raw_login_contract (SoupServer *server, WylHandle *handle,
   g_autofree gchar *stored_username = wyl_session_dup_username (stored_session);
   if (g_strcmp0 (stored_username, "login-user") != 0)
     return 479;
+  g_autofree gchar *stored_tenant = wyl_session_dup_tenant (stored_session);
+  if (g_strcmp0 (stored_tenant, "__wr_default") != 0)
+    return 485;
   if (wyl_daemon_http_remove_session_for_test (server, "unknown-session"))
     return 481;
   if (!wyl_daemon_http_remove_session_for_test (server, session_token))
@@ -1616,10 +1630,13 @@ check_policy_permission_mutation_contract (WylHandle *handle,
 
   g_autofree gchar *session_token = wyl_client_dup_session_token (client);
   g_autofree gchar *access_token = wyl_client_dup_access_token (client);
+  g_autofree gchar *client_tenant = wyl_client_dup_tenant (client);
   if (session_token == NULL)
     return 124;
   if (access_token == NULL)
     return 164;
+  if (g_strcmp0 (client_tenant, "__wr_default") != 0)
+    return 165;
 
   wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
   if (wyl_policy_store_upsert_permission (store, "site.policy.read",

--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -2467,6 +2467,20 @@ check_raw_audit_contract (SoupServer *server, WylHandle *handle,
       return invalid_tokens[i].failure_code;
   }
 
+  g_autofree gchar *unregistered_token = NULL;
+  if (sign_test_access_token_with_jti (server, "unregistered-access-token",
+          session_token, "http-audit-user", "authenticated", "wyrelogd",
+          "wyrelog-client", now, &unregistered_token) != WYRELOG_E_OK)
+    return 161;
+  g_clear_pointer (&body, g_free);
+  rc = send_raw_audit_bearer (session, base_url,
+      "guard_timestamp=123&guard_loc_class=public&guard_risk=69",
+      unregistered_token, &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 401 || strstr (body, "\"audit_auth_required\"") == NULL)
+    return 162;
+
   g_autofree gchar *session_jti_token = NULL;
   if (sign_test_access_token_with_jti (server, session_token, session_token,
           "http-audit-user", "authenticated", "wyrelogd", "wyrelog-client",

--- a/tests/test-jwt.c
+++ b/tests/test-jwt.c
@@ -6,6 +6,7 @@
 #include "wyrelog/auth/jwt-private.h"
 
 static const wyl_jwt_issue_input_t valid_input = {
+  .key_id = "wyrelogd-test-key",
   .jti = "01890c10-2e3f-7000-8000-000000000101",
   .subject = "alice",
   .issuer = "wyrelogd",
@@ -53,13 +54,18 @@ check_base64url_round_trip (void)
 }
 
 static gint
-check_header_json_is_fixed (void)
+check_header_json_contains_required_claims (void)
 {
   g_autofree gchar *header = NULL;
-  if (wyl_jwt_build_header_json (&header) != WYRELOG_E_OK)
+  if (wyl_jwt_build_header_json (valid_input.key_id, &header)
+      != WYRELOG_E_OK)
     return 20;
-  if (g_strcmp0 (header, "{\"alg\":\"HS256\",\"typ\":\"JWT\"}") != 0)
+  if (g_strcmp0 (header,
+          "{\"alg\":\"HS256\",\"typ\":\"JWT\",\"kid\":\"wyrelogd-test-key\"}")
+      != 0)
     return 21;
+  if (wyl_jwt_build_header_json ("", &header) != WYRELOG_E_INVALID)
+    return 22;
   return 0;
 }
 
@@ -135,8 +141,10 @@ check_unsigned_segments_are_base64url (void)
     return 62;
   gsize header_len = 0;
   const gchar *header = g_bytes_get_data (header_bytes, &header_len);
-  if (header_len != strlen ("{\"alg\":\"HS256\",\"typ\":\"JWT\"}") ||
-      memcmp (header, "{\"alg\":\"HS256\",\"typ\":\"JWT\"}", header_len) != 0)
+  const gchar *expected = "{\"alg\":\"HS256\",\"typ\":\"JWT\","
+      "\"kid\":\"wyrelogd-test-key\"}";
+  if (header_len != strlen (expected) || memcmp (header, expected,
+          header_len) != 0)
     return 63;
 
   g_autoptr (GBytes) payload_bytes = NULL;
@@ -148,6 +156,12 @@ check_unsigned_segments_are_base64url (void)
   g_autofree gchar *payload_text = g_strndup (payload, payload_len);
   if (payload_len == 0 || strstr (payload_text, "\"exp\":1900") == NULL)
     return 65;
+
+  g_autofree gchar *missing_header_segment = NULL;
+  g_autofree gchar *missing_payload_segment = NULL;
+  if (wyl_jwt_build_unsigned_segments (NULL, &missing_header_segment,
+          &missing_payload_segment) != WYRELOG_E_INVALID)
+    return 66;
   return 0;
 }
 
@@ -170,7 +184,8 @@ check_hs256_token_signature_round_trip (void)
 
   g_autoptr (GBytes) payload = NULL;
   if (wyl_jwt_verify_hs256_signature (token, secret,
-          strlen ((const gchar *) secret), &payload) != WYRELOG_E_OK)
+          strlen ((const gchar *) secret), valid_input.key_id, &payload)
+      != WYRELOG_E_OK)
     return 73;
   gsize payload_len = 0;
   const gchar *payload_data = g_bytes_get_data (payload, &payload_len);
@@ -192,10 +207,12 @@ check_hs256_signature_fails_closed (void)
 
   g_autoptr (GBytes) payload = NULL;
   if (wyl_jwt_verify_hs256_signature (token, wrong_secret,
-          strlen ((const gchar *) wrong_secret), &payload) != WYRELOG_E_POLICY)
+          strlen ((const gchar *) wrong_secret), valid_input.key_id, &payload)
+      != WYRELOG_E_POLICY)
     return 81;
   if (wyl_jwt_verify_hs256_signature ("a.b", secret,
-          strlen ((const gchar *) secret), &payload) != WYRELOG_E_INVALID)
+          strlen ((const gchar *) secret), valid_input.key_id, &payload)
+      != WYRELOG_E_INVALID)
     return 82;
   if (wyl_jwt_sign_hs256 (&valid_input, NULL, 0, &token)
       != WYRELOG_E_INVALID)
@@ -205,16 +222,19 @@ check_hs256_signature_fails_closed (void)
   g_autofree gchar *tampered_payload = g_strdup_printf ("%s.%sA.%s",
       parts[0], parts[1], parts[2]);
   if (wyl_jwt_verify_hs256_signature (tampered_payload, secret,
-          strlen ((const gchar *) secret), &payload) != WYRELOG_E_POLICY)
+          strlen ((const gchar *) secret), valid_input.key_id, &payload)
+      != WYRELOG_E_POLICY)
     return 84;
 
   g_autofree gchar *tampered_signature = g_strdup_printf ("%s.%s.%sA",
       parts[0], parts[1], parts[2]);
   if (wyl_jwt_verify_hs256_signature (tampered_signature, secret,
-          strlen ((const gchar *) secret), &payload) != WYRELOG_E_POLICY)
+          strlen ((const gchar *) secret), valid_input.key_id, &payload)
+      != WYRELOG_E_POLICY)
     return 85;
 
-  const gchar *none_header = "{\"alg\":\"none\",\"typ\":\"JWT\"}";
+  const gchar *none_header = "{\"alg\":\"none\",\"typ\":\"JWT\","
+      "\"kid\":\"wyrelogd-test-key\"}";
   g_autofree gchar *none_header_segment = NULL;
   if (wyl_jwt_base64url_encode ((const guint8 *) none_header,
           strlen (none_header), &none_header_segment) != WYRELOG_E_OK)
@@ -222,7 +242,8 @@ check_hs256_signature_fails_closed (void)
   g_autofree gchar *none_token = g_strdup_printf ("%s.%s.%s",
       none_header_segment, parts[1], parts[2]);
   if (wyl_jwt_verify_hs256_signature (none_token, secret,
-          strlen ((const gchar *) secret), &payload) != WYRELOG_E_POLICY)
+          strlen ((const gchar *) secret), valid_input.key_id, &payload)
+      != WYRELOG_E_POLICY)
     return 87;
   return 0;
 }
@@ -238,8 +259,8 @@ check_hs256_access_token_claims_and_time (void)
 
   g_autoptr (GBytes) payload = NULL;
   if (wyl_jwt_verify_hs256_access_token (token, secret,
-          strlen ((const gchar *) secret), "wyrelogd", "wyrelog-client", 1000,
-          &payload) != WYRELOG_E_OK)
+          strlen ((const gchar *) secret), valid_input.key_id, "wyrelogd",
+          "wyrelog-client", 1000, &payload) != WYRELOG_E_OK)
     return 91;
   if (payload == NULL)
     return 92;
@@ -262,44 +283,49 @@ check_hs256_access_token_claims_and_time (void)
 
   g_clear_pointer (&payload, g_bytes_unref);
   if (wyl_jwt_verify_hs256_access_token (token, secret,
-          strlen ((const gchar *) secret), "wyrelogd", "wyrelog-client", 1899,
-          &payload) != WYRELOG_E_OK)
+          strlen ((const gchar *) secret), valid_input.key_id, "wyrelogd",
+          "wyrelog-client", 1899, &payload) != WYRELOG_E_OK)
     return 93;
   g_clear_pointer (&payload, g_bytes_unref);
   if (wyl_jwt_verify_hs256_access_token (token, secret,
-          strlen ((const gchar *) secret), "other-issuer", "wyrelog-client",
-          1000, &payload) != WYRELOG_E_POLICY)
+          strlen ((const gchar *) secret), valid_input.key_id, "other-issuer",
+          "wyrelog-client", 1000, &payload) != WYRELOG_E_POLICY)
     return 94;
   if (wyl_jwt_verify_hs256_access_token (token, secret,
-          strlen ((const gchar *) secret), "wyrelogd", "other-audience", 1000,
-          &payload) != WYRELOG_E_POLICY)
+          strlen ((const gchar *) secret), valid_input.key_id, "wyrelogd",
+          "other-audience", 1000, &payload) != WYRELOG_E_POLICY)
     return 95;
   if (wyl_jwt_verify_hs256_access_token (token, secret,
-          strlen ((const gchar *) secret), "wyrelogd", "wyrelog-client", 999,
-          &payload) != WYRELOG_E_POLICY)
+          strlen ((const gchar *) secret), valid_input.key_id, "wyrelogd",
+          "wyrelog-client", 999, &payload) != WYRELOG_E_POLICY)
     return 96;
   if (wyl_jwt_verify_hs256_access_token (token, secret,
-          strlen ((const gchar *) secret), "wyrelogd", "wyrelog-client", 1900,
-          &payload) != WYRELOG_E_POLICY)
+          strlen ((const gchar *) secret), valid_input.key_id, "wyrelogd",
+          "wyrelog-client", 1900, &payload) != WYRELOG_E_POLICY)
     return 97;
   if (wyl_jwt_verify_hs256_access_token (token, secret,
-          strlen ((const gchar *) secret), "", "wyrelog-client", 1000,
-          &payload) != WYRELOG_E_INVALID)
+          strlen ((const gchar *) secret), valid_input.key_id, "",
+          "wyrelog-client", 1000, &payload) != WYRELOG_E_INVALID)
     return 98;
+  if (wyl_jwt_verify_hs256_access_token (token, secret,
+          strlen ((const gchar *) secret), "other-key", "wyrelogd",
+          "wyrelog-client", 1000, &payload) != WYRELOG_E_POLICY)
+    return 104;
   return 0;
 }
 
 static wyrelog_error_t
-sign_custom_payload_bytes (const guint8 *payload, gsize payload_len,
-    const guint8 *secret, gsize secret_len, gchar **out_token)
+sign_custom_header_payload_bytes (const gchar *header, const guint8 *payload,
+    gsize payload_len, const guint8 *secret, gsize secret_len,
+    gchar **out_token)
 {
-  if (payload == NULL || secret == NULL || secret_len == 0 || out_token == NULL)
+  if (header == NULL || payload == NULL || secret == NULL || secret_len == 0
+      || out_token == NULL)
     return WYRELOG_E_INVALID;
   *out_token = NULL;
   if (sodium_init () < 0)
     return WYRELOG_E_INTERNAL;
 
-  const gchar *header = "{\"alg\":\"HS256\",\"typ\":\"JWT\"}";
   g_autofree gchar *header_segment = NULL;
   g_autofree gchar *payload_segment = NULL;
   wyrelog_error_t rc = wyl_jwt_base64url_encode ((const guint8 *) header,
@@ -329,6 +355,16 @@ sign_custom_payload_bytes (const guint8 *payload, gsize payload_len,
 }
 
 static wyrelog_error_t
+sign_custom_payload_bytes (const guint8 *payload, gsize payload_len,
+    const guint8 *secret, gsize secret_len, gchar **out_token)
+{
+  const gchar *header = "{\"alg\":\"HS256\",\"typ\":\"JWT\","
+      "\"kid\":\"wyrelogd-test-key\"}";
+  return sign_custom_header_payload_bytes (header, payload, payload_len,
+      secret, secret_len, out_token);
+}
+
+static wyrelog_error_t
 sign_custom_payload (const gchar *payload, const guint8 *secret,
     gsize secret_len, gchar **out_token)
 {
@@ -336,6 +372,42 @@ sign_custom_payload (const gchar *payload, const guint8 *secret,
     return WYRELOG_E_INVALID;
   return sign_custom_payload_bytes ((const guint8 *) payload, strlen (payload),
       secret, secret_len, out_token);
+}
+
+static gint
+check_hs256_signature_rejects_ambiguous_headers (void)
+{
+  static const guint8 secret[] = "test-secret";
+  const gchar *payload =
+      "{\"jti\":\"jti\",\"sub\":\"alice\",\"iss\":\"wyrelogd\","
+      "\"aud\":\"wyrelog-client\",\"iat\":1000,\"nbf\":1000,\"exp\":1900,"
+      "\"tenant\":\"t\",\"principal_state_at_issue\":\"authenticated\","
+      "\"session_id\":\"session\"}";
+  const gchar *headers[] = {
+    "{\"alg\":\"HS256\",\"typ\":\"JWT\"}",
+    "{\"alg\":\"HS256\",\"typ\":\"JWT\",\"kid\":\"other-key\"}",
+    "{\"alg\":\"HS256\",\"typ\":\"JWT\",\"kid\":\"wyrelogd-test-key\","
+        "\"kid\":\"other-key\"}",
+    "{\"alg\":\"HS256\",\"typ\":\"JWT\",\"kid\":\"wyrelogd-test-key\","
+        "\"x5u\":\"https://example.invalid/key\"}",
+    "{\"alg\":{\"name\":\"HS256\"},\"typ\":\"JWT\","
+        "\"kid\":\"wyrelogd-test-key\"}",
+  };
+
+  for (guint i = 0; i < G_N_ELEMENTS (headers); i++) {
+    g_autofree gchar *token = NULL;
+    if (sign_custom_header_payload_bytes (headers[i], (const guint8 *) payload,
+            strlen (payload), secret, strlen ((const gchar *) secret),
+            &token) != WYRELOG_E_OK)
+      return 120 + (gint) i;
+
+    g_autoptr (GBytes) decoded_payload = NULL;
+    if (wyl_jwt_verify_hs256_signature (token, secret,
+            strlen ((const gchar *) secret), valid_input.key_id,
+            &decoded_payload) != WYRELOG_E_POLICY)
+      return 130 + (gint) i;
+  }
+  return 0;
 }
 
 static gint
@@ -355,8 +427,8 @@ check_hs256_access_token_rejects_ambiguous_claims (void)
 
   g_autoptr (GBytes) payload = NULL;
   if (wyl_jwt_verify_hs256_access_token (duplicate_token, secret,
-          strlen ((const gchar *) secret), "wyrelogd", "wyrelog-client", 1000,
-          &payload) != WYRELOG_E_POLICY)
+          strlen ((const gchar *) secret), valid_input.key_id, "wyrelogd",
+          "wyrelog-client", 1000, &payload) != WYRELOG_E_POLICY)
     return 111;
 
   const gchar *nested_payload =
@@ -370,8 +442,8 @@ check_hs256_access_token_rejects_ambiguous_claims (void)
           strlen ((const gchar *) secret), &nested_token) != WYRELOG_E_OK)
     return 112;
   if (wyl_jwt_verify_hs256_access_token (nested_token, secret,
-          strlen ((const gchar *) secret), "wyrelogd", "wyrelog-client", 1000,
-          &payload) != WYRELOG_E_POLICY)
+          strlen ((const gchar *) secret), valid_input.key_id, "wyrelogd",
+          "wyrelog-client", 1000, &payload) != WYRELOG_E_POLICY)
     return 113;
 
   const gchar *nul_issuer_payload =
@@ -384,8 +456,8 @@ check_hs256_access_token_rejects_ambiguous_claims (void)
           strlen ((const gchar *) secret), &nul_issuer_token) != WYRELOG_E_OK)
     return 114;
   if (wyl_jwt_verify_hs256_access_token (nul_issuer_token, secret,
-          strlen ((const gchar *) secret), "wyrelogd", "wyrelog-client", 1000,
-          &payload) != WYRELOG_E_POLICY)
+          strlen ((const gchar *) secret), valid_input.key_id, "wyrelogd",
+          "wyrelog-client", 1000, &payload) != WYRELOG_E_POLICY)
     return 115;
 
   const gchar *short_escape_payload =
@@ -399,8 +471,8 @@ check_hs256_access_token_rejects_ambiguous_claims (void)
       != WYRELOG_E_OK)
     return 116;
   if (wyl_jwt_verify_hs256_access_token (short_escape_token, secret,
-          strlen ((const gchar *) secret), "wyrelogd", "wyrelog-client", 1000,
-          &payload) != WYRELOG_E_POLICY)
+          strlen ((const gchar *) secret), valid_input.key_id, "wyrelogd",
+          "wyrelog-client", 1000, &payload) != WYRELOG_E_POLICY)
     return 117;
 
   static const guint8 raw_nul_payload[] =
@@ -414,8 +486,8 @@ check_hs256_access_token_rejects_ambiguous_claims (void)
       != WYRELOG_E_OK)
     return 118;
   if (wyl_jwt_verify_hs256_access_token (raw_nul_token, secret,
-          strlen ((const gchar *) secret), "wyrelogd", "wyrelog-client", 1000,
-          &payload) != WYRELOG_E_POLICY)
+          strlen ((const gchar *) secret), valid_input.key_id, "wyrelogd",
+          "wyrelog-client", 1000, &payload) != WYRELOG_E_POLICY)
     return 119;
   return 0;
 }
@@ -427,7 +499,7 @@ main (void)
 
   if ((rc = check_base64url_round_trip ()) != 0)
     return rc;
-  if ((rc = check_header_json_is_fixed ()) != 0)
+  if ((rc = check_header_json_contains_required_claims ()) != 0)
     return rc;
   if ((rc = check_payload_json_contains_required_claims ()) != 0)
     return rc;
@@ -442,6 +514,8 @@ main (void)
   if ((rc = check_hs256_signature_fails_closed ()) != 0)
     return rc;
   if ((rc = check_hs256_access_token_claims_and_time ()) != 0)
+    return rc;
+  if ((rc = check_hs256_signature_rejects_ambiguous_headers ()) != 0)
     return rc;
   if ((rc = check_hs256_access_token_rejects_ambiguous_claims ()) != 0)
     return rc;

--- a/tests/test-login-req.c
+++ b/tests/test-login-req.c
@@ -16,6 +16,8 @@ check_default_username_is_null (void)
     return 12;
   if (wyl_login_req_get_request_id (req) != NULL)
     return 13;
+  if (wyl_login_req_get_tenant (req) != NULL)
+    return 14;
   return 0;
 }
 
@@ -80,6 +82,8 @@ check_get_null_request (void)
     return 60;
   if (wyl_login_req_get_request_id (NULL) != NULL)
     return 61;
+  if (wyl_login_req_get_tenant (NULL) != NULL)
+    return 62;
   return 0;
 }
 
@@ -124,6 +128,19 @@ check_request_id_set_then_get (void)
   return 0;
 }
 
+static gint
+check_tenant_set_then_get (void)
+{
+  g_autoptr (wyl_login_req_t) req = wyl_login_req_new ();
+  wyl_login_req_set_tenant (req, "__wr_default");
+  if (g_strcmp0 (wyl_login_req_get_tenant (req), "__wr_default") != 0)
+    return 110;
+  wyl_login_req_set_tenant (req, NULL);
+  if (wyl_login_req_get_tenant (req) != NULL)
+    return 111;
+  return 0;
+}
+
 int
 main (void)
 {
@@ -148,6 +165,8 @@ main (void)
   if ((rc = check_skip_mfa_null_request ()) != 0)
     return rc;
   if ((rc = check_request_id_set_then_get ()) != 0)
+    return rc;
+  if ((rc = check_tenant_set_then_get ()) != 0)
     return rc;
 
   return 0;

--- a/tests/test-session-username.c
+++ b/tests/test-session-username.c
@@ -367,6 +367,57 @@ check_login_with_unset_username (void)
 }
 
 static gint
+check_login_binds_default_tenant (void)
+{
+  g_autoptr (WylSession) session = login_with_username ("tenant-user");
+  if (session == NULL)
+    return 34;
+  g_autofree gchar *tenant = wyl_session_dup_tenant (session);
+  if (g_strcmp0 (tenant, "__wr_default") != 0)
+    return 35;
+  return 0;
+}
+
+static gint
+check_login_rejects_unknown_tenant (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 36;
+
+  g_autoptr (wyl_login_req_t) req = wyl_login_req_new ();
+  wyl_login_req_set_username (req, "tenant-user");
+  wyl_login_req_set_tenant (req, "unknown");
+
+  g_autoptr (WylSession) session = NULL;
+  if (wyl_session_login (handle, req, &session) != WYRELOG_E_INVALID)
+    return 37;
+  if (session != NULL)
+    return 38;
+  return 0;
+}
+
+static gint
+check_login_rejects_unknown_tenant_before_skip_mfa (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 39;
+
+  g_autoptr (wyl_login_req_t) req = wyl_login_req_new ();
+  wyl_login_req_set_username (req, "tenant-user");
+  wyl_login_req_set_tenant (req, "unknown");
+  wyl_login_req_set_skip_mfa (req, TRUE);
+
+  g_autoptr (WylSession) session = NULL;
+  if (wyl_session_login (handle, req, &session) != WYRELOG_E_INVALID)
+    return 44;
+  if (session != NULL)
+    return 45;
+  return 0;
+}
+
+static gint
 check_request_buffer_independent_of_session (void)
 {
   g_autoptr (WylHandle) handle = NULL;
@@ -1808,6 +1859,12 @@ main (void)
   if ((rc = check_login_with_null_request ()) != 0)
     return rc;
   if ((rc = check_login_with_unset_username ()) != 0)
+    return rc;
+  if ((rc = check_login_binds_default_tenant ()) != 0)
+    return rc;
+  if ((rc = check_login_rejects_unknown_tenant ()) != 0)
+    return rc;
+  if ((rc = check_login_rejects_unknown_tenant_before_skip_mfa ()) != 0)
     return rc;
   if ((rc = check_request_buffer_independent_of_session ()) != 0)
     return rc;

--- a/wyrelog/auth/jwt-private.h
+++ b/wyrelog/auth/jwt-private.h
@@ -11,6 +11,7 @@ G_BEGIN_DECLS;
 
 typedef struct
 {
+  const gchar *key_id;
   const gchar *jti;
   const gchar *subject;
   const gchar *issuer;
@@ -40,7 +41,8 @@ wyrelog_error_t wyl_jwt_base64url_encode (const guint8 * data, gsize len,
     gchar ** out_text);
 wyrelog_error_t wyl_jwt_base64url_decode (const gchar * text,
     GBytes ** out_bytes);
-wyrelog_error_t wyl_jwt_build_header_json (gchar ** out_json);
+wyrelog_error_t wyl_jwt_build_header_json (const gchar * key_id,
+    gchar ** out_json);
 wyrelog_error_t wyl_jwt_build_payload_json (const wyl_jwt_issue_input_t *
     input, gchar ** out_json);
 wyrelog_error_t wyl_jwt_build_unsigned_segments (const wyl_jwt_issue_input_t *
@@ -48,11 +50,13 @@ wyrelog_error_t wyl_jwt_build_unsigned_segments (const wyl_jwt_issue_input_t *
 wyrelog_error_t wyl_jwt_sign_hs256 (const wyl_jwt_issue_input_t * input,
     const guint8 * secret, gsize secret_len, gchar ** out_token);
 wyrelog_error_t wyl_jwt_verify_hs256_signature (const gchar * token,
-    const guint8 * secret, gsize secret_len, GBytes ** out_payload_json);
+    const guint8 * secret, gsize secret_len, const gchar * expected_key_id,
+    GBytes ** out_payload_json);
 wyrelog_error_t wyl_jwt_parse_access_claims_json (GBytes * payload_json,
     wyl_jwt_access_claims_t * out_claims);
 wyrelog_error_t wyl_jwt_verify_hs256_access_token (const gchar * token,
-    const guint8 * secret, gsize secret_len, const gchar * expected_issuer,
-    const gchar * expected_audience, gint64 now, GBytes ** out_payload_json);
+    const guint8 * secret, gsize secret_len, const gchar * expected_key_id,
+    const gchar * expected_issuer, const gchar * expected_audience,
+    gint64 now, GBytes ** out_payload_json);
 
 G_END_DECLS;

--- a/wyrelog/auth/jwt.c
+++ b/wyrelog/auth/jwt.c
@@ -13,9 +13,9 @@ non_empty (const gchar *value)
 static wyrelog_error_t
 validate_issue_input (const wyl_jwt_issue_input_t *input)
 {
-  if (input == NULL || !non_empty (input->jti) || !non_empty (input->subject)
-      || !non_empty (input->issuer) || !non_empty (input->audience)
-      || !non_empty (input->tenant)
+  if (input == NULL || !non_empty (input->key_id) || !non_empty (input->jti)
+      || !non_empty (input->subject) || !non_empty (input->issuer)
+      || !non_empty (input->audience) || !non_empty (input->tenant)
       || !non_empty (input->principal_state_at_issue)
       || !non_empty (input->session_id) || input->issued_at < 0
       || input->ttl_seconds < 0)
@@ -120,11 +120,14 @@ wyl_jwt_base64url_decode (const gchar *text, GBytes **out_bytes)
 }
 
 wyrelog_error_t
-wyl_jwt_build_header_json (gchar **out_json)
+wyl_jwt_build_header_json (const gchar *key_id, gchar **out_json)
 {
-  if (out_json == NULL)
+  if (!non_empty (key_id) || out_json == NULL)
     return WYRELOG_E_INVALID;
-  *out_json = g_strdup ("{\"alg\":\"HS256\",\"typ\":\"JWT\"}");
+  GString *json = g_string_new ("{\"alg\":\"HS256\",\"typ\":\"JWT\",\"kid\":");
+  append_json_string (json, key_id);
+  g_string_append_c (json, '}');
+  *out_json = g_string_free (json, FALSE);
   return WYRELOG_E_OK;
 }
 
@@ -178,10 +181,13 @@ wyl_jwt_build_unsigned_segments (const wyl_jwt_issue_input_t *input,
     return WYRELOG_E_INVALID;
   *out_header_segment = NULL;
   *out_payload_segment = NULL;
+  wyrelog_error_t rc = validate_issue_input (input);
+  if (rc != WYRELOG_E_OK)
+    return rc;
 
   g_autofree gchar *header = NULL;
   g_autofree gchar *payload = NULL;
-  wyrelog_error_t rc = wyl_jwt_build_header_json (&header);
+  rc = wyl_jwt_build_header_json (input->key_id, &header);
   if (rc != WYRELOG_E_OK)
     return rc;
   rc = wyl_jwt_build_payload_json (input, &payload);
@@ -205,6 +211,9 @@ signing_secret_valid (const guint8 *secret, gsize secret_len)
     return WYRELOG_E_INVALID;
   return WYRELOG_E_OK;
 }
+
+static wyrelog_error_t validate_jwt_header_json (GBytes * header_json,
+    const gchar * expected_key_id);
 
 static wyrelog_error_t
 sign_hs256_input (const gchar *signing_input, const guint8 *secret,
@@ -259,10 +268,10 @@ wyl_jwt_sign_hs256 (const wyl_jwt_issue_input_t *input,
 
 wyrelog_error_t
 wyl_jwt_verify_hs256_signature (const gchar *token, const guint8 *secret,
-    gsize secret_len, GBytes **out_payload_json)
+    gsize secret_len, const gchar *expected_key_id, GBytes **out_payload_json)
 {
-  if (token == NULL || out_payload_json == NULL ||
-      signing_secret_valid (secret, secret_len) != WYRELOG_E_OK)
+  if (token == NULL || !non_empty (expected_key_id) || out_payload_json == NULL
+      || signing_secret_valid (secret, secret_len) != WYRELOG_E_OK)
     return WYRELOG_E_INVALID;
   *out_payload_json = NULL;
 
@@ -276,12 +285,9 @@ wyl_jwt_verify_hs256_signature (const gchar *token, const guint8 *secret,
   wyrelog_error_t rc = wyl_jwt_base64url_decode (parts[0], &header);
   if (rc != WYRELOG_E_OK)
     return rc;
-  gsize header_len = 0;
-  const gchar *header_data = g_bytes_get_data (header, &header_len);
-  if (header_len != strlen ("{\"alg\":\"HS256\",\"typ\":\"JWT\"}") ||
-      memcmp (header_data, "{\"alg\":\"HS256\",\"typ\":\"JWT\"}",
-          header_len) != 0)
-    return WYRELOG_E_POLICY;
+  rc = validate_jwt_header_json (header, expected_key_id);
+  if (rc != WYRELOG_E_OK)
+    return rc;
 
   g_autoptr (GBytes) signature = NULL;
   rc = wyl_jwt_base64url_decode (parts[2], &signature);
@@ -433,6 +439,138 @@ skip_json_ws (const gchar **cursor)
 {
   while (g_ascii_isspace (**cursor))
     (*cursor)++;
+}
+
+typedef struct
+{
+  gchar *algorithm;
+  gchar *type;
+  gchar *key_id;
+  guint seen_mask;
+} ParsedJwtHeader;
+
+enum
+{
+  HEADER_ALG = 1u << 0,
+  HEADER_TYP = 1u << 1,
+  HEADER_KID = 1u << 2,
+  HEADER_REQUIRED_MASK = HEADER_ALG | HEADER_TYP | HEADER_KID,
+};
+
+static void
+parsed_jwt_header_clear (ParsedJwtHeader *header)
+{
+  if (header == NULL)
+    return;
+  g_free (header->algorithm);
+  g_free (header->type);
+  g_free (header->key_id);
+  memset (header, 0, sizeof *header);
+}
+
+static wyrelog_error_t
+mark_header_seen (ParsedJwtHeader *header, guint bit)
+{
+  if ((header->seen_mask & bit) != 0)
+    return WYRELOG_E_POLICY;
+  header->seen_mask |= bit;
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+parse_header_string_value (const gchar **cursor, ParsedJwtHeader *header,
+    guint bit, gchar **out_value)
+{
+  wyrelog_error_t rc = mark_header_seen (header, bit);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  g_autofree gchar *value = NULL;
+  rc = parse_json_string (cursor, &value);
+  if (rc != WYRELOG_E_OK)
+    return WYRELOG_E_POLICY;
+  if (value[0] == '\0')
+    return WYRELOG_E_POLICY;
+  *out_value = g_steal_pointer (&value);
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+parse_jwt_header (const gchar *text, ParsedJwtHeader *header)
+{
+  if (text == NULL || header == NULL)
+    return WYRELOG_E_INVALID;
+  memset (header, 0, sizeof *header);
+
+  const gchar *p = text;
+  skip_json_ws (&p);
+  if (*p++ != '{')
+    return WYRELOG_E_POLICY;
+  skip_json_ws (&p);
+  while (*p != '}') {
+    g_autofree gchar *key = NULL;
+    wyrelog_error_t rc = parse_json_string (&p, &key);
+    if (rc != WYRELOG_E_OK)
+      return rc;
+    skip_json_ws (&p);
+    if (*p++ != ':')
+      return WYRELOG_E_POLICY;
+    skip_json_ws (&p);
+
+    if (g_strcmp0 (key, "alg") == 0)
+      rc = parse_header_string_value (&p, header, HEADER_ALG,
+          &header->algorithm);
+    else if (g_strcmp0 (key, "typ") == 0)
+      rc = parse_header_string_value (&p, header, HEADER_TYP, &header->type);
+    else if (g_strcmp0 (key, "kid") == 0)
+      rc = parse_header_string_value (&p, header, HEADER_KID, &header->key_id);
+    else
+      return WYRELOG_E_POLICY;
+    if (rc != WYRELOG_E_OK)
+      return rc;
+
+    skip_json_ws (&p);
+    if (*p == ',') {
+      p++;
+      skip_json_ws (&p);
+      if (*p == '}')
+        return WYRELOG_E_POLICY;
+    } else if (*p != '}') {
+      return WYRELOG_E_POLICY;
+    }
+  }
+  p++;
+  skip_json_ws (&p);
+  if (*p != '\0')
+    return WYRELOG_E_POLICY;
+  if ((header->seen_mask & HEADER_REQUIRED_MASK) != HEADER_REQUIRED_MASK)
+    return WYRELOG_E_POLICY;
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+validate_jwt_header_json (GBytes *header_json, const gchar *expected_key_id)
+{
+  if (header_json == NULL || !non_empty (expected_key_id))
+    return WYRELOG_E_INVALID;
+
+  gsize header_len = 0;
+  const gchar *header_data = g_bytes_get_data (header_json, &header_len);
+  if (memchr (header_data, '\0', header_len) != NULL)
+    return WYRELOG_E_POLICY;
+  g_autofree gchar *header_text = g_strndup (header_data, header_len);
+  ParsedJwtHeader header = { 0 };
+  wyrelog_error_t rc = parse_jwt_header (header_text, &header);
+  if (rc != WYRELOG_E_OK) {
+    parsed_jwt_header_clear (&header);
+    return rc;
+  }
+
+  gboolean valid = g_strcmp0 (header.algorithm, "HS256") == 0
+      && g_strcmp0 (header.type, "JWT") == 0
+      && g_strcmp0 (header.key_id, expected_key_id) == 0;
+  parsed_jwt_header_clear (&header);
+  return valid ? WYRELOG_E_OK : WYRELOG_E_POLICY;
 }
 
 typedef struct
@@ -619,17 +757,18 @@ wyl_jwt_parse_access_claims_json (GBytes *payload_json,
 
 wyrelog_error_t
 wyl_jwt_verify_hs256_access_token (const gchar *token, const guint8 *secret,
-    gsize secret_len, const gchar *expected_issuer,
-    const gchar *expected_audience, gint64 now, GBytes **out_payload_json)
+    gsize secret_len, const gchar *expected_key_id,
+    const gchar *expected_issuer, const gchar *expected_audience, gint64 now,
+    GBytes **out_payload_json)
 {
-  if (!non_empty (expected_issuer) || !non_empty (expected_audience) ||
-      now < 0 || out_payload_json == NULL)
+  if (!non_empty (expected_key_id) || !non_empty (expected_issuer) ||
+      !non_empty (expected_audience) || now < 0 || out_payload_json == NULL)
     return WYRELOG_E_INVALID;
   *out_payload_json = NULL;
 
   g_autoptr (GBytes) payload = NULL;
   wyrelog_error_t rc = wyl_jwt_verify_hs256_signature (token, secret,
-      secret_len, &payload);
+      secret_len, expected_key_id, &payload);
   if (rc != WYRELOG_E_OK)
     return rc;
 

--- a/wyrelog/client.h
+++ b/wyrelog/client.h
@@ -46,6 +46,7 @@ wyrelog_error_t wyl_client_login_skip_mfa (WylClient * client,
 gchar *wyl_client_dup_session_token (const WylClient * client);
 gchar *wyl_client_dup_access_token (const WylClient * client);
 gchar *wyl_client_dup_username (const WylClient * client);
+gchar *wyl_client_dup_tenant (const WylClient * client);
 gchar *wyl_client_dup_principal_state (const WylClient * client);
 gchar *wyl_client_dup_session_state (const WylClient * client);
 wyrelog_error_t wyl_client_token_refresh (WylClient * client);

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -25,16 +25,50 @@
 
 typedef struct
 {
+  gchar *jti;
+  gchar *session_id;
+  gchar *subject;
+  gchar *tenant;
+  gchar *key_id;
+  gboolean revoked;
+  gint64 expires_at;
+} WylAccessTokenState;
+
+typedef struct
+{
+  const gchar *session_id;
+  GPtrArray *token_ids;
+} WylSessionTokenCollect;
+
+typedef struct
+{
   WylHandle *handle;
   WylDaemonRuntime *runtime;
   guint8 access_token_secret[WYL_DAEMON_JWT_KEY_LEN];
   gboolean access_token_secret_ready;
   GHashTable *sessions_by_token;
+  GHashTable *access_tokens_by_jti;
   GMutex lock;
   GMutex policy_mutation_lock;
 } WylDaemonHttpContext;
 
 static WylDaemonHttpContext *wyl_daemon_http_get_context (SoupServer * server);
+
+static void
+wyl_access_token_state_free (gpointer data)
+{
+  WylAccessTokenState *state = data;
+
+  if (state == NULL)
+    return;
+
+  g_free (state->jti);
+  g_free (state->session_id);
+  g_free (state->subject);
+  g_free (state->tenant);
+  g_free (state->key_id);
+  g_free (state);
+}
 
 static void
 wyl_daemon_http_context_free (gpointer data)
@@ -46,6 +80,7 @@ wyl_daemon_http_context_free (gpointer data)
 
   sodium_memzero (ctx->access_token_secret, sizeof ctx->access_token_secret);
   g_hash_table_unref (ctx->sessions_by_token);
+  g_hash_table_unref (ctx->access_tokens_by_jti);
   g_mutex_clear (&ctx->lock);
   g_mutex_clear (&ctx->policy_mutation_lock);
   g_free (ctx);
@@ -64,9 +99,94 @@ wyl_daemon_http_context_new (WylHandle *handle, WylDaemonRuntime *runtime)
   }
   ctx->sessions_by_token =
       g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_object_unref);
+  ctx->access_tokens_by_jti = g_hash_table_new_full (g_str_hash, g_str_equal,
+      g_free, wyl_access_token_state_free);
   g_mutex_init (&ctx->lock);
   g_mutex_init (&ctx->policy_mutation_lock);
   return ctx;
+}
+
+static gboolean
+wyl_daemon_http_context_store_access_token (WylDaemonHttpContext *ctx,
+    const gchar *jti, const gchar *session_id, const gchar *subject,
+    const gchar *tenant, const gchar *key_id, gint64 expires_at)
+{
+  if (ctx == NULL || jti == NULL || jti[0] == '\0' || session_id == NULL ||
+      session_id[0] == '\0' || subject == NULL || subject[0] == '\0' ||
+      tenant == NULL || tenant[0] == '\0' || key_id == NULL ||
+      key_id[0] == '\0' || expires_at < 0)
+    return FALSE;
+
+  WylAccessTokenState *state = g_new0 (WylAccessTokenState, 1);
+  state->jti = g_strdup (jti);
+  state->session_id = g_strdup (session_id);
+  state->subject = g_strdup (subject);
+  state->tenant = g_strdup (tenant);
+  state->key_id = g_strdup (key_id);
+  state->expires_at = expires_at;
+
+  g_mutex_lock (&ctx->lock);
+  g_hash_table_replace (ctx->access_tokens_by_jti, g_strdup (jti), state);
+  g_mutex_unlock (&ctx->lock);
+  return TRUE;
+}
+
+static gboolean
+wyl_daemon_http_context_access_token_is_active (WylDaemonHttpContext *ctx,
+    const wyl_jwt_access_claims_t *claims, gint64 now)
+{
+  if (ctx == NULL || claims == NULL || claims->jti == NULL)
+    return FALSE;
+
+  g_mutex_lock (&ctx->lock);
+  WylAccessTokenState *state = g_hash_table_lookup (ctx->access_tokens_by_jti,
+      claims->jti);
+  gboolean active = state != NULL && !state->revoked && now < state->expires_at
+      && g_strcmp0 (state->session_id, claims->session_id) == 0
+      && g_strcmp0 (state->subject, claims->subject) == 0
+      && g_strcmp0 (state->tenant, claims->tenant) == 0
+      && g_strcmp0 (state->key_id, WYL_DAEMON_JWT_KEY_ID) == 0
+      && state->expires_at == claims->expires_at;
+  g_mutex_unlock (&ctx->lock);
+  return active;
+}
+
+static void
+collect_session_access_token (gpointer key, gpointer value, gpointer data)
+{
+  WylAccessTokenState *state = value;
+  WylSessionTokenCollect *collect = data;
+
+  if (state == NULL || collect == NULL || collect->token_ids == NULL)
+    return;
+  if (g_strcmp0 (state->session_id, collect->session_id) == 0)
+    g_ptr_array_add (collect->token_ids, g_strdup ((const gchar *) key));
+}
+
+static void
+wyl_daemon_http_context_revoke_session_access_tokens (WylDaemonHttpContext *ctx,
+    const gchar *session_id)
+{
+  if (ctx == NULL || session_id == NULL || session_id[0] == '\0')
+    return;
+
+  g_autoptr (GPtrArray) token_ids = g_ptr_array_new_with_free_func (g_free);
+  WylSessionTokenCollect collect = {
+    .session_id = session_id,
+    .token_ids = token_ids,
+  };
+
+  g_mutex_lock (&ctx->lock);
+  g_hash_table_foreach (ctx->access_tokens_by_jti, collect_session_access_token,
+      &collect);
+  for (guint i = 0; i < token_ids->len; i++) {
+    const gchar *jti = g_ptr_array_index (token_ids, i);
+    WylAccessTokenState *state =
+        g_hash_table_lookup (ctx->access_tokens_by_jti, jti);
+    if (state != NULL)
+      state->revoked = TRUE;
+  }
+  g_mutex_unlock (&ctx->lock);
 }
 
 #ifdef WYL_TEST_DAEMON_HTTP
@@ -286,20 +406,34 @@ issue_login_access_token (WylDaemonHttpContext *ctx, const gchar *session_token,
   }
 
   gint64 issued_at = wyl_session_get_created_at_us (session) / G_USEC_PER_SEC;
+  gint64 ttl = WYL_JWT_ACCESS_TTL_SECONDS;
+  if (issued_at > G_MAXINT64 - ttl) {
+    sodium_memzero (secret, sizeof secret);
+    return WYRELOG_E_INVALID;
+  }
+  const gchar *tenant = "__wr_default";
   wyl_jwt_issue_input_t input = {
     .key_id = WYL_DAEMON_JWT_KEY_ID,
     .jti = token_id_buf,
     .subject = username,
     .issuer = WYL_DAEMON_JWT_ISSUER,
     .audience = WYL_DAEMON_JWT_AUDIENCE,
-    .tenant = "__wr_default",
+    .tenant = tenant,
     .principal_state_at_issue = principal_state,
     .session_id = session_token,
     .issued_at = issued_at,
-    .ttl_seconds = WYL_JWT_ACCESS_TTL_SECONDS,
+    .ttl_seconds = ttl,
   };
   rc = wyl_jwt_sign_hs256 (&input, secret, sizeof secret, out_token);
   sodium_memzero (secret, sizeof secret);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if (!wyl_daemon_http_context_store_access_token (ctx, token_id_buf,
+          session_token, username, tenant, WYL_DAEMON_JWT_KEY_ID,
+          issued_at + ttl)) {
+    g_clear_pointer (out_token, g_free);
+    return WYRELOG_E_INTERNAL;
+  }
   return rc;
 }
 
@@ -352,6 +486,10 @@ resolve_bearer_session (SoupServer *server, WylDaemonHttpContext *ctx,
     return WYRELOG_E_POLICY;
   }
   if (g_strcmp0 (claims.jti, claims.session_id) == 0) {
+    wyl_jwt_access_claims_clear (&claims);
+    return WYRELOG_E_POLICY;
+  }
+  if (!wyl_daemon_http_context_access_token_is_active (ctx, &claims, now)) {
     wyl_jwt_access_claims_clear (&claims);
     return WYRELOG_E_POLICY;
   }
@@ -1181,6 +1319,7 @@ logout_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
     return;
   }
 
+  wyl_daemon_http_context_revoke_session_access_tokens (ctx, session_token);
   if (!wyl_daemon_http_context_remove_session (ctx, session_token)) {
     set_json_error (msg, 401, "logout_auth_required");
     return;

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -344,7 +344,8 @@ build_decide_json (const wyl_decide_resp_t *resp)
 
 static gchar *
 build_login_json (const gchar *session_token, const gchar *username,
-    const gchar *principal_state, const gchar *access_token)
+    const gchar *tenant, const gchar *principal_state,
+    const gchar *access_token)
 {
   g_autoptr (GString) json = g_string_new ("{");
 
@@ -352,6 +353,8 @@ build_login_json (const gchar *session_token, const gchar *username,
   append_json_string (json, session_token);
   g_string_append (json, ",\"username\":");
   append_json_string (json, username);
+  g_string_append (json, ",\"tenant\":");
+  append_json_string (json, tenant);
   g_string_append (json, ",\"principal_state\":");
   append_json_string (json, principal_state);
   g_string_append (json, ",\"session_state\":\"active\"");
@@ -377,14 +380,14 @@ copy_access_token_secret (WylDaemonHttpContext *ctx,
 
 static wyrelog_error_t
 issue_login_access_token (WylDaemonHttpContext *ctx, const gchar *session_token,
-    const gchar *username, const gchar *principal_state, WylSession *session,
-    gchar **out_token)
+    const gchar *username, const gchar *tenant, const gchar *principal_state,
+    WylSession *session, gchar **out_token)
 {
   if (out_token == NULL)
     return WYRELOG_E_INVALID;
   *out_token = NULL;
-  if (session_token == NULL || username == NULL || principal_state == NULL ||
-      session == NULL)
+  if (session_token == NULL || username == NULL || tenant == NULL ||
+      principal_state == NULL || session == NULL)
     return WYRELOG_E_INVALID;
 
   guint8 secret[WYL_DAEMON_JWT_KEY_LEN];
@@ -411,7 +414,6 @@ issue_login_access_token (WylDaemonHttpContext *ctx, const gchar *session_token,
     sodium_memzero (secret, sizeof secret);
     return WYRELOG_E_INVALID;
   }
-  const gchar *tenant = "__wr_default";
   wyl_jwt_issue_input_t input = {
     .key_id = WYL_DAEMON_JWT_KEY_ID,
     .jti = token_id_buf,
@@ -501,7 +503,9 @@ resolve_bearer_session (SoupServer *server, WylDaemonHttpContext *ctx,
     return WYRELOG_E_POLICY;
   }
   g_autofree gchar *live_username = wyl_session_dup_username (session);
-  if (g_strcmp0 (live_username, claims.subject) != 0) {
+  g_autofree gchar *live_tenant = wyl_session_dup_tenant (session);
+  if (g_strcmp0 (live_username, claims.subject) != 0 ||
+      g_strcmp0 (live_tenant, claims.tenant) != 0) {
     wyl_jwt_access_claims_clear (&claims);
     return WYRELOG_E_POLICY;
   }
@@ -1182,14 +1186,22 @@ login_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
   }
 
   const gchar *username = NULL;
+  const gchar *tenant = "__wr_default";
   const gchar *skip_mfa = NULL;
   const gchar *password = NULL;
   if (query != NULL) {
     username = g_hash_table_lookup (query, "username");
+    if (g_hash_table_contains (query, "tenant"))
+      tenant = g_hash_table_lookup (query, "tenant");
     skip_mfa = g_hash_table_lookup (query, "skip_mfa");
     password = g_hash_table_lookup (query, "password");
   }
   if (username == NULL || username[0] == '\0') {
+    set_json_error (msg, 400, "invalid_login_request");
+    return;
+  }
+  if (tenant == NULL || tenant[0] == '\0' ||
+      g_strcmp0 (tenant, "__wr_default") != 0) {
     set_json_error (msg, 400, "invalid_login_request");
     return;
   }
@@ -1212,6 +1224,7 @@ login_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
   WylHandle *handle = ctx->handle;
   g_autoptr (wyl_login_req_t) login = wyl_login_req_new ();
   wyl_login_req_set_username (login, username);
+  wyl_login_req_set_tenant (login, tenant);
   wyl_login_req_set_skip_mfa (login, skip_mfa_requested);
   wyl_login_req_set_request_id (login, ensure_request_id_header (msg));
 
@@ -1231,7 +1244,12 @@ login_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
   }
 
   g_autofree gchar *session_token = wyl_session_dup_id_string (session);
+  g_autofree gchar *session_tenant = wyl_session_dup_tenant (session);
   if (session_token == NULL) {
+    set_json_error (msg, 500, "login_failed");
+    return;
+  }
+  if (session_tenant == NULL || session_tenant[0] == '\0') {
     set_json_error (msg, 500, "login_failed");
     return;
   }
@@ -1240,7 +1258,7 @@ login_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
   g_autofree gchar *access_token = NULL;
   if (skip_mfa_requested) {
     rc = issue_login_access_token (ctx, session_token, username,
-        principal_state, session, &access_token);
+        session_tenant, principal_state, session, &access_token);
     if (rc != WYRELOG_E_OK) {
       set_json_error (msg, 500, "login_failed");
       return;
@@ -1253,7 +1271,7 @@ login_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
   }
 
   g_autofree gchar *body = build_login_json (session_token, username,
-      principal_state, access_token);
+      session_tenant, principal_state, access_token);
   attach_request_id_header (msg);
   soup_server_message_set_status (msg, 200, NULL);
   soup_server_message_set_response (msg, "application/json",

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -17,6 +17,7 @@
 
 #define WYL_DAEMON_JWT_ISSUER "wyrelogd"
 #define WYL_DAEMON_JWT_AUDIENCE "wyrelog-client"
+#define WYL_DAEMON_JWT_KEY_ID "__wr_default_hs256"
 #define WYL_DAEMON_JWT_KEY_LEN 32
 #define WYL_DAEMON_REQUEST_ID_HEADER "X-Wyrelog-Request-Id"
 #define WYL_DAEMON_REQUEST_ID_DATA "wyl-daemon-request-id"
@@ -286,6 +287,7 @@ issue_login_access_token (WylDaemonHttpContext *ctx, const gchar *session_token,
 
   gint64 issued_at = wyl_session_get_created_at_us (session) / G_USEC_PER_SEC;
   wyl_jwt_issue_input_t input = {
+    .key_id = WYL_DAEMON_JWT_KEY_ID,
     .jti = token_id_buf,
     .subject = username,
     .issuer = WYL_DAEMON_JWT_ISSUER,
@@ -335,7 +337,8 @@ resolve_bearer_session (SoupServer *server, WylDaemonHttpContext *ctx,
   g_autoptr (GBytes) payload = NULL;
   gint64 now = g_get_real_time () / G_USEC_PER_SEC;
   rc = wyl_jwt_verify_hs256_access_token (token, secret, sizeof secret,
-      WYL_DAEMON_JWT_ISSUER, WYL_DAEMON_JWT_AUDIENCE, now, &payload);
+      WYL_DAEMON_JWT_KEY_ID, WYL_DAEMON_JWT_ISSUER,
+      WYL_DAEMON_JWT_AUDIENCE, now, &payload);
   sodium_memzero (secret, sizeof secret);
   if (rc != WYRELOG_E_OK)
     return WYRELOG_E_POLICY;

--- a/wyrelog/session.h
+++ b/wyrelog/session.h
@@ -67,6 +67,8 @@ gboolean wyl_login_req_get_skip_mfa (const wyl_login_req_t * req);
 void wyl_login_req_set_request_id (wyl_login_req_t * req,
     const gchar * request_id);
 const gchar *wyl_login_req_get_request_id (const wyl_login_req_t * req);
+void wyl_login_req_set_tenant (wyl_login_req_t * req, const gchar * tenant);
+const gchar *wyl_login_req_get_tenant (const wyl_login_req_t * req);
 
 wyrelog_error_t wyl_session_login (WylHandle * handle,
     const wyl_login_req_t * req, WylSession ** out_session);
@@ -122,5 +124,6 @@ gint64 wyl_session_get_created_at_us (const WylSession * self);
  * Caller frees with g_free or g_autofree.
  */
 gchar *wyl_session_dup_username (const WylSession * self);
+gchar *wyl_session_dup_tenant (const WylSession * self);
 
 G_END_DECLS;

--- a/wyrelog/wyl-client.c
+++ b/wyrelog/wyl-client.c
@@ -9,6 +9,7 @@ struct _WylClient
   gchar *session_token;
   gchar *access_token;
   gchar *username;
+  gchar *tenant;
   gchar *principal_state;
   gchar *session_state;
   SoupSession *session;
@@ -19,7 +20,8 @@ G_DEFINE_FINAL_TYPE (WylClient, wyl_client, G_TYPE_OBJECT);
 static gboolean parse_login_response_json (const gchar * data, gsize size,
     gchar ** out_session_token,
     gchar ** out_access_token, gchar ** out_username,
-    gchar ** out_principal_state, gchar ** out_session_state);
+    gchar ** out_tenant, gchar ** out_principal_state,
+    gchar ** out_session_state);
 
 static void
 wyl_client_clear_login_state (WylClient *self)
@@ -27,6 +29,7 @@ wyl_client_clear_login_state (WylClient *self)
   g_clear_pointer (&self->session_token, g_free);
   g_clear_pointer (&self->access_token, g_free);
   g_clear_pointer (&self->username, g_free);
+  g_clear_pointer (&self->tenant, g_free);
   g_clear_pointer (&self->principal_state, g_free);
   g_clear_pointer (&self->session_state, g_free);
 }
@@ -108,6 +111,13 @@ wyl_client_dup_username (const WylClient *client)
 {
   g_return_val_if_fail (WYL_IS_CLIENT ((WylClient *) client), NULL);
   return g_strdup (client->username);
+}
+
+gchar *
+wyl_client_dup_tenant (const WylClient *client)
+{
+  g_return_val_if_fail (WYL_IS_CLIENT ((WylClient *) client), NULL);
+  return g_strdup (client->tenant);
 }
 
 gchar *
@@ -201,10 +211,12 @@ client_login_internal (WylClient *client, const gchar *username,
   g_autofree gchar *session_token = NULL;
   g_autofree gchar *access_token = NULL;
   g_autofree gchar *parsed_username = NULL;
+  g_autofree gchar *tenant = NULL;
   g_autofree gchar *principal_state = NULL;
   g_autofree gchar *session_state = NULL;
   if (!parse_login_response_json (body_data, body_size, &session_token,
-          &access_token, &parsed_username, &principal_state, &session_state)) {
+          &access_token, &parsed_username, &tenant, &principal_state,
+          &session_state)) {
     wyl_client_clear_login_state (client);
     return WYRELOG_E_IO;
   }
@@ -213,6 +225,7 @@ client_login_internal (WylClient *client, const gchar *username,
   client->session_token = g_steal_pointer (&session_token);
   client->access_token = g_steal_pointer (&access_token);
   client->username = g_steal_pointer (&parsed_username);
+  client->tenant = g_steal_pointer (&tenant);
   client->principal_state = g_steal_pointer (&principal_state);
   client->session_state = g_steal_pointer (&session_state);
   return WYRELOG_E_OK;
@@ -587,15 +600,16 @@ parse_decide_response_json (const gchar *data, gsize size, gint *out_decision)
 static gboolean
 parse_login_response_json (const gchar *data, gsize size,
     gchar **out_session_token, gchar **out_access_token, gchar **out_username,
-    gchar **out_principal_state, gchar **out_session_state)
+    gchar **out_tenant, gchar **out_principal_state, gchar **out_session_state)
 {
   if (data == NULL || out_session_token == NULL || out_username == NULL ||
-      out_access_token == NULL || out_principal_state == NULL ||
-      out_session_state == NULL)
+      out_access_token == NULL || out_tenant == NULL ||
+      out_principal_state == NULL || out_session_state == NULL)
     return FALSE;
   *out_session_token = NULL;
   *out_access_token = NULL;
   *out_username = NULL;
+  *out_tenant = NULL;
   *out_principal_state = NULL;
   *out_session_state = NULL;
 
@@ -606,6 +620,7 @@ parse_login_response_json (const gchar *data, gsize size,
   gboolean have_session_token = FALSE;
   gboolean have_access_token = FALSE;
   gboolean have_username = FALSE;
+  gboolean have_tenant = FALSE;
   gboolean have_principal_state = FALSE;
   gboolean have_session_state = FALSE;
   json_skip_ws (&cursor);
@@ -641,6 +656,14 @@ parse_login_response_json (const gchar *data, gsize size,
         return FALSE;
       have_username = TRUE;
       *out_username = g_steal_pointer (&value);
+    } else if (g_strcmp0 (key, "tenant") == 0) {
+      g_autofree gchar *value = NULL;
+      if (!json_parse_string (&cursor, &value))
+        return FALSE;
+      if (have_tenant || value[0] == '\0')
+        return FALSE;
+      have_tenant = TRUE;
+      *out_tenant = g_steal_pointer (&value);
     } else if (g_strcmp0 (key, "principal_state") == 0) {
       g_autofree gchar *value = NULL;
       if (!json_parse_string (&cursor, &value))
@@ -676,11 +699,13 @@ parse_login_response_json (const gchar *data, gsize size,
   }
 
   json_skip_ws (&cursor);
-  if (!have_session_token || !have_username || !have_principal_state ||
-      !have_session_state || cursor.pos != cursor.size) {
+  if (!have_session_token || !have_username || !have_tenant ||
+      !have_principal_state || !have_session_state ||
+      cursor.pos != cursor.size) {
     g_clear_pointer (out_session_token, g_free);
     g_clear_pointer (out_access_token, g_free);
     g_clear_pointer (out_username, g_free);
+    g_clear_pointer (out_tenant, g_free);
     g_clear_pointer (out_principal_state, g_free);
     g_clear_pointer (out_session_state, g_free);
     return FALSE;

--- a/wyrelog/wyl-perm.c
+++ b/wyrelog/wyl-perm.c
@@ -8,6 +8,7 @@
 struct _wyl_login_req
 {
   gchar *username;
+  gchar *tenant;
   gchar *request_id;
   gboolean skip_mfa;
 };
@@ -63,6 +64,7 @@ wyl_login_req_free (wyl_login_req_t *req)
   if (req == NULL)
     return;
   g_free (req->username);
+  g_free (req->tenant);
   g_free (req->request_id);
   g_free (req);
 }
@@ -80,6 +82,21 @@ wyl_login_req_get_username (const wyl_login_req_t *req)
 {
   g_return_val_if_fail (req != NULL, NULL);
   return req->username;
+}
+
+void
+wyl_login_req_set_tenant (wyl_login_req_t *req, const gchar *tenant)
+{
+  g_return_if_fail (req != NULL);
+  g_free (req->tenant);
+  req->tenant = g_strdup (tenant);
+}
+
+const gchar *
+wyl_login_req_get_tenant (const wyl_login_req_t *req)
+{
+  g_return_val_if_fail (req != NULL, NULL);
+  return req->tenant;
 }
 
 void

--- a/wyrelog/wyl-session.c
+++ b/wyrelog/wyl-session.c
@@ -14,6 +14,7 @@ struct _WylSession
   wyl_id_t id;
   gint64 created_at_us;
   gchar *username;
+  gchar *tenant;
   wyl_session_state_t state;
 };
 
@@ -25,6 +26,7 @@ wyl_session_finalize (GObject *object)
   WylSession *self = WYL_SESSION (object);
 
   g_free (self->username);
+  g_free (self->tenant);
 
   G_OBJECT_CLASS (wyl_session_parent_class)->finalize (object);
 }
@@ -60,6 +62,12 @@ reload_session_snapshot (WylHandle *handle)
   if (wyl_handle_get_read_engine (handle) == NULL)
     return WYRELOG_E_OK;
   return wyl_handle_reload_engine_pair (handle);
+}
+
+static gboolean
+login_tenant_is_valid (const gchar *tenant)
+{
+  return tenant != NULL && g_strcmp0 (tenant, "__wr_default") == 0;
 }
 
 static wyrelog_error_t
@@ -569,6 +577,12 @@ wyl_session_login (WylHandle *handle, const wyl_login_req_t *req,
   if (handle == NULL)
     return WYRELOG_E_INVALID;
 
+  const gchar *tenant = "__wr_default";
+  if (req != NULL && wyl_login_req_get_tenant (req) != NULL)
+    tenant = wyl_login_req_get_tenant (req);
+  if (!login_tenant_is_valid (tenant))
+    return WYRELOG_E_INVALID;
+
   if (req != NULL && wyl_login_req_get_skip_mfa (req)) {
     gboolean skip_mfa_allowed = FALSE;
     wyrelog_error_t rc = login_skip_mfa_allowed (handle, req,
@@ -592,6 +606,7 @@ wyl_session_login (WylHandle *handle, const wyl_login_req_t *req,
     username = wyl_login_req_get_username (req);
     session->username = g_strdup (username);
   }
+  session->tenant = g_strdup (tenant);
 
   g_autofree gchar *session_id = wyl_session_dup_id_string (session);
   if (username != NULL) {
@@ -878,4 +893,13 @@ wyl_session_dup_username (const WylSession *self)
   if (self->username == NULL)
     return NULL;
   return g_strdup (self->username);
+}
+
+gchar *
+wyl_session_dup_tenant (const WylSession *self)
+{
+  g_return_val_if_fail (WYL_IS_SESSION (self), NULL);
+  if (self->tenant == NULL)
+    return NULL;
+  return g_strdup (self->tenant);
 }


### PR DESCRIPTION
## Summary

- add `kid` to HS256 access tokens and strictly validate JWT headers
- require bearer tokens to match daemon-issued access-token state
- carry the default tenant through login, client state, JWT issuance, and
  bearer verification

## Verification

- `meson test -C builddir --print-errorlogs`
- `meson test -C builddir-audit --print-errorlogs`
