### PR TITLE
auth: add refresh token rotation

### DIFF
--- a/tests/test-client-smoke.c
+++ b/tests/test-client-smoke.c
@@ -23,6 +23,7 @@ typedef struct
   gchar *last_tenant;
   gchar *last_event;
   gchar *last_session_token;
+  gchar *last_refresh_token;
   gchar *last_authorization;
   gchar *last_password;
   gchar *last_skip_mfa;
@@ -76,6 +77,7 @@ test_http_server_handler (SoupServer *server, SoupServerMessage *msg,
   g_free (http->last_tenant);
   g_free (http->last_event);
   g_free (http->last_session_token);
+  g_free (http->last_refresh_token);
   g_free (http->last_authorization);
   g_free (http->last_password);
   g_free (http->last_skip_mfa);
@@ -107,6 +109,9 @@ test_http_server_handler (SoupServer *server, SoupServerMessage *msg,
   http->last_session_token =
       query != NULL ? g_strdup (g_hash_table_lookup (query,
           "session_token")) : NULL;
+  http->last_refresh_token =
+      query != NULL ? g_strdup (g_hash_table_lookup (query,
+          "refresh_token")) : NULL;
   http->last_authorization = g_strdup (soup_message_headers_get_one
       (soup_server_message_get_request_headers (msg), "Authorization"));
   http->last_password =
@@ -862,13 +867,28 @@ main (void)
 
   http.body = "{\"session_token\":\"session-relogin\",\"username\":\"alice\","
       "\"tenant\":\"__wr_default\",\"principal_state\":\"authenticated\","
-      "\"session_state\":\"active\",\"access_token\":\"access-relogin\"}";
+      "\"session_state\":\"active\",\"access_token\":\"access-relogin\","
+      "\"refresh_token\":\"refresh-relogin\"}";
   if (wyl_client_login_skip_mfa (local_client, "alice") != WYRELOG_E_OK)
     return 205;
   g_clear_pointer (&client_access_token, g_free);
   client_access_token = wyl_client_dup_access_token (local_client);
   if (g_strcmp0 (client_access_token, "access-relogin") != 0)
     return 206;
+  http.body = "{\"session_token\":\"session-relogin\",\"username\":\"alice\","
+      "\"tenant\":\"__wr_default\",\"principal_state\":\"authenticated\","
+      "\"session_state\":\"active\",\"access_token\":\"access-refresh\","
+      "\"refresh_token\":\"refresh-next\"}";
+  if (wyl_client_token_refresh (local_client) != WYRELOG_E_OK)
+    return 210;
+  if (g_strcmp0 (http.last_method, "POST") != 0 ||
+      g_strcmp0 (http.last_path, "/auth/refresh") != 0 ||
+      g_strcmp0 (http.last_refresh_token, "refresh-relogin") != 0)
+    return 211;
+  g_clear_pointer (&client_access_token, g_free);
+  client_access_token = wyl_client_dup_access_token (local_client);
+  if (g_strcmp0 (client_access_token, "access-refresh") != 0)
+    return 212;
 
   g_main_loop_quit (http.loop);
   g_thread_join (thread);
@@ -884,6 +904,7 @@ main (void)
   g_clear_pointer (&http.last_tenant, g_free);
   g_clear_pointer (&http.last_event, g_free);
   g_clear_pointer (&http.last_session_token, g_free);
+  g_clear_pointer (&http.last_refresh_token, g_free);
   g_clear_pointer (&http.last_authorization, g_free);
   g_clear_pointer (&http.last_password, g_free);
   g_clear_pointer (&http.last_skip_mfa, g_free);

--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -754,6 +754,41 @@ send_raw_login (SoupSession *session, const gchar *method,
       out_body, NULL);
 }
 
+static gint
+send_raw_refresh (SoupSession *session, const gchar *method,
+    const gchar *base_url, const gchar *refresh_token, guint *out_status,
+    gchar **out_body)
+{
+  g_autofree gchar *root = g_strdup (base_url);
+  while (root[0] != '\0' && g_str_has_suffix (root, "/"))
+    root[strlen (root) - 1] = '\0';
+
+  g_autofree gchar *uri = NULL;
+  if (refresh_token != NULL) {
+    g_autofree gchar *escaped = g_uri_escape_string (refresh_token, NULL, TRUE);
+    uri = g_strdup_printf ("%s/auth/refresh?refresh_token=%s", root, escaped);
+  } else {
+    uri = g_strdup_printf ("%s/auth/refresh", root);
+  }
+
+  g_autoptr (SoupMessage) msg = soup_message_new (method, uri);
+  if (msg == NULL)
+    return 1;
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GBytes) bytes = soup_session_send_and_read (session, msg, NULL,
+      &error);
+  if (bytes == NULL)
+    return 2;
+  gint rc = check_response_request_id_header (msg, 573);
+  if (rc != 0)
+    return rc;
+  gsize size = 0;
+  const gchar *data = g_bytes_get_data (bytes, &size);
+  *out_status = soup_message_get_status (msg);
+  *out_body = g_strndup (data, size);
+  return 0;
+}
+
 static gchar *
 extract_json_string (const gchar *body, const gchar *name)
 {
@@ -1108,6 +1143,74 @@ check_raw_login_contract (SoupServer *server, WylHandle *handle,
       "login-user", "authenticated", server);
   if (rc != 0)
     return rc;
+  g_autofree gchar *login_access_token =
+      extract_json_string (body, "access_token");
+  g_autofree gchar *login_refresh_token =
+      extract_json_string (body, "refresh_token");
+  if (login_access_token == NULL || login_refresh_token == NULL)
+    return 535;
+  g_clear_pointer (&body, g_free);
+
+  rc = send_raw_refresh (session, "GET", base_url, login_refresh_token,
+      &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 405 || strstr (body, "\"method_not_allowed\"") == NULL)
+    return 536;
+  g_clear_pointer (&body, g_free);
+
+  rc = send_raw_refresh (session, "POST", base_url, NULL, &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 400 || strstr (body, "\"invalid_refresh_request\"") == NULL)
+    return 537;
+  g_clear_pointer (&body, g_free);
+
+  rc = send_raw_refresh (session, "POST", base_url, login_refresh_token,
+      &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 200 ||
+      strstr (body, "\"principal_state\":\"authenticated\"") == NULL ||
+      strstr (body, "\"access_token\":\"") == NULL ||
+      strstr (body, "\"refresh_token\":\"") == NULL)
+    return 538;
+  g_autofree gchar *next_refresh_token =
+      extract_json_string (body, "refresh_token");
+  if (next_refresh_token == NULL ||
+      g_strcmp0 (next_refresh_token, login_refresh_token) == 0)
+    return 539;
+  rc = verify_login_access_token (body, authenticated_session_token,
+      "login-user", "authenticated", server);
+  if (rc != 0)
+    return rc;
+  g_clear_pointer (&body, g_free);
+
+  rc = send_raw_refresh (session, "POST", base_url, login_refresh_token,
+      &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 200 || strstr (body, next_refresh_token) == NULL)
+    return 540;
+  g_clear_pointer (&body, g_free);
+
+  if (!wyl_daemon_http_expire_refresh_grace_for_test (server,
+          login_refresh_token))
+    return 541;
+  rc = send_raw_refresh (session, "POST", base_url, login_refresh_token,
+      &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 401 || strstr (body, "\"refresh_reuse_detected\"") == NULL)
+    return 542;
+  g_clear_pointer (&body, g_free);
+
+  rc = send_raw_decide_bearer (session, "POST", base_url, "login-user",
+      "wr.login.skip_mfa", "login", NULL, login_access_token, &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 401 || strstr (body, "\"decide_auth_required\"") == NULL)
+    return 543;
   g_clear_pointer (&body, g_free);
 
   rc = send_raw_login (session, "POST", base_url,

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -20,6 +20,8 @@
 #define WYL_DAEMON_JWT_KEY_ID "__wr_default_hs256"
 #define WYL_DAEMON_DEFAULT_TENANT "__wr_default"
 #define WYL_DAEMON_JWT_KEY_LEN 32
+#define WYL_DAEMON_REFRESH_TTL_SECONDS 86400
+#define WYL_DAEMON_REFRESH_GRACE_SECONDS 30
 #define WYL_DAEMON_REQUEST_ID_HEADER "X-Wyrelog-Request-Id"
 #define WYL_DAEMON_REQUEST_ID_DATA "wyl-daemon-request-id"
 #define WYL_DAEMON_REQUEST_ID_ATTEMPTED_DATA "wyl-daemon-request-id-attempted"
@@ -51,12 +53,28 @@ typedef struct
 
 typedef struct
 {
+  gchar *token;
+  gchar *session_id;
+  gchar *subject;
+  gchar *tenant;
+  gchar *successor_token;
+  gchar *successor_access_token;
+  gboolean consumed;
+  gboolean revoked;
+  gint64 issued_at;
+  gint64 expires_at;
+  gint64 consumed_at;
+} WylRefreshTokenState;
+
+typedef struct
+{
   WylHandle *handle;
   WylDaemonRuntime *runtime;
   guint8 access_token_secret[WYL_DAEMON_JWT_KEY_LEN];
   gboolean access_token_secret_ready;
   GHashTable *sessions_by_token;
   GHashTable *access_tokens_by_jti;
+  GHashTable *refresh_tokens_by_token;
   GMutex lock;
   GMutex policy_mutation_lock;
 } WylDaemonHttpContext;
@@ -102,6 +120,23 @@ wyl_access_token_state_free (gpointer data)
 }
 
 static void
+wyl_refresh_token_state_free (gpointer data)
+{
+  WylRefreshTokenState *state = data;
+
+  if (state == NULL)
+    return;
+
+  g_free (state->token);
+  g_free (state->session_id);
+  g_free (state->subject);
+  g_free (state->tenant);
+  g_free (state->successor_token);
+  g_free (state->successor_access_token);
+  g_free (state);
+}
+
+static void
 wyl_daemon_http_context_free (gpointer data)
 {
   WylDaemonHttpContext *ctx = data;
@@ -112,6 +147,7 @@ wyl_daemon_http_context_free (gpointer data)
   sodium_memzero (ctx->access_token_secret, sizeof ctx->access_token_secret);
   g_hash_table_unref (ctx->sessions_by_token);
   g_hash_table_unref (ctx->access_tokens_by_jti);
+  g_hash_table_unref (ctx->refresh_tokens_by_token);
   g_mutex_clear (&ctx->lock);
   g_mutex_clear (&ctx->policy_mutation_lock);
   g_free (ctx);
@@ -132,6 +168,8 @@ wyl_daemon_http_context_new (WylHandle *handle, WylDaemonRuntime *runtime)
       g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_object_unref);
   ctx->access_tokens_by_jti = g_hash_table_new_full (g_str_hash, g_str_equal,
       g_free, wyl_access_token_state_free);
+  ctx->refresh_tokens_by_token = g_hash_table_new_full (g_str_hash, g_str_equal,
+      g_free, wyl_refresh_token_state_free);
   g_mutex_init (&ctx->lock);
   g_mutex_init (&ctx->policy_mutation_lock);
   return ctx;
@@ -158,6 +196,52 @@ wyl_daemon_http_context_store_access_token (WylDaemonHttpContext *ctx,
 
   g_mutex_lock (&ctx->lock);
   g_hash_table_replace (ctx->access_tokens_by_jti, g_strdup (jti), state);
+  g_mutex_unlock (&ctx->lock);
+  return TRUE;
+}
+
+static wyrelog_error_t
+new_token_id_string (gchar **out_token)
+{
+  if (out_token == NULL)
+    return WYRELOG_E_INVALID;
+  *out_token = NULL;
+
+  wyl_id_t id;
+  wyrelog_error_t rc = wyl_id_new (&id);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  gchar buf[WYL_ID_STRING_BUF];
+  rc = wyl_id_format (&id, buf, sizeof buf);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  *out_token = g_strdup (buf);
+  return WYRELOG_E_OK;
+}
+
+static gboolean
+wyl_daemon_http_context_store_refresh_token (WylDaemonHttpContext *ctx,
+    const gchar *token, const gchar *session_id, const gchar *subject,
+    const gchar *tenant, gint64 issued_at, gint64 expires_at)
+{
+  if (ctx == NULL || token == NULL || token[0] == '\0' ||
+      session_id == NULL || session_id[0] == '\0' || subject == NULL ||
+      subject[0] == '\0' || tenant == NULL || tenant[0] == '\0' ||
+      issued_at < 0 || expires_at <= issued_at)
+    return FALSE;
+
+  WylRefreshTokenState *state = g_new0 (WylRefreshTokenState, 1);
+  state->token = g_strdup (token);
+  state->session_id = g_strdup (session_id);
+  state->subject = g_strdup (subject);
+  state->tenant = g_strdup (tenant);
+  state->issued_at = issued_at;
+  state->expires_at = expires_at;
+
+  g_mutex_lock (&ctx->lock);
+  g_hash_table_replace (ctx->refresh_tokens_by_token, g_strdup (token), state);
   g_mutex_unlock (&ctx->lock);
   return TRUE;
 }
@@ -195,6 +279,18 @@ collect_session_access_token (gpointer key, gpointer value, gpointer data)
 }
 
 static void
+collect_session_refresh_token (gpointer key, gpointer value, gpointer data)
+{
+  WylRefreshTokenState *state = value;
+  WylSessionTokenCollect *collect = data;
+
+  if (state == NULL || collect == NULL || collect->token_ids == NULL)
+    return;
+  if (g_strcmp0 (state->session_id, collect->session_id) == 0)
+    g_ptr_array_add (collect->token_ids, g_strdup ((const gchar *) key));
+}
+
+static void
 wyl_daemon_http_context_revoke_session_access_tokens (WylDaemonHttpContext *ctx,
     const gchar *session_id)
 {
@@ -214,6 +310,32 @@ wyl_daemon_http_context_revoke_session_access_tokens (WylDaemonHttpContext *ctx,
     const gchar *jti = g_ptr_array_index (token_ids, i);
     WylAccessTokenState *state =
         g_hash_table_lookup (ctx->access_tokens_by_jti, jti);
+    if (state != NULL)
+      state->revoked = TRUE;
+  }
+  g_mutex_unlock (&ctx->lock);
+}
+
+static void
+wyl_daemon_http_context_revoke_session_refresh_tokens (WylDaemonHttpContext
+    *ctx, const gchar *session_id)
+{
+  if (ctx == NULL || session_id == NULL || session_id[0] == '\0')
+    return;
+
+  g_autoptr (GPtrArray) token_ids = g_ptr_array_new_with_free_func (g_free);
+  WylSessionTokenCollect collect = {
+    .session_id = session_id,
+    .token_ids = token_ids,
+  };
+
+  g_mutex_lock (&ctx->lock);
+  g_hash_table_foreach (ctx->refresh_tokens_by_token,
+      collect_session_refresh_token, &collect);
+  for (guint i = 0; i < token_ids->len; i++) {
+    const gchar *token = g_ptr_array_index (token_ids, i);
+    WylRefreshTokenState *state =
+        g_hash_table_lookup (ctx->refresh_tokens_by_token, token);
     if (state != NULL)
       state->revoked = TRUE;
   }
@@ -303,6 +425,26 @@ wyl_daemon_http_remove_session_for_test (SoupServer *server,
   WylDaemonHttpContext *ctx = wyl_daemon_http_get_context (server);
   return wyl_daemon_http_context_remove_session (ctx, session_token);
 }
+
+gboolean
+wyl_daemon_http_expire_refresh_grace_for_test (SoupServer *server,
+    const gchar *refresh_token)
+{
+  WylDaemonHttpContext *ctx = wyl_daemon_http_get_context (server);
+  if (ctx == NULL || refresh_token == NULL || refresh_token[0] == '\0')
+    return FALSE;
+
+  gboolean updated = FALSE;
+  g_mutex_lock (&ctx->lock);
+  WylRefreshTokenState *state =
+      g_hash_table_lookup (ctx->refresh_tokens_by_token, refresh_token);
+  if (state != NULL && state->consumed) {
+    state->consumed_at -= WYL_DAEMON_REFRESH_GRACE_SECONDS + 1;
+    updated = TRUE;
+  }
+  g_mutex_unlock (&ctx->lock);
+  return updated;
+}
 #endif
 
 static void
@@ -376,7 +518,7 @@ build_decide_json (const wyl_decide_resp_t *resp)
 static gchar *
 build_login_json (const gchar *session_token, const gchar *username,
     const gchar *tenant, const gchar *principal_state,
-    const gchar *access_token)
+    const gchar *access_token, const gchar *refresh_token)
 {
   g_autoptr (GString) json = g_string_new ("{");
 
@@ -392,6 +534,10 @@ build_login_json (const gchar *session_token, const gchar *username,
   if (access_token != NULL) {
     g_string_append (json, ",\"access_token\":");
     append_json_string (json, access_token);
+  }
+  if (refresh_token != NULL) {
+    g_string_append (json, ",\"refresh_token\":");
+    append_json_string (json, refresh_token);
   }
   g_string_append_c (json, '}');
   return g_string_free (g_steal_pointer (&json), FALSE);
@@ -410,15 +556,15 @@ copy_access_token_secret (WylDaemonHttpContext *ctx,
 }
 
 static wyrelog_error_t
-issue_login_access_token (WylDaemonHttpContext *ctx, const gchar *session_token,
+issue_access_token (WylDaemonHttpContext *ctx, const gchar *session_token,
     const gchar *username, const gchar *tenant, const gchar *principal_state,
-    WylSession *session, gchar **out_token)
+    gint64 issued_at, gchar **out_token)
 {
   if (out_token == NULL)
     return WYRELOG_E_INVALID;
   *out_token = NULL;
   if (session_token == NULL || username == NULL || tenant == NULL ||
-      principal_state == NULL || session == NULL)
+      principal_state == NULL || issued_at < 0)
     return WYRELOG_E_INVALID;
 
   guint8 secret[WYL_DAEMON_JWT_KEY_LEN];
@@ -426,20 +572,13 @@ issue_login_access_token (WylDaemonHttpContext *ctx, const gchar *session_token,
   if (rc != WYRELOG_E_OK)
     return rc;
 
-  wyl_id_t token_id;
-  rc = wyl_id_new (&token_id);
-  if (rc != WYRELOG_E_OK) {
-    sodium_memzero (secret, sizeof secret);
-    return rc;
-  }
-  gchar token_id_buf[WYL_ID_STRING_BUF];
-  rc = wyl_id_format (&token_id, token_id_buf, sizeof token_id_buf);
+  g_autofree gchar *token_id = NULL;
+  rc = new_token_id_string (&token_id);
   if (rc != WYRELOG_E_OK) {
     sodium_memzero (secret, sizeof secret);
     return rc;
   }
 
-  gint64 issued_at = wyl_session_get_created_at_us (session) / G_USEC_PER_SEC;
   gint64 ttl = WYL_JWT_ACCESS_TTL_SECONDS;
   if (issued_at > G_MAXINT64 - ttl) {
     sodium_memzero (secret, sizeof secret);
@@ -447,7 +586,7 @@ issue_login_access_token (WylDaemonHttpContext *ctx, const gchar *session_token,
   }
   wyl_jwt_issue_input_t input = {
     .key_id = WYL_DAEMON_JWT_KEY_ID,
-    .jti = token_id_buf,
+    .jti = token_id,
     .subject = username,
     .issuer = WYL_DAEMON_JWT_ISSUER,
     .audience = WYL_DAEMON_JWT_AUDIENCE,
@@ -461,13 +600,50 @@ issue_login_access_token (WylDaemonHttpContext *ctx, const gchar *session_token,
   sodium_memzero (secret, sizeof secret);
   if (rc != WYRELOG_E_OK)
     return rc;
-  if (!wyl_daemon_http_context_store_access_token (ctx, token_id_buf,
+  if (!wyl_daemon_http_context_store_access_token (ctx, token_id,
           session_token, username, tenant, WYL_DAEMON_JWT_KEY_ID,
           issued_at + ttl)) {
     g_clear_pointer (out_token, g_free);
     return WYRELOG_E_INTERNAL;
   }
   return rc;
+}
+
+static wyrelog_error_t
+issue_login_access_token (WylDaemonHttpContext *ctx, const gchar *session_token,
+    const gchar *username, const gchar *tenant, const gchar *principal_state,
+    gchar **out_token)
+{
+  return issue_access_token (ctx, session_token, username, tenant,
+      principal_state, g_get_real_time () / G_USEC_PER_SEC, out_token);
+}
+
+static wyrelog_error_t
+issue_refresh_token (WylDaemonHttpContext *ctx, const gchar *session_token,
+    const gchar *username, const gchar *tenant, gchar **out_token)
+{
+  if (out_token == NULL)
+    return WYRELOG_E_INVALID;
+  *out_token = NULL;
+  if (ctx == NULL || session_token == NULL || username == NULL ||
+      tenant == NULL)
+    return WYRELOG_E_INVALID;
+
+  g_autofree gchar *token = NULL;
+  wyrelog_error_t rc = new_token_id_string (&token);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  gint64 now = g_get_real_time () / G_USEC_PER_SEC;
+  if (now > G_MAXINT64 - WYL_DAEMON_REFRESH_TTL_SECONDS)
+    return WYRELOG_E_INVALID;
+
+  if (!wyl_daemon_http_context_store_refresh_token (ctx, token, session_token,
+          username, tenant, now, now + WYL_DAEMON_REFRESH_TTL_SECONDS))
+    return WYRELOG_E_INTERNAL;
+
+  *out_token = g_steal_pointer (&token);
+  return WYRELOG_E_OK;
 }
 
 static const gchar *
@@ -1380,9 +1556,13 @@ login_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
   const gchar *principal_state =
       skip_mfa_requested ? "authenticated" : "mfa_required";
   g_autofree gchar *access_token = NULL;
+  g_autofree gchar *refresh_token = NULL;
   if (skip_mfa_requested) {
     rc = issue_login_access_token (ctx, session_token, username,
-        session_tenant, principal_state, session, &access_token);
+        session_tenant, principal_state, &access_token);
+    if (rc == WYRELOG_E_OK)
+      rc = issue_refresh_token (ctx, session_token, username, session_tenant,
+          &refresh_token);
     if (rc != WYRELOG_E_OK) {
       set_json_error (msg, 500, "login_failed");
       return;
@@ -1395,7 +1575,114 @@ login_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
   }
 
   g_autofree gchar *body = build_login_json (session_token, username,
-      session_tenant, principal_state, access_token);
+      session_tenant, principal_state, access_token, refresh_token);
+  attach_request_id_header (msg);
+  soup_server_message_set_status (msg, 200, NULL);
+  soup_server_message_set_response (msg, "application/json",
+      SOUP_MEMORY_COPY, body, strlen (body));
+}
+
+static void
+refresh_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
+    GHashTable *query, gpointer user_data)
+{
+  (void) path;
+
+  if (g_strcmp0 (soup_server_message_get_method (msg), "POST") != 0) {
+    set_json_error (msg, 405, "method_not_allowed");
+    return;
+  }
+
+  const gchar *refresh_token = NULL;
+  if (query != NULL)
+    refresh_token = g_hash_table_lookup (query, "refresh_token");
+  if (refresh_token == NULL || refresh_token[0] == '\0') {
+    set_json_error (msg, 400, "invalid_refresh_request");
+    return;
+  }
+
+  WylDaemonHttpContext *ctx = user_data;
+  gint64 now = g_get_real_time () / G_USEC_PER_SEC;
+  g_autofree gchar *session_id = NULL;
+  g_autofree gchar *subject = NULL;
+  g_autofree gchar *tenant = NULL;
+  g_autofree gchar *cached_access_token = NULL;
+  g_autofree gchar *cached_refresh_token = NULL;
+  gboolean reuse_detected = FALSE;
+
+  g_mutex_lock (&ctx->lock);
+  WylRefreshTokenState *state =
+      g_hash_table_lookup (ctx->refresh_tokens_by_token, refresh_token);
+  if (state == NULL || state->revoked || now >= state->expires_at) {
+    g_mutex_unlock (&ctx->lock);
+    set_json_error (msg, 401, "refresh_auth_required");
+    return;
+  }
+  session_id = g_strdup (state->session_id);
+  subject = g_strdup (state->subject);
+  tenant = g_strdup (state->tenant);
+  if (state->consumed) {
+    if (now <= state->consumed_at + WYL_DAEMON_REFRESH_GRACE_SECONDS &&
+        state->successor_token != NULL
+        && state->successor_access_token != NULL) {
+      cached_refresh_token = g_strdup (state->successor_token);
+      cached_access_token = g_strdup (state->successor_access_token);
+    } else {
+      state->revoked = TRUE;
+      reuse_detected = TRUE;
+    }
+  }
+  g_mutex_unlock (&ctx->lock);
+
+  if (reuse_detected) {
+    wyl_daemon_http_context_revoke_session_access_tokens (ctx, session_id);
+    wyl_daemon_http_context_revoke_session_refresh_tokens (ctx, session_id);
+    set_json_error (msg, 401, "refresh_reuse_detected");
+    return;
+  }
+
+  g_autoptr (WylSession) session = wyl_daemon_http_ref_session (server,
+      session_id);
+  if (session == NULL) {
+    set_json_error (msg, 401, "refresh_auth_required");
+    return;
+  }
+  g_autofree gchar *live_username = wyl_session_dup_username (session);
+  g_autofree gchar *live_tenant = wyl_session_dup_tenant (session);
+  if (g_strcmp0 (live_username, subject) != 0 ||
+      g_strcmp0 (live_tenant, tenant) != 0) {
+    set_json_error (msg, 401, "refresh_auth_required");
+    return;
+  }
+
+  g_autofree gchar *access_token = g_steal_pointer (&cached_access_token);
+  g_autofree gchar *next_refresh_token =
+      g_steal_pointer (&cached_refresh_token);
+  wyrelog_error_t rc = WYRELOG_E_OK;
+  if (access_token == NULL || next_refresh_token == NULL) {
+    rc = issue_access_token (ctx, session_id, subject, tenant, "authenticated",
+        now, &access_token);
+    if (rc == WYRELOG_E_OK)
+      rc = issue_refresh_token (ctx, session_id, subject, tenant,
+          &next_refresh_token);
+    if (rc != WYRELOG_E_OK) {
+      set_json_error (msg, 500, "refresh_failed");
+      return;
+    }
+
+    g_mutex_lock (&ctx->lock);
+    state = g_hash_table_lookup (ctx->refresh_tokens_by_token, refresh_token);
+    if (state != NULL && !state->consumed && !state->revoked) {
+      state->consumed = TRUE;
+      state->consumed_at = now;
+      state->successor_token = g_strdup (next_refresh_token);
+      state->successor_access_token = g_strdup (access_token);
+    }
+    g_mutex_unlock (&ctx->lock);
+  }
+
+  g_autofree gchar *body = build_login_json (session_id, subject, tenant,
+      "authenticated", access_token, next_refresh_token);
   attach_request_id_header (msg);
   soup_server_message_set_status (msg, 200, NULL);
   soup_server_message_set_response (msg, "application/json",
@@ -1461,6 +1748,7 @@ logout_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
   }
 
   wyl_daemon_http_context_revoke_session_access_tokens (ctx, session_token);
+  wyl_daemon_http_context_revoke_session_refresh_tokens (ctx, session_token);
   if (!wyl_daemon_http_context_remove_session (ctx, session_token)) {
     set_json_error (msg, 401, "logout_auth_required");
     return;
@@ -1596,6 +1884,7 @@ wyl_daemon_start_http_server_with_runtime (const WylDaemonOptions *opts,
   soup_server_add_handler (server, "/healthz", healthz_handler, NULL, NULL);
   soup_server_add_handler (server, "/readyz", readyz_handler, ctx, NULL);
   soup_server_add_handler (server, "/auth/login", login_handler, ctx, NULL);
+  soup_server_add_handler (server, "/auth/refresh", refresh_handler, ctx, NULL);
   soup_server_add_handler (server, "/auth/logout", logout_handler, ctx, NULL);
   soup_server_add_handler (server, "/decide", decide_handler, ctx, NULL);
   soup_server_add_handler (server, "/policy/permissions/grant",

--- a/wyrelog/daemon/http.h
+++ b/wyrelog/daemon/http.h
@@ -23,5 +23,7 @@ wyrelog_error_t wyl_daemon_http_copy_access_token_secret (SoupServer * server,
     guint8 * out_secret, gsize out_len);
 gboolean wyl_daemon_http_remove_session_for_test (SoupServer * server,
     const gchar * session_token);
+gboolean wyl_daemon_http_expire_refresh_grace_for_test (SoupServer * server,
+    const gchar * refresh_token);
 #endif
 #endif

--- a/wyrelog/wyl-client.c
+++ b/wyrelog/wyl-client.c
@@ -8,6 +8,7 @@ struct _WylClient
   gchar *base_url;
   gchar *session_token;
   gchar *access_token;
+  gchar *refresh_token;
   gchar *username;
   gchar *tenant;
   gchar *selected_tenant;
@@ -28,8 +29,8 @@ G_DEFINE_FINAL_TYPE (WylClient, wyl_client, G_TYPE_OBJECT);
 
 static gboolean parse_login_response_json (const gchar * data, gsize size,
     gchar ** out_session_token,
-    gchar ** out_access_token, gchar ** out_username,
-    gchar ** out_tenant, gchar ** out_principal_state,
+    gchar ** out_access_token, gchar ** out_refresh_token,
+    gchar ** out_username, gchar ** out_tenant, gchar ** out_principal_state,
     gchar ** out_session_state);
 
 static void
@@ -37,6 +38,7 @@ wyl_client_clear_login_state (WylClient *self)
 {
   g_clear_pointer (&self->session_token, g_free);
   g_clear_pointer (&self->access_token, g_free);
+  g_clear_pointer (&self->refresh_token, g_free);
   g_clear_pointer (&self->username, g_free);
   g_clear_pointer (&self->tenant, g_free);
   g_clear_pointer (&self->selected_tenant, g_free);
@@ -292,13 +294,14 @@ client_login_internal (WylClient *client, const gchar *username,
   const gchar *body_data = g_bytes_get_data (body, &body_size);
   g_autofree gchar *session_token = NULL;
   g_autofree gchar *access_token = NULL;
+  g_autofree gchar *refresh_token = NULL;
   g_autofree gchar *parsed_username = NULL;
   g_autofree gchar *tenant = NULL;
   g_autofree gchar *principal_state = NULL;
   g_autofree gchar *session_state = NULL;
   if (!parse_login_response_json (body_data, body_size, &session_token,
-          &access_token, &parsed_username, &tenant, &principal_state,
-          &session_state)) {
+          &access_token, &refresh_token, &parsed_username, &tenant,
+          &principal_state, &session_state)) {
     wyl_client_clear_login_state (client);
     return WYRELOG_E_IO;
   }
@@ -306,6 +309,7 @@ client_login_internal (WylClient *client, const gchar *username,
   wyl_client_clear_login_state (client);
   client->session_token = g_steal_pointer (&session_token);
   client->access_token = g_steal_pointer (&access_token);
+  client->refresh_token = g_steal_pointer (&refresh_token);
   client->username = g_steal_pointer (&parsed_username);
   client->tenant = g_steal_pointer (&tenant);
   client->selected_tenant = g_strdup (client->tenant);
@@ -346,8 +350,54 @@ wyl_client_set_bearer_credentials (WylClient *client,
 wyrelog_error_t
 wyl_client_token_refresh (WylClient *client)
 {
-  (void) client;
-  return WYRELOG_E_INTERNAL;
+  if (client == NULL || !WYL_IS_CLIENT (client))
+    return WYRELOG_E_INVALID;
+  if (client->refresh_token == NULL || client->refresh_token[0] == '\0')
+    return WYRELOG_E_INVALID;
+
+  g_autofree gchar *base_url = wyl_client_dup_base_url (client);
+  if (base_url == NULL)
+    return WYRELOG_E_INVALID;
+  while (base_url[0] != '\0' && g_str_has_suffix (base_url, "/"))
+    base_url[strlen (base_url) - 1] = '\0';
+
+  g_autofree gchar *escaped_refresh =
+      g_uri_escape_string (client->refresh_token, NULL, TRUE);
+  g_autofree gchar *uri = g_strdup_printf ("%s/auth/refresh?refresh_token=%s",
+      base_url, escaped_refresh);
+  g_autoptr (SoupMessage) message = soup_message_new ("POST", uri);
+  if (message == NULL)
+    return WYRELOG_E_INVALID;
+
+  g_autoptr (GBytes) body = NULL;
+  wyrelog_error_t rc = wyl_client_send_message (client, message, &body);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  gsize body_size = 0;
+  const gchar *body_data = g_bytes_get_data (body, &body_size);
+  g_autofree gchar *session_token = NULL;
+  g_autofree gchar *access_token = NULL;
+  g_autofree gchar *refresh_token = NULL;
+  g_autofree gchar *parsed_username = NULL;
+  g_autofree gchar *tenant = NULL;
+  g_autofree gchar *principal_state = NULL;
+  g_autofree gchar *session_state = NULL;
+  if (!parse_login_response_json (body_data, body_size, &session_token,
+          &access_token, &refresh_token, &parsed_username, &tenant,
+          &principal_state, &session_state))
+    return WYRELOG_E_IO;
+
+  wyl_client_clear_login_state (client);
+  client->session_token = g_steal_pointer (&session_token);
+  client->access_token = g_steal_pointer (&access_token);
+  client->refresh_token = g_steal_pointer (&refresh_token);
+  client->username = g_steal_pointer (&parsed_username);
+  client->tenant = g_steal_pointer (&tenant);
+  client->selected_tenant = g_strdup (client->tenant);
+  client->principal_state = g_steal_pointer (&principal_state);
+  client->session_state = g_steal_pointer (&session_state);
+  return WYRELOG_E_OK;
 }
 
 wyrelog_error_t
@@ -759,15 +809,18 @@ wyl_client_decision_dup_deny_origin (const WylClientDecision *result)
 
 static gboolean
 parse_login_response_json (const gchar *data, gsize size,
-    gchar **out_session_token, gchar **out_access_token, gchar **out_username,
-    gchar **out_tenant, gchar **out_principal_state, gchar **out_session_state)
+    gchar **out_session_token, gchar **out_access_token,
+    gchar **out_refresh_token, gchar **out_username, gchar **out_tenant,
+    gchar **out_principal_state, gchar **out_session_state)
 {
   if (data == NULL || out_session_token == NULL || out_username == NULL ||
-      out_access_token == NULL || out_tenant == NULL ||
+      out_access_token == NULL || out_refresh_token == NULL ||
+      out_tenant == NULL ||
       out_principal_state == NULL || out_session_state == NULL)
     return FALSE;
   *out_session_token = NULL;
   *out_access_token = NULL;
+  *out_refresh_token = NULL;
   *out_username = NULL;
   *out_tenant = NULL;
   *out_principal_state = NULL;
@@ -779,6 +832,7 @@ parse_login_response_json (const gchar *data, gsize size,
 
   gboolean have_session_token = FALSE;
   gboolean have_access_token = FALSE;
+  gboolean have_refresh_token = FALSE;
   gboolean have_username = FALSE;
   gboolean have_tenant = FALSE;
   gboolean have_principal_state = FALSE;
@@ -808,6 +862,14 @@ parse_login_response_json (const gchar *data, gsize size,
         return FALSE;
       have_access_token = TRUE;
       *out_access_token = g_steal_pointer (&value);
+    } else if (g_strcmp0 (key, "refresh_token") == 0) {
+      g_autofree gchar *value = NULL;
+      if (!json_parse_string (&cursor, &value))
+        return FALSE;
+      if (have_refresh_token || value[0] == '\0')
+        return FALSE;
+      have_refresh_token = TRUE;
+      *out_refresh_token = g_steal_pointer (&value);
     } else if (g_strcmp0 (key, "username") == 0) {
       g_autofree gchar *value = NULL;
       if (!json_parse_string (&cursor, &value))
@@ -864,6 +926,7 @@ parse_login_response_json (const gchar *data, gsize size,
       cursor.pos != cursor.size) {
     g_clear_pointer (out_session_token, g_free);
     g_clear_pointer (out_access_token, g_free);
+    g_clear_pointer (out_refresh_token, g_free);
     g_clear_pointer (out_username, g_free);
     g_clear_pointer (out_tenant, g_free);
     g_clear_pointer (out_principal_state, g_free);


### PR DESCRIPTION
## Scope

Adds refresh-token rotation to the daemon HTTP authentication path and client library.

## Changes

- Issue refresh tokens alongside authenticated login responses.
- Add `POST /auth/refresh` with refresh-token rotation.
- Allow consumed refresh tokens to replay inside a 30s grace window and return the cached successor pair.
- Detect consumed-token reuse after grace, revoke the session access/refresh chain, and reject subsequent bearer access.
- Revoke refresh tokens on logout.
- Store refresh tokens in `WylClient` and implement `wyl_client_token_refresh()`.
- Cover client refresh request shape and daemon refresh rotation/reuse behavior.

## Verification

- `meson test -C builddir --print-errorlogs` -> 52 OK / 1 SKIP / 0 FAIL
- `meson test -C builddir-audit --print-errorlogs` -> 57 OK / 1 SKIP / 0 FAIL
- `git diff --check`
