### PR TITLE
tests: split daemon-http-decide for parallel-suite headroom

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -379,15 +379,29 @@ test_login_req = executable('test-login-req',
 
 test('login-req', test_login_req)
 
+test_session_username_c_args = [
+  '-DWYL_TEST_TEMPLATE_DIR="' + meson.project_source_root() / 'templates' / 'access' + '"',
+  # The two session-username variants share one source file with one
+  # main() per variant; helpers irrelevant to the active variant remain
+  # defined to keep the source readable.
+  '-Wno-unused-function',
+]
+
 test_session_username = executable('test-session-username',
   'test-session-username.c',
-  c_args : [
-    '-DWYL_TEST_TEMPLATE_DIR="' + meson.project_source_root() / 'templates' / 'access' + '"',
-  ],
+  c_args : test_session_username_c_args,
   dependencies : [wyrelog_dep, wirelog_dep],
 )
 
 test('session-username', test_session_username)
+
+test_session_username_lifecycle = executable('test-session-username-lifecycle',
+  'test-session-username.c',
+  c_args : test_session_username_c_args + '-DWYL_TEST_VARIANT_LIFECYCLE',
+  dependencies : [wyrelog_dep, wirelog_dep],
+)
+
+test('session-username-lifecycle', test_session_username_lifecycle)
 
 test_decide_req = executable('test-decide-req',
   'test-decide-req.c',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -78,6 +78,10 @@ if build_client
     '-DWYL_HAS_DAEMON_HTTP',
     '-DWYL_TEST_DAEMON_HTTP',
     '-DWYL_TEST_TEMPLATE_DIR="' + meson.project_source_root() / 'templates' / 'access' + '"',
+    # The two daemon-http-decide variants share one source file with one
+    # main() per variant; helpers irrelevant to the active variant remain
+    # defined to keep the source readable.
+    '-Wno-unused-function',
   ]
   test_daemon_http_decide_deps = [
     wyrelog_dep,
@@ -99,6 +103,19 @@ if build_client
   )
 
   test('daemon-http-decide', test_daemon_http_decide)
+
+  if get_option('enable_audit').allowed()
+    test_daemon_http_decide_audit = executable('test-daemon-http-decide-audit',
+      'test-daemon-http-decide.c',
+      '../wyrelog/daemon/http.c',
+      '../wyrelog/daemon/delta.c',
+      c_args : test_daemon_http_decide_c_args + '-DWYL_TEST_VARIANT_AUDIT',
+      include_directories : [wyrelog_inc, include_directories('../wyrelog')],
+      dependencies : test_daemon_http_decide_deps,
+    )
+
+    test('daemon-http-decide-audit', test_daemon_http_decide_audit)
+  endif
 endif
 
 test_client_audit_daemon_c_args = []

--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -2777,6 +2777,27 @@ check_audit_event_present (WylClient *client, const gchar *filter,
 }
 #endif
 
+/*
+ * The daemon-http-decide test surface has been split across two binaries
+ * compiled from this single translation unit:
+ *
+ *   - WYL_TEST_VARIANT_AUDIT undefined: HTTP-decide protocol contracts
+ *     (readyz, request-id headers, raw decide, policy mutation, raw login)
+ *     plus the login + decide and login + guarded-decide flows.
+ *
+ *   - WYL_TEST_VARIANT_AUDIT defined: end-to-end audit pipeline. Generates
+ *     the decide and policy events the audit verification depends on, then
+ *     verifies the audit log via raw HTTP, the readyz audit-projection
+ *     contract, and a series of audit_event_present queries.
+ *
+ * Splitting was driven by Meson's per-test 30s timeout: under CI parallel
+ * scheduling the merged test serialised on local TCP and DuckDB and crossed
+ * the wall-clock ceiling. Both variants now run in parallel, each with its
+ * own daemon, and each finishes well under the timeout. Variant-irrelevant
+ * static helpers stay defined in this file; the build silences the
+ * resulting -Wunused-function warnings.
+ */
+#ifndef WYL_TEST_VARIANT_AUDIT
 int
 main (void)
 {
@@ -2823,13 +2844,6 @@ main (void)
   if (readyz_rc != 0)
     return readyz_rc;
 
-#ifdef WYL_HAS_AUDIT
-  readyz_rc = check_readyz_malformed_audit_projection_contract (handle,
-      base_url);
-  if (readyz_rc != 0)
-    return readyz_rc;
-#endif
-
   gint request_id_rc = check_request_id_header_contract (base_url);
   if (request_id_rc != 0)
     return request_id_rc;
@@ -2872,11 +2886,110 @@ main (void)
   if (decision != WYL_DECISION_DENY)
     return 13;
 
+  raw_rc = check_raw_login_contract (http.server, handle, base_url);
+  if (raw_rc != 0)
+    return raw_rc;
+
+  g_main_loop_quit (http.loop);
+  g_thread_join (thread);
+  soup_server_disconnect (http.server);
+  g_clear_object (&http.server);
+  g_clear_pointer (&http.loop, g_main_loop_unref);
+  return 0;
+}
+#else /* WYL_TEST_VARIANT_AUDIT */
+int
+main (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 1;
+  if (insert_allow_fixture (handle) != WYRELOG_E_OK)
+    return 2;
+  if (insert_not_armed_fixture (handle) != WYRELOG_E_OK)
+    return 10;
+  if (insert_guarded_fixture (handle) != WYRELOG_E_OK)
+    return 11;
+
+  WylDaemonOptions opts = {
+    .template_dir = WYL_TEST_TEMPLATE_DIR,
+    .listen_port = 0,
+  };
+  WylDaemonRuntime runtime = {
+    .handle = handle,
+  };
+  if (wyl_daemon_start_delta_callbacks (handle, &runtime) != WYRELOG_E_OK)
+    return 14;
+  TestHttpServer http = { 0 };
+  http.loop = g_main_loop_new (NULL, FALSE);
+  g_autoptr (GError) error = NULL;
+  http.server = wyl_daemon_start_http_server_with_runtime (&opts, handle,
+      &runtime, &error);
+  if (http.server == NULL)
+    return 3;
+  GThread *thread = g_thread_new ("daemon-http-decide-audit",
+      test_http_server_thread, &http);
+
+  GSList *uris = soup_server_get_uris (http.server);
+  if (uris == NULL)
+    return 4;
+  g_autofree gchar *base_url = g_uri_to_string (uris->data);
+  g_slist_free_full (uris, (GDestroyNotify) g_uri_unref);
+
+  g_autoptr (WylClient) client = NULL;
+  if (wyl_client_new (base_url, &client) != WYRELOG_E_OK)
+    return 5;
+
+  gint readyz_rc = check_readyz_malformed_audit_projection_contract (handle,
+      base_url);
+  if (readyz_rc != 0)
+    return readyz_rc;
+
+  /* Seed http.not_armed (http-deny-user) and other negative-decide audit
+   * events that the audit_event_present series below relies on. The full
+   * raw decide protocol contract is exercised in the non-audit variant. */
+  gint raw_rc = check_raw_decide_contract (handle, base_url);
+  if (raw_rc != 0)
+    return raw_rc;
+  gint decision = -1;
+  wyl_handle_set_login_skip_mfa_allowed (handle, TRUE);
+  if (wyl_client_login_skip_mfa (client, "http-allow-user") != WYRELOG_E_OK) {
+    wyl_handle_set_login_skip_mfa_allowed (handle, FALSE);
+    return 1819;
+  }
+  wyl_handle_set_login_skip_mfa_allowed (handle, FALSE);
+  if (insert_allow_fixture (handle) != WYRELOG_E_OK)
+    return 1822;
+  if (wyl_client_decide (client, "http-allow-user", "http.allow",
+          "http-allow-scope", &decision) != WYRELOG_E_OK)
+    return 8;
+  if (decision != WYL_DECISION_ALLOW)
+    return 9;
+  wyl_handle_set_login_skip_mfa_allowed (handle, TRUE);
+  if (wyl_client_login_skip_mfa (client, "http-guard-user") != WYRELOG_E_OK) {
+    wyl_handle_set_login_skip_mfa_allowed (handle, FALSE);
+    return 1820;
+  }
+  wyl_handle_set_login_skip_mfa_allowed (handle, FALSE);
+  if (insert_guarded_fixture (handle) != WYRELOG_E_OK)
+    return 1823;
+  if (wyl_client_decide_with_guard_context (client, "http-guard-user",
+          "wr.audit.read", "http-guard-scope", 123, "public", 69,
+          &decision) != WYRELOG_E_OK)
+    return 10;
+  if (decision != WYL_DECISION_ALLOW)
+    return 11;
+  if (wyl_client_decide_with_guard_context (client, "http-guard-user",
+          "wr.audit.read", "http-guard-scope", 123, "public", 70,
+          &decision) != WYRELOG_E_OK)
+    return 12;
+  if (decision != WYL_DECISION_DENY)
+    return 13;
+
   raw_rc = check_policy_permission_mutation_contract (handle, client, base_url);
   if (raw_rc != 0)
     return raw_rc;
 
-#ifdef WYL_HAS_AUDIT
   wyl_handle_set_login_skip_mfa_allowed (handle, TRUE);
   if (wyl_client_login_skip_mfa (client, "http-audit-user") != WYRELOG_E_OK)
     return 84;
@@ -2963,11 +3076,6 @@ main (void)
       WYL_DECISION_ALLOW, NULL, "site.reader");
   if (audit_rc != 0)
     return audit_rc;
-#endif
-
-  raw_rc = check_raw_login_contract (http.server, handle, base_url);
-  if (raw_rc != 0)
-    return raw_rc;
 
   g_main_loop_quit (http.loop);
   g_thread_join (thread);
@@ -2976,3 +3084,4 @@ main (void)
   g_clear_pointer (&http.loop, g_main_loop_unref);
   return 0;
 }
+#endif /* WYL_TEST_VARIANT_AUDIT */

--- a/tests/test-session-username.c
+++ b/tests/test-session-username.c
@@ -1849,6 +1849,26 @@ check_session_elevation_rejects_invalid_args (void)
   return 0;
 }
 
+/*
+ * The session-username test surface has been split across two binaries
+ * compiled from this single translation unit:
+ *
+ *   - WYL_TEST_VARIANT_LIFECYCLE undefined: login + MFA flows (username
+ *     propagation, tenant binding, request buffers, MFA verify, skip-mfa
+ *     policy paths, login decision-scope wiring).
+ *
+ *   - WYL_TEST_VARIANT_LIFECYCLE defined: session lifecycle transitions
+ *     (close, elevate / drop-elevation, idle timeout, expire) and their
+ *     decision-scope and wirelog event side-effects.
+ *
+ * Splitting was driven by Meson's per-test 30s timeout: under CI parallel
+ * scheduling the merged test crossed the wall-clock ceiling on Windows
+ * (30.10s SIGTERM, 22.77s on prior main). Both variants now run in
+ * parallel and each finishes well under the timeout. Variant-irrelevant
+ * static helpers stay defined in this file; the build silences the
+ * resulting -Wunused-function warnings.
+ */
+#ifndef WYL_TEST_VARIANT_LIFECYCLE
 int
 main (void)
 {
@@ -1912,6 +1932,15 @@ main (void)
     return rc;
   if ((rc = check_login_skip_mfa_does_not_bypass_guarded_permission ()) != 0)
     return rc;
+
+  return 0;
+}
+#else /* WYL_TEST_VARIANT_LIFECYCLE */
+int
+main (void)
+{
+  gint rc;
+
   if ((rc = check_session_close_persists_closed_state ()) != 0)
     return rc;
   if ((rc = check_session_close_inserts_wirelog_session_fired ()) != 0)
@@ -1951,3 +1980,4 @@ main (void)
 
   return 0;
 }
+#endif /* WYL_TEST_VARIANT_LIFECYCLE */


### PR DESCRIPTION
## Summary

- Split `tests/test-daemon-http-decide.c` into two variants compiled from the same source via `#ifdef WYL_TEST_VARIANT_AUDIT`: `daemon-http-decide` (protocol contracts) and `daemon-http-decide-audit` (end-to-end audit pipeline).
- The merged test had crossed Meson's 30s default timeout on Ubuntu CI under parallel-suite contention (local 2.2s, CI 30.02s SIGTERM). Both new binaries fit comfortably under the timeout.

## Coverage

Every original `check_*` invocation lands in at least one variant (verified by inspection):

| Function | Original | decide | audit |
|---|---|---|---|
| `check_readyz_runtime_liveness_contract` | 1 | 1 | 0 |
| `check_readyz_malformed_audit_projection_contract` | 1 | 0 | 1 |
| `check_request_id_header_contract` | 1 | 1 | 0 |
| `check_raw_decide_contract` | 1 | 1 | 1 |
| `check_raw_login_contract` | 1 | 1 | 0 |
| `check_policy_permission_mutation_contract` | 1 | 0 | 1 |
| `check_raw_audit_contract` | 1 | 0 | 1 |
| `check_audit_event_present` | 11 | 0 | 11 |

The audit variant re-runs the decide and login flows to seed the audit log; this is intentional and noted inline. The `enable_audit` gate is preserved: the new `daemon-http-decide-audit` binary is only registered when `enable_audit.allowed()`.

## Local timings

| Variant | Direct | meson test |
|---|---|---|
| `daemon-http-decide` | 0.50s | 4.79s |
| `daemon-http-decide-audit` | 2.00s | 7.50s |

Both well under the 30s timeout. Total wall time across the two parallel binaries is similar to the original merged test on a workstation, but each fits independently under the per-test ceiling.

## Test plan

- [x] `meson compile -C builddir test-daemon-http-decide test-daemon-http-decide-audit` — clean
- [x] `./builddir/tests/test-daemon-http-decide` — exit 0
- [x] `./builddir/tests/test-daemon-http-decide-audit` — exit 0
- [x] `meson test -C builddir daemon-http-decide daemon-http-decide-audit` — both pass (4.79s + 7.50s)
- [x] `meson test -C builddir --suite wyrelog` — same set of pre-existing failures as `main` (no new regressions); pre-existing failures tracked in #265 (wirelog upstream regression)
- [x] `./tools/gst-indent tests/test-daemon-http-decide.c` — no diff
- [ ] CI on this PR — confirm both variants stay under 30s on Ubuntu runners under real parallel-suite load
- [ ] Follow-up issue: lighter-weight `http.not_armed` audit-event seeder for the audit variant (currently re-runs `check_raw_decide_contract` in full); review feedback NIT

Closes #266