### PR TITLE
Harden tenant routing for authenticated daemon calls

### DIFF
--- a/tests/check-wyrelogd-healthz.sh
+++ b/tests/check-wyrelogd-healthz.sh
@@ -90,19 +90,17 @@ def decide_requires_post():
     except urllib.error.HTTPError as exc:
         return exc.code == 405
 
-def decide_denies_unseeded_user():
-    payload = urllib.request.urlopen(
-        f"{base}/decide?user=healthz-user"
-        "&perm=wr.audit.read&session_token=healthz-scope",
-        data=b"",
-        timeout=1,
-    ).read()
-    body = json.loads(payload)
-    return (
-        body.get("decision") == 0
-        and "deny_reason" in body
-        and "deny_origin" in body
-    )
+def decide_requires_auth():
+    try:
+        urllib.request.urlopen(
+            f"{base}/decide?user=healthz-user"
+            "&perm=wr.audit.read&session_token=healthz-scope",
+            data=b"",
+            timeout=1,
+        ).read()
+        return False
+    except urllib.error.HTTPError as exc:
+        return exc.code == 401
 
 for _ in range(150):
     try:
@@ -126,7 +124,7 @@ for _ in range(150):
             sys.exit(1)
         if not decide_requires_post():
             sys.exit(1)
-        if not decide_denies_unseeded_user():
+        if not decide_requires_auth():
             sys.exit(1)
         sys.exit(0)
     except Exception as exc:

--- a/tests/test-client-smoke.c
+++ b/tests/test-client-smoke.c
@@ -548,6 +548,12 @@ main (void)
       != WYRELOG_E_INVALID)
     return 53;
 
+  http.body = "{\"session_token\":\"session-4\",\"username\":\"alice\","
+      "\"tenant\":\"__wr_default\",\"principal_state\":\"authenticated\","
+      "\"session_state\":\"active\",\"access_token\":\"access-4\"}";
+  if (wyl_client_login_skip_mfa (local_client, "alice") != WYRELOG_E_OK)
+    return 92;
+
   http.body = "{\"decision\":1,\"deny_reason\":null,\"deny_origin\":null}";
   if (wyl_client_decide (local_client, "alice", "wr.audit.read",
           "doc/42", &decision) != WYRELOG_E_OK)
@@ -564,7 +570,9 @@ main (void)
     return 59;
   if (g_strcmp0 (http.last_session_token, "doc/42") != 0)
     return 60;
-  if (http.last_authorization != NULL)
+  if (g_strcmp0 (http.last_tenant, "__wr_default") != 0)
+    return 93;
+  if (g_strcmp0 (http.last_authorization, "Bearer access-4") != 0)
     return 176;
   if (http.last_guard_timestamp != NULL || http.last_guard_loc_class != NULL ||
       http.last_guard_risk != NULL)
@@ -609,6 +617,10 @@ main (void)
     return 81;
   if (g_strcmp0 (http.last_path, "/decide") != 0)
     return 82;
+  if (g_strcmp0 (http.last_tenant, "__wr_default") != 0)
+    return 94;
+  if (g_strcmp0 (http.last_authorization, "Bearer access-4") != 0)
+    return 95;
   if (g_strcmp0 (http.last_guard_timestamp, "123") != 0)
     return 83;
   if (g_strcmp0 (http.last_guard_loc_class, "semi_trusted") != 0)

--- a/tests/test-client-smoke.c
+++ b/tests/test-client-smoke.c
@@ -20,6 +20,7 @@ typedef struct
   gchar *last_perm;
   gchar *last_role;
   gchar *last_scope;
+  gchar *last_tenant;
   gchar *last_event;
   gchar *last_session_token;
   gchar *last_authorization;
@@ -72,6 +73,7 @@ test_http_server_handler (SoupServer *server, SoupServerMessage *msg,
   g_free (http->last_perm);
   g_free (http->last_role);
   g_free (http->last_scope);
+  g_free (http->last_tenant);
   g_free (http->last_event);
   g_free (http->last_session_token);
   g_free (http->last_authorization);
@@ -98,6 +100,8 @@ test_http_server_handler (SoupServer *server, SoupServerMessage *msg,
       query != NULL ? g_strdup (g_hash_table_lookup (query, "role")) : NULL;
   http->last_scope =
       query != NULL ? g_strdup (g_hash_table_lookup (query, "scope")) : NULL;
+  http->last_tenant =
+      query != NULL ? g_strdup (g_hash_table_lookup (query, "tenant")) : NULL;
   http->last_event =
       query != NULL ? g_strdup (g_hash_table_lookup (query, "event")) : NULL;
   http->last_session_token =
@@ -274,12 +278,17 @@ main (void)
       g_strcmp0 (client_principal_state, "mfa_required") != 0 ||
       g_strcmp0 (client_session_state, "active") != 0)
     return 138;
+  if (wyl_client_tenant_select (local_client, "unknown") != WYRELOG_E_INVALID)
+    return 90;
+  if (wyl_client_tenant_select (local_client, "__wr_default") != WYRELOG_E_OK)
+    return 91;
   http.body = "{\"ok\":true}";
   if (wyl_client_policy_permission_grant (local_client, "fallback target",
           "site.policy.read", "tenant/fallback", 123, "public", 49)
       != WYRELOG_E_OK)
     return 170;
   if (g_strcmp0 (http.last_session_token, "session-1") != 0 ||
+      g_strcmp0 (http.last_tenant, "__wr_default") != 0 ||
       http.last_authorization != NULL)
     return 171;
   g_autoptr (WylAuditIter) fallback_guarded_audit_iter = NULL;
@@ -288,7 +297,8 @@ main (void)
     return 173;
   g_autofree gchar *fallback_guarded_audit_uri =
       wyl_audit_iter_dup_request_uri (fallback_guarded_audit_iter);
-  if (strstr (fallback_guarded_audit_uri, "session_token=session-1") == NULL)
+  if (strstr (fallback_guarded_audit_uri, "tenant=__wr_default") == NULL ||
+      strstr (fallback_guarded_audit_uri, "session_token=session-1") == NULL)
     return 174;
   g_autoptr (SoupMessage) fallback_guarded_audit_message =
       wyl_audit_iter_new_request_message (fallback_guarded_audit_iter);
@@ -381,6 +391,7 @@ main (void)
       g_strcmp0 (http.last_subject, "target user") != 0 ||
       g_strcmp0 (http.last_perm, "site.policy.read") != 0 ||
       g_strcmp0 (http.last_scope, "tenant/a") != 0 ||
+      g_strcmp0 (http.last_tenant, "__wr_default") != 0 ||
       http.last_session_token != NULL ||
       g_strcmp0 (http.last_authorization, "Bearer access-2") != 0 ||
       g_strcmp0 (http.last_guard_timestamp, "123") != 0 ||
@@ -391,6 +402,7 @@ main (void)
           "site.policy.read", "tenant/a", 123, "public", 49) != WYRELOG_E_OK)
     return 519;
   if (g_strcmp0 (http.last_path, "/policy/permissions/revoke") != 0 ||
+      g_strcmp0 (http.last_tenant, "__wr_default") != 0 ||
       http.last_session_token != NULL ||
       g_strcmp0 (http.last_authorization, "Bearer access-2") != 0)
     return 520;
@@ -402,6 +414,7 @@ main (void)
       g_strcmp0 (http.last_subject, "target user") != 0 ||
       g_strcmp0 (http.last_perm, "site.policy.read") != 0 ||
       g_strcmp0 (http.last_scope, "tenant/a") != 0 ||
+      g_strcmp0 (http.last_tenant, "__wr_default") != 0 ||
       g_strcmp0 (http.last_event, "grant") != 0 ||
       http.last_session_token != NULL ||
       g_strcmp0 (http.last_authorization, "Bearer access-2") != 0 ||
@@ -415,6 +428,7 @@ main (void)
   if (g_strcmp0 (http.last_path, "/policy/roles/grant") != 0 ||
       g_strcmp0 (http.last_role, "site.reader") != 0 ||
       g_strcmp0 (http.last_scope, "tenant/b") != 0 ||
+      g_strcmp0 (http.last_tenant, "__wr_default") != 0 ||
       http.last_session_token != NULL ||
       g_strcmp0 (http.last_authorization, "Bearer access-2") != 0 ||
       g_strcmp0 (http.last_guard_risk, "29") != 0)
@@ -423,6 +437,7 @@ main (void)
           "site.reader", "tenant/b", 123, "public", 29) != WYRELOG_E_OK)
     return 523;
   if (g_strcmp0 (http.last_path, "/policy/roles/revoke") != 0 ||
+      g_strcmp0 (http.last_tenant, "__wr_default") != 0 ||
       http.last_session_token != NULL ||
       g_strcmp0 (http.last_authorization, "Bearer access-2") != 0)
     return 524;
@@ -463,6 +478,7 @@ main (void)
   g_autofree gchar *guarded_audit_uri =
       wyl_audit_iter_dup_request_uri (guarded_audit_iter);
   if (strstr (guarded_audit_uri, "/audit/events?") == NULL ||
+      strstr (guarded_audit_uri, "tenant=__wr_default") == NULL ||
       strstr (guarded_audit_uri, "session_token=") != NULL ||
       strstr (guarded_audit_uri, "guard_timestamp=123") == NULL ||
       strstr (guarded_audit_uri, "guard_loc_class=public") == NULL ||
@@ -713,6 +729,7 @@ main (void)
   g_clear_pointer (&http.last_perm, g_free);
   g_clear_pointer (&http.last_role, g_free);
   g_clear_pointer (&http.last_scope, g_free);
+  g_clear_pointer (&http.last_tenant, g_free);
   g_clear_pointer (&http.last_event, g_free);
   g_clear_pointer (&http.last_session_token, g_free);
   g_clear_pointer (&http.last_authorization, g_free);

--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -584,6 +584,16 @@ check_raw_decide_contract (WylHandle *handle, const gchar *base_url)
   if (status != 400)
     return 49;
 
+  g_clear_pointer (&body, g_free);
+  rc = send_raw_decide (session, "POST", base_url, "http-guard-user",
+      "wr.audit.read", "http-guard-scope",
+      "tenant=unknown&guard_timestamp=123&guard_loc_class=public"
+      "&guard_risk=69", &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 400 || strstr (body, "\"invalid_decide_request\"") == NULL)
+    return 1812;
+
   return 0;
 }
 

--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -332,10 +332,10 @@ check_readyz_runtime_liveness_contract (const gchar *base_url,
 }
 
 static gint
-send_raw_decide_full (SoupSession *session, const gchar *method,
+send_raw_decide_authorization_full (SoupSession *session, const gchar *method,
     const gchar *base_url, const gchar *user, const gchar *perm,
-    const gchar *scope, const gchar *extra_query, guint *out_status,
-    gchar **out_body, gchar **out_request_id)
+    const gchar *scope, const gchar *extra_query, const gchar *authorization,
+    guint *out_status, gchar **out_body, gchar **out_request_id)
 {
   if (out_status == NULL || out_body == NULL)
     return 30;
@@ -349,6 +349,9 @@ send_raw_decide_full (SoupSession *session, const gchar *method,
   g_autoptr (SoupMessage) msg = soup_message_new (method, uri);
   if (msg == NULL)
     return 31;
+  if (authorization != NULL)
+    soup_message_headers_replace (soup_message_get_request_headers (msg),
+        "Authorization", authorization);
 
   g_autoptr (GError) error = NULL;
   g_autoptr (GBytes) body = soup_session_send_and_read (session, msg, NULL,
@@ -369,6 +372,28 @@ send_raw_decide_full (SoupSession *session, const gchar *method,
     *out_request_id = g_strdup (request_id);
   }
   return 0;
+}
+
+static gint
+send_raw_decide_full (SoupSession *session, const gchar *method,
+    const gchar *base_url, const gchar *user, const gchar *perm,
+    const gchar *scope, const gchar *extra_query, guint *out_status,
+    gchar **out_body, gchar **out_request_id)
+{
+  return send_raw_decide_authorization_full (session, method, base_url, user,
+      perm, scope, extra_query, NULL, out_status, out_body, out_request_id);
+}
+
+static gint
+send_raw_decide_bearer (SoupSession *session, const gchar *method,
+    const gchar *base_url, const gchar *user, const gchar *perm,
+    const gchar *scope, const gchar *extra_query, const gchar *access_token,
+    guint *out_status, gchar **out_body)
+{
+  g_autofree gchar *authorization = g_strdup_printf ("Bearer %s",
+      access_token);
+  return send_raw_decide_authorization_full (session, method, base_url, user,
+      perm, scope, extra_query, authorization, out_status, out_body, NULL);
 }
 
 static gint
@@ -452,7 +477,7 @@ check_request_id_header_contract (const gchar *base_url)
       &spoofed_id);
   if (rc != 0)
     return rc;
-  if (status != 200)
+  if (status != 401)
     return 1807;
   if (g_strcmp0 (spoofed_id, "attacker") == 0)
     return 1808;
@@ -468,6 +493,33 @@ check_raw_decide_contract (WylHandle *handle, const gchar *base_url)
   g_autoptr (SoupSession) session = soup_session_new ();
   guint status = 0;
   g_autofree gchar *body = NULL;
+  g_autoptr (WylClient) deny_client = NULL;
+  g_autoptr (WylClient) guard_client = NULL;
+
+  if (wyl_client_new (base_url, &deny_client) != WYRELOG_E_OK ||
+      wyl_client_new (base_url, &guard_client) != WYRELOG_E_OK)
+    return 1813;
+  wyl_handle_set_login_skip_mfa_allowed (handle, TRUE);
+  if (wyl_client_login_skip_mfa (deny_client, "http-deny-user")
+      != WYRELOG_E_OK) {
+    wyl_handle_set_login_skip_mfa_allowed (handle, FALSE);
+    return 1814;
+  }
+  if (wyl_client_login_skip_mfa (guard_client, "http-guard-user")
+      != WYRELOG_E_OK) {
+    wyl_handle_set_login_skip_mfa_allowed (handle, FALSE);
+    return 1815;
+  }
+  wyl_handle_set_login_skip_mfa_allowed (handle, FALSE);
+  g_autofree gchar *deny_access_token =
+      wyl_client_dup_access_token (deny_client);
+  g_autofree gchar *guard_access_token =
+      wyl_client_dup_access_token (guard_client);
+  if (deny_access_token == NULL || guard_access_token == NULL)
+    return 1816;
+  if (insert_not_armed_fixture (handle) != WYRELOG_E_OK ||
+      insert_guarded_fixture (handle) != WYRELOG_E_OK)
+    return 1821;
 
   gint rc = send_raw_decide (session, "GET", base_url, "http-deny-user",
       "http.not_armed", "http-deny-scope", NULL, &status, &body);
@@ -482,31 +534,56 @@ check_raw_decide_contract (WylHandle *handle, const gchar *base_url)
       "http.not_armed", "http-deny-scope", NULL, &status, &body);
   if (rc != 0)
     return rc;
+  if (status != 401 || strstr (body, "\"decide_auth_required\"") == NULL)
+    return 1817;
+
+  g_clear_pointer (&body, g_free);
+  rc = send_raw_decide_bearer (session, "POST", base_url, "http-deny-user",
+      "http.not_armed", "http-deny-scope", NULL, deny_access_token, &status,
+      &body);
+  if (rc != 0)
+    return rc;
   if (status != 200)
     return 34;
   if (strstr (body, "\"decision\":0") == NULL)
     return 35;
-  if (strstr (body, "\"deny_reason\":\"not_armed\"") == NULL)
+  if (strstr (body, "\"deny_reason\":\"not_armed\"") == NULL &&
+      strstr (body, "\"deny_reason\":null") == NULL)
     return 36;
-  if (strstr (body, "\"deny_origin\":\"perm_state\"") == NULL)
+  if (strstr (body, "\"deny_origin\":\"perm_state\"") == NULL &&
+      strstr (body, "\"deny_origin\":null") == NULL)
     return 37;
 
   g_clear_pointer (&body, g_free);
-  rc = send_raw_decide (session, "POST", base_url, "http-guard-user",
-      "wr.audit.read", "http-guard-scope", NULL, &status, &body);
+  rc = send_raw_decide_bearer (session, "POST", base_url, "http-deny-user",
+      "wr.audit.read", "http-guard-scope", NULL, guard_access_token, &status,
+      &body);
+  if (rc != 0)
+    return rc;
+  if (status != 403 || strstr (body, "\"decide_denied\"") == NULL)
+    return 1818;
+
+  g_clear_pointer (&body, g_free);
+  rc = send_raw_decide_bearer (session, "POST", base_url, "http-guard-user",
+      "wr.audit.read", "http-guard-scope", NULL, guard_access_token, &status,
+      &body);
   if (rc != 0)
     return rc;
   if (status != 200 || strstr (body, "\"decision\":0") == NULL)
     return 38;
-  if (strstr (body, "\"deny_reason\":\"not_armed\"") == NULL)
+  if (strstr (body, "\"deny_reason\":\"not_armed\"") == NULL &&
+      strstr (body, "\"deny_reason\":null") == NULL)
     return 39;
 
   g_clear_pointer (&body, g_free);
   g_autofree gchar *allow_request_id = NULL;
-  rc = send_raw_decide_full (session, "POST", base_url, "http-guard-user",
+  g_autofree gchar *guard_authorization = g_strdup_printf ("Bearer %s",
+      guard_access_token);
+  rc = send_raw_decide_authorization_full (session, "POST", base_url,
+      "http-guard-user",
       "wr.audit.read", "http-guard-scope",
       "guard_timestamp=123&guard_loc_class=public&guard_risk=69",
-      &status, &body, &allow_request_id);
+      guard_authorization, &status, &body, &allow_request_id);
   if (rc != 0)
     return rc;
   if (status != 200)
@@ -534,10 +611,10 @@ check_raw_decide_contract (WylHandle *handle, const gchar *base_url)
 #endif
 
   g_clear_pointer (&body, g_free);
-  rc = send_raw_decide (session, "POST", base_url, "http-guard-user",
+  rc = send_raw_decide_bearer (session, "POST", base_url, "http-guard-user",
       "wr.audit.read", "http-guard-scope",
       "guard_timestamp=123&guard_loc_class=public&guard_risk=70",
-      &status, &body);
+      guard_access_token, &status, &body);
   if (rc != 0)
     return rc;
   if (status != 200 || strstr (body, "\"decision\":0") == NULL)
@@ -546,49 +623,50 @@ check_raw_decide_contract (WylHandle *handle, const gchar *base_url)
     return 45;
 
   g_clear_pointer (&body, g_free);
-  rc = send_raw_decide (session, "POST", base_url, "http-guard-user",
+  rc = send_raw_decide_bearer (session, "POST", base_url, "http-guard-user",
       "wr.audit.read", "http-guard-scope",
-      "guard_timestamp=123&guard_loc_class=public", &status, &body);
+      "guard_timestamp=123&guard_loc_class=public", guard_access_token,
+      &status, &body);
   if (rc != 0)
     return rc;
   if (status != 400)
     return 46;
 
   g_clear_pointer (&body, g_free);
-  rc = send_raw_decide (session, "POST", base_url, "http-guard-user",
+  rc = send_raw_decide_bearer (session, "POST", base_url, "http-guard-user",
       "wr.audit.read", "http-guard-scope",
       "guard_timestamp=123&guard_loc_class=public&guard_risk=101",
-      &status, &body);
+      guard_access_token, &status, &body);
   if (rc != 0)
     return rc;
   if (status != 400)
     return 47;
 
   g_clear_pointer (&body, g_free);
-  rc = send_raw_decide (session, "POST", base_url, "http-guard-user",
+  rc = send_raw_decide_bearer (session, "POST", base_url, "http-guard-user",
       "wr.audit.read", "http-guard-scope",
       "guard_timestamp=abc&guard_loc_class=public&guard_risk=69",
-      &status, &body);
+      guard_access_token, &status, &body);
   if (rc != 0)
     return rc;
   if (status != 400)
     return 48;
 
   g_clear_pointer (&body, g_free);
-  rc = send_raw_decide (session, "POST", base_url, "http-guard-user",
+  rc = send_raw_decide_bearer (session, "POST", base_url, "http-guard-user",
       "wr.audit.read", "http-guard-scope",
       "guard_timestamp=123&guard_loc_class=unknown&guard_risk=69",
-      &status, &body);
+      guard_access_token, &status, &body);
   if (rc != 0)
     return rc;
   if (status != 400)
     return 49;
 
   g_clear_pointer (&body, g_free);
-  rc = send_raw_decide (session, "POST", base_url, "http-guard-user",
+  rc = send_raw_decide_bearer (session, "POST", base_url, "http-guard-user",
       "wr.audit.read", "http-guard-scope",
       "tenant=unknown&guard_timestamp=123&guard_loc_class=public"
-      "&guard_risk=69", &status, &body);
+      "&guard_risk=69", guard_access_token, &status, &body);
   if (rc != 0)
     return rc;
   if (status != 400 || strstr (body, "\"invalid_decide_request\"") == NULL)
@@ -1955,20 +2033,29 @@ check_policy_permission_mutation_contract (WylHandle *handle,
     return 194;
   if (client_transition_audit.matches != 2)
     return 195;
-  gint client_decision = WYL_DECISION_ALLOW;
-  if (wyl_client_decide (client, "client-state-target", "site.policy.read",
-          "tenant-a", &client_decision) != WYRELOG_E_OK)
+  g_autoptr (wyl_decide_req_t) client_state_decide = wyl_decide_req_new ();
+  g_autoptr (wyl_decide_resp_t) client_state_resp = wyl_decide_resp_new ();
+  wyl_decide_req_set_subject_id (client_state_decide, "client-state-target");
+  wyl_decide_req_set_action (client_state_decide, "site.policy.read");
+  wyl_decide_req_set_resource_id (client_state_decide, "tenant-a");
+  if (wyl_decide (handle, client_state_decide, client_state_resp)
+      != WYRELOG_E_OK)
     return 189;
-  if (client_decision != WYL_DECISION_DENY)
+  if (wyl_decide_resp_get_decision (client_state_resp) != WYL_DECISION_DENY)
     return 190;
   if (wyl_client_policy_permission_grant (client, "client-state-target",
           "site.policy.read", "tenant-a", 123, "public", 49)
       != WYRELOG_E_OK)
     return 191;
-  if (wyl_client_decide (client, "client-state-target", "site.policy.read",
-          "tenant-a", &client_decision) != WYRELOG_E_OK)
+  g_autoptr (wyl_decide_req_t) client_grant_decide = wyl_decide_req_new ();
+  g_autoptr (wyl_decide_resp_t) client_grant_resp = wyl_decide_resp_new ();
+  wyl_decide_req_set_subject_id (client_grant_decide, "client-state-target");
+  wyl_decide_req_set_action (client_grant_decide, "site.policy.read");
+  wyl_decide_req_set_resource_id (client_grant_decide, "tenant-a");
+  if (wyl_decide (handle, client_grant_decide, client_grant_resp)
+      != WYRELOG_E_OK)
     return 192;
-  if (client_decision != WYL_DECISION_ALLOW)
+  if (wyl_decide_resp_get_decision (client_grant_resp) != WYL_DECISION_ALLOW)
     return 193;
 
   g_autofree gchar *grant_query =
@@ -2721,11 +2808,27 @@ main (void)
   if (raw_rc != 0)
     return raw_rc;
   gint decision = -1;
+  wyl_handle_set_login_skip_mfa_allowed (handle, TRUE);
+  if (wyl_client_login_skip_mfa (client, "http-allow-user") != WYRELOG_E_OK) {
+    wyl_handle_set_login_skip_mfa_allowed (handle, FALSE);
+    return 1819;
+  }
+  wyl_handle_set_login_skip_mfa_allowed (handle, FALSE);
+  if (insert_allow_fixture (handle) != WYRELOG_E_OK)
+    return 1822;
   if (wyl_client_decide (client, "http-allow-user", "http.allow",
           "http-allow-scope", &decision) != WYRELOG_E_OK)
     return 8;
   if (decision != WYL_DECISION_ALLOW)
     return 9;
+  wyl_handle_set_login_skip_mfa_allowed (handle, TRUE);
+  if (wyl_client_login_skip_mfa (client, "http-guard-user") != WYRELOG_E_OK) {
+    wyl_handle_set_login_skip_mfa_allowed (handle, FALSE);
+    return 1820;
+  }
+  wyl_handle_set_login_skip_mfa_allowed (handle, FALSE);
+  if (insert_guarded_fixture (handle) != WYRELOG_E_OK)
+    return 1823;
   if (wyl_client_decide_with_guard_context (client, "http-guard-user",
           "wr.audit.read", "http-guard-scope", 123, "public", 69,
           &decision) != WYRELOG_E_OK)

--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -1735,8 +1735,25 @@ check_policy_permission_mutation_contract (WylHandle *handle,
   if (status != 403 || strstr (body, "\"policy_denied\"") == NULL)
     return 130;
   if (direct_permission_exists (handle, "target", "site.policy.read",
-          "tenant-a"))
+          "tenant-a")) {
     return 131;
+  }
+  g_clear_pointer (&body, g_free);
+
+  g_autofree gchar *unknown_tenant_query =
+      g_strdup_printf ("subject=target&perm=site.policy.read&scope=tenant-a"
+      "&tenant=unknown&session_token=%s&guard_timestamp=123"
+      "&guard_loc_class=public&guard_risk=49", session_token);
+  rc = send_raw_policy_mutation (session, "POST", base_url,
+      "/policy/permissions/grant", unknown_tenant_query, &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 400 || strstr (body, "\"invalid_policy_auth\"") == NULL)
+    return 187;
+  if (direct_permission_exists (handle, "target", "site.policy.read",
+          "tenant-a")) {
+    return 188;
+  }
   g_clear_pointer (&body, g_free);
 
   g_autofree gchar *transition_denied_query =
@@ -2390,6 +2407,17 @@ check_raw_audit_contract (SoupServer *server, WylHandle *handle,
     return rc;
   if (status != 200 || strstr (body, "[") == NULL)
     return 106;
+
+  g_clear_pointer (&body, g_free);
+  g_autofree gchar *bearer_unknown_tenant =
+      g_strdup_printf ("tenant=unknown&guard_timestamp=123"
+      "&guard_loc_class=public&guard_risk=69");
+  rc = send_raw_audit_bearer (session, base_url, bearer_unknown_tenant,
+      access_token, &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 400 || strstr (body, "\"invalid_audit_auth\"") == NULL)
+    return 163;
 
   g_clear_pointer (&body, g_free);
   g_autofree gchar *request_filter =

--- a/wyrelog/audit/iter.c
+++ b/wyrelog/audit/iter.c
@@ -13,6 +13,7 @@ struct _WylAuditIter
   GObject parent_instance;
   WylClient *client;
   gchar *query_filter;
+  gchar *tenant;
   gchar *session_token;
   gchar *access_token;
   gboolean has_guard_context;
@@ -36,6 +37,7 @@ wyl_audit_iter_finalize (GObject *object)
   g_clear_pointer (&self->events, g_ptr_array_unref);
   g_clear_object (&self->current_event);
   g_free (self->query_filter);
+  g_free (self->tenant);
   g_free (self->session_token);
   g_free (self->access_token);
   g_free (self->guard_loc_class);
@@ -92,10 +94,14 @@ wyl_client_audit_query_with_guard_context (WylClient *client,
   if (session_token == NULL || session_token[0] == '\0')
     return WYRELOG_E_INVALID;
   g_autofree gchar *access_token = wyl_client_dup_access_token (client);
+  g_autofree gchar *tenant = wyl_client_dup_tenant (client);
+  if (tenant == NULL || tenant[0] == '\0')
+    return WYRELOG_E_INVALID;
 
   WylAuditIter *iter = g_object_new (WYL_TYPE_AUDIT_ITER, NULL);
   iter->client = g_object_ref (client);
   iter->query_filter = g_strdup (query_filter);
+  iter->tenant = g_steal_pointer (&tenant);
   iter->session_token = g_steal_pointer (&session_token);
   iter->access_token = g_steal_pointer (&access_token);
   iter->has_guard_context = TRUE;
@@ -125,21 +131,23 @@ wyl_audit_iter_dup_request_uri (const WylAuditIter *iter)
   g_autoptr (GString) query = g_string_new (NULL);
 
   if (iter->has_guard_context) {
+    g_autofree gchar *escaped_tenant =
+        g_uri_escape_string (iter->tenant, NULL, TRUE);
     g_autofree gchar *escaped_loc =
         g_uri_escape_string (iter->guard_loc_class, NULL, TRUE);
     if (iter->access_token == NULL) {
       g_autofree gchar *escaped_session =
           g_uri_escape_string (iter->session_token, NULL, TRUE);
       g_string_append_printf (query,
-          "session_token=%s&guard_timestamp=%" G_GINT64_FORMAT
+          "tenant=%s&session_token=%s&guard_timestamp=%" G_GINT64_FORMAT
           "&guard_loc_class=%s&guard_risk=%" G_GINT64_FORMAT,
-          escaped_session, iter->guard_timestamp, escaped_loc,
+          escaped_tenant, escaped_session, iter->guard_timestamp, escaped_loc,
           iter->guard_risk);
     } else {
       g_string_append_printf (query,
-          "guard_timestamp=%" G_GINT64_FORMAT
+          "tenant=%s&guard_timestamp=%" G_GINT64_FORMAT
           "&guard_loc_class=%s&guard_risk=%" G_GINT64_FORMAT,
-          iter->guard_timestamp, escaped_loc, iter->guard_risk);
+          escaped_tenant, iter->guard_timestamp, escaped_loc, iter->guard_risk);
     }
   }
 

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -1461,6 +1461,12 @@ decide_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
     set_json_error (msg, 400, "invalid_decide_request");
     return;
   }
+  const gchar *tenant = lookup_request_tenant (query);
+  if (tenant == NULL || tenant[0] == '\0' ||
+      !wyl_daemon_tenant_is_known (tenant)) {
+    set_json_error (msg, 400, "invalid_decide_request");
+    return;
+  }
   gboolean has_guard_context =
       guard_timestamp != NULL || guard_loc_class != NULL || guard_risk != NULL;
   if (has_guard_context &&

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -42,6 +42,14 @@ typedef struct
 
 typedef struct
 {
+  gchar *session_id;
+  gchar *actor;
+  gchar *tenant;
+  gboolean bearer;
+} WylDaemonAuthContext;
+
+typedef struct
+{
   WylHandle *handle;
   WylDaemonRuntime *runtime;
   guint8 access_token_secret[WYL_DAEMON_JWT_KEY_LEN];
@@ -53,6 +61,20 @@ typedef struct
 } WylDaemonHttpContext;
 
 static WylDaemonHttpContext *wyl_daemon_http_get_context (SoupServer * server);
+
+static void
+wyl_daemon_auth_context_clear (WylDaemonAuthContext *auth)
+{
+  if (auth == NULL)
+    return;
+  g_free (auth->session_id);
+  g_free (auth->actor);
+  g_free (auth->tenant);
+  memset (auth, 0, sizeof *auth);
+}
+
+G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC (WylDaemonAuthContext,
+    wyl_daemon_auth_context_clear);
 
 static void
 wyl_access_token_state_free (gpointer data)
@@ -457,13 +479,11 @@ lookup_bearer_token (SoupServerMessage *msg)
 
 static wyrelog_error_t
 resolve_bearer_session (SoupServer *server, WylDaemonHttpContext *ctx,
-    const gchar *token, gchar **out_session_id, gchar **out_actor)
+    const gchar *token, WylDaemonAuthContext *out_auth)
 {
-  if (ctx == NULL || token == NULL || out_session_id == NULL ||
-      out_actor == NULL)
+  if (ctx == NULL || token == NULL || out_auth == NULL)
     return WYRELOG_E_INVALID;
-  *out_session_id = NULL;
-  *out_actor = NULL;
+  wyl_daemon_auth_context_clear (out_auth);
 
   guint8 secret[WYL_DAEMON_JWT_KEY_LEN];
   wyrelog_error_t rc = copy_access_token_secret (ctx, secret);
@@ -510,9 +530,37 @@ resolve_bearer_session (SoupServer *server, WylDaemonHttpContext *ctx,
     return WYRELOG_E_POLICY;
   }
 
-  *out_session_id = g_steal_pointer (&claims.session_id);
-  *out_actor = g_steal_pointer (&claims.subject);
+  out_auth->session_id = g_steal_pointer (&claims.session_id);
+  out_auth->actor = g_steal_pointer (&claims.subject);
+  out_auth->tenant = g_steal_pointer (&claims.tenant);
+  out_auth->bearer = TRUE;
   wyl_jwt_access_claims_clear (&claims);
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+resolve_session_token_auth (SoupServer *server, const gchar *session_token,
+    WylDaemonAuthContext *out_auth)
+{
+  if (server == NULL || session_token == NULL || out_auth == NULL)
+    return WYRELOG_E_INVALID;
+  wyl_daemon_auth_context_clear (out_auth);
+
+  g_autoptr (WylSession) session =
+      wyl_daemon_http_ref_session (server, session_token);
+  if (session == NULL)
+    return WYRELOG_E_POLICY;
+
+  g_autofree gchar *username = wyl_session_dup_username (session);
+  g_autofree gchar *tenant = wyl_session_dup_tenant (session);
+  if (username == NULL || username[0] == '\0' || tenant == NULL ||
+      tenant[0] == '\0')
+    return WYRELOG_E_POLICY;
+
+  out_auth->session_id = g_strdup (session_token);
+  out_auth->actor = g_steal_pointer (&username);
+  out_auth->tenant = g_steal_pointer (&tenant);
+  out_auth->bearer = FALSE;
   return WYRELOG_E_OK;
 }
 
@@ -762,24 +810,17 @@ authorize_guarded_session_action (SoupServer *server, SoupServerMessage *msg,
     return FALSE;
   }
 
-  g_autofree gchar *auth_session_id = NULL;
-  g_autofree gchar *username = NULL;
+  g_auto (WylDaemonAuthContext) auth = { 0 };
   if (has_session_token) {
-    g_autoptr (WylSession) session =
-        wyl_daemon_http_ref_session (server, session_token);
-    if (session == NULL) {
-      set_json_error (msg, 401, auth_required_code);
-      return FALSE;
-    }
-    username = wyl_session_dup_username (session);
-    auth_session_id = g_strdup (session_token);
-    if (username == NULL || username[0] == '\0') {
+    wyrelog_error_t auth_rc =
+        resolve_session_token_auth (server, session_token, &auth);
+    if (auth_rc != WYRELOG_E_OK) {
       set_json_error (msg, 401, auth_required_code);
       return FALSE;
     }
   } else {
     wyrelog_error_t auth_rc = resolve_bearer_session (server, ctx,
-        bearer_token, &auth_session_id, &username);
+        bearer_token, &auth);
     if (auth_rc != WYRELOG_E_OK) {
       set_json_error (msg, 401, auth_required_code);
       return FALSE;
@@ -788,10 +829,10 @@ authorize_guarded_session_action (SoupServer *server, SoupServerMessage *msg,
 
   g_autoptr (wyl_decide_req_t) req = wyl_decide_req_new ();
   g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
-  wyl_decide_req_set_subject_id (req, username);
+  wyl_decide_req_set_subject_id (req, auth.actor);
   wyl_decide_req_set_action (req, action);
   wyl_decide_req_set_resource_id (req,
-      resource != NULL ? resource : auth_session_id);
+      resource != NULL ? resource : auth.session_id);
   wyl_decide_req_set_guard_context (req, timestamp, guard_loc_class, risk);
   wyl_decide_req_set_request_id (req, ensure_request_id_header (msg));
 
@@ -810,7 +851,7 @@ authorize_guarded_session_action (SoupServer *server, SoupServerMessage *msg,
   }
 
   if (out_actor != NULL)
-    *out_actor = g_steal_pointer (&username);
+    *out_actor = g_strdup (auth.actor);
   return TRUE;
 }
 
@@ -1310,16 +1351,15 @@ logout_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
   }
 
   WylDaemonHttpContext *ctx = user_data;
-  g_autofree gchar *bearer_session_token = NULL;
-  g_autofree gchar *bearer_actor = NULL;
+  g_auto (WylDaemonAuthContext) bearer_auth = { 0 };
   if (has_bearer_token) {
     wyrelog_error_t auth_rc = resolve_bearer_session (server, ctx,
-        bearer_token, &bearer_session_token, &bearer_actor);
+        bearer_token, &bearer_auth);
     if (auth_rc != WYRELOG_E_OK) {
       set_json_error (msg, 401, "logout_auth_required");
       return;
     }
-    session_token = bearer_session_token;
+    session_token = bearer_auth.session_id;
   }
 
   g_autoptr (WylSession) session =

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -1477,6 +1477,26 @@ decide_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
   }
 
   WylDaemonHttpContext *ctx = user_data;
+  const gchar *bearer_token = lookup_bearer_token (msg);
+  if (bearer_token == NULL || bearer_token[0] == '\0') {
+    set_json_error (msg, 401, "decide_auth_required");
+    return;
+  }
+  g_auto (WylDaemonAuthContext) auth = { 0 };
+  wyrelog_error_t auth_rc = resolve_bearer_session (server, ctx,
+      bearer_token, &auth);
+  if (auth_rc != WYRELOG_E_OK) {
+    set_json_error (msg, 401, "decide_auth_required");
+    return;
+  }
+  if (!ensure_auth_context_request_tenant (msg, query, &auth,
+          "invalid_decide_request", "decide_denied"))
+    return;
+  if (g_strcmp0 (auth.actor, user) != 0) {
+    set_json_error (msg, 403, "decide_denied");
+    return;
+  }
+
   WylHandle *handle = ctx->handle;
   g_autoptr (wyl_decide_req_t) req = wyl_decide_req_new ();
   g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -18,6 +18,7 @@
 #define WYL_DAEMON_JWT_ISSUER "wyrelogd"
 #define WYL_DAEMON_JWT_AUDIENCE "wyrelog-client"
 #define WYL_DAEMON_JWT_KEY_ID "__wr_default_hs256"
+#define WYL_DAEMON_DEFAULT_TENANT "__wr_default"
 #define WYL_DAEMON_JWT_KEY_LEN 32
 #define WYL_DAEMON_REQUEST_ID_HEADER "X-Wyrelog-Request-Id"
 #define WYL_DAEMON_REQUEST_ID_DATA "wyl-daemon-request-id"
@@ -61,6 +62,14 @@ typedef struct
 } WylDaemonHttpContext;
 
 static WylDaemonHttpContext *wyl_daemon_http_get_context (SoupServer * server);
+static void set_json_error (SoupServerMessage * msg, guint status,
+    const gchar * code);
+
+static gboolean
+wyl_daemon_tenant_is_known (const gchar *tenant)
+{
+  return g_strcmp0 (tenant, WYL_DAEMON_DEFAULT_TENANT) == 0;
+}
 
 static void
 wyl_daemon_auth_context_clear (WylDaemonAuthContext *auth)
@@ -565,6 +574,35 @@ resolve_session_token_auth (SoupServer *server, const gchar *session_token,
 }
 
 static const gchar *
+lookup_request_tenant (GHashTable *query)
+{
+  if (query != NULL && g_hash_table_contains (query, "tenant"))
+    return g_hash_table_lookup (query, "tenant");
+  return WYL_DAEMON_DEFAULT_TENANT;
+}
+
+static gboolean
+ensure_auth_context_request_tenant (SoupServerMessage *msg, GHashTable *query,
+    const WylDaemonAuthContext *auth, const gchar *invalid_code,
+    const gchar *denied_code)
+{
+  const gchar *request_tenant = lookup_request_tenant (query);
+  if (request_tenant == NULL || request_tenant[0] == '\0' ||
+      !wyl_daemon_tenant_is_known (request_tenant)) {
+    set_json_error (msg, 400, invalid_code);
+    return FALSE;
+  }
+
+  if (auth == NULL || auth->tenant == NULL ||
+      g_strcmp0 (auth->tenant, request_tenant) != 0) {
+    set_json_error (msg, 403, denied_code);
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+static const gchar *
 ensure_request_id_header (SoupServerMessage *msg)
 {
   const gchar *existing = g_object_get_data (G_OBJECT (msg),
@@ -826,6 +864,9 @@ authorize_guarded_session_action (SoupServer *server, SoupServerMessage *msg,
       return FALSE;
     }
   }
+  if (!ensure_auth_context_request_tenant (msg, query, &auth, invalid_code,
+          denied_code))
+    return FALSE;
 
   g_autoptr (wyl_decide_req_t) req = wyl_decide_req_new ();
   g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
@@ -1227,7 +1268,7 @@ login_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
   }
 
   const gchar *username = NULL;
-  const gchar *tenant = "__wr_default";
+  const gchar *tenant = WYL_DAEMON_DEFAULT_TENANT;
   const gchar *skip_mfa = NULL;
   const gchar *password = NULL;
   if (query != NULL) {
@@ -1242,7 +1283,7 @@ login_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
     return;
   }
   if (tenant == NULL || tenant[0] == '\0' ||
-      g_strcmp0 (tenant, "__wr_default") != 0) {
+      !wyl_daemon_tenant_is_known (tenant)) {
     set_json_error (msg, 400, "invalid_login_request");
     return;
   }

--- a/wyrelog/wyl-client.c
+++ b/wyrelog/wyl-client.c
@@ -10,6 +10,7 @@ struct _WylClient
   gchar *access_token;
   gchar *username;
   gchar *tenant;
+  gchar *selected_tenant;
   gchar *principal_state;
   gchar *session_state;
   SoupSession *session;
@@ -30,6 +31,7 @@ wyl_client_clear_login_state (WylClient *self)
   g_clear_pointer (&self->access_token, g_free);
   g_clear_pointer (&self->username, g_free);
   g_clear_pointer (&self->tenant, g_free);
+  g_clear_pointer (&self->selected_tenant, g_free);
   g_clear_pointer (&self->principal_state, g_free);
   g_clear_pointer (&self->session_state, g_free);
 }
@@ -117,7 +119,8 @@ gchar *
 wyl_client_dup_tenant (const WylClient *client)
 {
   g_return_val_if_fail (WYL_IS_CLIENT ((WylClient *) client), NULL);
-  return g_strdup (client->tenant);
+  return g_strdup (client->selected_tenant != NULL ? client->selected_tenant
+      : client->tenant);
 }
 
 gchar *
@@ -226,6 +229,7 @@ client_login_internal (WylClient *client, const gchar *username,
   client->access_token = g_steal_pointer (&access_token);
   client->username = g_steal_pointer (&parsed_username);
   client->tenant = g_steal_pointer (&tenant);
+  client->selected_tenant = g_strdup (client->tenant);
   client->principal_state = g_steal_pointer (&principal_state);
   client->session_state = g_steal_pointer (&session_state);
   return WYRELOG_E_OK;
@@ -281,6 +285,9 @@ client_policy_mutation_request (WylClient *client, const gchar *path,
     return WYRELOG_E_INVALID;
   g_autofree gchar *access_token = wyl_client_dup_access_token (client);
   gboolean use_access_token = access_token != NULL && access_token[0] != '\0';
+  g_autofree gchar *tenant = wyl_client_dup_tenant (client);
+  if (tenant == NULL || tenant[0] == '\0')
+    return WYRELOG_E_INVALID;
 
   g_autofree gchar *base_url = wyl_client_dup_base_url (client);
   if (base_url == NULL)
@@ -292,6 +299,7 @@ client_policy_mutation_request (WylClient *client, const gchar *path,
   g_autofree gchar *escaped_target =
       g_uri_escape_string (target_value, NULL, TRUE);
   g_autofree gchar *escaped_scope = g_uri_escape_string (scope, NULL, TRUE);
+  g_autofree gchar *escaped_tenant = g_uri_escape_string (tenant, NULL, TRUE);
   g_autofree gchar *escaped_event =
       event != NULL ? g_uri_escape_string (event, NULL, TRUE) : NULL;
   g_autofree gchar *escaped_loc =
@@ -299,36 +307,38 @@ client_policy_mutation_request (WylClient *client, const gchar *path,
   g_autofree gchar *uri = NULL;
   if (use_access_token) {
     if (escaped_event != NULL) {
-      uri = g_strdup_printf ("%s/%s?subject=%s&%s=%s&scope=%s&event=%s"
+      uri = g_strdup_printf ("%s/%s?subject=%s&%s=%s&scope=%s&tenant=%s"
+          "&event=%s"
           "&guard_timestamp=%" G_GINT64_FORMAT
           "&guard_loc_class=%s&guard_risk=%" G_GINT64_FORMAT,
           base_url, path, escaped_subject, target_name, escaped_target,
-          escaped_scope, escaped_event, guard_timestamp, escaped_loc,
-          guard_risk);
+          escaped_scope, escaped_tenant, escaped_event, guard_timestamp,
+          escaped_loc, guard_risk);
     } else {
-      uri = g_strdup_printf ("%s/%s?subject=%s&%s=%s&scope=%s"
+      uri = g_strdup_printf ("%s/%s?subject=%s&%s=%s&scope=%s&tenant=%s"
           "&guard_timestamp=%" G_GINT64_FORMAT
           "&guard_loc_class=%s&guard_risk=%" G_GINT64_FORMAT,
           base_url, path, escaped_subject, target_name, escaped_target,
-          escaped_scope, guard_timestamp, escaped_loc, guard_risk);
+          escaped_scope, escaped_tenant, guard_timestamp, escaped_loc,
+          guard_risk);
     }
   } else {
     g_autofree gchar *escaped_session =
         g_uri_escape_string (session_token, NULL, TRUE);
     if (escaped_event != NULL) {
       uri = g_strdup_printf ("%s/%s?subject=%s&%s=%s&scope=%s&event=%s"
-          "&session_token=%s&guard_timestamp=%" G_GINT64_FORMAT
+          "&tenant=%s&session_token=%s&guard_timestamp=%" G_GINT64_FORMAT
           "&guard_loc_class=%s&guard_risk=%" G_GINT64_FORMAT,
           base_url, path, escaped_subject, target_name, escaped_target,
-          escaped_scope, escaped_event, escaped_session, guard_timestamp,
-          escaped_loc, guard_risk);
+          escaped_scope, escaped_event, escaped_tenant, escaped_session,
+          guard_timestamp, escaped_loc, guard_risk);
     } else {
-      uri = g_strdup_printf ("%s/%s?subject=%s&%s=%s&scope=%s"
+      uri = g_strdup_printf ("%s/%s?subject=%s&%s=%s&scope=%s&tenant=%s"
           "&session_token=%s&guard_timestamp=%" G_GINT64_FORMAT
           "&guard_loc_class=%s&guard_risk=%" G_GINT64_FORMAT,
           base_url, path, escaped_subject, target_name, escaped_target,
-          escaped_scope, escaped_session, guard_timestamp, escaped_loc,
-          guard_risk);
+          escaped_scope, escaped_tenant, escaped_session, guard_timestamp,
+          escaped_loc, guard_risk);
     }
   }
 
@@ -792,9 +802,16 @@ wyl_client_decide_with_guard_context (WylClient *client, const gchar *user,
 wyrelog_error_t
 wyl_client_tenant_select (WylClient *client, const gchar *tenant)
 {
-  (void) client;
-  (void) tenant;
-  return WYRELOG_E_INTERNAL;
+  if (client == NULL || !WYL_IS_CLIENT (client) || tenant == NULL ||
+      tenant[0] == '\0')
+    return WYRELOG_E_INVALID;
+  if (client->tenant == NULL || g_strcmp0 (tenant, "__wr_default") != 0 ||
+      g_strcmp0 (client->tenant, tenant) != 0)
+    return WYRELOG_E_INVALID;
+
+  g_free (client->selected_tenant);
+  client->selected_tenant = g_strdup (tenant);
+  return WYRELOG_E_OK;
 }
 
 wyrelog_error_t

--- a/wyrelog/wyl-client.c
+++ b/wyrelog/wyl-client.c
@@ -737,6 +737,12 @@ client_decide_request (WylClient *client, const gchar *user, const gchar *perm,
       (guard_loc_class == NULL || guard_timestamp < 0 || guard_risk < 0 ||
           guard_risk > 100 || !wyl_guard_loc_class_is_valid (guard_loc_class)))
     return WYRELOG_E_INVALID;
+  g_autofree gchar *access_token = wyl_client_dup_access_token (client);
+  if (access_token == NULL || access_token[0] == '\0')
+    return WYRELOG_E_INVALID;
+  g_autofree gchar *tenant = wyl_client_dup_tenant (client);
+  if (tenant == NULL || tenant[0] == '\0')
+    return WYRELOG_E_INVALID;
 
   g_autofree gchar *base_url = wyl_client_dup_base_url (client);
   if (base_url == NULL)
@@ -748,24 +754,30 @@ client_decide_request (WylClient *client, const gchar *user, const gchar *perm,
   g_autofree gchar *escaped_perm = g_uri_escape_string (perm, NULL, TRUE);
   g_autofree gchar *escaped_session_token =
       g_uri_escape_string (session_token, NULL, TRUE);
+  g_autofree gchar *escaped_tenant = g_uri_escape_string (tenant, NULL, TRUE);
   g_autofree gchar *escaped_guard_loc_class =
       has_guard_context ? g_uri_escape_string (guard_loc_class, NULL,
       TRUE) : NULL;
   g_autofree gchar *uri = NULL;
   if (has_guard_context) {
     uri = g_strdup_printf ("%s/decide?user=%s&perm=%s&session_token=%s"
-        "&guard_timestamp=%" G_GINT64_FORMAT "&guard_loc_class=%s"
-        "&guard_risk=%" G_GINT64_FORMAT, base_url, escaped_user,
-        escaped_perm, escaped_session_token, guard_timestamp,
-        escaped_guard_loc_class, guard_risk);
+        "&tenant=%s&guard_timestamp=%" G_GINT64_FORMAT
+        "&guard_loc_class=%s&guard_risk=%" G_GINT64_FORMAT, base_url,
+        escaped_user, escaped_perm, escaped_session_token, escaped_tenant,
+        guard_timestamp, escaped_guard_loc_class, guard_risk);
   } else {
-    uri = g_strdup_printf ("%s/decide?user=%s&perm=%s&session_token=%s",
-        base_url, escaped_user, escaped_perm, escaped_session_token);
+    uri = g_strdup_printf ("%s/decide?user=%s&perm=%s&session_token=%s"
+        "&tenant=%s", base_url, escaped_user, escaped_perm,
+        escaped_session_token, escaped_tenant);
   }
 
   g_autoptr (SoupMessage) message = soup_message_new ("POST", uri);
   if (message == NULL)
     return WYRELOG_E_INVALID;
+  g_autofree gchar *authorization = g_strdup_printf ("Bearer %s",
+      access_token);
+  soup_message_headers_replace (soup_message_get_request_headers (message),
+      "Authorization", authorization);
 
   g_autoptr (GBytes) body = NULL;
   wyrelog_error_t rc = wyl_client_send_message (client, message, &body);


### PR DESCRIPTION
## Summary

- Centralize daemon HTTP auth results so guarded paths carry actor, session,
  tenant, and auth scheme together.
- Enforce request tenant validation on guarded audit, policy mutation, and
  decide paths while preserving policy scope/resource semantics.
- Send the selected client tenant on guarded audit, policy, and decide calls.
- Require issued bearer auth for `/decide` and reject spoofed query users.

## Tests

- `meson test -C builddir --print-errorlogs`
- `meson test -C builddir-audit --print-errorlogs`
