### PR TITLE
wyctl: add daemon status skeleton

### DIFF
--- a/tests/check-wyctl-status-daemon.sh
+++ b/tests/check-wyctl-status-daemon.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+set -eu
+
+WYCTL=$1
+WYRELOGD=$2
+TEMPLATE_DIR=$3
+PYTHON=$4
+PORT=$("$PYTHON" - <<'PY'
+import socket
+
+with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+    sock.bind(("127.0.0.1", 0))
+    print(sock.getsockname()[1])
+PY
+)
+BASE_URL="http://127.0.0.1:$PORT"
+TMPDIR=$(mktemp -d)
+POLICY_DB="$TMPDIR/policy.sqlite"
+OUT="$TMPDIR/wyctl.out"
+ERR="$TMPDIR/wyctl.err"
+PID=
+
+cleanup() {
+  if [ -n "$PID" ]; then
+    kill "$PID" 2>/dev/null || true
+  fi
+  rm -rf "$TMPDIR"
+}
+trap cleanup EXIT INT TERM
+
+"$WYRELOGD" --template-dir "$TEMPLATE_DIR" --policy-db "$POLICY_DB" \
+  --listen-port "$PORT" &
+PID=$!
+
+i=0
+while [ "$i" -lt 150 ]; do
+  i=$((i + 1))
+  if "$WYCTL" --daemon-url "$BASE_URL" --timeout-ms 500 status \
+      >"$OUT" 2>"$ERR"; then
+    if [ "$(cat "$OUT")" = "ok" ] && [ ! -s "$ERR" ]; then
+      kill -TERM "$PID"
+      wait "$PID"
+      PID=
+      trap - EXIT INT TERM
+      rm -rf "$TMPDIR"
+      exit 0
+    fi
+    echo "wyctl status returned unexpected output" >&2
+    cat "$OUT" >&2
+    cat "$ERR" >&2
+    exit 1
+  fi
+  sleep 0.1
+done
+
+echo "wyctl status did not reach live daemon" >&2
+cat "$ERR" >&2
+exit 1

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -118,7 +118,7 @@ if build_client
     c_args : [
       '-DWYL_TEST_WYCTL_PATH="' + wyctl_exe.full_path() + '"',
     ],
-    dependencies : [glib_dep],
+    dependencies : [glib_dep, gio_dep],
   )
 
   test('wyctl-basic', test_wyctl_basic,

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -112,6 +112,20 @@ test_client_audit_daemon = executable('test-client-audit-daemon',
   dependencies : [wyrelog_client_dep],
 )
 
+if build_client
+  test_wyctl_basic = executable('test-wyctl-basic',
+    'test-wyctl-basic.c',
+    c_args : [
+      '-DWYL_TEST_WYCTL_PATH="' + wyctl_exe.full_path() + '"',
+    ],
+    dependencies : [glib_dep],
+  )
+
+  test('wyctl-basic', test_wyctl_basic,
+    depends : wyctl_exe,
+  )
+endif
+
 if host_machine.system() != 'windows' and build_client
   test('client-audit-daemon', sh,
     args : [

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -127,6 +127,17 @@ if build_client
 endif
 
 if host_machine.system() != 'windows' and build_client
+  test('wyctl-status-daemon', sh,
+    args : [
+      meson.current_source_dir() / 'check-wyctl-status-daemon.sh',
+      wyctl_exe.full_path(),
+      wyrelogd_exe.full_path(),
+      meson.project_source_root() / 'templates' / 'access',
+      python3.full_path(),
+    ],
+    depends : [wyctl_exe, wyrelogd_exe],
+  )
+
   test('client-audit-daemon', sh,
     args : [
       meson.current_source_dir() / 'check-client-audit-daemon.sh',

--- a/tests/test-wyctl-basic.c
+++ b/tests/test-wyctl-basic.c
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #include <glib.h>
+#include <gio/gio.h>
 #include <string.h>
 
 #ifndef WYL_TEST_WYCTL_PATH
@@ -53,6 +54,8 @@ test_status_connection_failure (void)
     WYL_TEST_WYCTL_PATH,
     "--daemon-url",
     "http://127.0.0.1:1",
+    "--timeout-ms",
+    "100",
     "status",
     NULL,
   };
@@ -61,6 +64,116 @@ test_status_connection_failure (void)
   gint wait_status = 0;
 
   run_child (argv, &stdout_buf, &stderr_buf, &wait_status);
+
+  g_assert_false (wait_status_is_success (wait_status));
+  g_assert_cmpstr (stdout_buf, ==, "");
+  g_assert_nonnull (stderr_buf);
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1,
+          "wyctl: daemon unavailable:"));
+  g_assert_null (g_strstr_len (stderr_buf, -1, "backtrace"));
+  g_assert_null (g_strstr_len (stderr_buf, -1, "assertion"));
+  g_assert_null (g_strstr_len (stderr_buf, -1, "tracker"));
+}
+
+static void
+assert_status_invalid_timeout (const gchar *timeout_ms)
+{
+  gchar *argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "--daemon-url",
+    "http://127.0.0.1:1",
+    "--timeout-ms",
+    (gchar *) timeout_ms,
+    "status",
+    NULL,
+  };
+  g_autofree gchar *stdout_buf = NULL;
+  g_autofree gchar *stderr_buf = NULL;
+  gint wait_status = 0;
+
+  run_child (argv, &stdout_buf, &stderr_buf, &wait_status);
+
+  g_assert_false (wait_status_is_success (wait_status));
+  g_assert_cmpstr (stdout_buf, ==, "");
+  g_assert_nonnull (stderr_buf);
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1, "wyctl: invalid timeout"));
+}
+
+static void
+test_status_rejects_invalid_timeout (void)
+{
+  assert_status_invalid_timeout ("0");
+  assert_status_invalid_timeout ("-1");
+  assert_status_invalid_timeout ("abc");
+  assert_status_invalid_timeout ("60001");
+}
+
+typedef struct
+{
+  GSocketListener *listener;
+} SlowHealthzServer;
+
+static gpointer
+slow_healthz_server_thread (gpointer data)
+{
+  SlowHealthzServer *server = data;
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GSocketConnection) conn =
+      g_socket_listener_accept (server->listener, NULL, NULL, &error);
+  if (conn == NULL)
+    return NULL;
+
+  gchar buffer[512];
+  GInputStream *input = g_io_stream_get_input_stream (G_IO_STREAM (conn));
+  GOutputStream *output = g_io_stream_get_output_stream (G_IO_STREAM (conn));
+
+  (void) g_input_stream_read (input, buffer, sizeof buffer, NULL, NULL);
+  g_usleep (250 * 1000);
+  (void) g_output_stream_write (output,
+      "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok", 40, NULL, NULL);
+  (void) g_io_stream_close (G_IO_STREAM (conn), NULL, NULL);
+
+  return NULL;
+}
+
+static void
+test_status_times_out (void)
+{
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GSocketListener) listener = g_socket_listener_new ();
+  g_autoptr (GInetAddress) address =
+      g_inet_address_new_loopback (G_SOCKET_FAMILY_IPV4);
+  g_autoptr (GSocketAddress) socket_address =
+      g_inet_socket_address_new (address, 0);
+  g_autoptr (GSocketAddress) effective_address = NULL;
+
+  g_assert_true (g_socket_listener_add_address (listener, socket_address,
+          G_SOCKET_TYPE_STREAM, G_SOCKET_PROTOCOL_TCP, NULL, &effective_address,
+          &error));
+  g_assert_no_error (error);
+
+  guint16 port =
+      g_inet_socket_address_get_port (G_INET_SOCKET_ADDRESS
+      (effective_address));
+  g_autofree gchar *daemon_url = g_strdup_printf ("http://127.0.0.1:%u", port);
+  gchar *argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "--daemon-url",
+    daemon_url,
+    "--timeout-ms",
+    "50",
+    "status",
+    NULL,
+  };
+  SlowHealthzServer server = {.listener = listener };
+  GThread *server_thread = g_thread_new ("slow-healthz",
+      slow_healthz_server_thread, &server);
+  g_autofree gchar *stdout_buf = NULL;
+  g_autofree gchar *stderr_buf = NULL;
+  gint wait_status = 0;
+
+  run_child (argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_thread_join (server_thread);
 
   g_assert_false (wait_status_is_success (wait_status));
   g_assert_cmpstr (stdout_buf, ==, "");
@@ -118,6 +231,9 @@ main (int argc, char **argv)
   g_test_add_func ("/wyctl/version", test_version);
   g_test_add_func ("/wyctl/status-connection-failure",
       test_status_connection_failure);
+  g_test_add_func ("/wyctl/status-rejects-invalid-timeout",
+      test_status_rejects_invalid_timeout);
+  g_test_add_func ("/wyctl/status-times-out", test_status_times_out);
   g_test_add_func ("/wyctl/status-requires-daemon-url",
       test_status_requires_daemon_url);
   g_test_add_func ("/wyctl/status-rejects-invalid-daemon-url",

--- a/tests/test-wyctl-basic.c
+++ b/tests/test-wyctl-basic.c
@@ -1,0 +1,127 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <glib.h>
+#include <string.h>
+
+#ifndef WYL_TEST_WYCTL_PATH
+#error "WYL_TEST_WYCTL_PATH is required"
+#endif
+
+static void
+run_child (gchar **argv, gchar **stdout_buf, gchar **stderr_buf,
+    gint *wait_status)
+{
+  g_autoptr (GError) error = NULL;
+
+  g_assert_true (g_spawn_sync (NULL, argv, NULL, G_SPAWN_DEFAULT, NULL, NULL,
+          stdout_buf, stderr_buf, wait_status, &error));
+  g_assert_no_error (error);
+}
+
+static gboolean
+wait_status_is_success (gint wait_status)
+{
+  g_autoptr (GError) error = NULL;
+
+  if (g_spawn_check_wait_status (wait_status, &error))
+    return TRUE;
+
+  g_clear_error (&error);
+  return FALSE;
+}
+
+static void
+test_version (void)
+{
+  gchar *argv[] = { WYL_TEST_WYCTL_PATH, "--version", NULL };
+  g_autofree gchar *stdout_buf = NULL;
+  g_autofree gchar *stderr_buf = NULL;
+  gint wait_status = 0;
+
+  run_child (argv, &stdout_buf, &stderr_buf, &wait_status);
+
+  g_assert_true (wait_status_is_success (wait_status));
+  g_assert_nonnull (stdout_buf);
+  g_assert_cmpstr (stdout_buf, !=, "");
+  g_assert_null (strchr (stdout_buf, ' '));
+  g_assert_cmpstr (stderr_buf, ==, "");
+}
+
+static void
+test_status_connection_failure (void)
+{
+  gchar *argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "--daemon-url",
+    "http://127.0.0.1:1",
+    "status",
+    NULL,
+  };
+  g_autofree gchar *stdout_buf = NULL;
+  g_autofree gchar *stderr_buf = NULL;
+  gint wait_status = 0;
+
+  run_child (argv, &stdout_buf, &stderr_buf, &wait_status);
+
+  g_assert_false (wait_status_is_success (wait_status));
+  g_assert_cmpstr (stdout_buf, ==, "");
+  g_assert_nonnull (stderr_buf);
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1,
+          "wyctl: daemon unavailable:"));
+  g_assert_null (g_strstr_len (stderr_buf, -1, "backtrace"));
+  g_assert_null (g_strstr_len (stderr_buf, -1, "assertion"));
+  g_assert_null (g_strstr_len (stderr_buf, -1, "tracker"));
+}
+
+static void
+test_status_requires_daemon_url (void)
+{
+  gchar *argv[] = { WYL_TEST_WYCTL_PATH, "status", NULL };
+  g_autofree gchar *stdout_buf = NULL;
+  g_autofree gchar *stderr_buf = NULL;
+  gint wait_status = 0;
+
+  run_child (argv, &stdout_buf, &stderr_buf, &wait_status);
+
+  g_assert_false (wait_status_is_success (wait_status));
+  g_assert_cmpstr (stdout_buf, ==, "");
+  g_assert_nonnull (stderr_buf);
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1, "wyctl: missing daemon URL"));
+}
+
+static void
+test_status_rejects_invalid_daemon_url (void)
+{
+  gchar *argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "--daemon-url",
+    "not-a-url",
+    "status",
+    NULL,
+  };
+  g_autofree gchar *stdout_buf = NULL;
+  g_autofree gchar *stderr_buf = NULL;
+  gint wait_status = 0;
+
+  run_child (argv, &stdout_buf, &stderr_buf, &wait_status);
+
+  g_assert_false (wait_status_is_success (wait_status));
+  g_assert_cmpstr (stdout_buf, ==, "");
+  g_assert_nonnull (stderr_buf);
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1, "wyctl: invalid daemon URL"));
+}
+
+int
+main (int argc, char **argv)
+{
+  g_test_init (&argc, &argv, NULL);
+
+  g_test_add_func ("/wyctl/version", test_version);
+  g_test_add_func ("/wyctl/status-connection-failure",
+      test_status_connection_failure);
+  g_test_add_func ("/wyctl/status-requires-daemon-url",
+      test_status_requires_daemon_url);
+  g_test_add_func ("/wyctl/status-rejects-invalid-daemon-url",
+      test_status_rejects_invalid_daemon_url);
+
+  return g_test_run ();
+}

--- a/wyrelog/meson.build
+++ b/wyrelog/meson.build
@@ -112,8 +112,16 @@ if build_client
     include_directories : wyrelog_inc,
     dependencies : [wyrelog_dep, glib_dep, gio_dep],
   )
+
+  wyctl_exe = executable('wyctl',
+    files('wyctl/wyctl.c'),
+    include_directories : wyrelog_inc,
+    dependencies : [wyrelog_client_dep, glib_dep, gio_dep, libsoup_dep],
+    install : true,
+  )
 else
   wyrelog_client_dep = disabler()
+  wyctl_exe = disabler()
 endif
 
 wyrelogd_deps = [wyrelog_dep, glib_dep, gio_dep]

--- a/wyrelog/wyctl/wyctl.c
+++ b/wyrelog/wyctl/wyctl.c
@@ -1,0 +1,115 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <glib.h>
+#include <libsoup/soup.h>
+#include <string.h>
+
+#include "wyrelog/version.h"
+
+typedef struct
+{
+  gchar *daemon_url;
+  gboolean show_version;
+} WyctlOptions;
+
+static gchar *
+build_healthz_uri (const gchar *daemon_url)
+{
+  g_autofree gchar *root = g_strdup (daemon_url);
+
+  while (root[0] != '\0' && g_str_has_suffix (root, "/"))
+    root[strlen (root) - 1] = '\0';
+  return g_strdup_printf ("%s/healthz", root);
+}
+
+static gboolean
+daemon_url_is_valid (const gchar *daemon_url)
+{
+  if (daemon_url == NULL || daemon_url[0] == '\0')
+    return FALSE;
+
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GUri) uri = g_uri_parse (daemon_url, G_URI_FLAGS_NONE, &error);
+  if (uri == NULL)
+    return FALSE;
+
+  const gchar *scheme = g_uri_get_scheme (uri);
+  return g_strcmp0 (scheme, "http") == 0 || g_strcmp0 (scheme, "https") == 0;
+}
+
+static int
+run_status (const WyctlOptions *opts)
+{
+  if (opts->daemon_url == NULL || opts->daemon_url[0] == '\0') {
+    g_printerr ("wyctl: missing daemon URL\n");
+    return 2;
+  }
+
+  if (!daemon_url_is_valid (opts->daemon_url)) {
+    g_printerr ("wyctl: invalid daemon URL\n");
+    return 2;
+  }
+
+  g_autofree gchar *uri = build_healthz_uri (opts->daemon_url);
+  g_autoptr (SoupMessage) msg = soup_message_new ("GET", uri);
+  if (msg == NULL) {
+    g_printerr ("wyctl: invalid daemon URL\n");
+    return 2;
+  }
+
+  g_autoptr (SoupSession) session = soup_session_new ();
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GBytes) body =
+      soup_session_send_and_read (session, msg, NULL, &error);
+  if (body == NULL) {
+    g_printerr ("wyctl: daemon unavailable: %s\n", opts->daemon_url);
+    return 1;
+  }
+
+  guint status = soup_message_get_status (msg);
+  if (status < 200 || status >= 300) {
+    g_printerr ("wyctl: daemon unavailable: %s\n", opts->daemon_url);
+    return 1;
+  }
+
+  g_print ("ok\n");
+  return 0;
+}
+
+int
+main (int argc, char **argv)
+{
+  WyctlOptions opts = { 0 };
+  GOptionEntry entries[] = {
+    {"daemon-url", 0, 0, G_OPTION_ARG_STRING, &opts.daemon_url,
+        "Daemon URL", "URL"},
+    {"version", 0, 0, G_OPTION_ARG_NONE, &opts.show_version,
+        "Print version and exit", NULL},
+    {NULL}
+  };
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GOptionContext) context =
+      g_option_context_new ("COMMAND - wyrelog control client");
+  g_option_context_add_main_entries (context, entries, NULL);
+
+  if (!g_option_context_parse (context, &argc, &argv, &error)) {
+    g_printerr ("wyctl: %s\n", error->message);
+    return 2;
+  }
+
+  if (opts.show_version) {
+    g_print ("%s\n", wyrelog_version_string ());
+    return 0;
+  }
+
+  if (argc < 2) {
+    g_autofree gchar *help = g_option_context_get_help (context, TRUE, NULL);
+    g_printerr ("%s", help);
+    return 2;
+  }
+
+  if (g_strcmp0 (argv[1], "status") == 0)
+    return run_status (&opts);
+
+  g_printerr ("wyctl: unknown command: %s\n", argv[1]);
+  return 2;
+}

--- a/wyrelog/wyctl/wyctl.c
+++ b/wyrelog/wyctl/wyctl.c
@@ -1,6 +1,8 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #include <glib.h>
+#include <gio/gio.h>
 #include <libsoup/soup.h>
+#include <errno.h>
 #include <string.h>
 
 #include "wyrelog/version.h"
@@ -8,8 +10,64 @@
 typedef struct
 {
   gchar *daemon_url;
+  gchar *timeout_ms_arg;
   gboolean show_version;
 } WyctlOptions;
+
+#define WYCTL_DEFAULT_TIMEOUT_MS 2000
+#define WYCTL_MAX_TIMEOUT_MS 60000
+
+typedef struct
+{
+  GCancellable *cancellable;
+  GCond cond;
+  GMutex mutex;
+  gboolean done;
+  guint timeout_ms;
+} WyctlTimeout;
+
+static gpointer
+timeout_thread_func (gpointer data)
+{
+  WyctlTimeout *timeout = data;
+
+  g_mutex_lock (&timeout->mutex);
+  gint64 deadline = g_get_monotonic_time () + (gint64) timeout->timeout_ms
+      * 1000;
+  while (!timeout->done) {
+    if (!g_cond_wait_until (&timeout->cond, &timeout->mutex, deadline))
+      break;
+  }
+  if (!timeout->done)
+    g_cancellable_cancel (timeout->cancellable);
+  g_mutex_unlock (&timeout->mutex);
+
+  return NULL;
+}
+
+static gboolean
+parse_timeout_ms (const gchar *raw, guint *out_timeout_ms)
+{
+  if (raw == NULL) {
+    *out_timeout_ms = WYCTL_DEFAULT_TIMEOUT_MS;
+    return TRUE;
+  }
+
+  if (raw[0] == '\0')
+    return FALSE;
+
+  errno = 0;
+  gchar *end = NULL;
+  gint64 parsed = g_ascii_strtoll (raw, &end, 10);
+  if (errno != 0 || end == raw || *end != '\0')
+    return FALSE;
+
+  if (parsed < 1 || parsed > WYCTL_MAX_TIMEOUT_MS)
+    return FALSE;
+
+  *out_timeout_ms = (guint) parsed;
+  return TRUE;
+}
 
 static gchar *
 build_healthz_uri (const gchar *daemon_url)
@@ -49,6 +107,12 @@ run_status (const WyctlOptions *opts)
     return 2;
   }
 
+  guint timeout_ms = 0;
+  if (!parse_timeout_ms (opts->timeout_ms_arg, &timeout_ms)) {
+    g_printerr ("wyctl: invalid timeout\n");
+    return 2;
+  }
+
   g_autofree gchar *uri = build_healthz_uri (opts->daemon_url);
   g_autoptr (SoupMessage) msg = soup_message_new ("GET", uri);
   if (msg == NULL) {
@@ -57,9 +121,28 @@ run_status (const WyctlOptions *opts)
   }
 
   g_autoptr (SoupSession) session = soup_session_new ();
+  g_autoptr (GCancellable) cancellable = g_cancellable_new ();
+  WyctlTimeout timeout = {
+    .cancellable = cancellable,
+    .timeout_ms = timeout_ms,
+  };
+  g_cond_init (&timeout.cond);
+  g_mutex_init (&timeout.mutex);
+  GThread *timeout_thread = g_thread_new ("wyctl-timeout", timeout_thread_func,
+      &timeout);
+
   g_autoptr (GError) error = NULL;
   g_autoptr (GBytes) body =
-      soup_session_send_and_read (session, msg, NULL, &error);
+      soup_session_send_and_read (session, msg, cancellable, &error);
+
+  g_mutex_lock (&timeout.mutex);
+  timeout.done = TRUE;
+  g_cond_signal (&timeout.cond);
+  g_mutex_unlock (&timeout.mutex);
+  g_thread_join (timeout_thread);
+  g_mutex_clear (&timeout.mutex);
+  g_cond_clear (&timeout.cond);
+
   if (body == NULL) {
     g_printerr ("wyctl: daemon unavailable: %s\n", opts->daemon_url);
     return 1;
@@ -82,6 +165,8 @@ main (int argc, char **argv)
   GOptionEntry entries[] = {
     {"daemon-url", 0, 0, G_OPTION_ARG_STRING, &opts.daemon_url,
         "Daemon URL", "URL"},
+    {"timeout-ms", 0, 0, G_OPTION_ARG_STRING, &opts.timeout_ms_arg,
+        "Daemon probe timeout in milliseconds", "N"},
     {"version", 0, 0, G_OPTION_ARG_NONE, &opts.show_version,
         "Print version and exit", NULL},
     {NULL}


### PR DESCRIPTION
## Summary

- add the initial `wyctl` executable with offline `--version` output
- add `status --daemon-url URL` probing against the daemon health endpoint
- bound status probes with `--timeout-ms` validation and stable failure UX
- cover validation, timeout, and live daemon status paths in Meson tests

## Testing

- `meson test -C builddir --print-errorlogs`
- `meson test -C builddir-audit --print-errorlogs`
