### PR TITLE
Add structured runtime status reporting

### DIFF
--- a/tests/check-wyctl-status-daemon.sh
+++ b/tests/check-wyctl-status-daemon.sh
@@ -40,6 +40,19 @@ while [ "$i" -lt 150 ]; do
   if "$WYCTL" --daemon-url "$BASE_URL" --timeout-ms 500 status \
       >"$OUT" 2>"$ERR"; then
     if [ "$(cat "$OUT")" = "ok" ] && [ ! -s "$ERR" ]; then
+      if ! "$WYCTL" --daemon-url "$BASE_URL" --timeout-ms 500 status \
+          --readiness >"$OUT" 2>"$ERR"; then
+        echo "wyctl readiness status failed" >&2
+        cat "$OUT" >&2
+        cat "$ERR" >&2
+        exit 1
+      fi
+      if [ "$(cat "$OUT")" != "status=ready" ] || [ -s "$ERR" ]; then
+        echo "wyctl readiness status returned unexpected output" >&2
+        cat "$OUT" >&2
+        cat "$ERR" >&2
+        exit 1
+      fi
       kill -TERM "$PID"
       wait "$PID"
       PID=

--- a/tests/test-boot-smoke.c
+++ b/tests/test-boot-smoke.c
@@ -31,6 +31,15 @@ main (void)
   /* Non-zero count with NULL seq is an invalid argument. */
   if (wyl_boot_run (NULL, 1, NULL) != WYRELOG_E_INVALID)
     return 2;
+  if (g_strcmp0 (wyl_boot_phase_failure_code (BOOT_01_TPM_PROBE),
+          "boot_tpm_probe_failed") != 0)
+    return 9;
+  if (g_strcmp0 (wyl_boot_phase_failure_code (BOOT_02_DEK_UNSEAL),
+          "boot_dek_unseal_failed") != 0)
+    return 10;
+  if (g_strcmp0 (wyl_boot_phase_failure_code (BOOT_LAST),
+          "boot_phase_failed") != 0)
+    return 11;
 
   /* All-success sequence runs every phase and returns OK. */
   call_count = 0;

--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -300,11 +300,25 @@ check_readyz_runtime_liveness_contract (const gchar *base_url,
     return 1905;
 
   g_clear_pointer (&body, g_free);
+  if (send_raw_path (session, "GET", base_url, "/healthz?format=json", &status,
+          &body) != 0)
+    return 1921;
+  if (status != 200 || strstr (body, "\"status\":\"ok\"") == NULL)
+    return 1922;
+
+  g_clear_pointer (&body, g_free);
   if (send_raw_path (session, "GET", base_url, "/readyz", &status, &body)
       != 0)
     return 1906;
   if (status != 200 || strstr (body, "ready") == NULL)
     return 1907;
+
+  g_clear_pointer (&body, g_free);
+  if (send_raw_path (session, "GET", base_url, "/readyz?format=json", &status,
+          &body) != 0)
+    return 1923;
+  if (status != 200 || strstr (body, "\"status\":\"ready\"") == NULL)
+    return 1924;
 
   g_atomic_int_set (&runtime->delta_session_live, FALSE);
   g_clear_pointer (&body, g_free);
@@ -314,6 +328,14 @@ check_readyz_runtime_liveness_contract (const gchar *base_url,
   if (status != 503 || strstr (body, "\"delta_not_ready\"") == NULL)
     return 1909;
 
+  g_clear_pointer (&body, g_free);
+  if (send_raw_path (session, "GET", base_url, "/readyz?format=json", &status,
+          &body) != 0)
+    return 1925;
+  if (status != 503 || strstr (body, "\"status\":\"not_ready\"") == NULL ||
+      strstr (body, "\"reason\":\"delta_not_ready\"") == NULL)
+    return 1926;
+
   g_atomic_int_set (&runtime->delta_session_live, TRUE);
   g_atomic_int_set (&runtime->audit_degraded, TRUE);
   g_clear_pointer (&body, g_free);
@@ -322,6 +344,14 @@ check_readyz_runtime_liveness_contract (const gchar *base_url,
     return 1910;
   if (status != 503 || strstr (body, "\"audit_degraded\"") == NULL)
     return 1911;
+
+  g_clear_pointer (&body, g_free);
+  if (send_raw_path (session, "GET", base_url, "/readyz?format=json", &status,
+          &body) != 0)
+    return 1927;
+  if (status != 503 || strstr (body, "\"status\":\"not_ready\"") == NULL ||
+      strstr (body, "\"reason\":\"audit_degraded\"") == NULL)
+    return 1928;
 
   g_atomic_int_set (&runtime->audit_degraded, FALSE);
   g_clear_pointer (&body, g_free);

--- a/tests/test-wyctl-basic.c
+++ b/tests/test-wyctl-basic.c
@@ -114,6 +114,14 @@ typedef struct
   GSocketListener *listener;
 } SlowHealthzServer;
 
+typedef struct
+{
+  GSocketListener *listener;
+  guint status;
+  const gchar *body;
+  gchar *request;
+} StatusProbeServer;
+
 static gpointer
 slow_healthz_server_thread (gpointer data)
 {
@@ -135,6 +143,59 @@ slow_healthz_server_thread (gpointer data)
   (void) g_io_stream_close (G_IO_STREAM (conn), NULL, NULL);
 
   return NULL;
+}
+
+static gpointer
+status_probe_server_thread (gpointer data)
+{
+  StatusProbeServer *server = data;
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GSocketConnection) conn =
+      g_socket_listener_accept (server->listener, NULL, NULL, &error);
+  if (conn == NULL)
+    return NULL;
+
+  gchar buffer[1024];
+  GInputStream *input = g_io_stream_get_input_stream (G_IO_STREAM (conn));
+  GOutputStream *output = g_io_stream_get_output_stream (G_IO_STREAM (conn));
+  gssize n = g_input_stream_read (input, buffer, sizeof buffer - 1, NULL, NULL);
+  if (n > 0) {
+    buffer[n] = '\0';
+    server->request = g_strdup (buffer);
+  }
+
+  const gchar *body = server->body != NULL ? server->body : "{}";
+  g_autofree gchar *response =
+      g_strdup_printf ("HTTP/1.1 %u OK\r\nContent-Type: application/json\r\n"
+      "Content-Length: %" G_GSIZE_FORMAT "\r\n\r\n%s",
+      server->status, strlen (body), body);
+  (void) g_output_stream_write (output, response, strlen (response), NULL,
+      NULL);
+  (void) g_io_stream_close (G_IO_STREAM (conn), NULL, NULL);
+  return NULL;
+}
+
+static gchar *
+listen_url_for_test_server (GSocketListener **out_listener)
+{
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GSocketListener) listener = g_socket_listener_new ();
+  g_autoptr (GInetAddress) address =
+      g_inet_address_new_loopback (G_SOCKET_FAMILY_IPV4);
+  g_autoptr (GSocketAddress) socket_address =
+      g_inet_socket_address_new (address, 0);
+  g_autoptr (GSocketAddress) effective_address = NULL;
+
+  g_assert_true (g_socket_listener_add_address (listener, socket_address,
+          G_SOCKET_TYPE_STREAM, G_SOCKET_PROTOCOL_TCP, NULL, &effective_address,
+          &error));
+  g_assert_no_error (error);
+
+  guint16 port =
+      g_inet_socket_address_get_port (G_INET_SOCKET_ADDRESS
+      (effective_address));
+  *out_listener = g_steal_pointer (&listener);
+  return g_strdup_printf ("http://127.0.0.1:%u", port);
 }
 
 static void
@@ -187,6 +248,67 @@ test_status_times_out (void)
 }
 
 static void
+run_status_readiness_case (guint status, const gchar *body,
+    const gchar *expected_output, gboolean expect_success,
+    const gchar *expected_error)
+{
+  g_autoptr (GSocketListener) listener = NULL;
+  g_autofree gchar *daemon_url = listen_url_for_test_server (&listener);
+  StatusProbeServer server = {
+    .listener = listener,
+    .status = status,
+    .body = body,
+  };
+  GThread *server_thread = g_thread_new ("status-readiness",
+      status_probe_server_thread, &server);
+  gchar *argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "--daemon-url",
+    daemon_url,
+    "--timeout-ms",
+    "1000",
+    "status",
+    "--readiness",
+    NULL,
+  };
+  g_autofree gchar *stdout_buf = NULL;
+  g_autofree gchar *stderr_buf = NULL;
+  gint wait_status = 0;
+
+  run_child (argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_thread_join (server_thread);
+
+  g_assert_cmpint (wait_status_is_success (wait_status), ==, expect_success);
+  g_assert_cmpstr (stdout_buf, ==, expected_output);
+  if (expected_error == NULL)
+    g_assert_cmpstr (stderr_buf, ==, "");
+  else
+    g_assert_nonnull (g_strstr_len (stderr_buf, -1, expected_error));
+  g_assert_nonnull (server.request);
+  g_assert_nonnull (g_strstr_len (server.request, -1,
+          "GET /readyz?format=json"));
+
+  g_free (server.request);
+}
+
+static void
+test_status_readiness (void)
+{
+  run_status_readiness_case (200, "{\"status\":\"ready\"}", "status=ready\n",
+      TRUE, NULL);
+  run_status_readiness_case (503,
+      "{\"status\":\"not_ready\",\"reason\":\"delta_not_ready\"}",
+      "status=not_ready reason=delta_not_ready\n", FALSE, NULL);
+  run_status_readiness_case (200, "{\"status\":\"ok\"}", "",
+      FALSE, "wyctl: daemon readiness failed");
+  run_status_readiness_case (200, "not-json {\"status\":\"ready\"}", "",
+      FALSE, "wyctl: daemon readiness failed");
+  run_status_readiness_case (503,
+      "{\"status\":\"not_ready\",\"reason\":\"unknown\"}", "",
+      FALSE, "wyctl: daemon unavailable:");
+}
+
+static void
 test_status_requires_daemon_url (void)
 {
   gchar *argv[] = { WYL_TEST_WYCTL_PATH, "status", NULL };
@@ -236,6 +358,7 @@ test_status_help_command_first (void)
 
   g_assert_true (wait_status_is_success (wait_status));
   g_assert_nonnull (g_strstr_len (stdout_buf, -1, "--daemon-url"));
+  g_assert_nonnull (g_strstr_len (stdout_buf, -1, "--readiness"));
   g_assert_cmpstr (stderr_buf, ==, "");
 }
 
@@ -1143,6 +1266,7 @@ main (int argc, char **argv)
   g_test_add_func ("/wyctl/status-rejects-invalid-timeout",
       test_status_rejects_invalid_timeout);
   g_test_add_func ("/wyctl/status-times-out", test_status_times_out);
+  g_test_add_func ("/wyctl/status-readiness", test_status_readiness);
   g_test_add_func ("/wyctl/status-requires-daemon-url",
       test_status_requires_daemon_url);
   g_test_add_func ("/wyctl/status-rejects-invalid-daemon-url",

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -655,6 +655,33 @@ set_json_error (SoupServerMessage *msg, guint status, const gchar *code)
 }
 
 static gboolean
+wants_json_format (GHashTable *query)
+{
+  const gchar *format = query != NULL ? g_hash_table_lookup (query,
+      "format") : NULL;
+  return g_strcmp0 (format, "json") == 0;
+}
+
+static void
+set_status_json (SoupServerMessage *msg, guint status, const gchar *state,
+    const gchar *reason)
+{
+  attach_request_id_header (msg);
+
+  g_autoptr (GString) body = g_string_new ("{\"status\":");
+  append_json_string (body, state);
+  if (reason != NULL) {
+    g_string_append (body, ",\"reason\":");
+    append_json_string (body, reason);
+  }
+  g_string_append_c (body, '}');
+
+  soup_server_message_set_status (msg, status, NULL);
+  soup_server_message_set_response (msg, "application/json",
+      SOUP_MEMORY_COPY, body->str, body->len);
+}
+
+static gboolean
 parse_int64_query_param (const gchar *value, gint64 *out_value)
 {
   if (value == NULL || value[0] == '\0' || out_value == NULL)
@@ -675,8 +702,12 @@ healthz_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
 {
   (void) server;
   (void) path;
-  (void) query;
   (void) user_data;
+
+  if (wants_json_format (query)) {
+    set_status_json (msg, 200, "ok", NULL);
+    return;
+  }
 
   const gchar *body = "ok\n";
   attach_request_id_header (msg);
@@ -777,19 +808,30 @@ readyz_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
 {
   (void) server;
   (void) path;
-  (void) query;
 
   WylDaemonHttpContext *ctx = user_data;
+  gboolean json = wants_json_format (query);
   const gchar *liveness_error = check_runtime_liveness_ready (ctx->runtime);
   if (liveness_error != NULL) {
-    set_json_error (msg, 503, liveness_error);
+    if (json)
+      set_status_json (msg, 503, "not_ready", liveness_error);
+    else
+      set_json_error (msg, 503, liveness_error);
     return;
   }
 
   const gchar *readiness_error = "not_ready";
   wyrelog_error_t rc = check_runtime_ready (ctx->handle, &readiness_error);
   if (rc != WYRELOG_E_OK) {
-    set_json_error (msg, 503, readiness_error);
+    if (json)
+      set_status_json (msg, 503, "not_ready", readiness_error);
+    else
+      set_json_error (msg, 503, readiness_error);
+    return;
+  }
+
+  if (json) {
+    set_status_json (msg, 200, "ready", NULL);
     return;
   }
 

--- a/wyrelog/wyctl/wyctl.c
+++ b/wyrelog/wyctl/wyctl.c
@@ -16,6 +16,7 @@ typedef struct
   gchar *daemon_url;
   gchar *timeout_ms_arg;
   gboolean show_version;
+  gboolean readiness;
 } WyctlOptions;
 
 typedef struct
@@ -247,13 +248,25 @@ append_audit_event_json (GString *json, const WylAuditEvent *event)
 }
 
 static gchar *
-build_healthz_uri (const gchar *daemon_url)
+build_daemon_path_uri (const gchar *daemon_url, const gchar *path)
 {
   g_autofree gchar *root = g_strdup (daemon_url);
 
   while (root[0] != '\0' && g_str_has_suffix (root, "/"))
     root[strlen (root) - 1] = '\0';
-  return g_strdup_printf ("%s/healthz", root);
+  return g_strdup_printf ("%s%s", root, path);
+}
+
+static gchar *
+build_healthz_uri (const gchar *daemon_url)
+{
+  return build_daemon_path_uri (daemon_url, "/healthz");
+}
+
+static gchar *
+build_readyz_json_uri (const gchar *daemon_url)
+{
+  return build_daemon_path_uri (daemon_url, "/readyz?format=json");
 }
 
 static gboolean
@@ -272,17 +285,163 @@ daemon_url_is_valid (const gchar *daemon_url)
 }
 
 static int
+send_status_probe (const gchar *uri, guint timeout_ms, guint *out_status,
+    gchar **out_body)
+{
+  g_autoptr (SoupMessage) msg = soup_message_new ("GET", uri);
+  if (out_status == NULL || out_body == NULL || msg == NULL)
+    return 2;
+  *out_status = 0;
+  *out_body = NULL;
+
+  g_autoptr (SoupSession) session = soup_session_new ();
+  g_autoptr (GCancellable) cancellable = g_cancellable_new ();
+  WyctlTimeout timeout = {
+    .cancellable = cancellable,
+    .timeout_ms = timeout_ms,
+  };
+  g_cond_init (&timeout.cond);
+  g_mutex_init (&timeout.mutex);
+  GThread *timeout_thread = g_thread_new ("wyctl-timeout", timeout_thread_func,
+      &timeout);
+
+  g_autoptr (GError) io_error = NULL;
+  g_autoptr (GBytes) body =
+      soup_session_send_and_read (session, msg, cancellable, &io_error);
+
+  g_mutex_lock (&timeout.mutex);
+  timeout.done = TRUE;
+  g_cond_signal (&timeout.cond);
+  g_mutex_unlock (&timeout.mutex);
+  g_thread_join (timeout_thread);
+  g_mutex_clear (&timeout.mutex);
+  g_cond_clear (&timeout.cond);
+
+  if (body == NULL)
+    return 1;
+
+  *out_status = soup_message_get_status (msg);
+  gsize body_size = 0;
+  const gchar *body_data = g_bytes_get_data (body, &body_size);
+  *out_body = g_strndup (body_data, body_size);
+  return 0;
+}
+
+static const gchar *
+skip_json_ws (const gchar *p)
+{
+  while (p != NULL && g_ascii_isspace (*p))
+    p++;
+  return p;
+}
+
+static gboolean
+parse_json_code_string (const gchar **inout_p, gchar **out_value)
+{
+  const gchar *p = skip_json_ws (*inout_p);
+  if (p == NULL || *p != '"' || out_value == NULL)
+    return FALSE;
+  p++;
+
+  const gchar *start = p;
+  while (g_ascii_isalnum (*p) || *p == '_')
+    p++;
+  if (p == start || *p != '"')
+    return FALSE;
+
+  *out_value = g_strndup (start, (gsize) (p - start));
+  *inout_p = p + 1;
+  return TRUE;
+}
+
+static gboolean
+parse_readiness_json (const gchar *body, gchar **out_status, gchar **out_reason)
+{
+  if (body == NULL || out_status == NULL || out_reason == NULL)
+    return FALSE;
+  *out_status = NULL;
+  *out_reason = NULL;
+
+  const gchar *p = skip_json_ws (body);
+  if (*p != '{')
+    return FALSE;
+  p++;
+
+  g_autofree gchar *key = NULL;
+  if (!parse_json_code_string (&p, &key) || g_strcmp0 (key, "status") != 0)
+    return FALSE;
+  p = skip_json_ws (p);
+  if (*p != ':')
+    return FALSE;
+  p++;
+  if (!parse_json_code_string (&p, out_status))
+    return FALSE;
+
+  p = skip_json_ws (p);
+  if (*p == ',') {
+    p++;
+    g_clear_pointer (&key, g_free);
+    if (!parse_json_code_string (&p, &key) || g_strcmp0 (key, "reason") != 0)
+      return FALSE;
+    p = skip_json_ws (p);
+    if (*p != ':')
+      return FALSE;
+    p++;
+    if (!parse_json_code_string (&p, out_reason))
+      return FALSE;
+    p = skip_json_ws (p);
+  }
+
+  if (*p != '}')
+    return FALSE;
+  p = skip_json_ws (p + 1);
+  return *p == '\0';
+}
+
+static gboolean
+readiness_reason_is_known (const gchar *reason)
+{
+  if (reason == NULL)
+    return FALSE;
+  return g_strcmp0 (reason, "delta_not_ready") == 0 ||
+      g_strcmp0 (reason, "audit_degraded") == 0 ||
+      g_strcmp0 (reason, "not_ready") == 0;
+}
+
+static const gchar *
+readiness_reason_from_body (const gchar *body)
+{
+  g_autofree gchar *status = NULL;
+  g_autofree gchar *reason = NULL;
+  if (!parse_readiness_json (body, &status, &reason))
+    return NULL;
+  if (g_strcmp0 (status, "not_ready") != 0 ||
+      !readiness_reason_is_known (reason))
+    return NULL;
+  if (g_strcmp0 (reason, "delta_not_ready") == 0)
+    return "delta_not_ready";
+  if (g_strcmp0 (reason, "audit_degraded") == 0)
+    return "audit_degraded";
+  if (g_strcmp0 (reason, "not_ready") == 0)
+    return "not_ready";
+  return NULL;
+}
+
+static int
 run_status (const WyctlOptions *global_opts, gint argc, gchar **argv)
 {
   WyctlOptions opts = {
     .daemon_url = global_opts->daemon_url,
     .timeout_ms_arg = global_opts->timeout_ms_arg,
+    .readiness = global_opts->readiness,
   };
   GOptionEntry entries[] = {
     {"daemon-url", 0, 0, G_OPTION_ARG_STRING, &opts.daemon_url,
         "Daemon URL", "URL"},
     {"timeout-ms", 0, 0, G_OPTION_ARG_STRING, &opts.timeout_ms_arg,
         "Daemon probe timeout in milliseconds", "N"},
+    {"readiness", 0, 0, G_OPTION_ARG_NONE, &opts.readiness,
+        "Report daemon readiness", NULL},
     {NULL}
   };
   g_autoptr (GError) error = NULL;
@@ -315,45 +474,43 @@ run_status (const WyctlOptions *global_opts, gint argc, gchar **argv)
     return 2;
   }
 
-  g_autofree gchar *uri = build_healthz_uri (opts.daemon_url);
-  g_autoptr (SoupMessage) msg = soup_message_new ("GET", uri);
-  if (msg == NULL) {
+  g_autofree gchar *uri =
+      opts.readiness ? build_readyz_json_uri (opts.daemon_url) :
+      build_healthz_uri (opts.daemon_url);
+  guint status = 0;
+  g_autofree gchar *body = NULL;
+  int probe_rc = send_status_probe (uri, timeout_ms, &status, &body);
+  if (probe_rc == 2) {
     g_printerr ("wyctl: invalid daemon URL\n");
     return 2;
   }
-
-  g_autoptr (SoupSession) session = soup_session_new ();
-  g_autoptr (GCancellable) cancellable = g_cancellable_new ();
-  WyctlTimeout timeout = {
-    .cancellable = cancellable,
-    .timeout_ms = timeout_ms,
-  };
-  g_cond_init (&timeout.cond);
-  g_mutex_init (&timeout.mutex);
-  GThread *timeout_thread = g_thread_new ("wyctl-timeout", timeout_thread_func,
-      &timeout);
-
-  g_autoptr (GError) io_error = NULL;
-  g_autoptr (GBytes) body =
-      soup_session_send_and_read (session, msg, cancellable, &io_error);
-
-  g_mutex_lock (&timeout.mutex);
-  timeout.done = TRUE;
-  g_cond_signal (&timeout.cond);
-  g_mutex_unlock (&timeout.mutex);
-  g_thread_join (timeout_thread);
-  g_mutex_clear (&timeout.mutex);
-  g_cond_clear (&timeout.cond);
-
-  if (body == NULL) {
+  if (probe_rc != 0) {
     g_printerr ("wyctl: daemon unavailable: %s\n", opts.daemon_url);
     return 1;
   }
 
-  guint status = soup_message_get_status (msg);
   if (status < 200 || status >= 300) {
+    if (opts.readiness && status == 503) {
+      const gchar *reason = readiness_reason_from_body (body);
+      if (reason != NULL) {
+        g_print ("status=not_ready reason=%s\n", reason);
+        return 1;
+      }
+    }
     g_printerr ("wyctl: daemon unavailable: %s\n", opts.daemon_url);
     return 1;
+  }
+
+  if (opts.readiness) {
+    g_autofree gchar *ready_status = NULL;
+    g_autofree gchar *ready_reason = NULL;
+    if (!parse_readiness_json (body, &ready_status, &ready_reason) ||
+        g_strcmp0 (ready_status, "ready") != 0 || ready_reason != NULL) {
+      g_printerr ("wyctl: daemon readiness failed\n");
+      return 1;
+    }
+    g_print ("status=ready\n");
+    return 0;
   }
 
   g_print ("ok\n");

--- a/wyrelog/wyl-boot-private.h
+++ b/wyrelog/wyl-boot-private.h
@@ -48,5 +48,6 @@ typedef struct boot_phase_t
  * NULL while n > 0.
  */
 wyrelog_error_t wyl_boot_run (const boot_phase_t * seq, gsize n, gpointer ctx);
+const gchar *wyl_boot_phase_failure_code (boot_phase_id_t id);
 
 G_END_DECLS;

--- a/wyrelog/wyl-boot.c
+++ b/wyrelog/wyl-boot.c
@@ -2,6 +2,19 @@
 #include "wyl-boot-private.h"
 #include "wyl-common-private.h"
 
+const gchar *
+wyl_boot_phase_failure_code (boot_phase_id_t id)
+{
+  switch (id) {
+    case BOOT_01_TPM_PROBE:
+      return "boot_tpm_probe_failed";
+    case BOOT_02_DEK_UNSEAL:
+      return "boot_dek_unseal_failed";
+    default:
+      return "boot_phase_failed";
+  }
+}
+
 wyrelog_error_t
 wyl_boot_run (const boot_phase_t *seq, gsize n, gpointer ctx)
 {
@@ -28,13 +41,15 @@ wyl_boot_run (const boot_phase_t *seq, gsize n, gpointer ctx)
     if (rc != WYRELOG_E_OK) {
       if (phase->fail_closed) {
         WYL_LOG_ERROR (WYL_LOG_SECTION_BOOT,
-            "boot phase %d (%s) failed; halting",
-            phase->id, phase->name ? phase->name : "?");
+            "boot phase %d (%s) failed; code=%s; halting",
+            phase->id, phase->name ? phase->name : "?",
+            wyl_boot_phase_failure_code (phase->id));
         return rc;
       }
       WYL_LOG_WARN (WYL_LOG_SECTION_BOOT,
-          "boot phase %d (%s) failed (continuing)",
-          phase->id, phase->name ? phase->name : "?");
+          "boot phase %d (%s) failed; code=%s (continuing)",
+          phase->id, phase->name ? phase->name : "?",
+          wyl_boot_phase_failure_code (phase->id));
     }
   }
 


### PR DESCRIPTION
## Summary

- add opt-in JSON health and readiness responses for the daemon
- add explicit `wyctl status --readiness` output for readiness checks
- preserve the existing default health-only status behavior
- add stable private boot phase failure code mapping

## Testing

- `meson test -C builddir --print-errorlogs`
- `meson test -C builddir-audit --print-errorlogs`
