### PR TITLE
wyctl: add policy check and explain

### DIFF
--- a/tests/test-client-smoke.c
+++ b/tests/test-client-smoke.c
@@ -547,6 +547,14 @@ main (void)
   if (wyl_client_decide (local_client, "alice", "read", "doc/42", NULL)
       != WYRELOG_E_INVALID)
     return 53;
+  g_autoptr (WylClientDecision) decision_result = NULL;
+  if (wyl_client_decide_ex (local_client, "alice", "read", "doc/42", NULL)
+      != WYRELOG_E_INVALID)
+    return 177;
+  if (wyl_client_decision_get_decision (NULL) != WYL_DECISION_DENY ||
+      wyl_client_decision_get_deny_reason (NULL) != NULL ||
+      wyl_client_decision_get_deny_origin (NULL) != NULL)
+    return 178;
 
   http.body = "{\"session_token\":\"session-4\",\"username\":\"alice\","
       "\"tenant\":\"__wr_default\",\"principal_state\":\"authenticated\","
@@ -577,6 +585,22 @@ main (void)
   if (http.last_guard_timestamp != NULL || http.last_guard_loc_class != NULL ||
       http.last_guard_risk != NULL)
     return 69;
+  http.body = "{\"decision\":1,\"deny_reason\":null,\"deny_origin\":null}";
+  if (wyl_client_decide_ex (local_client, "alice", "wr.audit.read",
+          "doc/42", &decision_result) != WYRELOG_E_OK)
+    return 179;
+  if (decision_result == NULL ||
+      wyl_client_decision_get_decision (decision_result) != WYL_DECISION_ALLOW)
+    return 180;
+  if (wyl_client_decision_get_deny_reason (decision_result) != NULL ||
+      wyl_client_decision_get_deny_origin (decision_result) != NULL)
+    return 181;
+  if (wyl_client_decide_ex (local_client, NULL, "wr.audit.read", "doc/42",
+          &decision_result) != WYRELOG_E_INVALID)
+    return 186;
+  if (decision_result != NULL)
+    return 187;
+  g_clear_pointer (&decision_result, wyl_client_decision_free);
 
   if (wyl_client_decide_with_guard_context (NULL, "alice", "read", "doc/42",
           123, "public", 69, &decision) != WYRELOG_E_INVALID)
@@ -627,6 +651,19 @@ main (void)
     return 84;
   if (g_strcmp0 (http.last_guard_risk, "69") != 0)
     return 85;
+  http.body = "{\"decision\":1,\"deny_reason\":null,\"deny_origin\":null}";
+  if (wyl_client_decide_with_guard_context_ex (local_client, "alice",
+          "wr.audit.read", "doc/42", 123, "semi_trusted", 69,
+          &decision_result) != WYRELOG_E_OK)
+    return 188;
+  if (decision_result == NULL)
+    return 189;
+  if (wyl_client_decide_with_guard_context_ex (local_client, "alice",
+          "wr.audit.read", "doc/42", 123, NULL, 69,
+          &decision_result) != WYRELOG_E_INVALID)
+    return 190;
+  if (decision_result != NULL)
+    return 191;
 
   http.body = "{\"decision\":0,\"deny_reason\":\"missing_grant\","
       "\"deny_origin\":\"policy\"}";
@@ -635,6 +672,27 @@ main (void)
     return 86;
   if (decision != WYL_DECISION_DENY)
     return 87;
+  http.body = "{\"decision\":0,\"deny_reason\":\"missing_grant\","
+      "\"deny_origin\":\"policy\"}";
+  if (wyl_client_decide_ex (local_client, "bob", "write", "doc/43",
+          &decision_result) != WYRELOG_E_OK)
+    return 182;
+  if (decision_result == NULL ||
+      wyl_client_decision_get_decision (decision_result) != WYL_DECISION_DENY)
+    return 183;
+  if (g_strcmp0 (wyl_client_decision_get_deny_reason (decision_result),
+          "missing_grant") != 0 ||
+      g_strcmp0 (wyl_client_decision_get_deny_origin (decision_result),
+          "policy") != 0)
+    return 184;
+  g_autofree gchar *dup_deny_reason =
+      wyl_client_decision_dup_deny_reason (decision_result);
+  g_autofree gchar *dup_deny_origin =
+      wyl_client_decision_dup_deny_origin (decision_result);
+  if (g_strcmp0 (dup_deny_reason, "missing_grant") != 0 ||
+      g_strcmp0 (dup_deny_origin, "policy") != 0)
+    return 185;
+  g_clear_pointer (&decision_result, wyl_client_decision_free);
 
   http.body = "not-json";
   if (wyl_client_decide (local_client, "bob", "write", "doc/43", &decision)

--- a/tests/test-client-smoke.c
+++ b/tests/test-client-smoke.c
@@ -338,6 +338,27 @@ main (void)
       g_strcmp0 (client_principal_state, "authenticated") != 0 ||
       g_strcmp0 (client_session_state, "active") != 0)
     return 152;
+  if (wyl_client_set_bearer_credentials (NULL, "access-ctl",
+          "__wr_default") != WYRELOG_E_INVALID)
+    return 192;
+  if (wyl_client_set_bearer_credentials (local_client, NULL,
+          "__wr_default") != WYRELOG_E_INVALID)
+    return 193;
+  if (wyl_client_set_bearer_credentials (local_client, "",
+          "__wr_default") != WYRELOG_E_INVALID)
+    return 194;
+  if (wyl_client_set_bearer_credentials (local_client, "access ctl",
+          "__wr_default") != WYRELOG_E_INVALID)
+    return 195;
+  if (wyl_client_set_bearer_credentials (local_client, "access-ctl",
+          NULL) != WYRELOG_E_INVALID)
+    return 196;
+  if (wyl_client_set_bearer_credentials (local_client, "access-ctl",
+          "") != WYRELOG_E_INVALID)
+    return 197;
+  if (wyl_client_set_bearer_credentials (local_client, "access-ctl",
+          "__wr default") != WYRELOG_E_INVALID)
+    return 198;
 
   if (wyl_client_policy_permission_grant (NULL, "target", "read", "scope",
           123, "public", 49) != WYRELOG_E_INVALID)
@@ -787,6 +808,44 @@ main (void)
   has_next = FALSE;
   if (wyl_audit_iter_next (invalid_iter, &has_next) == WYRELOG_E_OK)
     return 37;
+
+  if (wyl_client_set_bearer_credentials (local_client, "access-ctl",
+          "__wr_default") != WYRELOG_E_OK)
+    return 199;
+  g_clear_pointer (&client_access_token, g_free);
+  client_access_token = wyl_client_dup_access_token (local_client);
+  g_clear_pointer (&client_tenant, g_free);
+  client_tenant = wyl_client_dup_tenant (local_client);
+  g_clear_pointer (&client_session_token, g_free);
+  client_session_token = wyl_client_dup_session_token (local_client);
+  g_clear_pointer (&client_username, g_free);
+  client_username = wyl_client_dup_username (local_client);
+  if (g_strcmp0 (client_access_token, "access-ctl") != 0 ||
+      g_strcmp0 (client_tenant, "__wr_default") != 0 ||
+      client_session_token != NULL || client_username != NULL)
+    return 200;
+
+  http.body = "{\"decision\":1,\"deny_reason\":null,\"deny_origin\":null}";
+  if (wyl_client_decide_ex (local_client, "alice", "wr.audit.read",
+          "doc/42", &decision_result) != WYRELOG_E_OK)
+    return 201;
+  if (g_strcmp0 (http.last_authorization, "Bearer access-ctl") != 0)
+    return 202;
+  if (g_strcmp0 (http.last_tenant, "__wr_default") != 0)
+    return 203;
+  if (g_strcmp0 (http.last_session_token, "doc/42") != 0)
+    return 204;
+  g_clear_pointer (&decision_result, wyl_client_decision_free);
+
+  http.body = "{\"session_token\":\"session-relogin\",\"username\":\"alice\","
+      "\"tenant\":\"__wr_default\",\"principal_state\":\"authenticated\","
+      "\"session_state\":\"active\",\"access_token\":\"access-relogin\"}";
+  if (wyl_client_login_skip_mfa (local_client, "alice") != WYRELOG_E_OK)
+    return 205;
+  g_clear_pointer (&client_access_token, g_free);
+  client_access_token = wyl_client_dup_access_token (local_client);
+  if (g_strcmp0 (client_access_token, "access-relogin") != 0)
+    return 206;
 
   g_main_loop_quit (http.loop);
   g_thread_join (thread);

--- a/tests/test-wyctl-basic.c
+++ b/tests/test-wyctl-basic.c
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #include <glib.h>
+#include <glib/gstdio.h>
 #include <gio/gio.h>
 #include <string.h>
 
@@ -275,6 +276,72 @@ test_policy_help (void)
 static void
 test_policy_validation (void)
 {
+  g_autofree gchar *token_path = NULL;
+  g_autoptr (GError) error = NULL;
+  gint fd = g_file_open_tmp ("wyctl-token-XXXXXX", &token_path, &error);
+  g_assert_no_error (error);
+  g_assert_cmpint (fd, >=, 0);
+  g_assert_true (g_close (fd, NULL));
+  g_assert_true (g_file_set_contents (token_path, "token-1\n", -1, &error));
+  g_assert_no_error (error);
+
+  g_autofree gchar *empty_token_path = NULL;
+  fd = g_file_open_tmp ("wyctl-empty-token-XXXXXX", &empty_token_path, &error);
+  g_assert_no_error (error);
+  g_assert_cmpint (fd, >=, 0);
+  g_assert_true (g_close (fd, NULL));
+
+  g_autofree gchar *invalid_token_path = NULL;
+  fd = g_file_open_tmp ("wyctl-invalid-token-XXXXXX", &invalid_token_path,
+      &error);
+  g_assert_no_error (error);
+  g_assert_cmpint (fd, >=, 0);
+  g_assert_true (g_close (fd, NULL));
+  g_assert_true (g_file_set_contents (invalid_token_path, "token-1\nbad\n",
+          -1, &error));
+  g_assert_no_error (error);
+
+  g_autofree gchar *nul_token_path = NULL;
+  fd = g_file_open_tmp ("wyctl-nul-token-XXXXXX", &nul_token_path, &error);
+  g_assert_no_error (error);
+  g_assert_cmpint (fd, >=, 0);
+  g_assert_true (g_close (fd, NULL));
+  {
+    const gchar token_with_nul[] = { 't', 'o', 'k', 'e', 'n', '\0', 'b' };
+    g_assert_true (g_file_set_contents (nul_token_path, token_with_nul,
+            sizeof token_with_nul, &error));
+    g_assert_no_error (error);
+  }
+
+  g_autofree gchar *leading_token_path = NULL;
+  fd = g_file_open_tmp ("wyctl-leading-token-XXXXXX", &leading_token_path,
+      &error);
+  g_assert_no_error (error);
+  g_assert_cmpint (fd, >=, 0);
+  g_assert_true (g_close (fd, NULL));
+  g_assert_true (g_file_set_contents (leading_token_path, "\ntoken-1\n", -1,
+          &error));
+  g_assert_no_error (error);
+
+  g_autofree gchar *trailing_blank_token_path = NULL;
+  fd = g_file_open_tmp ("wyctl-trailing-token-XXXXXX",
+      &trailing_blank_token_path, &error);
+  g_assert_no_error (error);
+  g_assert_cmpint (fd, >=, 0);
+  g_assert_true (g_close (fd, NULL));
+  g_assert_true (g_file_set_contents (trailing_blank_token_path,
+          "token-1\n\n", -1, &error));
+  g_assert_no_error (error);
+
+  g_autofree gchar *space_token_path = NULL;
+  fd = g_file_open_tmp ("wyctl-space-token-XXXXXX", &space_token_path, &error);
+  g_assert_no_error (error);
+  g_assert_cmpint (fd, >=, 0);
+  g_assert_true (g_close (fd, NULL));
+  g_assert_true (g_file_set_contents (space_token_path, " token-1\n", -1,
+          &error));
+  g_assert_no_error (error);
+
   gchar *missing_resource_argv[] = {
     WYL_TEST_WYCTL_PATH,
     "policy",
@@ -283,6 +350,132 @@ test_policy_validation (void)
     "alice",
     "--permission",
     "wr.audit.read",
+    "--access-token-file",
+    token_path,
+    NULL,
+  };
+  gchar *missing_token_argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "policy",
+    "check",
+    "--user",
+    "alice",
+    "--permission",
+    "wr.audit.read",
+    "--resource",
+    "doc/42",
+    NULL,
+  };
+  gchar *unreadable_token_argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "policy",
+    "check",
+    "--user",
+    "alice",
+    "--permission",
+    "wr.audit.read",
+    "--resource",
+    "doc/42",
+    "--access-token-file",
+    "/nonexistent/wyctl-token",
+    NULL,
+  };
+  gchar *empty_token_argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "policy",
+    "check",
+    "--user",
+    "alice",
+    "--permission",
+    "wr.audit.read",
+    "--resource",
+    "doc/42",
+    "--access-token-file",
+    empty_token_path,
+    NULL,
+  };
+  gchar *invalid_token_argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "policy",
+    "check",
+    "--user",
+    "alice",
+    "--permission",
+    "wr.audit.read",
+    "--resource",
+    "doc/42",
+    "--access-token-file",
+    invalid_token_path,
+    NULL,
+  };
+  gchar *nul_token_argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "policy",
+    "check",
+    "--user",
+    "alice",
+    "--permission",
+    "wr.audit.read",
+    "--resource",
+    "doc/42",
+    "--access-token-file",
+    nul_token_path,
+    NULL,
+  };
+  gchar *leading_token_argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "policy",
+    "check",
+    "--user",
+    "alice",
+    "--permission",
+    "wr.audit.read",
+    "--resource",
+    "doc/42",
+    "--access-token-file",
+    leading_token_path,
+    NULL,
+  };
+  gchar *trailing_blank_token_argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "policy",
+    "check",
+    "--user",
+    "alice",
+    "--permission",
+    "wr.audit.read",
+    "--resource",
+    "doc/42",
+    "--access-token-file",
+    trailing_blank_token_path,
+    NULL,
+  };
+  gchar *space_token_argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "policy",
+    "check",
+    "--user",
+    "alice",
+    "--permission",
+    "wr.audit.read",
+    "--resource",
+    "doc/42",
+    "--access-token-file",
+    space_token_path,
+    NULL,
+  };
+  gchar *valid_scaffold_argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "policy",
+    "check",
+    "--user",
+    "alice",
+    "--permission",
+    "wr.audit.read",
+    "--resource",
+    "doc/42",
+    "--access-token-file",
+    token_path,
     NULL,
   };
   gchar *unknown_argv[] = {
@@ -301,6 +494,8 @@ test_policy_validation (void)
     "wr.audit.read",
     "--resource",
     "doc/42",
+    "--access-token-file",
+    token_path,
     "extra",
     NULL,
   };
@@ -312,6 +507,78 @@ test_policy_validation (void)
   g_assert_false (wait_status_is_success (wait_status));
   g_assert_cmpstr (stdout_buf, ==, "");
   g_assert_nonnull (g_strstr_len (stderr_buf, -1, "wyctl: missing --resource"));
+
+  g_clear_pointer (&stdout_buf, g_free);
+  g_clear_pointer (&stderr_buf, g_free);
+  run_child (missing_token_argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_assert_false (wait_status_is_success (wait_status));
+  g_assert_cmpstr (stdout_buf, ==, "");
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1,
+          "wyctl: missing --access-token-file"));
+
+  g_clear_pointer (&stdout_buf, g_free);
+  g_clear_pointer (&stderr_buf, g_free);
+  run_child (unreadable_token_argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_assert_false (wait_status_is_success (wait_status));
+  g_assert_cmpstr (stdout_buf, ==, "");
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1,
+          "wyctl: unable to read access token file"));
+
+  g_clear_pointer (&stdout_buf, g_free);
+  g_clear_pointer (&stderr_buf, g_free);
+  run_child (empty_token_argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_assert_false (wait_status_is_success (wait_status));
+  g_assert_cmpstr (stdout_buf, ==, "");
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1,
+          "wyctl: empty access token file"));
+
+  g_clear_pointer (&stdout_buf, g_free);
+  g_clear_pointer (&stderr_buf, g_free);
+  run_child (invalid_token_argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_assert_false (wait_status_is_success (wait_status));
+  g_assert_cmpstr (stdout_buf, ==, "");
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1,
+          "wyctl: invalid access token file"));
+
+  g_clear_pointer (&stdout_buf, g_free);
+  g_clear_pointer (&stderr_buf, g_free);
+  run_child (leading_token_argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_assert_false (wait_status_is_success (wait_status));
+  g_assert_cmpstr (stdout_buf, ==, "");
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1,
+          "wyctl: invalid access token file"));
+
+  g_clear_pointer (&stdout_buf, g_free);
+  g_clear_pointer (&stderr_buf, g_free);
+  run_child (trailing_blank_token_argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_assert_false (wait_status_is_success (wait_status));
+  g_assert_cmpstr (stdout_buf, ==, "");
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1,
+          "wyctl: invalid access token file"));
+
+  g_clear_pointer (&stdout_buf, g_free);
+  g_clear_pointer (&stderr_buf, g_free);
+  run_child (space_token_argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_assert_false (wait_status_is_success (wait_status));
+  g_assert_cmpstr (stdout_buf, ==, "");
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1,
+          "wyctl: invalid access token file"));
+
+  g_clear_pointer (&stdout_buf, g_free);
+  g_clear_pointer (&stderr_buf, g_free);
+  run_child (nul_token_argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_assert_false (wait_status_is_success (wait_status));
+  g_assert_cmpstr (stdout_buf, ==, "");
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1,
+          "wyctl: invalid access token file"));
+
+  g_clear_pointer (&stdout_buf, g_free);
+  g_clear_pointer (&stderr_buf, g_free);
+  run_child (valid_scaffold_argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_assert_false (wait_status_is_success (wait_status));
+  g_assert_cmpstr (stdout_buf, ==, "");
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1,
+          "wyctl: policy check is not implemented"));
 
   g_clear_pointer (&stdout_buf, g_free);
   g_clear_pointer (&stderr_buf, g_free);
@@ -328,6 +595,14 @@ test_policy_validation (void)
   g_assert_cmpstr (stdout_buf, ==, "");
   g_assert_nonnull (g_strstr_len (stderr_buf, -1,
           "wyctl: unexpected policy check argument"));
+
+  g_unlink (token_path);
+  g_unlink (empty_token_path);
+  g_unlink (invalid_token_path);
+  g_unlink (nul_token_path);
+  g_unlink (leading_token_path);
+  g_unlink (trailing_blank_token_path);
+  g_unlink (space_token_path);
 }
 
 int

--- a/tests/test-wyctl-basic.c
+++ b/tests/test-wyctl-basic.c
@@ -667,8 +667,9 @@ listen_url_for_policy_server (GSocketListener **out_listener)
 }
 
 static void
-run_policy_check_case (const gchar *response_body, const gchar *expected_output,
-    gboolean expect_success, guint delay_us, const gchar *timeout_ms)
+run_policy_decision_case (const gchar *command, const gchar *response_body,
+    const gchar *expected_output, gboolean expect_success, guint delay_us,
+    const gchar *timeout_ms)
 {
   g_autofree gchar *token_path = NULL;
   g_autoptr (GError) error = NULL;
@@ -695,7 +696,7 @@ run_policy_check_case (const gchar *response_body, const gchar *expected_output,
     "--timeout-ms",
     (gchar *) timeout_ms,
     "policy",
-    "check",
+    (gchar *) command,
     "--user",
     "alice",
     "--permission",
@@ -717,9 +718,11 @@ run_policy_check_case (const gchar *response_body, const gchar *expected_output,
   g_assert_cmpstr (stdout_buf, ==, expected_output);
   if (expected_output[0] != '\0')
     g_assert_cmpstr (stderr_buf, ==, "");
-  else
-    g_assert_nonnull (g_strstr_len (stderr_buf, -1,
-            "wyctl: policy check failed"));
+  else {
+    g_autofree gchar *failure = g_strdup_printf ("wyctl: policy %s failed",
+        command);
+    g_assert_nonnull (g_strstr_len (stderr_buf, -1, failure));
+  }
   g_assert_nonnull (server.request);
   g_assert_nonnull (g_strstr_len (server.request, -1, "POST /decide?"));
   g_assert_nonnull (g_strstr_len (server.request, -1, "user=alice"));
@@ -737,14 +740,19 @@ run_policy_check_case (const gchar *response_body, const gchar *expected_output,
 static void
 test_policy_check (void)
 {
-  run_policy_check_case
-      ("{\"decision\":1,\"deny_reason\":null,\"deny_origin\":null}", "allow\n",
-      TRUE, 0, "1000");
-  run_policy_check_case ("{\"decision\":0,\"deny_reason\":\"missing_grant\","
+  run_policy_decision_case
+      ("check", "{\"decision\":1,\"deny_reason\":null,\"deny_origin\":null}",
+      "allow\n", TRUE, 0, "1000");
+  run_policy_decision_case ("check",
+      "{\"decision\":0,\"deny_reason\":\"missing_grant\","
       "\"deny_origin\":\"policy\"}", "deny\n", FALSE, 0, "1000");
-  run_policy_check_case
-      ("{\"decision\":1,\"deny_reason\":null,\"deny_origin\":null}", "", FALSE,
+  run_policy_decision_case ("check",
+      "{\"decision\":1,\"deny_reason\":null,\"deny_origin\":null}", "", FALSE,
       250 * 1000, "50");
+  run_policy_decision_case ("explain",
+      "{\"decision\":0,\"deny_reason\":\"missing_grant\","
+      "\"deny_origin\":\"policy\"}",
+      "deny\nreason=missing_grant\norigin=policy\n", TRUE, 0, "1000");
 }
 
 int

--- a/tests/test-wyctl-basic.c
+++ b/tests/test-wyctl-basic.c
@@ -52,11 +52,11 @@ test_status_connection_failure (void)
 {
   gchar *argv[] = {
     WYL_TEST_WYCTL_PATH,
+    "status",
     "--daemon-url",
     "http://127.0.0.1:1",
     "--timeout-ms",
     "100",
-    "status",
     NULL,
   };
   g_autofree gchar *stdout_buf = NULL;
@@ -223,6 +223,113 @@ test_status_rejects_invalid_daemon_url (void)
   g_assert_nonnull (g_strstr_len (stderr_buf, -1, "wyctl: invalid daemon URL"));
 }
 
+static void
+test_status_help_command_first (void)
+{
+  gchar *argv[] = { WYL_TEST_WYCTL_PATH, "status", "--help", NULL };
+  g_autofree gchar *stdout_buf = NULL;
+  g_autofree gchar *stderr_buf = NULL;
+  gint wait_status = 0;
+
+  run_child (argv, &stdout_buf, &stderr_buf, &wait_status);
+
+  g_assert_true (wait_status_is_success (wait_status));
+  g_assert_nonnull (g_strstr_len (stdout_buf, -1, "--daemon-url"));
+  g_assert_cmpstr (stderr_buf, ==, "");
+}
+
+static void
+test_policy_help (void)
+{
+  gchar *check_argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "policy",
+    "check",
+    "--help",
+    NULL,
+  };
+  gchar *explain_argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "policy",
+    "explain",
+    "--help",
+    NULL,
+  };
+  g_autofree gchar *stdout_buf = NULL;
+  g_autofree gchar *stderr_buf = NULL;
+  gint wait_status = 0;
+
+  run_child (check_argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_assert_true (wait_status_is_success (wait_status));
+  g_assert_nonnull (g_strstr_len (stdout_buf, -1, "--permission"));
+  g_assert_cmpstr (stderr_buf, ==, "");
+
+  g_clear_pointer (&stdout_buf, g_free);
+  g_clear_pointer (&stderr_buf, g_free);
+  run_child (explain_argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_assert_true (wait_status_is_success (wait_status));
+  g_assert_nonnull (g_strstr_len (stdout_buf, -1, "--resource"));
+  g_assert_cmpstr (stderr_buf, ==, "");
+}
+
+static void
+test_policy_validation (void)
+{
+  gchar *missing_resource_argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "policy",
+    "check",
+    "--user",
+    "alice",
+    "--permission",
+    "wr.audit.read",
+    NULL,
+  };
+  gchar *unknown_argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "policy",
+    "unknown",
+    NULL,
+  };
+  gchar *extra_argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "policy",
+    "check",
+    "--user",
+    "alice",
+    "--permission",
+    "wr.audit.read",
+    "--resource",
+    "doc/42",
+    "extra",
+    NULL,
+  };
+  g_autofree gchar *stdout_buf = NULL;
+  g_autofree gchar *stderr_buf = NULL;
+  gint wait_status = 0;
+
+  run_child (missing_resource_argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_assert_false (wait_status_is_success (wait_status));
+  g_assert_cmpstr (stdout_buf, ==, "");
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1, "wyctl: missing --resource"));
+
+  g_clear_pointer (&stdout_buf, g_free);
+  g_clear_pointer (&stderr_buf, g_free);
+  run_child (unknown_argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_assert_false (wait_status_is_success (wait_status));
+  g_assert_cmpstr (stdout_buf, ==, "");
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1,
+          "wyctl: unknown policy command"));
+
+  g_clear_pointer (&stdout_buf, g_free);
+  g_clear_pointer (&stderr_buf, g_free);
+  run_child (extra_argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_assert_false (wait_status_is_success (wait_status));
+  g_assert_cmpstr (stdout_buf, ==, "");
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1,
+          "wyctl: unexpected policy check argument"));
+}
+
 int
 main (int argc, char **argv)
 {
@@ -238,6 +345,10 @@ main (int argc, char **argv)
       test_status_requires_daemon_url);
   g_test_add_func ("/wyctl/status-rejects-invalid-daemon-url",
       test_status_rejects_invalid_daemon_url);
+  g_test_add_func ("/wyctl/status-help-command-first",
+      test_status_help_command_first);
+  g_test_add_func ("/wyctl/policy-help", test_policy_help);
+  g_test_add_func ("/wyctl/policy-validation", test_policy_validation);
 
   return g_test_run ();
 }

--- a/tests/test-wyctl-basic.c
+++ b/tests/test-wyctl-basic.c
@@ -577,8 +577,7 @@ test_policy_validation (void)
   run_child (valid_scaffold_argv, &stdout_buf, &stderr_buf, &wait_status);
   g_assert_false (wait_status_is_success (wait_status));
   g_assert_cmpstr (stdout_buf, ==, "");
-  g_assert_nonnull (g_strstr_len (stderr_buf, -1,
-          "wyctl: policy check is not implemented"));
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1, "wyctl: missing daemon URL"));
 
   g_clear_pointer (&stdout_buf, g_free);
   g_clear_pointer (&stderr_buf, g_free);
@@ -605,6 +604,149 @@ test_policy_validation (void)
   g_unlink (space_token_path);
 }
 
+typedef struct
+{
+  GSocketListener *listener;
+  const gchar *response_body;
+  guint delay_us;
+  gchar *request;
+} PolicyCheckServer;
+
+static gpointer
+policy_check_server_thread (gpointer data)
+{
+  PolicyCheckServer *server = data;
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GSocketConnection) conn =
+      g_socket_listener_accept (server->listener, NULL, NULL, &error);
+  if (conn == NULL)
+    return NULL;
+
+  gchar buffer[4096];
+  GInputStream *input = g_io_stream_get_input_stream (G_IO_STREAM (conn));
+  GOutputStream *output = g_io_stream_get_output_stream (G_IO_STREAM (conn));
+  gssize n = g_input_stream_read (input, buffer, sizeof buffer - 1, NULL, NULL);
+  if (n > 0) {
+    buffer[n] = '\0';
+    server->request = g_strdup (buffer);
+  }
+  if (server->delay_us > 0)
+    g_usleep (server->delay_us);
+
+  g_autofree gchar *response =
+      g_strdup_printf ("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n"
+      "Content-Length: %" G_GSIZE_FORMAT "\r\n\r\n%s",
+      strlen (server->response_body), server->response_body);
+  (void) g_output_stream_write (output, response, strlen (response), NULL,
+      NULL);
+  (void) g_io_stream_close (G_IO_STREAM (conn), NULL, NULL);
+  return NULL;
+}
+
+static gchar *
+listen_url_for_policy_server (GSocketListener **out_listener)
+{
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GSocketListener) listener = g_socket_listener_new ();
+  g_autoptr (GInetAddress) address =
+      g_inet_address_new_loopback (G_SOCKET_FAMILY_IPV4);
+  g_autoptr (GSocketAddress) socket_address =
+      g_inet_socket_address_new (address, 0);
+  g_autoptr (GSocketAddress) effective_address = NULL;
+
+  g_assert_true (g_socket_listener_add_address (listener, socket_address,
+          G_SOCKET_TYPE_STREAM, G_SOCKET_PROTOCOL_TCP, NULL, &effective_address,
+          &error));
+  g_assert_no_error (error);
+
+  guint16 port =
+      g_inet_socket_address_get_port (G_INET_SOCKET_ADDRESS
+      (effective_address));
+  *out_listener = g_steal_pointer (&listener);
+  return g_strdup_printf ("http://127.0.0.1:%u", port);
+}
+
+static void
+run_policy_check_case (const gchar *response_body, const gchar *expected_output,
+    gboolean expect_success, guint delay_us, const gchar *timeout_ms)
+{
+  g_autofree gchar *token_path = NULL;
+  g_autoptr (GError) error = NULL;
+  gint fd = g_file_open_tmp ("wyctl-policy-token-XXXXXX", &token_path, &error);
+  g_assert_no_error (error);
+  g_assert_cmpint (fd, >=, 0);
+  g_assert_true (g_close (fd, NULL));
+  g_assert_true (g_file_set_contents (token_path, "token-1\n", -1, &error));
+  g_assert_no_error (error);
+
+  g_autoptr (GSocketListener) listener = NULL;
+  g_autofree gchar *daemon_url = listen_url_for_policy_server (&listener);
+  PolicyCheckServer server = {
+    .listener = listener,
+    .response_body = response_body,
+    .delay_us = delay_us,
+  };
+  GThread *server_thread = g_thread_new ("policy-check",
+      policy_check_server_thread, &server);
+  gchar *argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "--daemon-url",
+    daemon_url,
+    "--timeout-ms",
+    (gchar *) timeout_ms,
+    "policy",
+    "check",
+    "--user",
+    "alice",
+    "--permission",
+    "wr.audit.read",
+    "--resource",
+    "doc/42",
+    "--access-token-file",
+    token_path,
+    NULL,
+  };
+  g_autofree gchar *stdout_buf = NULL;
+  g_autofree gchar *stderr_buf = NULL;
+  gint wait_status = 0;
+
+  run_child (argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_thread_join (server_thread);
+
+  g_assert_cmpint (wait_status_is_success (wait_status), ==, expect_success);
+  g_assert_cmpstr (stdout_buf, ==, expected_output);
+  if (expected_output[0] != '\0')
+    g_assert_cmpstr (stderr_buf, ==, "");
+  else
+    g_assert_nonnull (g_strstr_len (stderr_buf, -1,
+            "wyctl: policy check failed"));
+  g_assert_nonnull (server.request);
+  g_assert_nonnull (g_strstr_len (server.request, -1, "POST /decide?"));
+  g_assert_nonnull (g_strstr_len (server.request, -1, "user=alice"));
+  g_assert_nonnull (g_strstr_len (server.request, -1, "perm=wr.audit.read"));
+  g_assert_nonnull (g_strstr_len (server.request, -1,
+          "session_token=doc%2F42"));
+  g_assert_nonnull (g_strstr_len (server.request, -1, "tenant=__wr_default"));
+  g_assert_nonnull (g_strstr_len (server.request, -1,
+          "Authorization: Bearer token-1"));
+
+  g_free (server.request);
+  g_unlink (token_path);
+}
+
+static void
+test_policy_check (void)
+{
+  run_policy_check_case
+      ("{\"decision\":1,\"deny_reason\":null,\"deny_origin\":null}", "allow\n",
+      TRUE, 0, "1000");
+  run_policy_check_case ("{\"decision\":0,\"deny_reason\":\"missing_grant\","
+      "\"deny_origin\":\"policy\"}", "deny\n", FALSE, 0, "1000");
+  run_policy_check_case
+      ("{\"decision\":1,\"deny_reason\":null,\"deny_origin\":null}", "", FALSE,
+      250 * 1000, "50");
+}
+
 int
 main (int argc, char **argv)
 {
@@ -624,6 +766,7 @@ main (int argc, char **argv)
       test_status_help_command_first);
   g_test_add_func ("/wyctl/policy-help", test_policy_help);
   g_test_add_func ("/wyctl/policy-validation", test_policy_validation);
+  g_test_add_func ("/wyctl/policy-check", test_policy_check);
 
   return g_test_run ();
 }

--- a/wyrelog/client.h
+++ b/wyrelog/client.h
@@ -45,6 +45,8 @@ wyrelog_error_t wyl_client_login (WylClient * client,
  */
 wyrelog_error_t wyl_client_login_skip_mfa (WylClient * client,
     const gchar * username);
+wyrelog_error_t wyl_client_set_bearer_credentials (WylClient * client,
+    const gchar * access_token, const gchar * tenant);
 gchar *wyl_client_dup_session_token (const WylClient * client);
 gchar *wyl_client_dup_access_token (const WylClient * client);
 gchar *wyl_client_dup_username (const WylClient * client);

--- a/wyrelog/client.h
+++ b/wyrelog/client.h
@@ -29,6 +29,8 @@ G_DECLARE_FINAL_TYPE (WylClient, wyl_client, WYL, CLIENT, GObject);
 G_DECLARE_FINAL_TYPE (WylAuditIter, wyl_audit_iter, WYL, AUDIT_ITER, GObject);
 #define WYL_TYPE_AUDIT_ITER (wyl_audit_iter_get_type ())
 
+typedef struct _WylClientDecision WylClientDecision;
+
 /* Lifecycle */
 wyrelog_error_t wyl_client_new (const gchar * base_url,
     WylClient ** out_client);
@@ -56,12 +58,31 @@ wyrelog_error_t wyl_client_mfa_verify (WylClient * client, const gchar * otp);
 wyrelog_error_t wyl_client_decide (WylClient * client,
     const gchar * user,
     const gchar * perm, const gchar * session_token, gint * out_decision);
+wyrelog_error_t wyl_client_decide_ex (WylClient * client,
+    const gchar * user,
+    const gchar * perm,
+    const gchar * session_token, WylClientDecision ** out_result);
 wyrelog_error_t wyl_client_decide_with_guard_context (WylClient * client,
     const gchar * user,
     const gchar * perm,
     const gchar * session_token,
     gint64 guard_timestamp,
     const gchar * guard_loc_class, gint64 guard_risk, gint * out_decision);
+wyrelog_error_t wyl_client_decide_with_guard_context_ex (WylClient * client,
+    const gchar * user,
+    const gchar * perm,
+    const gchar * session_token,
+    gint64 guard_timestamp,
+    const gchar * guard_loc_class,
+    gint64 guard_risk, WylClientDecision ** out_result);
+void wyl_client_decision_free (WylClientDecision * result);
+gint wyl_client_decision_get_decision (const WylClientDecision * result);
+const gchar *wyl_client_decision_get_deny_reason (const WylClientDecision *
+    result);
+const gchar *wyl_client_decision_get_deny_origin (const WylClientDecision *
+    result);
+gchar *wyl_client_decision_dup_deny_reason (const WylClientDecision * result);
+gchar *wyl_client_decision_dup_deny_origin (const WylClientDecision * result);
 
 /* Audit query (iterator) */
 wyrelog_error_t wyl_client_audit_query (WylClient * client,
@@ -120,3 +141,5 @@ wyrelog_error_t wyl_client_event_emit (WylClient * client,
 const gchar *wyrelog_client_version_string (void);
 
 G_END_DECLS;
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (WylClientDecision, wyl_client_decision_free)

--- a/wyrelog/wyctl/wyctl.c
+++ b/wyrelog/wyctl/wyctl.c
@@ -14,6 +14,13 @@ typedef struct
   gboolean show_version;
 } WyctlOptions;
 
+typedef struct
+{
+  gchar *user;
+  gchar *permission;
+  gchar *resource;
+} WyctlPolicyOptions;
+
 #define WYCTL_DEFAULT_TIMEOUT_MS 2000
 #define WYCTL_MAX_TIMEOUT_MS 60000
 
@@ -95,25 +102,50 @@ daemon_url_is_valid (const gchar *daemon_url)
 }
 
 static int
-run_status (const WyctlOptions *opts)
+run_status (const WyctlOptions *global_opts, gint argc, gchar **argv)
 {
-  if (opts->daemon_url == NULL || opts->daemon_url[0] == '\0') {
+  WyctlOptions opts = {
+    .daemon_url = global_opts->daemon_url,
+    .timeout_ms_arg = global_opts->timeout_ms_arg,
+  };
+  GOptionEntry entries[] = {
+    {"daemon-url", 0, 0, G_OPTION_ARG_STRING, &opts.daemon_url,
+        "Daemon URL", "URL"},
+    {"timeout-ms", 0, 0, G_OPTION_ARG_STRING, &opts.timeout_ms_arg,
+        "Daemon probe timeout in milliseconds", "N"},
+    {NULL}
+  };
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GOptionContext) context =
+      g_option_context_new ("- wyrelog daemon status");
+  g_option_context_add_main_entries (context, entries, NULL);
+
+  if (!g_option_context_parse (context, &argc, &argv, &error)) {
+    g_printerr ("wyctl: %s\n", error->message);
+    return 2;
+  }
+  if (argc > 1) {
+    g_printerr ("wyctl: unexpected status argument: %s\n", argv[1]);
+    return 2;
+  }
+
+  if (opts.daemon_url == NULL || opts.daemon_url[0] == '\0') {
     g_printerr ("wyctl: missing daemon URL\n");
     return 2;
   }
 
-  if (!daemon_url_is_valid (opts->daemon_url)) {
+  if (!daemon_url_is_valid (opts.daemon_url)) {
     g_printerr ("wyctl: invalid daemon URL\n");
     return 2;
   }
 
   guint timeout_ms = 0;
-  if (!parse_timeout_ms (opts->timeout_ms_arg, &timeout_ms)) {
+  if (!parse_timeout_ms (opts.timeout_ms_arg, &timeout_ms)) {
     g_printerr ("wyctl: invalid timeout\n");
     return 2;
   }
 
-  g_autofree gchar *uri = build_healthz_uri (opts->daemon_url);
+  g_autofree gchar *uri = build_healthz_uri (opts.daemon_url);
   g_autoptr (SoupMessage) msg = soup_message_new ("GET", uri);
   if (msg == NULL) {
     g_printerr ("wyctl: invalid daemon URL\n");
@@ -131,9 +163,9 @@ run_status (const WyctlOptions *opts)
   GThread *timeout_thread = g_thread_new ("wyctl-timeout", timeout_thread_func,
       &timeout);
 
-  g_autoptr (GError) error = NULL;
+  g_autoptr (GError) io_error = NULL;
   g_autoptr (GBytes) body =
-      soup_session_send_and_read (session, msg, cancellable, &error);
+      soup_session_send_and_read (session, msg, cancellable, &io_error);
 
   g_mutex_lock (&timeout.mutex);
   timeout.done = TRUE;
@@ -144,18 +176,76 @@ run_status (const WyctlOptions *opts)
   g_cond_clear (&timeout.cond);
 
   if (body == NULL) {
-    g_printerr ("wyctl: daemon unavailable: %s\n", opts->daemon_url);
+    g_printerr ("wyctl: daemon unavailable: %s\n", opts.daemon_url);
     return 1;
   }
 
   guint status = soup_message_get_status (msg);
   if (status < 200 || status >= 300) {
-    g_printerr ("wyctl: daemon unavailable: %s\n", opts->daemon_url);
+    g_printerr ("wyctl: daemon unavailable: %s\n", opts.daemon_url);
     return 1;
   }
 
   g_print ("ok\n");
   return 0;
+}
+
+static int
+run_policy_decision_command (const gchar *command, gint argc, gchar **argv)
+{
+  WyctlPolicyOptions opts = { 0 };
+  GOptionEntry entries[] = {
+    {"user", 0, 0, G_OPTION_ARG_STRING, &opts.user, "Decision user", "USER"},
+    {"permission", 0, 0, G_OPTION_ARG_STRING, &opts.permission,
+        "Decision permission", "PERMISSION"},
+    {"resource", 0, 0, G_OPTION_ARG_STRING, &opts.resource,
+        "Decision resource", "RESOURCE"},
+    {NULL}
+  };
+  g_autoptr (GError) error = NULL;
+  g_autofree gchar *summary = g_strdup_printf ("- wyrelog policy %s", command);
+  g_autoptr (GOptionContext) context = g_option_context_new (summary);
+  g_option_context_add_main_entries (context, entries, NULL);
+
+  if (!g_option_context_parse (context, &argc, &argv, &error)) {
+    g_printerr ("wyctl: %s\n", error->message);
+    return 2;
+  }
+  if (argc > 1) {
+    g_printerr ("wyctl: unexpected policy %s argument: %s\n", command, argv[1]);
+    return 2;
+  }
+
+  if (opts.user == NULL || opts.user[0] == '\0') {
+    g_printerr ("wyctl: missing --user\n");
+    return 2;
+  }
+  if (opts.permission == NULL || opts.permission[0] == '\0') {
+    g_printerr ("wyctl: missing --permission\n");
+    return 2;
+  }
+  if (opts.resource == NULL || opts.resource[0] == '\0') {
+    g_printerr ("wyctl: missing --resource\n");
+    return 2;
+  }
+
+  g_printerr ("wyctl: policy %s is not implemented\n", command);
+  return 3;
+}
+
+static int
+run_policy (gint argc, gchar **argv)
+{
+  if (argc < 2) {
+    g_printerr ("wyctl: missing policy command\n");
+    return 2;
+  }
+
+  if (g_strcmp0 (argv[1], "check") == 0 || g_strcmp0 (argv[1], "explain") == 0)
+    return run_policy_decision_command (argv[1], argc - 1, argv + 1);
+
+  g_printerr ("wyctl: unknown policy command: %s\n", argv[1]);
+  return 2;
 }
 
 int
@@ -175,6 +265,7 @@ main (int argc, char **argv)
   g_autoptr (GOptionContext) context =
       g_option_context_new ("COMMAND - wyrelog control client");
   g_option_context_add_main_entries (context, entries, NULL);
+  g_option_context_set_strict_posix (context, TRUE);
 
   if (!g_option_context_parse (context, &argc, &argv, &error)) {
     g_printerr ("wyctl: %s\n", error->message);
@@ -193,7 +284,9 @@ main (int argc, char **argv)
   }
 
   if (g_strcmp0 (argv[1], "status") == 0)
-    return run_status (&opts);
+    return run_status (&opts, argc - 1, argv + 1);
+  if (g_strcmp0 (argv[1], "policy") == 0)
+    return run_policy (argc - 1, argv + 1);
 
   g_printerr ("wyctl: unknown command: %s\n", argv[1]);
   return 2;

--- a/wyrelog/wyctl/wyctl.c
+++ b/wyrelog/wyctl/wyctl.c
@@ -260,9 +260,14 @@ load_access_token_file (const gchar *path, gchar **out_access_token)
 }
 
 static int
-run_policy_check (const WyctlOptions *global_opts,
-    const WyctlPolicyOptions *policy_opts, const gchar *access_token)
+run_policy_decide_request (const WyctlOptions *global_opts,
+    const WyctlPolicyOptions *policy_opts, const gchar *access_token,
+    const gchar *command, WylClientDecision **out_result)
 {
+  if (out_result == NULL)
+    return 2;
+  *out_result = NULL;
+
   if (global_opts->daemon_url == NULL || global_opts->daemon_url[0] == '\0') {
     g_printerr ("wyctl: missing daemon URL\n");
     return 2;
@@ -291,9 +296,23 @@ run_policy_check (const WyctlOptions *global_opts,
   wyrelog_error_t rc = wyl_client_decide_ex (client, policy_opts->user,
       policy_opts->permission, policy_opts->resource, &result);
   if (rc != WYRELOG_E_OK) {
-    g_printerr ("wyctl: policy check failed\n");
+    g_printerr ("wyctl: policy %s failed\n", command);
     return 3;
   }
+
+  *out_result = g_steal_pointer (&result);
+  return 0;
+}
+
+static int
+run_policy_check (const WyctlOptions *global_opts,
+    const WyctlPolicyOptions *policy_opts, const gchar *access_token)
+{
+  g_autoptr (WylClientDecision) result = NULL;
+  int rc = run_policy_decide_request (global_opts, policy_opts, access_token,
+      "check", &result);
+  if (rc != 0)
+    return rc;
 
   gint decision = wyl_client_decision_get_decision (result);
   if (decision == WYL_DECISION_ALLOW) {
@@ -303,6 +322,32 @@ run_policy_check (const WyctlOptions *global_opts,
 
   g_print ("deny\n");
   return 1;
+}
+
+static int
+run_policy_explain (const WyctlOptions *global_opts,
+    const WyctlPolicyOptions *policy_opts, const gchar *access_token)
+{
+  g_autoptr (WylClientDecision) result = NULL;
+  int rc = run_policy_decide_request (global_opts, policy_opts, access_token,
+      "explain", &result);
+  if (rc != 0)
+    return rc;
+
+  gint decision = wyl_client_decision_get_decision (result);
+  if (decision == WYL_DECISION_ALLOW) {
+    g_print ("allow\n");
+    return 0;
+  }
+
+  g_print ("deny\n");
+  const gchar *deny_reason = wyl_client_decision_get_deny_reason (result);
+  const gchar *deny_origin = wyl_client_decision_get_deny_origin (result);
+  if (deny_reason != NULL)
+    g_print ("reason=%s\n", deny_reason);
+  if (deny_origin != NULL)
+    g_print ("origin=%s\n", deny_origin);
+  return 0;
 }
 
 static int
@@ -353,6 +398,8 @@ run_policy_decision_command (const WyctlOptions *global_opts,
 
   if (g_strcmp0 (command, "check") == 0)
     return run_policy_check (global_opts, &opts, access_token);
+  if (g_strcmp0 (command, "explain") == 0)
+    return run_policy_explain (global_opts, &opts, access_token);
 
   g_printerr ("wyctl: policy %s is not implemented\n", command);
   return 3;

--- a/wyrelog/wyctl/wyctl.c
+++ b/wyrelog/wyctl/wyctl.c
@@ -19,6 +19,7 @@ typedef struct
   gchar *user;
   gchar *permission;
   gchar *resource;
+  gchar *access_token_file;
 } WyctlPolicyOptions;
 
 #define WYCTL_DEFAULT_TIMEOUT_MS 2000
@@ -73,6 +74,39 @@ parse_timeout_ms (const gchar *raw, guint *out_timeout_ms)
     return FALSE;
 
   *out_timeout_ms = (guint) parsed;
+  return TRUE;
+}
+
+static gboolean
+normalize_access_token_file (gchar *access_token, gsize access_token_size)
+{
+  if (access_token_size == 0)
+    return FALSE;
+
+  for (gsize i = 0; i < access_token_size; i++) {
+    if (access_token[i] == '\0')
+      return FALSE;
+  }
+
+  gsize token_len = access_token_size;
+  if (access_token[token_len - 1] == '\n') {
+    token_len--;
+    if (token_len > 0 && access_token[token_len - 1] == '\r')
+      token_len--;
+  }
+  if (token_len == 0)
+    return FALSE;
+
+  for (gsize i = 0; i < token_len; i++) {
+    if (g_ascii_isspace (access_token[i]) || g_ascii_iscntrl (access_token[i]))
+      return FALSE;
+  }
+  for (gsize i = token_len; i < access_token_size; i++) {
+    if (access_token[i] != '\r' && access_token[i] != '\n')
+      return FALSE;
+  }
+
+  access_token[token_len] = '\0';
   return TRUE;
 }
 
@@ -200,6 +234,8 @@ run_policy_decision_command (const gchar *command, gint argc, gchar **argv)
         "Decision permission", "PERMISSION"},
     {"resource", 0, 0, G_OPTION_ARG_STRING, &opts.resource,
         "Decision resource", "RESOURCE"},
+    {"access-token-file", 0, 0, G_OPTION_ARG_STRING, &opts.access_token_file,
+        "Bearer access token file", "PATH"},
     {NULL}
   };
   g_autoptr (GError) error = NULL;
@@ -226,6 +262,26 @@ run_policy_decision_command (const gchar *command, gint argc, gchar **argv)
   }
   if (opts.resource == NULL || opts.resource[0] == '\0') {
     g_printerr ("wyctl: missing --resource\n");
+    return 2;
+  }
+  if (opts.access_token_file == NULL || opts.access_token_file[0] == '\0') {
+    g_printerr ("wyctl: missing --access-token-file\n");
+    return 2;
+  }
+
+  g_autofree gchar *access_token = NULL;
+  gsize access_token_size = 0;
+  if (!g_file_get_contents (opts.access_token_file, &access_token,
+          &access_token_size, &error)) {
+    g_printerr ("wyctl: unable to read access token file\n");
+    return 2;
+  }
+  if (access_token_size == 0) {
+    g_printerr ("wyctl: empty access token file\n");
+    return 2;
+  }
+  if (!normalize_access_token_file (access_token, access_token_size)) {
+    g_printerr ("wyctl: invalid access token file\n");
     return 2;
   }
 

--- a/wyrelog/wyctl/wyctl.c
+++ b/wyrelog/wyctl/wyctl.c
@@ -5,7 +5,10 @@
 #include <errno.h>
 #include <string.h>
 
+#include "wyrelog/client.h"
+#include "wyrelog/decide.h"
 #include "wyrelog/version.h"
+#include "wyrelog/wyl-client-private.h"
 
 typedef struct
 {
@@ -225,7 +228,86 @@ run_status (const WyctlOptions *global_opts, gint argc, gchar **argv)
 }
 
 static int
-run_policy_decision_command (const gchar *command, gint argc, gchar **argv)
+load_access_token_file (const gchar *path, gchar **out_access_token)
+{
+  if (out_access_token == NULL)
+    return 2;
+  *out_access_token = NULL;
+
+  if (path == NULL || path[0] == '\0') {
+    g_printerr ("wyctl: missing --access-token-file\n");
+    return 2;
+  }
+
+  g_autoptr (GError) error = NULL;
+  g_autofree gchar *access_token = NULL;
+  gsize access_token_size = 0;
+  if (!g_file_get_contents (path, &access_token, &access_token_size, &error)) {
+    g_printerr ("wyctl: unable to read access token file\n");
+    return 2;
+  }
+  if (access_token_size == 0) {
+    g_printerr ("wyctl: empty access token file\n");
+    return 2;
+  }
+  if (!normalize_access_token_file (access_token, access_token_size)) {
+    g_printerr ("wyctl: invalid access token file\n");
+    return 2;
+  }
+
+  *out_access_token = g_steal_pointer (&access_token);
+  return 0;
+}
+
+static int
+run_policy_check (const WyctlOptions *global_opts,
+    const WyctlPolicyOptions *policy_opts, const gchar *access_token)
+{
+  if (global_opts->daemon_url == NULL || global_opts->daemon_url[0] == '\0') {
+    g_printerr ("wyctl: missing daemon URL\n");
+    return 2;
+  }
+  if (!daemon_url_is_valid (global_opts->daemon_url)) {
+    g_printerr ("wyctl: invalid daemon URL\n");
+    return 2;
+  }
+
+  guint timeout_ms = 0;
+  if (!parse_timeout_ms (global_opts->timeout_ms_arg, &timeout_ms)) {
+    g_printerr ("wyctl: invalid timeout\n");
+    return 2;
+  }
+
+  g_autoptr (WylClient) client = NULL;
+  if (wyl_client_new (global_opts->daemon_url, &client) != WYRELOG_E_OK ||
+      wyl_client_set_bearer_credentials (client, access_token,
+          "__wr_default") != WYRELOG_E_OK) {
+    g_printerr ("wyctl: invalid policy credentials\n");
+    return 2;
+  }
+  wyl_client_set_timeout_ms (client, timeout_ms);
+
+  g_autoptr (WylClientDecision) result = NULL;
+  wyrelog_error_t rc = wyl_client_decide_ex (client, policy_opts->user,
+      policy_opts->permission, policy_opts->resource, &result);
+  if (rc != WYRELOG_E_OK) {
+    g_printerr ("wyctl: policy check failed\n");
+    return 3;
+  }
+
+  gint decision = wyl_client_decision_get_decision (result);
+  if (decision == WYL_DECISION_ALLOW) {
+    g_print ("allow\n");
+    return 0;
+  }
+
+  g_print ("deny\n");
+  return 1;
+}
+
+static int
+run_policy_decision_command (const WyctlOptions *global_opts,
+    const gchar *command, gint argc, gchar **argv)
 {
   WyctlPolicyOptions opts = { 0 };
   GOptionEntry entries[] = {
@@ -264,33 +346,20 @@ run_policy_decision_command (const gchar *command, gint argc, gchar **argv)
     g_printerr ("wyctl: missing --resource\n");
     return 2;
   }
-  if (opts.access_token_file == NULL || opts.access_token_file[0] == '\0') {
-    g_printerr ("wyctl: missing --access-token-file\n");
-    return 2;
-  }
-
   g_autofree gchar *access_token = NULL;
-  gsize access_token_size = 0;
-  if (!g_file_get_contents (opts.access_token_file, &access_token,
-          &access_token_size, &error)) {
-    g_printerr ("wyctl: unable to read access token file\n");
-    return 2;
-  }
-  if (access_token_size == 0) {
-    g_printerr ("wyctl: empty access token file\n");
-    return 2;
-  }
-  if (!normalize_access_token_file (access_token, access_token_size)) {
-    g_printerr ("wyctl: invalid access token file\n");
-    return 2;
-  }
+  int token_rc = load_access_token_file (opts.access_token_file, &access_token);
+  if (token_rc != 0)
+    return token_rc;
+
+  if (g_strcmp0 (command, "check") == 0)
+    return run_policy_check (global_opts, &opts, access_token);
 
   g_printerr ("wyctl: policy %s is not implemented\n", command);
   return 3;
 }
 
 static int
-run_policy (gint argc, gchar **argv)
+run_policy (const WyctlOptions *global_opts, gint argc, gchar **argv)
 {
   if (argc < 2) {
     g_printerr ("wyctl: missing policy command\n");
@@ -298,7 +367,8 @@ run_policy (gint argc, gchar **argv)
   }
 
   if (g_strcmp0 (argv[1], "check") == 0 || g_strcmp0 (argv[1], "explain") == 0)
-    return run_policy_decision_command (argv[1], argc - 1, argv + 1);
+    return run_policy_decision_command (global_opts, argv[1], argc - 1,
+        argv + 1);
 
   g_printerr ("wyctl: unknown policy command: %s\n", argv[1]);
   return 2;
@@ -342,7 +412,7 @@ main (int argc, char **argv)
   if (g_strcmp0 (argv[1], "status") == 0)
     return run_status (&opts, argc - 1, argv + 1);
   if (g_strcmp0 (argv[1], "policy") == 0)
-    return run_policy (argc - 1, argv + 1);
+    return run_policy (&opts, argc - 1, argv + 1);
 
   g_printerr ("wyctl: unknown command: %s\n", argv[1]);
   return 2;

--- a/wyrelog/wyl-client-private.h
+++ b/wyrelog/wyl-client-private.h
@@ -7,6 +7,7 @@
 #include "wyrelog/client.h"
 
 SoupSession *wyl_client_get_soup_session (WylClient * client);
+void wyl_client_set_timeout_ms (WylClient * client, guint timeout_ms);
 wyrelog_error_t wyl_client_send_message (WylClient * client,
     SoupMessage * message, GBytes ** out_body);
 

--- a/wyrelog/wyl-client.c
+++ b/wyrelog/wyl-client.c
@@ -14,6 +14,7 @@ struct _WylClient
   gchar *principal_state;
   gchar *session_state;
   SoupSession *session;
+  guint timeout_ms;
 };
 
 struct _WylClientDecision
@@ -164,6 +165,41 @@ wyl_client_get_soup_session (WylClient *client)
   return client->session;
 }
 
+void
+wyl_client_set_timeout_ms (WylClient *client, guint timeout_ms)
+{
+  g_return_if_fail (WYL_IS_CLIENT (client));
+  client->timeout_ms = timeout_ms;
+}
+
+typedef struct
+{
+  GCancellable *cancellable;
+  GCond cond;
+  GMutex mutex;
+  gboolean done;
+  guint timeout_ms;
+} WylClientTimeout;
+
+static gpointer
+client_timeout_thread_func (gpointer data)
+{
+  WylClientTimeout *timeout = data;
+
+  g_mutex_lock (&timeout->mutex);
+  gint64 deadline = g_get_monotonic_time () + (gint64) timeout->timeout_ms
+      * 1000;
+  while (!timeout->done) {
+    if (!g_cond_wait_until (&timeout->cond, &timeout->mutex, deadline))
+      break;
+  }
+  if (!timeout->done)
+    g_cancellable_cancel (timeout->cancellable);
+  g_mutex_unlock (&timeout->mutex);
+
+  return NULL;
+}
+
 wyrelog_error_t
 wyl_client_send_message (WylClient *client, SoupMessage *message,
     GBytes **out_body)
@@ -174,8 +210,31 @@ wyl_client_send_message (WylClient *client, SoupMessage *message,
   *out_body = NULL;
 
   g_autoptr (GError) error = NULL;
-  GBytes *body = soup_session_send_and_read (client->session, message, NULL,
-      &error);
+  g_autoptr (GCancellable) cancellable =
+      client->timeout_ms > 0 ? g_cancellable_new () : NULL;
+  WylClientTimeout timeout = {
+    .cancellable = cancellable,
+    .timeout_ms = client->timeout_ms,
+  };
+  GThread *timeout_thread = NULL;
+  if (cancellable != NULL) {
+    g_cond_init (&timeout.cond);
+    g_mutex_init (&timeout.mutex);
+    timeout_thread = g_thread_new ("wyl-client-timeout",
+        client_timeout_thread_func, &timeout);
+  }
+
+  GBytes *body = soup_session_send_and_read (client->session, message,
+      cancellable, &error);
+  if (timeout_thread != NULL) {
+    g_mutex_lock (&timeout.mutex);
+    timeout.done = TRUE;
+    g_cond_signal (&timeout.cond);
+    g_mutex_unlock (&timeout.mutex);
+    g_thread_join (timeout_thread);
+    g_mutex_clear (&timeout.mutex);
+    g_cond_clear (&timeout.cond);
+  }
   if (body == NULL)
     return WYRELOG_E_IO;
 

--- a/wyrelog/wyl-client.c
+++ b/wyrelog/wyl-client.c
@@ -69,6 +69,19 @@ wyl_client_init (WylClient *self)
   (void) self;
 }
 
+static gboolean
+credential_part_is_valid (const gchar *value)
+{
+  if (value == NULL || value[0] == '\0')
+    return FALSE;
+
+  for (const gchar * p = value; *p != '\0'; p++) {
+    if (g_ascii_isspace (*p) || g_ascii_iscntrl (*p))
+      return FALSE;
+  }
+  return TRUE;
+}
+
 wyrelog_error_t
 wyl_client_new (const gchar *base_url, WylClient **out_client)
 {
@@ -253,6 +266,22 @@ wyrelog_error_t
 wyl_client_login_skip_mfa (WylClient *client, const gchar *username)
 {
   return client_login_internal (client, username, NULL, TRUE);
+}
+
+wyrelog_error_t
+wyl_client_set_bearer_credentials (WylClient *client,
+    const gchar *access_token, const gchar *tenant)
+{
+  if (client == NULL || !WYL_IS_CLIENT (client) ||
+      !credential_part_is_valid (access_token) ||
+      !credential_part_is_valid (tenant))
+    return WYRELOG_E_INVALID;
+
+  wyl_client_clear_login_state (client);
+  client->access_token = g_strdup (access_token);
+  client->tenant = g_strdup (tenant);
+  client->selected_tenant = g_strdup (tenant);
+  return WYRELOG_E_OK;
 }
 
 wyrelog_error_t

--- a/wyrelog/wyl-client.c
+++ b/wyrelog/wyl-client.c
@@ -16,6 +16,13 @@ struct _WylClient
   SoupSession *session;
 };
 
+struct _WylClientDecision
+{
+  gint decision;
+  gchar *deny_reason;
+  gchar *deny_origin;
+};
+
 G_DEFINE_FINAL_TYPE (WylClient, wyl_client, G_TYPE_OBJECT);
 
 static gboolean parse_login_response_json (const gchar * data, gsize size,
@@ -517,8 +524,12 @@ json_parse_string (JsonCursor *cursor, gchar **out_string)
 }
 
 static gboolean
-json_parse_nullable_string (JsonCursor *cursor)
+json_parse_nullable_string_value (JsonCursor *cursor, gchar **out_value)
 {
+  if (out_value == NULL)
+    return FALSE;
+  *out_value = NULL;
+
   json_skip_ws (cursor);
   if (cursor->pos + 4 <= cursor->size &&
       memcmp (cursor->data + cursor->pos, "null", 4) == 0) {
@@ -526,8 +537,7 @@ json_parse_nullable_string (JsonCursor *cursor)
     return TRUE;
   }
 
-  g_autofree gchar *value = NULL;
-  return json_parse_string (cursor, &value);
+  return json_parse_string (cursor, out_value);
 }
 
 static gboolean
@@ -548,10 +558,12 @@ json_parse_decision (JsonCursor *cursor, gint *out_decision)
 }
 
 static gboolean
-parse_decide_response_json (const gchar *data, gsize size, gint *out_decision)
+parse_decide_response_json (const gchar *data, gsize size,
+    WylClientDecision **out_result)
 {
-  if (data == NULL || out_decision == NULL)
+  if (data == NULL || out_result == NULL)
     return FALSE;
+  *out_result = NULL;
 
   JsonCursor cursor = { data, size, 0 };
   if (!json_consume (&cursor, '{'))
@@ -561,6 +573,8 @@ parse_decide_response_json (const gchar *data, gsize size, gint *out_decision)
   gboolean have_deny_reason = FALSE;
   gboolean have_deny_origin = FALSE;
   gint decision = WYL_DECISION_DENY;
+  g_autofree gchar *deny_reason = NULL;
+  g_autofree gchar *deny_origin = NULL;
   json_skip_ws (&cursor);
   if (cursor.pos < cursor.size && cursor.data[cursor.pos] == '}')
     return FALSE;
@@ -578,9 +592,11 @@ parse_decide_response_json (const gchar *data, gsize size, gint *out_decision)
         g_strcmp0 (key, "deny_origin") == 0) {
       gboolean *seen = g_strcmp0 (key, "deny_reason") == 0 ?
           &have_deny_reason : &have_deny_origin;
+      gchar **target = g_strcmp0 (key, "deny_reason") == 0 ?
+          &deny_reason : &deny_origin;
       if (*seen)
         return FALSE;
-      if (!json_parse_nullable_string (&cursor))
+      if (!json_parse_nullable_string_value (&cursor, target))
         return FALSE;
       *seen = TRUE;
     } else {
@@ -603,8 +619,54 @@ parse_decide_response_json (const gchar *data, gsize size, gint *out_decision)
   if (!have_decision || !have_deny_reason || !have_deny_origin ||
       cursor.pos != cursor.size)
     return FALSE;
-  *out_decision = decision;
+
+  WylClientDecision *result = g_new0 (WylClientDecision, 1);
+  result->decision = decision;
+  result->deny_reason = g_steal_pointer (&deny_reason);
+  result->deny_origin = g_steal_pointer (&deny_origin);
+  *out_result = result;
   return TRUE;
+}
+
+void
+wyl_client_decision_free (WylClientDecision *result)
+{
+  if (result == NULL)
+    return;
+
+  g_free (result->deny_reason);
+  g_free (result->deny_origin);
+  g_free (result);
+}
+
+gint
+wyl_client_decision_get_decision (const WylClientDecision *result)
+{
+  return result != NULL ? result->decision : WYL_DECISION_DENY;
+}
+
+const gchar *
+wyl_client_decision_get_deny_reason (const WylClientDecision *result)
+{
+  return result != NULL ? result->deny_reason : NULL;
+}
+
+const gchar *
+wyl_client_decision_get_deny_origin (const WylClientDecision *result)
+{
+  return result != NULL ? result->deny_origin : NULL;
+}
+
+gchar *
+wyl_client_decision_dup_deny_reason (const WylClientDecision *result)
+{
+  return g_strdup (wyl_client_decision_get_deny_reason (result));
+}
+
+gchar *
+wyl_client_decision_dup_deny_origin (const WylClientDecision *result)
+{
+  return g_strdup (wyl_client_decision_get_deny_origin (result));
 }
 
 static gboolean
@@ -727,12 +789,14 @@ static wyrelog_error_t
 client_decide_request (WylClient *client, const gchar *user, const gchar *perm,
     const gchar *session_token, gboolean has_guard_context,
     gint64 guard_timestamp, const gchar *guard_loc_class, gint64 guard_risk,
-    gint *out_decision)
+    WylClientDecision **out_result)
 {
-  if (client == NULL || !WYL_IS_CLIENT (client) || user == NULL ||
-      perm == NULL || session_token == NULL || out_decision == NULL)
+  if (out_result == NULL)
     return WYRELOG_E_INVALID;
-  *out_decision = WYL_DECISION_DENY;
+  *out_result = NULL;
+  if (client == NULL || !WYL_IS_CLIENT (client) || user == NULL ||
+      perm == NULL || session_token == NULL)
+    return WYRELOG_E_INVALID;
   if (has_guard_context &&
       (guard_loc_class == NULL || guard_timestamp < 0 || guard_risk < 0 ||
           guard_risk > 100 || !wyl_guard_loc_class_is_valid (guard_loc_class)))
@@ -786,20 +850,48 @@ client_decide_request (WylClient *client, const gchar *user, const gchar *perm,
 
   gsize body_size = 0;
   const gchar *body_data = g_bytes_get_data (body, &body_size);
-  gint decision = WYL_DECISION_DENY;
-  if (!parse_decide_response_json (body_data, body_size, &decision))
+  g_autoptr (WylClientDecision) result = NULL;
+  if (!parse_decide_response_json (body_data, body_size, &result))
     return WYRELOG_E_IO;
 
-  *out_decision = decision;
+  *out_result = g_steal_pointer (&result);
   return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
+wyl_client_decide_ex (WylClient *client, const gchar *user, const gchar *perm,
+    const gchar *session_token, WylClientDecision **out_result)
+{
+  return client_decide_request (client, user, perm, session_token, FALSE, 0,
+      NULL, 0, out_result);
 }
 
 wyrelog_error_t
 wyl_client_decide (WylClient *client, const gchar *user, const gchar *perm,
     const gchar *session_token, gint *out_decision)
 {
-  return client_decide_request (client, user, perm, session_token, FALSE, 0,
-      NULL, 0, out_decision);
+  if (out_decision == NULL)
+    return WYRELOG_E_INVALID;
+  *out_decision = WYL_DECISION_DENY;
+
+  g_autoptr (WylClientDecision) result = NULL;
+  wyrelog_error_t rc =
+      wyl_client_decide_ex (client, user, perm, session_token, &result);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  *out_decision = wyl_client_decision_get_decision (result);
+  return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
+wyl_client_decide_with_guard_context_ex (WylClient *client, const gchar *user,
+    const gchar *perm, const gchar *session_token, gint64 guard_timestamp,
+    const gchar *guard_loc_class, gint64 guard_risk,
+    WylClientDecision **out_result)
+{
+  return client_decide_request (client, user, perm, session_token, TRUE,
+      guard_timestamp, guard_loc_class, guard_risk, out_result);
 }
 
 wyrelog_error_t
@@ -807,8 +899,19 @@ wyl_client_decide_with_guard_context (WylClient *client, const gchar *user,
     const gchar *perm, const gchar *session_token, gint64 guard_timestamp,
     const gchar *guard_loc_class, gint64 guard_risk, gint *out_decision)
 {
-  return client_decide_request (client, user, perm, session_token, TRUE,
-      guard_timestamp, guard_loc_class, guard_risk, out_decision);
+  if (out_decision == NULL)
+    return WYRELOG_E_INVALID;
+  *out_decision = WYL_DECISION_DENY;
+
+  g_autoptr (WylClientDecision) result = NULL;
+  wyrelog_error_t rc =
+      wyl_client_decide_with_guard_context_ex (client, user, perm,
+      session_token, guard_timestamp, guard_loc_class, guard_risk, &result);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  *out_decision = wyl_client_decision_get_decision (result);
+  return WYRELOG_E_OK;
 }
 
 wyrelog_error_t


### PR DESCRIPTION
## Summary

- expose structured policy decision results in the client API
- allow externally supplied bearer credentials for command clients
- add `wyctl policy check` and `wyctl policy explain` commands
- preserve bounded command timeouts and strict token-file validation

## Testing

- `meson test -C builddir --print-errorlogs`
- `meson test -C builddir-audit --print-errorlogs`
