### PR TITLE
wyctl: add audit query command

### DIFF
--- a/tests/test-client-smoke.c
+++ b/tests/test-client-smoke.c
@@ -837,6 +837,29 @@ main (void)
     return 204;
   g_clear_pointer (&decision_result, wyl_client_decision_free);
 
+  g_autoptr (WylAuditIter) bearer_guarded_audit_iter = NULL;
+  if (wyl_client_audit_query_with_guard_context (local_client,
+          "decision=deny", 321, "semi_trusted", 89, &bearer_guarded_audit_iter)
+      != WYRELOG_E_OK)
+    return 207;
+  g_autofree gchar *bearer_guarded_audit_uri =
+      wyl_audit_iter_dup_request_uri (bearer_guarded_audit_iter);
+  if (strstr (bearer_guarded_audit_uri, "/audit/events?") == NULL ||
+      strstr (bearer_guarded_audit_uri, "tenant=__wr_default") == NULL ||
+      strstr (bearer_guarded_audit_uri, "session_token=") != NULL ||
+      strstr (bearer_guarded_audit_uri, "guard_timestamp=321") == NULL ||
+      strstr (bearer_guarded_audit_uri,
+          "guard_loc_class=semi_trusted") == NULL ||
+      strstr (bearer_guarded_audit_uri, "guard_risk=89") == NULL ||
+      strstr (bearer_guarded_audit_uri, "filter=decision%3Ddeny") == NULL)
+    return 208;
+  g_autoptr (SoupMessage) bearer_guarded_audit_message =
+      wyl_audit_iter_new_request_message (bearer_guarded_audit_iter);
+  if (g_strcmp0 (soup_message_headers_get_one (soup_message_get_request_headers
+              (bearer_guarded_audit_message), "Authorization"),
+          "Bearer access-ctl") != 0)
+    return 209;
+
   http.body = "{\"session_token\":\"session-relogin\",\"username\":\"alice\","
       "\"tenant\":\"__wr_default\",\"principal_state\":\"authenticated\","
       "\"session_state\":\"active\",\"access_token\":\"access-relogin\"}";

--- a/tests/test-wyctl-basic.c
+++ b/tests/test-wyctl-basic.c
@@ -274,6 +274,274 @@ test_policy_help (void)
 }
 
 static void
+test_audit_help (void)
+{
+  gchar *argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "audit",
+    "query",
+    "--help",
+    NULL,
+  };
+  g_autofree gchar *stdout_buf = NULL;
+  g_autofree gchar *stderr_buf = NULL;
+  gint wait_status = 0;
+
+  run_child (argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_assert_true (wait_status_is_success (wait_status));
+  g_assert_nonnull (g_strstr_len (stdout_buf, -1, "--access-token-file"));
+  g_assert_nonnull (g_strstr_len (stdout_buf, -1, "--guard-timestamp"));
+  g_assert_nonnull (g_strstr_len (stdout_buf, -1, "--guard-loc-class"));
+  g_assert_nonnull (g_strstr_len (stdout_buf, -1, "--guard-risk"));
+  g_assert_cmpstr (stderr_buf, ==, "");
+}
+
+static void
+test_audit_validation (void)
+{
+  g_autofree gchar *token_path = NULL;
+  g_autoptr (GError) error = NULL;
+  gint fd = g_file_open_tmp ("wyctl-audit-token-XXXXXX", &token_path, &error);
+  g_assert_no_error (error);
+  g_assert_cmpint (fd, >=, 0);
+  g_assert_true (g_close (fd, NULL));
+  g_assert_true (g_file_set_contents (token_path, "token-1\n", -1, &error));
+  g_assert_no_error (error);
+
+  gchar *missing_daemon_argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "audit",
+    "query",
+    "--access-token-file",
+    token_path,
+    "--guard-timestamp",
+    "123",
+    "--guard-loc-class",
+    "public",
+    "--guard-risk",
+    "69",
+    NULL,
+  };
+  gchar *invalid_daemon_argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "--daemon-url",
+    "file:///tmp/wyrelog",
+    "audit",
+    "query",
+    "--access-token-file",
+    token_path,
+    "--guard-timestamp",
+    "123",
+    "--guard-loc-class",
+    "public",
+    "--guard-risk",
+    "69",
+    NULL,
+  };
+  gchar *missing_timestamp_argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "--daemon-url",
+    "http://127.0.0.1:1",
+    "audit",
+    "query",
+    "--access-token-file",
+    token_path,
+    "--guard-loc-class",
+    "public",
+    "--guard-risk",
+    "69",
+    NULL,
+  };
+  gchar *invalid_loc_argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "--daemon-url",
+    "http://127.0.0.1:1",
+    "audit",
+    "query",
+    "--access-token-file",
+    token_path,
+    "--guard-timestamp",
+    "123",
+    "--guard-loc-class",
+    "unknown",
+    "--guard-risk",
+    "69",
+    NULL,
+  };
+  gchar *invalid_risk_argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "--daemon-url",
+    "http://127.0.0.1:1",
+    "audit",
+    "query",
+    "--access-token-file",
+    token_path,
+    "--guard-timestamp",
+    "123",
+    "--guard-loc-class",
+    "public",
+    "--guard-risk",
+    "101",
+    NULL,
+  };
+  gchar *invalid_limit_argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "--daemon-url",
+    "http://127.0.0.1:1",
+    "audit",
+    "query",
+    "--access-token-file",
+    token_path,
+    "--guard-timestamp",
+    "123",
+    "--guard-loc-class",
+    "public",
+    "--guard-risk",
+    "69",
+    "--limit",
+    "0",
+    NULL,
+  };
+  gchar *missing_token_argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "--daemon-url",
+    "http://127.0.0.1:1",
+    "audit",
+    "query",
+    "--guard-timestamp",
+    "123",
+    "--guard-loc-class",
+    "public",
+    "--guard-risk",
+    "69",
+    NULL,
+  };
+  gchar *extra_argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "--daemon-url",
+    "http://127.0.0.1:1",
+    "audit",
+    "query",
+    "--access-token-file",
+    token_path,
+    "--guard-timestamp",
+    "123",
+    "--guard-loc-class",
+    "public",
+    "--guard-risk",
+    "69",
+    "extra",
+    NULL,
+  };
+  gchar *valid_scaffold_argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "--daemon-url",
+    "http://127.0.0.1:1",
+    "audit",
+    "query",
+    "--access-token-file",
+    token_path,
+    "--guard-timestamp",
+    "123",
+    "--guard-loc-class",
+    "public",
+    "--guard-risk",
+    "69",
+    "--filter",
+    "decision=deny",
+    "--limit",
+    "10",
+    NULL,
+  };
+  gchar *unknown_argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "audit",
+    "unknown",
+    NULL,
+  };
+  g_autofree gchar *stdout_buf = NULL;
+  g_autofree gchar *stderr_buf = NULL;
+  gint wait_status = 0;
+
+  run_child (missing_daemon_argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_assert_false (wait_status_is_success (wait_status));
+  g_assert_cmpstr (stdout_buf, ==, "");
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1, "wyctl: missing daemon URL"));
+
+  g_clear_pointer (&stdout_buf, g_free);
+  g_clear_pointer (&stderr_buf, g_free);
+  run_child (invalid_daemon_argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_assert_false (wait_status_is_success (wait_status));
+  g_assert_cmpstr (stdout_buf, ==, "");
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1, "wyctl: invalid daemon URL"));
+
+  g_clear_pointer (&stdout_buf, g_free);
+  g_clear_pointer (&stderr_buf, g_free);
+  run_child (missing_timestamp_argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_assert_false (wait_status_is_success (wait_status));
+  g_assert_cmpstr (stdout_buf, ==, "");
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1,
+          "wyctl: invalid --guard-timestamp"));
+
+  g_clear_pointer (&stdout_buf, g_free);
+  g_clear_pointer (&stderr_buf, g_free);
+  run_child (invalid_loc_argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_assert_false (wait_status_is_success (wait_status));
+  g_assert_cmpstr (stdout_buf, ==, "");
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1,
+          "wyctl: invalid --guard-loc-class"));
+
+  g_clear_pointer (&stdout_buf, g_free);
+  g_clear_pointer (&stderr_buf, g_free);
+  run_child (invalid_risk_argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_assert_false (wait_status_is_success (wait_status));
+  g_assert_cmpstr (stdout_buf, ==, "");
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1,
+          "wyctl: invalid --guard-risk"));
+
+  g_clear_pointer (&stdout_buf, g_free);
+  g_clear_pointer (&stderr_buf, g_free);
+  run_child (invalid_limit_argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_assert_false (wait_status_is_success (wait_status));
+  g_assert_cmpstr (stdout_buf, ==, "");
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1, "wyctl: invalid --limit"));
+
+  g_clear_pointer (&stdout_buf, g_free);
+  g_clear_pointer (&stderr_buf, g_free);
+  run_child (missing_token_argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_assert_false (wait_status_is_success (wait_status));
+  g_assert_cmpstr (stdout_buf, ==, "");
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1,
+          "wyctl: missing --access-token-file"));
+
+  g_clear_pointer (&stdout_buf, g_free);
+  g_clear_pointer (&stderr_buf, g_free);
+  run_child (extra_argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_assert_false (wait_status_is_success (wait_status));
+  g_assert_cmpstr (stdout_buf, ==, "");
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1,
+          "wyctl: unexpected audit query argument"));
+
+  g_clear_pointer (&stdout_buf, g_free);
+  g_clear_pointer (&stderr_buf, g_free);
+  run_child (valid_scaffold_argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_assert_false (wait_status_is_success (wait_status));
+  g_assert_cmpstr (stdout_buf, ==, "");
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1,
+          "wyctl: audit query is not implemented"));
+
+  g_clear_pointer (&stdout_buf, g_free);
+  g_clear_pointer (&stderr_buf, g_free);
+  run_child (unknown_argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_assert_false (wait_status_is_success (wait_status));
+  g_assert_cmpstr (stdout_buf, ==, "");
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1,
+          "wyctl: unknown audit command"));
+
+  g_unlink (token_path);
+}
+
+static void
 test_policy_validation (void)
 {
   g_autofree gchar *token_path = NULL;
@@ -775,6 +1043,8 @@ main (int argc, char **argv)
   g_test_add_func ("/wyctl/policy-help", test_policy_help);
   g_test_add_func ("/wyctl/policy-validation", test_policy_validation);
   g_test_add_func ("/wyctl/policy-check", test_policy_check);
+  g_test_add_func ("/wyctl/audit-help", test_audit_help);
+  g_test_add_func ("/wyctl/audit-validation", test_audit_validation);
 
   return g_test_run ();
 }

--- a/tests/test-wyctl-basic.c
+++ b/tests/test-wyctl-basic.c
@@ -527,8 +527,7 @@ test_audit_validation (void)
   run_child (valid_scaffold_argv, &stdout_buf, &stderr_buf, &wait_status);
   g_assert_false (wait_status_is_success (wait_status));
   g_assert_cmpstr (stdout_buf, ==, "");
-  g_assert_nonnull (g_strstr_len (stderr_buf, -1,
-          "wyctl: audit query is not implemented"));
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1, "wyctl: audit query failed"));
 
   g_clear_pointer (&stdout_buf, g_free);
   g_clear_pointer (&stderr_buf, g_free);
@@ -1023,6 +1022,116 @@ test_policy_check (void)
       "deny\nreason=missing_grant\norigin=policy\n", TRUE, 0, "1000");
 }
 
+static void
+run_audit_query_case (const gchar *response_body, const gchar *expected_output,
+    guint delay_us, const gchar *timeout_ms, const gchar *limit)
+{
+  g_autofree gchar *token_path = NULL;
+  g_autoptr (GError) error = NULL;
+  gint fd = g_file_open_tmp ("wyctl-audit-token-XXXXXX", &token_path, &error);
+  g_assert_no_error (error);
+  g_assert_cmpint (fd, >=, 0);
+  g_assert_true (g_close (fd, NULL));
+  g_assert_true (g_file_set_contents (token_path, "token-1\n", -1, &error));
+  g_assert_no_error (error);
+
+  g_autoptr (GSocketListener) listener = NULL;
+  g_autofree gchar *daemon_url = listen_url_for_policy_server (&listener);
+  PolicyCheckServer server = {
+    .listener = listener,
+    .response_body = response_body,
+    .delay_us = delay_us,
+  };
+  GThread *server_thread = g_thread_new ("audit-query",
+      policy_check_server_thread, &server);
+  gchar *argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "--daemon-url",
+    daemon_url,
+    "--timeout-ms",
+    (gchar *) timeout_ms,
+    "audit",
+    "query",
+    "--access-token-file",
+    token_path,
+    "--guard-timestamp",
+    "123",
+    "--guard-loc-class",
+    "public",
+    "--guard-risk",
+    "69",
+    "--filter",
+    "decision=deny",
+    "--limit",
+    (gchar *) limit,
+    NULL,
+  };
+  g_autofree gchar *stdout_buf = NULL;
+  g_autofree gchar *stderr_buf = NULL;
+  gint wait_status = 0;
+
+  run_child (argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_thread_join (server_thread);
+
+  g_assert_cmpint (wait_status_is_success (wait_status),
+      ==, expected_output[0] != '\0');
+  g_assert_cmpstr (stdout_buf, ==, expected_output);
+  if (expected_output[0] != '\0')
+    g_assert_cmpstr (stderr_buf, ==, "");
+  else
+    g_assert_nonnull (g_strstr_len (stderr_buf, -1,
+            "wyctl: audit query failed"));
+  g_assert_nonnull (server.request);
+  g_assert_nonnull (g_strstr_len (server.request, -1, "GET /audit/events?"));
+  g_assert_nonnull (g_strstr_len (server.request, -1, "tenant=__wr_default"));
+  g_assert_nonnull (g_strstr_len (server.request, -1, "guard_timestamp=123"));
+  g_assert_nonnull (g_strstr_len (server.request, -1,
+          "guard_loc_class=public"));
+  g_assert_nonnull (g_strstr_len (server.request, -1, "guard_risk=69"));
+  g_assert_nonnull (g_strstr_len (server.request, -1,
+          "filter=decision%3Ddeny"));
+  g_assert_null (g_strstr_len (server.request, -1, "session_token="));
+  g_assert_nonnull (g_strstr_len (server.request, -1,
+          "Authorization: Bearer token-1"));
+
+  g_free (server.request);
+  g_unlink (token_path);
+}
+
+static void
+test_audit_query (void)
+{
+  run_audit_query_case
+      ("[{\"id\":\"018f3f9b-7f4d-7a2e-8a51-467a0bc7d001\","
+      "\"created_at_us\":1234567,"
+      "\"subject_id\":\"ali\\nce\","
+      "\"action\":\"read\","
+      "\"resource_id\":\"doc/42\","
+      "\"deny_reason\":null,"
+      "\"deny_origin\":null,"
+      "\"request_id\":null,"
+      "\"decision\":1},"
+      "{\"id\":\"018f3f9b-7f4d-7a2e-8a51-467a0bc7d002\","
+      "\"created_at_us\":1234568,"
+      "\"subject_id\":\"bob\","
+      "\"action\":\"write\","
+      "\"resource_id\":\"doc/43\","
+      "\"deny_reason\":\"missing_grant\","
+      "\"deny_origin\":\"policy\","
+      "\"request_id\":\"req-audit\","
+      "\"decision\":0}]",
+      "[{\"id\":\"018f3f9b-7f4d-7a2e-8a51-467a0bc7d001\","
+      "\"created_at_us\":1234567,"
+      "\"subject_id\":\"ali\\nce\","
+      "\"action\":\"read\","
+      "\"resource_id\":\"doc/42\","
+      "\"deny_reason\":null,"
+      "\"deny_origin\":null,"
+      "\"request_id\":null," "\"decision\":1}]\n", 0, "1000", "1");
+  run_audit_query_case ("[]", "[]\n", 0, "1000", "100");
+  run_audit_query_case ("[]", "", 250 * 1000, "50", "100");
+}
+
 int
 main (int argc, char **argv)
 {
@@ -1045,6 +1154,7 @@ main (int argc, char **argv)
   g_test_add_func ("/wyctl/policy-check", test_policy_check);
   g_test_add_func ("/wyctl/audit-help", test_audit_help);
   g_test_add_func ("/wyctl/audit-validation", test_audit_validation);
+  g_test_add_func ("/wyctl/audit-query", test_audit_query);
 
   return g_test_run ();
 }

--- a/wyrelog/audit/iter.c
+++ b/wyrelog/audit/iter.c
@@ -90,10 +90,11 @@ wyl_client_audit_query_with_guard_context (WylClient *client,
       guard_risk > 100 || !wyl_guard_loc_class_is_valid (guard_loc_class))
     return WYRELOG_E_INVALID;
 
-  g_autofree gchar *session_token = wyl_client_dup_session_token (client);
-  if (session_token == NULL || session_token[0] == '\0')
-    return WYRELOG_E_INVALID;
   g_autofree gchar *access_token = wyl_client_dup_access_token (client);
+  g_autofree gchar *session_token = wyl_client_dup_session_token (client);
+  if ((access_token == NULL || access_token[0] == '\0') &&
+      (session_token == NULL || session_token[0] == '\0'))
+    return WYRELOG_E_INVALID;
   g_autofree gchar *tenant = wyl_client_dup_tenant (client);
   if (tenant == NULL || tenant[0] == '\0')
     return WYRELOG_E_INVALID;

--- a/wyrelog/wyctl/wyctl.c
+++ b/wyrelog/wyctl/wyctl.c
@@ -9,6 +9,7 @@
 #include "wyrelog/decide.h"
 #include "wyrelog/version.h"
 #include "wyrelog/wyl-client-private.h"
+#include "wyrelog/wyl-permission-scope-private.h"
 
 typedef struct
 {
@@ -25,8 +26,20 @@ typedef struct
   gchar *access_token_file;
 } WyctlPolicyOptions;
 
+typedef struct
+{
+  gchar *filter;
+  gchar *limit_arg;
+  gchar *access_token_file;
+  gchar *guard_timestamp_arg;
+  gchar *guard_loc_class;
+  gchar *guard_risk_arg;
+} WyctlAuditOptions;
+
 #define WYCTL_DEFAULT_TIMEOUT_MS 2000
 #define WYCTL_MAX_TIMEOUT_MS 60000
+#define WYCTL_AUDIT_DEFAULT_LIMIT 100
+#define WYCTL_AUDIT_MAX_LIMIT 100
 
 typedef struct
 {
@@ -77,6 +90,45 @@ parse_timeout_ms (const gchar *raw, guint *out_timeout_ms)
     return FALSE;
 
   *out_timeout_ms = (guint) parsed;
+  return TRUE;
+}
+
+static gboolean
+parse_nonnegative_int64 (const gchar *raw, gint64 *out_value)
+{
+  if (raw == NULL || raw[0] == '\0' || out_value == NULL)
+    return FALSE;
+
+  errno = 0;
+  gchar *end = NULL;
+  gint64 parsed = g_ascii_strtoll (raw, &end, 10);
+  if (errno != 0 || end == raw || *end != '\0' || parsed < 0)
+    return FALSE;
+
+  *out_value = parsed;
+  return TRUE;
+}
+
+static gboolean
+parse_audit_limit (const gchar *raw, guint *out_limit)
+{
+  if (out_limit == NULL)
+    return FALSE;
+  if (raw == NULL) {
+    *out_limit = WYCTL_AUDIT_DEFAULT_LIMIT;
+    return TRUE;
+  }
+  if (raw[0] == '\0')
+    return FALSE;
+
+  errno = 0;
+  gchar *end = NULL;
+  gint64 parsed = g_ascii_strtoll (raw, &end, 10);
+  if (errno != 0 || end == raw || *end != '\0' || parsed < 1 ||
+      parsed > WYCTL_AUDIT_MAX_LIMIT)
+    return FALSE;
+
+  *out_limit = (guint) parsed;
   return TRUE;
 }
 
@@ -421,6 +473,105 @@ run_policy (const WyctlOptions *global_opts, gint argc, gchar **argv)
   return 2;
 }
 
+static int
+run_audit_query (const WyctlOptions *global_opts, gint argc, gchar **argv)
+{
+  WyctlAuditOptions opts = { 0 };
+  GOptionEntry entries[] = {
+    {"filter", 0, 0, G_OPTION_ARG_STRING, &opts.filter,
+        "Audit event filter", "FILTER"},
+    {"limit", 0, 0, G_OPTION_ARG_STRING, &opts.limit_arg,
+        "Maximum events to print", "N"},
+    {"access-token-file", 0, 0, G_OPTION_ARG_STRING, &opts.access_token_file,
+        "Bearer access token file", "PATH"},
+    {"guard-timestamp", 0, 0, G_OPTION_ARG_STRING,
+        &opts.guard_timestamp_arg, "Guard timestamp", "US"},
+    {"guard-loc-class", 0, 0, G_OPTION_ARG_STRING, &opts.guard_loc_class,
+        "Guard location class", "CLASS"},
+    {"guard-risk", 0, 0, G_OPTION_ARG_STRING, &opts.guard_risk_arg,
+        "Guard risk score", "N"},
+    {NULL}
+  };
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GOptionContext) context =
+      g_option_context_new ("- wyrelog audit query");
+  g_option_context_add_main_entries (context, entries, NULL);
+
+  if (!g_option_context_parse (context, &argc, &argv, &error)) {
+    g_printerr ("wyctl: %s\n", error->message);
+    return 2;
+  }
+  if (argc > 1) {
+    g_printerr ("wyctl: unexpected audit query argument: %s\n", argv[1]);
+    return 2;
+  }
+
+  if (global_opts->daemon_url == NULL || global_opts->daemon_url[0] == '\0') {
+    g_printerr ("wyctl: missing daemon URL\n");
+    return 2;
+  }
+  if (!daemon_url_is_valid (global_opts->daemon_url)) {
+    g_printerr ("wyctl: invalid daemon URL\n");
+    return 2;
+  }
+
+  guint timeout_ms = 0;
+  if (!parse_timeout_ms (global_opts->timeout_ms_arg, &timeout_ms)) {
+    g_printerr ("wyctl: invalid timeout\n");
+    return 2;
+  }
+
+  gint64 guard_timestamp = 0;
+  if (!parse_nonnegative_int64 (opts.guard_timestamp_arg, &guard_timestamp)) {
+    g_printerr ("wyctl: invalid --guard-timestamp\n");
+    return 2;
+  }
+  if (opts.guard_loc_class == NULL ||
+      !wyl_guard_loc_class_is_valid (opts.guard_loc_class)) {
+    g_printerr ("wyctl: invalid --guard-loc-class\n");
+    return 2;
+  }
+  gint64 guard_risk = 0;
+  if (!parse_nonnegative_int64 (opts.guard_risk_arg, &guard_risk) ||
+      guard_risk > 100) {
+    g_printerr ("wyctl: invalid --guard-risk\n");
+    return 2;
+  }
+  guint limit = 0;
+  if (!parse_audit_limit (opts.limit_arg, &limit)) {
+    g_printerr ("wyctl: invalid --limit\n");
+    return 2;
+  }
+
+  g_autofree gchar *access_token = NULL;
+  int token_rc = load_access_token_file (opts.access_token_file, &access_token);
+  if (token_rc != 0)
+    return token_rc;
+
+  (void) timeout_ms;
+  (void) guard_timestamp;
+  (void) guard_risk;
+  (void) limit;
+  (void) access_token;
+  g_printerr ("wyctl: audit query is not implemented\n");
+  return 3;
+}
+
+static int
+run_audit (const WyctlOptions *global_opts, gint argc, gchar **argv)
+{
+  if (argc < 2) {
+    g_printerr ("wyctl: missing audit command\n");
+    return 2;
+  }
+
+  if (g_strcmp0 (argv[1], "query") == 0)
+    return run_audit_query (global_opts, argc - 1, argv + 1);
+
+  g_printerr ("wyctl: unknown audit command: %s\n", argv[1]);
+  return 2;
+}
+
 int
 main (int argc, char **argv)
 {
@@ -460,6 +611,8 @@ main (int argc, char **argv)
     return run_status (&opts, argc - 1, argv + 1);
   if (g_strcmp0 (argv[1], "policy") == 0)
     return run_policy (&opts, argc - 1, argv + 1);
+  if (g_strcmp0 (argv[1], "audit") == 0)
+    return run_audit (&opts, argc - 1, argv + 1);
 
   g_printerr ("wyctl: unknown command: %s\n", argv[1]);
   return 2;

--- a/wyrelog/wyctl/wyctl.c
+++ b/wyrelog/wyctl/wyctl.c
@@ -165,6 +165,87 @@ normalize_access_token_file (gchar *access_token, gsize access_token_size)
   return TRUE;
 }
 
+static void
+append_json_string (GString *json, const gchar *value)
+{
+  g_string_append_c (json, '"');
+  for (const guchar * p = (const guchar *)value; p != NULL && *p != '\0'; p++) {
+    switch (*p) {
+      case '"':
+        g_string_append (json, "\\\"");
+        break;
+      case '\\':
+        g_string_append (json, "\\\\");
+        break;
+      case '\b':
+        g_string_append (json, "\\b");
+        break;
+      case '\f':
+        g_string_append (json, "\\f");
+        break;
+      case '\n':
+        g_string_append (json, "\\n");
+        break;
+      case '\r':
+        g_string_append (json, "\\r");
+        break;
+      case '\t':
+        g_string_append (json, "\\t");
+        break;
+      default:
+        if (*p < 0x20)
+          g_string_append_printf (json, "\\u%04x", (guint) * p);
+        else
+          g_string_append_c (json, (gchar) * p);
+        break;
+    }
+  }
+  g_string_append_c (json, '"');
+}
+
+static void
+append_json_nullable_string_member (GString *json, const gchar *name,
+    const gchar *value)
+{
+  append_json_string (json, name);
+  g_string_append_c (json, ':');
+  if (value == NULL)
+    g_string_append (json, "null");
+  else
+    append_json_string (json, value);
+}
+
+static void
+append_audit_event_json (GString *json, const WylAuditEvent *event)
+{
+  g_autofree gchar *id = wyl_audit_event_dup_id_string (event);
+
+  g_string_append_c (json, '{');
+  append_json_nullable_string_member (json, "id", id);
+  g_string_append_printf (json, ",\"created_at_us\":%" G_GINT64_FORMAT,
+      wyl_audit_event_get_created_at_us (event));
+  g_string_append_c (json, ',');
+  append_json_nullable_string_member (json, "subject_id",
+      wyl_audit_event_get_subject_id (event));
+  g_string_append_c (json, ',');
+  append_json_nullable_string_member (json, "action",
+      wyl_audit_event_get_action (event));
+  g_string_append_c (json, ',');
+  append_json_nullable_string_member (json, "resource_id",
+      wyl_audit_event_get_resource_id (event));
+  g_string_append_c (json, ',');
+  append_json_nullable_string_member (json, "deny_reason",
+      wyl_audit_event_get_deny_reason (event));
+  g_string_append_c (json, ',');
+  append_json_nullable_string_member (json, "deny_origin",
+      wyl_audit_event_get_deny_origin (event));
+  g_string_append_c (json, ',');
+  append_json_nullable_string_member (json, "request_id",
+      wyl_audit_event_get_request_id (event));
+  g_string_append_printf (json, ",\"decision\":%d}",
+      wyl_audit_event_get_decision (event));
+}
+
 static gchar *
 build_healthz_uri (const gchar *daemon_url)
 {
@@ -548,13 +629,48 @@ run_audit_query (const WyctlOptions *global_opts, gint argc, gchar **argv)
   if (token_rc != 0)
     return token_rc;
 
-  (void) timeout_ms;
-  (void) guard_timestamp;
-  (void) guard_risk;
-  (void) limit;
-  (void) access_token;
-  g_printerr ("wyctl: audit query is not implemented\n");
-  return 3;
+  g_autoptr (WylClient) client = NULL;
+  if (wyl_client_new (global_opts->daemon_url, &client) != WYRELOG_E_OK ||
+      wyl_client_set_bearer_credentials (client, access_token,
+          "__wr_default") != WYRELOG_E_OK) {
+    g_printerr ("wyctl: invalid audit credentials\n");
+    return 2;
+  }
+  wyl_client_set_timeout_ms (client, timeout_ms);
+
+  g_autoptr (WylAuditIter) iter = NULL;
+  wyrelog_error_t query_rc = wyl_client_audit_query_with_guard_context (client,
+      opts.filter, guard_timestamp, opts.guard_loc_class, guard_risk, &iter);
+  if (query_rc != WYRELOG_E_OK) {
+    g_printerr ("wyctl: audit query failed\n");
+    return 3;
+  }
+
+  g_autoptr (GString) json = g_string_new ("[");
+  guint emitted = 0;
+  gboolean has_next = FALSE;
+  while (emitted < limit) {
+    wyrelog_error_t next_rc = wyl_audit_iter_next (iter, &has_next);
+    if (next_rc != WYRELOG_E_OK) {
+      g_printerr ("wyctl: audit query failed\n");
+      return 3;
+    }
+    if (!has_next)
+      break;
+
+    g_autoptr (WylAuditEvent) event = wyl_audit_iter_ref_event (iter);
+    if (event == NULL) {
+      g_printerr ("wyctl: audit query failed\n");
+      return 3;
+    }
+    if (emitted > 0)
+      g_string_append_c (json, ',');
+    append_audit_event_json (json, event);
+    emitted++;
+  }
+  g_string_append (json, "]\n");
+  g_print ("%s", json->str);
+  return 0;
 }
 
 static int


### PR DESCRIPTION
## Summary

- allow guarded audit queries to use bearer-only client credentials
- add `wyctl audit query` parsing with explicit guard context validation
- emit bounded compact JSON from the existing audit iterator
- cover request shape, authorization, output limits, escaping, and timeout failure

## Testing

- `meson test -C builddir --print-errorlogs`
- `meson test -C builddir-audit --print-errorlogs`
