### PR TITLE
session: implement real session logout teardown

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -458,6 +458,16 @@ test_session_logout = executable('test-session-logout',
 
 test('session-logout', test_session_logout)
 
+test_session_registry = executable('test-session-registry',
+  'test-session-registry.c',
+  c_args : [
+    '-DWYL_TEST_TEMPLATE_DIR="' + meson.project_source_root() / 'templates' / 'access' + '"',
+  ],
+  dependencies : [wyrelog_dep],
+)
+
+test('session-registry', test_session_registry)
+
 # NOTE: WYL_TEST_TEMPLATE_DIR points at the in-tree source layout
 # only. The installed layout (${datadir}/wyrelog/access) — produced
 # by install_subdir at the top-level meson.build — is not

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -453,6 +453,9 @@ test('perm', test_perm)
 
 test_session_logout = executable('test-session-logout',
   'test-session-logout.c',
+  c_args : [
+    '-DWYL_TEST_TEMPLATE_DIR="' + meson.project_source_root() / 'templates' / 'access' + '"',
+  ],
   dependencies : [wyrelog_dep],
 )
 

--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -1498,6 +1498,16 @@ check_raw_login_contract (SoupServer *server, WylHandle *handle,
     return rc;
   if (status != 401 || strstr (body, "\"refresh_auth_required\"") == NULL)
     return 525;
+  /*
+   * The logout teardown must mark the session as revoked in the
+   * daemon-side gate so the store paths refuse any token state an
+   * in-flight /auth/refresh might still try to insert after the
+   * snapshot-walking revoke pass returned. The revoked-session set
+   * is the structural fix for the residual store-after-revoke
+   * window the snapshot revoke alone leaves open.
+   */
+  if (!wyl_daemon_http_session_is_revoked (server, bearer_logout_session_token))
+    return 526;
 #ifdef WYL_HAS_AUDIT
   AuditEventProbe bearer_close_audit = {
     .subject_id = bearer_logout_session_token,

--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -1443,6 +1443,10 @@ check_raw_login_contract (SoupServer *server, WylHandle *handle,
       extract_json_string (body, "access_token");
   if (bearer_logout_access_token == NULL)
     return 504;
+  g_autofree gchar *bearer_logout_refresh_token =
+      extract_json_string (body, "refresh_token");
+  if (bearer_logout_refresh_token == NULL)
+    return 524;
   g_clear_pointer (&body, g_free);
   if (grant_policy_write_authority (handle, "bearer-logout-user",
           bearer_logout_session_token) != WYRELOG_E_OK)
@@ -1479,6 +1483,21 @@ check_raw_login_contract (SoupServer *server, WylHandle *handle,
       wyl_daemon_http_ref_session (server, bearer_logout_session_token);
   if (bearer_logged_out_session != NULL)
     return 509;
+  /*
+   * Refresh token captured at login must be rejected after the
+   * bearer logout completes. The teardown order in logout_handler
+   * revokes refresh tokens before driving the session FSM, so the
+   * window during which a captured refresh could rotate into a
+   * fresh access/refresh pair is closed before the public reply
+   * lands at the caller.
+   */
+  g_clear_pointer (&body, g_free);
+  rc = send_raw_refresh (session, "POST", base_url,
+      bearer_logout_refresh_token, &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 401 || strstr (body, "\"refresh_auth_required\"") == NULL)
+    return 525;
 #ifdef WYL_HAS_AUDIT
   AuditEventProbe bearer_close_audit = {
     .subject_id = bearer_logout_session_token,

--- a/tests/test-session-logout.c
+++ b/tests/test-session-logout.c
@@ -3,46 +3,192 @@
 
 #include "wyrelog/wyrelog.h"
 
-/*
- * v0 contract for wyl_session_logout: validate handle, record the
- * logout in the audit log when audit is enabled, and return
- * WYRELOG_E_OK without touching a durable session table. The
- * session-store teardown is a follow-up.
- */
+#ifndef WYL_TEST_TEMPLATE_DIR
+#error "WYL_TEST_TEMPLATE_DIR must be defined by the build."
+#endif
 
-static gint
-check_logout_returns_ok (void)
+static WylSession *
+login_one (WylHandle *handle, const gchar *username)
 {
-  g_autoptr (WylHandle) handle = NULL;
-  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
-    return 10;
+  g_autoptr (wyl_login_req_t) req = wyl_login_req_new ();
+  if (username != NULL)
+    wyl_login_req_set_username (req, username);
 
-  if (wyl_session_logout (handle, 42) != WYRELOG_E_OK)
-    return 11;
-  return 0;
+  WylSession *session = NULL;
+  if (wyl_session_login (handle, req, &session) != WYRELOG_E_OK)
+    return NULL;
+  return session;
 }
 
 static gint
 check_logout_rejects_null_handle (void)
 {
   if (wyl_session_logout (NULL, 42) != WYRELOG_E_INVALID)
-    return 20;
+    return 1;
+  if (wyl_session_logout_with_request_id (NULL, 42, "req-1")
+      != WYRELOG_E_INVALID)
+    return 2;
   return 0;
 }
 
 static gint
-check_logout_accepts_zero_sid (void)
+check_logout_unknown_sid_returns_not_found (void)
 {
   g_autoptr (WylHandle) handle = NULL;
-  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 10;
+
+  /* Sid 0 is reserved for "uninitialised" by wyl_session_get_id and is
+   * never minted by the registry, so it is necessarily unknown. */
+  if (wyl_session_logout (handle, 0) != WYRELOG_E_NOT_FOUND)
+    return 11;
+
+  /* A high integer that the registry has never minted is also unknown
+   * regardless of how many sessions have ever been registered. */
+  if (wyl_session_logout (handle, 999999) != WYRELOG_E_NOT_FOUND)
+    return 12;
+  return 0;
+}
+
+static gint
+check_logout_drives_active_session_to_closed (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 20;
+
+  g_autoptr (WylSession) session = login_one (handle, "alice");
+  if (session == NULL)
+    return 21;
+
+  wyl_session_id_t sid = wyl_session_get_id (session);
+  if (sid == 0)
+    return 22;
+
+  if (wyl_session_logout (handle, sid) != WYRELOG_E_OK)
+    return 23;
+  return 0;
+}
+
+static gint
+check_logout_is_idempotent_on_repeat (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
     return 30;
 
-  /* sid is an opaque integer at this layer; the session-table
-   * implementation will reject unknown ids in a future commit, but
-   * v0 has no table to consult so any well-formed integer is
-   * accepted. */
-  if (wyl_session_logout (handle, 0) != WYRELOG_E_OK)
+  g_autoptr (WylSession) session = login_one (handle, "alice");
+  if (session == NULL)
     return 31;
+
+  wyl_session_id_t sid = wyl_session_get_id (session);
+  if (wyl_session_logout (handle, sid) != WYRELOG_E_OK)
+    return 32;
+  /* Repeat: the registry entry is now tombstoned. The contract is
+   * idempotent E_OK without re-driving the FSM (which has no
+   * (closed, logout) transition row) and without re-emitting an
+   * audit row. */
+  if (wyl_session_logout (handle, sid) != WYRELOG_E_OK)
+    return 33;
+  if (wyl_session_logout (handle, sid) != WYRELOG_E_OK)
+    return 34;
+  return 0;
+}
+
+static gint
+check_logout_after_session_close_is_idempotent (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 40;
+
+  g_autoptr (WylSession) session = login_one (handle, "alice");
+  if (session == NULL)
+    return 41;
+  wyl_session_id_t sid = wyl_session_get_id (session);
+
+  /* Drive the session to the terminal CLOSED state through the
+   * WylSession* surface; the registry holds a strong ref and is
+   * NOT yet tombstoned. */
+  if (wyl_session_close (handle, session) != WYRELOG_E_OK)
+    return 42;
+
+  /* Logout via the integer-sid surface must short-circuit to E_OK
+   * (no FSM step possible from CLOSED) and tombstone the registry
+   * so the strong ref is released. */
+  if (wyl_session_logout (handle, sid) != WYRELOG_E_OK)
+    return 43;
+  if (wyl_session_logout (handle, sid) != WYRELOG_E_OK)
+    return 44;
+  return 0;
+}
+
+static gint
+check_logout_with_request_id_propagates (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 50;
+
+  g_autoptr (WylSession) session = login_one (handle, "alice");
+  if (session == NULL)
+    return 51;
+  wyl_session_id_t sid = wyl_session_get_id (session);
+
+  /* The request-id-bearing variant must succeed end-to-end. The
+   * audit row's request_id field is checked by tests that exercise
+   * the audit projection in the daemon-http-decide-audit suite. */
+  if (wyl_session_logout_with_request_id (handle, sid, "req-logout-7")
+      != WYRELOG_E_OK)
+    return 52;
+  return 0;
+}
+
+static gint
+check_logout_with_null_request_id_matches_plain (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 60;
+
+  g_autoptr (WylSession) a = login_one (handle, "alice");
+  g_autoptr (WylSession) b = login_one (handle, "bob");
+  if (a == NULL || b == NULL)
+    return 61;
+
+  if (wyl_session_logout_with_request_id (handle, wyl_session_get_id (a), NULL)
+      != WYRELOG_E_OK)
+    return 62;
+  if (wyl_session_logout (handle, wyl_session_get_id (b)) != WYRELOG_E_OK)
+    return 63;
+  return 0;
+}
+
+static gint
+check_logout_isolates_sessions_by_id (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 70;
+
+  g_autoptr (WylSession) a = login_one (handle, "alice");
+  g_autoptr (WylSession) b = login_one (handle, "bob");
+  if (a == NULL || b == NULL)
+    return 71;
+
+  wyl_session_id_t sid_a = wyl_session_get_id (a);
+  wyl_session_id_t sid_b = wyl_session_get_id (b);
+  if (sid_a == sid_b)
+    return 72;
+
+  /* Logging out alice must not affect bob. */
+  if (wyl_session_logout (handle, sid_a) != WYRELOG_E_OK)
+    return 73;
+  if (wyl_session_logout (handle, sid_b) != WYRELOG_E_OK)
+    return 74;
+  /* And bob must still report idempotent E_OK on the second call. */
+  if (wyl_session_logout (handle, sid_b) != WYRELOG_E_OK)
+    return 75;
   return 0;
 }
 
@@ -50,11 +196,23 @@ int
 main (void)
 {
   gint rc;
-  if ((rc = check_logout_returns_ok ()) != 0)
-    return rc;
+
   if ((rc = check_logout_rejects_null_handle ()) != 0)
     return rc;
-  if ((rc = check_logout_accepts_zero_sid ()) != 0)
+  if ((rc = check_logout_unknown_sid_returns_not_found ()) != 0)
     return rc;
+  if ((rc = check_logout_drives_active_session_to_closed ()) != 0)
+    return rc;
+  if ((rc = check_logout_is_idempotent_on_repeat ()) != 0)
+    return rc;
+  if ((rc = check_logout_after_session_close_is_idempotent ()) != 0)
+    return rc;
+  if ((rc = check_logout_with_request_id_propagates ()) != 0)
+    return rc;
+  if ((rc = check_logout_with_null_request_id_matches_plain ()) != 0)
+    return rc;
+  if ((rc = check_logout_isolates_sessions_by_id ()) != 0)
+    return rc;
+
   return 0;
 }

--- a/tests/test-session-registry.c
+++ b/tests/test-session-registry.c
@@ -1,0 +1,145 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <glib.h>
+
+#include "wyrelog/wyrelog.h"
+#include "wyrelog/wyl-handle-private.h"
+
+#ifndef WYL_TEST_TEMPLATE_DIR
+#error "WYL_TEST_TEMPLATE_DIR must be defined by the build."
+#endif
+
+static WylSession *
+login_one (WylHandle *handle, const gchar *username)
+{
+  g_autoptr (wyl_login_req_t) req = wyl_login_req_new ();
+  if (username != NULL)
+    wyl_login_req_set_username (req, username);
+
+  WylSession *session = NULL;
+  if (wyl_session_login (handle, req, &session) != WYRELOG_E_OK)
+    return NULL;
+  return session;
+}
+
+static gint
+check_login_assigns_nonzero_sid (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 1;
+
+  g_autoptr (WylSession) session = login_one (handle, "alice");
+  if (session == NULL)
+    return 2;
+
+  if (wyl_session_get_id (session) == 0)
+    return 3;
+  return 0;
+}
+
+static gint
+check_two_logins_distinct_sids (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 10;
+
+  g_autoptr (WylSession) a = login_one (handle, "alice");
+  g_autoptr (WylSession) b = login_one (handle, "bob");
+  if (a == NULL || b == NULL)
+    return 11;
+
+  if (wyl_session_get_id (a) == 0 || wyl_session_get_id (b) == 0)
+    return 12;
+  if (wyl_session_get_id (a) == wyl_session_get_id (b))
+    return 13;
+  return 0;
+}
+
+static gint
+check_lookup_returns_registered_session (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 20;
+
+  g_autoptr (WylSession) session = login_one (handle, "alice");
+  if (session == NULL)
+    return 21;
+
+  wyl_session_id_t sid = wyl_session_get_id (session);
+  if (wyl_handle_lookup_session_by_id (handle, sid) != session)
+    return 22;
+  return 0;
+}
+
+static gint
+check_lookup_unknown_returns_null (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 30;
+
+  if (wyl_handle_lookup_session_by_id (handle, 999999) != NULL)
+    return 31;
+  return 0;
+}
+
+static gint
+check_lookup_null_handle_returns_null (void)
+{
+  if (wyl_handle_lookup_session_by_id (NULL, 1) != NULL)
+    return 40;
+  return 0;
+}
+
+static gint
+check_get_id_null_session_returns_zero (void)
+{
+  if (wyl_session_get_id (NULL) != 0)
+    return 50;
+  return 0;
+}
+
+static gint
+check_lookups_isolated_per_handle (void)
+{
+  g_autoptr (WylHandle) ha = NULL;
+  g_autoptr (WylHandle) hb = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &ha) != WYRELOG_E_OK)
+    return 60;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &hb) != WYRELOG_E_OK)
+    return 61;
+
+  g_autoptr (WylSession) sa = login_one (ha, "alice");
+  if (sa == NULL)
+    return 62;
+
+  /* Looking up A's sid on B must not return A's session. */
+  if (wyl_handle_lookup_session_by_id (hb, wyl_session_get_id (sa)) != NULL)
+    return 63;
+  return 0;
+}
+
+int
+main (void)
+{
+  gint rc;
+
+  if ((rc = check_login_assigns_nonzero_sid ()) != 0)
+    return rc;
+  if ((rc = check_two_logins_distinct_sids ()) != 0)
+    return rc;
+  if ((rc = check_lookup_returns_registered_session ()) != 0)
+    return rc;
+  if ((rc = check_lookup_unknown_returns_null ()) != 0)
+    return rc;
+  if ((rc = check_lookup_null_handle_returns_null ()) != 0)
+    return rc;
+  if ((rc = check_get_id_null_session_returns_zero ()) != 0)
+    return rc;
+  if ((rc = check_lookups_isolated_per_handle ()) != 0)
+    return rc;
+
+  return 0;
+}

--- a/tests/test-session-registry.c
+++ b/tests/test-session-registry.c
@@ -121,6 +121,78 @@ check_lookups_isolated_per_handle (void)
   return 0;
 }
 
+static gint
+check_handle_finalize_releases_registered_sessions (void)
+{
+  WylHandle *handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 70;
+
+  WylSession *session = login_one (handle, "alice");
+  if (session == NULL) {
+    g_object_unref (handle);
+    return 71;
+  }
+
+  /* Track the session through a weak pointer so we can observe
+   * finalize without holding a strong reference of our own. The
+   * registry inside |handle| holds the only remaining strong
+   * reference once we drop the caller's ref below. */
+  gpointer weak_session = session;
+  g_object_add_weak_pointer (G_OBJECT (session), &weak_session);
+  g_object_unref (session);
+
+  if (weak_session == NULL) {
+    /* The registry's strong reference should still keep the session
+     * alive, so the weak pointer must not have been cleared yet. */
+    g_object_unref (handle);
+    return 72;
+  }
+
+  g_object_unref (handle);
+
+  /* After the handle is finalized the registry is unrefed, dropping
+   * its strong reference; the session must finalize and the weak
+   * pointer must be cleared. */
+  if (weak_session != NULL)
+    return 73;
+  return 0;
+}
+
+static gint
+check_logout_tombstones_registry_entry (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 80;
+
+  WylSession *session = login_one (handle, "alice");
+  if (session == NULL)
+    return 81;
+  wyl_session_id_t sid = wyl_session_get_id (session);
+
+  /* Track the session via a weak pointer; the registry holds the
+   * only strong reference after we drop the caller's. */
+  gpointer weak_session = session;
+  g_object_add_weak_pointer (G_OBJECT (session), &weak_session);
+  g_object_unref (session);
+  if (weak_session == NULL)
+    return 82;
+
+  /* Logout must drop the registry's strong reference so the session
+   * is finalized synchronously (no other refs are held by the test). */
+  if (wyl_session_logout (handle, sid) != WYRELOG_E_OK)
+    return 83;
+  if (weak_session != NULL)
+    return 84;
+
+  /* The borrowed-pointer lookup must now report a tombstone (entry
+   * present, session NULL) rather than returning a freed pointer. */
+  if (wyl_handle_lookup_session_by_id (handle, sid) != NULL)
+    return 85;
+  return 0;
+}
+
 int
 main (void)
 {
@@ -139,6 +211,10 @@ main (void)
   if ((rc = check_get_id_null_session_returns_zero ()) != 0)
     return rc;
   if ((rc = check_lookups_isolated_per_handle ()) != 0)
+    return rc;
+  if ((rc = check_handle_finalize_releases_registered_sessions ()) != 0)
+    return rc;
+  if ((rc = check_logout_tombstones_registry_entry ()) != 0)
     return rc;
 
   return 0;

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -75,6 +75,19 @@ typedef struct
   GHashTable *sessions_by_token;
   GHashTable *access_tokens_by_jti;
   GHashTable *refresh_tokens_by_token;
+  /*
+   * Set of session_token strings that have entered the logout
+   * teardown path. Once a session is in this set, both
+   * wyl_daemon_http_context_store_access_token and _store_refresh_token
+   * refuse to insert any new state for that session, closing the
+   * window in which an /auth/refresh that already passed the
+   * lock-protected revoked-state check could mint a fresh access
+   * or refresh token after the logout's revoke pass had already
+   * snapshotted the existing tokens. Entries are added under
+   * ctx->lock during logout teardown and live for the lifetime of
+   * the context.
+   */
+  GHashTable *revoked_session_ids;
   GMutex lock;
   GMutex policy_mutation_lock;
 } WylDaemonHttpContext;
@@ -148,6 +161,7 @@ wyl_daemon_http_context_free (gpointer data)
   g_hash_table_unref (ctx->sessions_by_token);
   g_hash_table_unref (ctx->access_tokens_by_jti);
   g_hash_table_unref (ctx->refresh_tokens_by_token);
+  g_clear_pointer (&ctx->revoked_session_ids, g_hash_table_unref);
   g_mutex_clear (&ctx->lock);
   g_mutex_clear (&ctx->policy_mutation_lock);
   g_free (ctx);
@@ -170,9 +184,23 @@ wyl_daemon_http_context_new (WylHandle *handle, WylDaemonRuntime *runtime)
       g_free, wyl_access_token_state_free);
   ctx->refresh_tokens_by_token = g_hash_table_new_full (g_str_hash, g_str_equal,
       g_free, wyl_refresh_token_state_free);
+  ctx->revoked_session_ids = g_hash_table_new_full (g_str_hash, g_str_equal,
+      g_free, NULL);
   g_mutex_init (&ctx->lock);
   g_mutex_init (&ctx->policy_mutation_lock);
   return ctx;
+}
+
+static void
+wyl_daemon_http_context_mark_session_revoked (WylDaemonHttpContext *ctx,
+    const gchar *session_id)
+{
+  if (ctx == NULL || session_id == NULL || session_id[0] == '\0')
+    return;
+
+  g_mutex_lock (&ctx->lock);
+  g_hash_table_add (ctx->revoked_session_ids, g_strdup (session_id));
+  g_mutex_unlock (&ctx->lock);
 }
 
 static gboolean
@@ -195,6 +223,19 @@ wyl_daemon_http_context_store_access_token (WylDaemonHttpContext *ctx,
   state->expires_at = expires_at;
 
   g_mutex_lock (&ctx->lock);
+  /*
+   * Refuse to register tokens for a session that has already entered
+   * the logout teardown path. This closes the window in which a
+   * concurrent /auth/refresh that snapshotted state->revoked == FALSE
+   * before the teardown's revoke pass landed could otherwise insert
+   * a freshly-minted access token whose jti the teardown's snapshot
+   * never saw.
+   */
+  if (g_hash_table_contains (ctx->revoked_session_ids, session_id)) {
+    g_mutex_unlock (&ctx->lock);
+    wyl_access_token_state_free (state);
+    return FALSE;
+  }
   g_hash_table_replace (ctx->access_tokens_by_jti, g_strdup (jti), state);
   g_mutex_unlock (&ctx->lock);
   return TRUE;
@@ -241,6 +282,17 @@ wyl_daemon_http_context_store_refresh_token (WylDaemonHttpContext *ctx,
   state->expires_at = expires_at;
 
   g_mutex_lock (&ctx->lock);
+  /*
+   * Same revoked-session gate as the access-token store path: refuse
+   * to register a refresh token for a session that has already
+   * entered logout teardown. Pairs with /auth/refresh handling so
+   * the rotation cannot mint a new refresh that survives logout.
+   */
+  if (g_hash_table_contains (ctx->revoked_session_ids, session_id)) {
+    g_mutex_unlock (&ctx->lock);
+    wyl_refresh_token_state_free (state);
+    return FALSE;
+  }
   g_hash_table_replace (ctx->refresh_tokens_by_token, g_strdup (token), state);
   g_mutex_unlock (&ctx->lock);
   return TRUE;
@@ -358,6 +410,23 @@ wyl_daemon_http_copy_access_token_secret (SoupServer *server,
 
   memcpy (out_secret, ctx->access_token_secret, WYL_DAEMON_JWT_KEY_LEN);
   return WYRELOG_E_OK;
+}
+
+gboolean
+wyl_daemon_http_session_is_revoked (SoupServer *server, const gchar *session_id)
+{
+  if (server == NULL || session_id == NULL || session_id[0] == '\0')
+    return FALSE;
+
+  WylDaemonHttpContext *ctx = wyl_daemon_http_get_context (server);
+  if (ctx == NULL)
+    return FALSE;
+
+  g_mutex_lock (&ctx->lock);
+  gboolean revoked = g_hash_table_contains (ctx->revoked_session_ids,
+      session_id);
+  g_mutex_unlock (&ctx->lock);
+  return revoked;
 }
 #endif
 
@@ -1748,18 +1817,28 @@ logout_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
    * session_id (the rotation path will see a revoked refresh and
    * fail before issuing a new access token).
    *
-   * Then revoke any access tokens already minted, then drive the
-   * FSM through the durable close primitive. Returning to the
+   * Then revoke any access tokens already minted. After both
+   * snapshot-walks complete, mark the session as revoked so the
+   * store paths refuse any token state that an /auth/refresh which
+   * already passed the lock-protected revoked-state check could
+   * still try to insert after our snapshots ran. Returning to the
    * caller before token revocation completes would leave a replay
    * window during which a captured access token still resolves
    * against the registry; the order here closes that window.
+   *
+   * Drive the FSM through the public logout primitive (which
+   * resolves the integer sid, runs the FSM transition, emits the
+   * canonical session-state audit row, and tombstones the
+   * handle's session registry) so HTTP and the core API converge
+   * on a single FSM call site.
    */
   wyl_daemon_http_context_revoke_session_refresh_tokens (ctx, session_token);
   wyl_daemon_http_context_revoke_session_access_tokens (ctx, session_token);
+  wyl_daemon_http_context_mark_session_revoked (ctx, session_token);
 
   const gchar *request_id = ensure_request_id_header (msg);
-  wyrelog_error_t rc =
-      wyl_session_close_with_request_id (ctx->handle, session, request_id);
+  wyrelog_error_t rc = wyl_session_logout_with_request_id (ctx->handle,
+      wyl_session_get_id (session), request_id);
   if (rc != WYRELOG_E_OK) {
     set_json_error (msg, 500, "logout_failed");
     return;

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -1739,6 +1739,24 @@ logout_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
     return;
   }
 
+  /*
+   * Revoke refresh tokens FIRST so a concurrent /auth/refresh that
+   * lands during teardown cannot rotate the refresh into a fresh
+   * access/refresh pair bound to the now-being-killed session;
+   * each revoke takes ctx->lock internally, so the window between
+   * the two passes cannot mint a new refresh through the same
+   * session_id (the rotation path will see a revoked refresh and
+   * fail before issuing a new access token).
+   *
+   * Then revoke any access tokens already minted, then drive the
+   * FSM through the durable close primitive. Returning to the
+   * caller before token revocation completes would leave a replay
+   * window during which a captured access token still resolves
+   * against the registry; the order here closes that window.
+   */
+  wyl_daemon_http_context_revoke_session_refresh_tokens (ctx, session_token);
+  wyl_daemon_http_context_revoke_session_access_tokens (ctx, session_token);
+
   const gchar *request_id = ensure_request_id_header (msg);
   wyrelog_error_t rc =
       wyl_session_close_with_request_id (ctx->handle, session, request_id);
@@ -1747,8 +1765,6 @@ logout_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
     return;
   }
 
-  wyl_daemon_http_context_revoke_session_access_tokens (ctx, session_token);
-  wyl_daemon_http_context_revoke_session_refresh_tokens (ctx, session_token);
   if (!wyl_daemon_http_context_remove_session (ctx, session_token)) {
     set_json_error (msg, 401, "logout_auth_required");
     return;

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -87,7 +87,7 @@ typedef struct
    * ctx->lock during logout teardown and live for the lifetime of
    * the context.
    */
-  GHashTable *revoked_session_ids;
+  GHashTable *revoked_session_tokens;
   GMutex lock;
   GMutex policy_mutation_lock;
 } WylDaemonHttpContext;
@@ -161,7 +161,7 @@ wyl_daemon_http_context_free (gpointer data)
   g_hash_table_unref (ctx->sessions_by_token);
   g_hash_table_unref (ctx->access_tokens_by_jti);
   g_hash_table_unref (ctx->refresh_tokens_by_token);
-  g_clear_pointer (&ctx->revoked_session_ids, g_hash_table_unref);
+  g_clear_pointer (&ctx->revoked_session_tokens, g_hash_table_unref);
   g_mutex_clear (&ctx->lock);
   g_mutex_clear (&ctx->policy_mutation_lock);
   g_free (ctx);
@@ -184,7 +184,7 @@ wyl_daemon_http_context_new (WylHandle *handle, WylDaemonRuntime *runtime)
       g_free, wyl_access_token_state_free);
   ctx->refresh_tokens_by_token = g_hash_table_new_full (g_str_hash, g_str_equal,
       g_free, wyl_refresh_token_state_free);
-  ctx->revoked_session_ids = g_hash_table_new_full (g_str_hash, g_str_equal,
+  ctx->revoked_session_tokens = g_hash_table_new_full (g_str_hash, g_str_equal,
       g_free, NULL);
   g_mutex_init (&ctx->lock);
   g_mutex_init (&ctx->policy_mutation_lock);
@@ -193,13 +193,13 @@ wyl_daemon_http_context_new (WylHandle *handle, WylDaemonRuntime *runtime)
 
 static void
 wyl_daemon_http_context_mark_session_revoked (WylDaemonHttpContext *ctx,
-    const gchar *session_id)
+    const gchar *session_token)
 {
-  if (ctx == NULL || session_id == NULL || session_id[0] == '\0')
+  if (ctx == NULL || session_token == NULL || session_token[0] == '\0')
     return;
 
   g_mutex_lock (&ctx->lock);
-  g_hash_table_add (ctx->revoked_session_ids, g_strdup (session_id));
+  g_hash_table_add (ctx->revoked_session_tokens, g_strdup (session_token));
   g_mutex_unlock (&ctx->lock);
 }
 
@@ -231,7 +231,7 @@ wyl_daemon_http_context_store_access_token (WylDaemonHttpContext *ctx,
    * a freshly-minted access token whose jti the teardown's snapshot
    * never saw.
    */
-  if (g_hash_table_contains (ctx->revoked_session_ids, session_id)) {
+  if (g_hash_table_contains (ctx->revoked_session_tokens, session_id)) {
     g_mutex_unlock (&ctx->lock);
     wyl_access_token_state_free (state);
     return FALSE;
@@ -288,7 +288,7 @@ wyl_daemon_http_context_store_refresh_token (WylDaemonHttpContext *ctx,
    * entered logout teardown. Pairs with /auth/refresh handling so
    * the rotation cannot mint a new refresh that survives logout.
    */
-  if (g_hash_table_contains (ctx->revoked_session_ids, session_id)) {
+  if (g_hash_table_contains (ctx->revoked_session_tokens, session_id)) {
     g_mutex_unlock (&ctx->lock);
     wyl_refresh_token_state_free (state);
     return FALSE;
@@ -413,9 +413,10 @@ wyl_daemon_http_copy_access_token_secret (SoupServer *server,
 }
 
 gboolean
-wyl_daemon_http_session_is_revoked (SoupServer *server, const gchar *session_id)
+wyl_daemon_http_session_is_revoked (SoupServer *server,
+    const gchar *session_token)
 {
-  if (server == NULL || session_id == NULL || session_id[0] == '\0')
+  if (server == NULL || session_token == NULL || session_token[0] == '\0')
     return FALSE;
 
   WylDaemonHttpContext *ctx = wyl_daemon_http_get_context (server);
@@ -423,8 +424,8 @@ wyl_daemon_http_session_is_revoked (SoupServer *server, const gchar *session_id)
     return FALSE;
 
   g_mutex_lock (&ctx->lock);
-  gboolean revoked = g_hash_table_contains (ctx->revoked_session_ids,
-      session_id);
+  gboolean revoked = g_hash_table_contains (ctx->revoked_session_tokens,
+      session_token);
   g_mutex_unlock (&ctx->lock);
   return revoked;
 }

--- a/wyrelog/daemon/http.h
+++ b/wyrelog/daemon/http.h
@@ -26,6 +26,6 @@ gboolean wyl_daemon_http_remove_session_for_test (SoupServer * server,
 gboolean wyl_daemon_http_expire_refresh_grace_for_test (SoupServer * server,
     const gchar * refresh_token);
 gboolean wyl_daemon_http_session_is_revoked (SoupServer * server,
-    const gchar * session_id);
+    const gchar * session_token);
 #endif
 #endif

--- a/wyrelog/daemon/http.h
+++ b/wyrelog/daemon/http.h
@@ -25,5 +25,7 @@ gboolean wyl_daemon_http_remove_session_for_test (SoupServer * server,
     const gchar * session_token);
 gboolean wyl_daemon_http_expire_refresh_grace_for_test (SoupServer * server,
     const gchar * refresh_token);
+gboolean wyl_daemon_http_session_is_revoked (SoupServer * server,
+    const gchar * session_id);
 #endif
 #endif

--- a/wyrelog/error.h
+++ b/wyrelog/error.h
@@ -24,6 +24,16 @@ typedef enum wyrelog_error_t
    * violation) so operators can route incidents correctly.
    */
   WYRELOG_E_EXEC = -8,
+  /*
+   * Caller-supplied identifier resolved past argument validation but
+   * names no entity the callee currently tracks. Distinct from
+   * WYRELOG_E_INVALID (argument-shape failure: NULL handle, NULL
+   * out-pointer, or otherwise malformed input) so callers can
+   * distinguish "you asked for something that no longer exists" from
+   * "you handed me junk." Used today by wyl_session_logout to flag a
+   * sid the handle has never registered.
+   */
+  WYRELOG_E_NOT_FOUND = -9,
 } wyrelog_error_t;
 
 const gchar *wyrelog_error_string (wyrelog_error_t err);

--- a/wyrelog/session.h
+++ b/wyrelog/session.h
@@ -98,13 +98,42 @@ wyrelog_error_t wyl_session_expire (WylHandle * handle, WylSession * session);
 wyrelog_error_t wyl_session_close (WylHandle * handle, WylSession * session);
 wyrelog_error_t wyl_session_close_with_request_id (WylHandle * handle,
     WylSession * session, const gchar * request_id);
+/*
+ * Drives the durable session identified by |sid| through the session
+ * FSM into the closed terminal state and releases the handle's
+ * registry reference so token caches and other derived state can be
+ * reclaimed. Resolves |sid| against the per-handle registry (the
+ * integer minted on the wyl_session_login success path); the
+ * lookup is the single source of truth for what the call does next:
+ *
+ *   - sid not registered: returns WYRELOG_E_NOT_FOUND so the caller
+ *     can distinguish "you asked for a session this handle never
+ *     knew about" from a malformed call.
+ *   - sid registered but already torn down (idempotent re-logout
+ *     or post-close cleanup): returns WYRELOG_E_OK without driving
+ *     the FSM and without emitting a fresh audit row.
+ *   - sid registered and live in {idle, active, elevated, expiring}:
+ *     drives WYL_SESSION_EVENT_LOGOUT through the FSM, records the
+ *     durable state-transition audit row, and tombstones the
+ *     registry entry so subsequent calls take the idempotent path.
+ *   - sid registered and live in the closed terminal state (e.g.
+ *     wyl_session_close was already invoked through the WylSession*
+ *     surface): tombstones the registry entry and returns
+ *     WYRELOG_E_OK without re-entering the FSM (which has no
+ *     transition row from closed).
+ *
+ * Returns WYRELOG_E_INVALID for a NULL handle and propagates
+ * WYRELOG_E_INTERNAL or any I/O error from the durable transition
+ * primitive on the live, non-closed path. The plain entry point is
+ * exactly equivalent to passing NULL through the request-id variant.
+ */
 wyrelog_error_t wyl_session_logout (WylHandle * handle, wyl_session_id_t sid);
 
 /*
- * Same as wyl_session_logout but propagates a caller-supplied
- * request_id into the durable transition audit row so logout can be
- * correlated with the originating wyl_session_login. Pass NULL to
- * mirror wyl_session_logout exactly.
+ * Same contract as wyl_session_logout but propagates a caller-supplied
+ * |request_id| into the durable transition audit row so the logout
+ * event can be correlated with the originating wyl_session_login.
+ * Pass NULL to mirror wyl_session_logout exactly.
  */
 wyrelog_error_t wyl_session_logout_with_request_id (WylHandle * handle,
     wyl_session_id_t sid, const gchar * request_id);

--- a/wyrelog/session.h
+++ b/wyrelog/session.h
@@ -101,6 +101,15 @@ wyrelog_error_t wyl_session_close_with_request_id (WylHandle * handle,
 wyrelog_error_t wyl_session_logout (WylHandle * handle, wyl_session_id_t sid);
 
 /*
+ * Same as wyl_session_logout but propagates a caller-supplied
+ * request_id into the durable transition audit row so logout can be
+ * correlated with the originating wyl_session_login. Pass NULL to
+ * mirror wyl_session_logout exactly.
+ */
+wyrelog_error_t wyl_session_logout_with_request_id (WylHandle * handle,
+    wyl_session_id_t sid, const gchar * request_id);
+
+/*
  * Returns the session's construct-time identifier as a 36-character
  * canonical string (caller frees with g_free or g_autofree). May
  * return NULL only if the session is NULL or not a WylSession. The

--- a/wyrelog/session.h
+++ b/wyrelog/session.h
@@ -117,6 +117,16 @@ gchar *wyl_session_dup_id_string (const WylSession * self);
 gint64 wyl_session_get_created_at_us (const WylSession * self);
 
 /*
+ * Returns the handle-scoped integer session id assigned to |self| on
+ * the wyl_session_login success path. The id is non-zero for any
+ * session returned through wyl_session_login and stable across the
+ * lifetime of the owning WylHandle. Pass it to wyl_session_logout to
+ * tear down the durable session state. Returns 0 when |self| is NULL
+ * or not a WylSession.
+ */
+wyl_session_id_t wyl_session_get_id (const WylSession * self);
+
+/*
  * Returns a heap-allocated copy of the principal username carried
  * into the session by wyl_session_login (i.e. wyl_login_req's
  * username field at login time). Returns NULL when the request

--- a/wyrelog/wyl-error.c
+++ b/wyrelog/wyl-error.c
@@ -23,6 +23,8 @@ wyrelog_error_string (wyrelog_error_t err)
       return "internal invariant violated";
     case WYRELOG_E_EXEC:
       return "policy evaluation runtime fault";
+    case WYRELOG_E_NOT_FOUND:
+      return "no entity registered for the supplied identifier";
   }
   return "unknown error";
 }

--- a/wyrelog/wyl-handle-private.h
+++ b/wyrelog/wyl-handle-private.h
@@ -72,11 +72,48 @@ wyrelog_error_t wyl_handle_register_session (WylHandle * self,
 /*
  * Returns a borrowed pointer to the WylSession previously registered
  * with |sid|, or NULL if no such session exists in this handle's
- * registry. The lifetime of the returned pointer is bounded by the
- * registry's strong reference, which is held until handle finalize.
- * Callers must not unref the returned pointer.
+ * registry. The borrowed pointer is valid only until the next
+ * registry mutation (wyl_handle_tombstone_session) or handle finalize,
+ * whichever comes first. Internal call sites that need to outlive
+ * the lookup must use wyl_handle_lookup_session_by_id_ref instead.
+ * Callers of this borrowed-pointer variant must not unref it.
  */
 WylSession *wyl_handle_lookup_session_by_id (WylHandle * self,
+    wyl_session_id_t sid);
+
+/*
+ * Discriminant returned by wyl_handle_lookup_session_by_id_ref so
+ * callers can distinguish "this sid was never registered" from
+ * "this sid was registered but has since been torn down". The two
+ * cases drive different return codes in wyl_session_logout.
+ */
+typedef enum
+{
+  WYL_SESSION_LOOKUP_UNKNOWN = 0,
+  WYL_SESSION_LOOKUP_TOMBSTONED = 1,
+  WYL_SESSION_LOOKUP_LIVE = 2,
+} wyl_session_lookup_state_t;
+
+/*
+ * Race-safe variant of wyl_handle_lookup_session_by_id. On a live
+ * lookup, |*out_session| is set to a fresh strong reference that
+ * the caller must release with g_object_unref. On a tombstoned or
+ * unknown lookup, |*out_session| is set to NULL and |*out_state|
+ * disambiguates the two cases. Returns WYRELOG_E_INVALID for NULL
+ * out-pointers or a NULL/non-WylHandle handle.
+ */
+wyrelog_error_t wyl_handle_lookup_session_by_id_ref (WylHandle * self,
+    wyl_session_id_t sid, wyl_session_lookup_state_t * out_state,
+    WylSession ** out_session);
+
+/*
+ * Marks the registry entry for |sid| as torn down: drops the strong
+ * reference to the underlying WylSession while leaving the entry in
+ * place so that subsequent lookups can distinguish "logged out" from
+ * "never registered". Idempotent on an already-tombstoned entry.
+ * Returns WYRELOG_E_NOT_FOUND when no entry exists for |sid|.
+ */
+wyrelog_error_t wyl_handle_tombstone_session (WylHandle * self,
     wyl_session_id_t sid);
 
 /*

--- a/wyrelog/wyl-handle-private.h
+++ b/wyrelog/wyl-handle-private.h
@@ -6,6 +6,7 @@
 #include "wyrelog/handle.h"
 #include "wyrelog/engine.h"
 #include "wyrelog/audit.h"
+#include "wyrelog/session.h"
 #include "policy/store-private.h"
 
 #ifdef WYL_HAS_AUDIT
@@ -55,6 +56,28 @@ wyrelog_error_t wyl_handle_load_policy_store_audit_events (WylHandle * self);
  * valid until wyl_shutdown or g_object_unref.
  */
 wyl_policy_store_t *wyl_handle_get_policy_store (WylHandle * self);
+
+/*
+ * Mints a fresh, handle-scoped wyl_session_id_t for |session| and stores
+ * a strong reference in the handle's session registry so a subsequent
+ * lookup by the integer id can resolve back to the live WylSession*. The
+ * returned id is non-zero. The handle retains a reference for the
+ * registry; callers must not unref the session below their own
+ * reference count to compensate. Reserved for the wyl_session_login
+ * success path.
+ */
+wyrelog_error_t wyl_handle_register_session (WylHandle * self,
+    WylSession * session, wyl_session_id_t * out_sid);
+
+/*
+ * Returns a borrowed pointer to the WylSession previously registered
+ * with |sid|, or NULL if no such session exists in this handle's
+ * registry. The lifetime of the returned pointer is bounded by the
+ * registry's strong reference, which is held until handle finalize.
+ * Callers must not unref the returned pointer.
+ */
+WylSession *wyl_handle_lookup_session_by_id (WylHandle * self,
+    wyl_session_id_t sid);
 
 /*
  * Host-side ingress guard for login requests that carry skip_mfa. Explicitly

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -31,6 +31,31 @@ typedef struct
   WylDeltaKind kind;
 } WylPendingDelta;
 
+/*
+ * Per-sid registry entry. A live entry holds a strong reference to
+ * the session through |session|; once the session reaches the closed
+ * terminal state the strong reference is dropped and |session| is
+ * NULL. The entry survives in the table so that wyl_session_logout
+ * can distinguish a sid that was never registered (table miss) from
+ * a sid whose session has already been torn down (entry present
+ * with session == NULL), which keeps repeated logout idempotent.
+ */
+typedef struct
+{
+  WylSession *session;
+} WylSessionRegistryEntry;
+
+static void
+wyl_session_registry_entry_free (gpointer data)
+{
+  WylSessionRegistryEntry *entry = data;
+
+  if (entry == NULL)
+    return;
+  g_clear_object (&entry->session);
+  g_free (entry);
+}
+
 struct _WylHandle
 {
   GObject parent_instance;
@@ -169,7 +194,7 @@ wyl_handle_init (WylHandle *self)
    */
   g_mutex_init (&self->sessions_lock);
   self->sessions_by_id = g_hash_table_new_full (g_int64_hash, g_int64_equal,
-      g_free, g_object_unref);
+      g_free, wyl_session_registry_entry_free);
   self->next_session_id = 1;
 }
 
@@ -181,11 +206,14 @@ wyl_handle_register_session (WylHandle *self, WylSession *session,
       || !WYL_IS_HANDLE (self) || !WYL_IS_SESSION (session))
     return WYRELOG_E_INVALID;
 
+  WylSessionRegistryEntry *entry = g_new0 (WylSessionRegistryEntry, 1);
+  entry->session = g_object_ref (session);
+
   g_mutex_lock (&self->sessions_lock);
   guint64 sid = self->next_session_id++;
   guint64 *key = g_new (guint64, 1);
   *key = sid;
-  g_hash_table_replace (self->sessions_by_id, key, g_object_ref (session));
+  g_hash_table_replace (self->sessions_by_id, key, entry);
   g_mutex_unlock (&self->sessions_lock);
 
   *out_sid = sid;
@@ -195,14 +223,72 @@ wyl_handle_register_session (WylHandle *self, WylSession *session,
 WylSession *
 wyl_handle_lookup_session_by_id (WylHandle *self, wyl_session_id_t sid)
 {
+  /*
+   * Borrowed-pointer convenience: the returned pointer is valid only
+   * until the next mutation of |self->sessions_by_id| (which today
+   * means the next wyl_handle_tombstone_session call or handle
+   * finalize). Internal call sites that need to outlive the lookup
+   * must use wyl_handle_lookup_session_by_id_ref instead.
+   */
   if (self == NULL || !WYL_IS_HANDLE (self))
     return NULL;
 
   g_mutex_lock (&self->sessions_lock);
   guint64 key = sid;
-  WylSession *session = g_hash_table_lookup (self->sessions_by_id, &key);
+  WylSessionRegistryEntry *entry =
+      g_hash_table_lookup (self->sessions_by_id, &key);
+  WylSession *session = (entry != NULL) ? entry->session : NULL;
   g_mutex_unlock (&self->sessions_lock);
   return session;
+}
+
+wyrelog_error_t
+wyl_handle_lookup_session_by_id_ref (WylHandle *self, wyl_session_id_t sid,
+    wyl_session_lookup_state_t *out_state, WylSession **out_session)
+{
+  if (self == NULL || out_state == NULL || out_session == NULL
+      || !WYL_IS_HANDLE (self))
+    return WYRELOG_E_INVALID;
+
+  *out_state = WYL_SESSION_LOOKUP_UNKNOWN;
+  *out_session = NULL;
+
+  g_mutex_lock (&self->sessions_lock);
+  guint64 key = sid;
+  WylSessionRegistryEntry *entry =
+      g_hash_table_lookup (self->sessions_by_id, &key);
+  if (entry == NULL) {
+    g_mutex_unlock (&self->sessions_lock);
+    return WYRELOG_E_OK;
+  }
+  if (entry->session == NULL) {
+    *out_state = WYL_SESSION_LOOKUP_TOMBSTONED;
+    g_mutex_unlock (&self->sessions_lock);
+    return WYRELOG_E_OK;
+  }
+  *out_state = WYL_SESSION_LOOKUP_LIVE;
+  *out_session = g_object_ref (entry->session);
+  g_mutex_unlock (&self->sessions_lock);
+  return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
+wyl_handle_tombstone_session (WylHandle *self, wyl_session_id_t sid)
+{
+  if (self == NULL || !WYL_IS_HANDLE (self))
+    return WYRELOG_E_INVALID;
+
+  g_mutex_lock (&self->sessions_lock);
+  guint64 key = sid;
+  WylSessionRegistryEntry *entry =
+      g_hash_table_lookup (self->sessions_by_id, &key);
+  if (entry == NULL) {
+    g_mutex_unlock (&self->sessions_lock);
+    return WYRELOG_E_NOT_FOUND;
+  }
+  g_clear_object (&entry->session);
+  g_mutex_unlock (&self->sessions_lock);
+  return WYRELOG_E_OK;
 }
 
 static wyrelog_error_t wyl_handle_make_guard_expr_node_compound (WylHandle *

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -46,6 +46,16 @@ struct _WylHandle
   wyl_policy_store_t *policy_store;
   gboolean login_skip_mfa_allowed;
   gboolean engine_pair_poisoned;
+  /*
+   * Per-handle registry mapping wyl_session_id_t to live WylSession*.
+   * Strong references; sessions stay alive at least until handle
+   * finalize. The registry exists so wyl_session_logout (which only
+   * receives the integer id) can resolve back to the session that
+   * owns the durable state about to be torn down.
+   */
+  GMutex sessions_lock;
+  GHashTable *sessions_by_id;
+  guint64 next_session_id;
 #ifdef WYL_HAS_AUDIT
   wyl_audit_conn_t *audit_conn;
 #endif
@@ -115,6 +125,8 @@ wyl_handle_finalize (GObject *object)
   g_clear_pointer (&self->template_dir, g_free);
   g_clear_pointer (&self->pending_deltas, g_ptr_array_unref);
   g_clear_pointer (&self->policy_store, wyl_policy_store_close);
+  g_clear_pointer (&self->sessions_by_id, g_hash_table_unref);
+  g_mutex_clear (&self->sessions_lock);
 #ifdef WYL_HAS_AUDIT
   /* NULL-safe: if wyl_shutdown already closed the conn the pointer
    * was reset to NULL there; otherwise this is the only close site
@@ -149,6 +161,48 @@ wyl_handle_init (WylHandle *self)
       g_hash_table_new_full (g_int64_hash, g_int64_equal, g_free, g_free);
   self->pending_deltas =
       g_ptr_array_new_with_free_func (wyl_pending_delta_free);
+  /*
+   * Sessions registered through wyl_handle_register_session hold a
+   * strong reference; releasing on hash-table free drops the ref.
+   * Sid 0 is reserved for "uninitialised", so the counter starts at
+   * 1 and is incremented on every successful registration.
+   */
+  g_mutex_init (&self->sessions_lock);
+  self->sessions_by_id = g_hash_table_new_full (g_int64_hash, g_int64_equal,
+      g_free, g_object_unref);
+  self->next_session_id = 1;
+}
+
+wyrelog_error_t
+wyl_handle_register_session (WylHandle *self, WylSession *session,
+    wyl_session_id_t *out_sid)
+{
+  if (self == NULL || session == NULL || out_sid == NULL
+      || !WYL_IS_HANDLE (self) || !WYL_IS_SESSION (session))
+    return WYRELOG_E_INVALID;
+
+  g_mutex_lock (&self->sessions_lock);
+  guint64 sid = self->next_session_id++;
+  guint64 *key = g_new (guint64, 1);
+  *key = sid;
+  g_hash_table_replace (self->sessions_by_id, key, g_object_ref (session));
+  g_mutex_unlock (&self->sessions_lock);
+
+  *out_sid = sid;
+  return WYRELOG_E_OK;
+}
+
+WylSession *
+wyl_handle_lookup_session_by_id (WylHandle *self, wyl_session_id_t sid)
+{
+  if (self == NULL || !WYL_IS_HANDLE (self))
+    return NULL;
+
+  g_mutex_lock (&self->sessions_lock);
+  guint64 key = sid;
+  WylSession *session = g_hash_table_lookup (self->sessions_by_id, &key);
+  g_mutex_unlock (&self->sessions_lock);
+  return session;
 }
 
 static wyrelog_error_t wyl_handle_make_guard_expr_node_compound (WylHandle *

--- a/wyrelog/wyl-session.c
+++ b/wyrelog/wyl-session.c
@@ -858,31 +858,65 @@ wyl_session_expire (WylHandle *handle, WylSession *session)
 }
 
 wyrelog_error_t
-wyl_session_logout (WylHandle *handle, wyl_session_id_t sid)
+wyl_session_logout_with_request_id (WylHandle *handle, wyl_session_id_t sid,
+    const gchar *request_id)
 {
   if (handle == NULL)
     return WYRELOG_E_INVALID;
 
-#ifdef WYL_HAS_AUDIT
-  /* Mirror the logout in the audit log so session terminations are
-   * observable even before the session table that owns the sid is
-   * wired. The action column carries "logout" semantics; the
-   * subject_id column carries the integer session handle as text
-   * so log readers can tie the event back to the originating
-   * wyl_session_login. */
-  g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
-  g_autofree gchar *sid_str = g_strdup_printf ("%" G_GUINT64_FORMAT, sid);
-  wyl_audit_event_set_subject_id (ev, sid_str);
-  wyl_audit_event_set_action (ev, "logout");
-  wyl_audit_event_set_decision (ev, WYL_DECISION_ALLOW);
-  (void) wyl_audit_emit (handle, ev);
-#else
-  (void) sid;
-#endif
+  /*
+   * State matrix (resolved against the per-handle session registry):
+   *   - sid not registered: WYRELOG_E_NOT_FOUND. Distinct from
+   *     WYRELOG_E_INVALID so callers can tell "you handed me junk"
+   *     from "you asked for a session this handle never knew about".
+   *   - sid registered but tombstoned (already torn down): idempotent
+   *     WYRELOG_E_OK with no FSM step and no fresh audit row.
+   *   - sid registered and live in {idle, active, elevated, expiring}:
+   *     drive the session FSM through WYL_SESSION_EVENT_LOGOUT (which
+   *     is the canonical event for those four source states), record
+   *     the durable transition + audit row through the existing
+   *     close-with-request-id primitive, then tombstone the registry
+   *     entry so a repeat logout collapses to the idempotent path.
+   *   - sid registered and live but already in the terminal CLOSED
+   *     state (e.g. wyl_session_close was driven directly through the
+   *     WylSession* surface and the registry was not yet tombstoned):
+   *     skip the FSM step (the FSM has no (closed, logout) row),
+   *     tombstone the entry, and return E_OK so this entry point is
+   *     idempotent against both prior code paths.
+   */
+  wyl_session_lookup_state_t state = WYL_SESSION_LOOKUP_UNKNOWN;
+  g_autoptr (WylSession) live = NULL;
+  wyrelog_error_t rc = wyl_handle_lookup_session_by_id_ref (handle, sid,
+      &state, &live);
+  if (rc != WYRELOG_E_OK)
+    return rc;
 
-  /* Real session-table teardown lands in a follow-up; v0 returns
-   * E_OK after argument validation and audit recording. */
+  switch (state) {
+    case WYL_SESSION_LOOKUP_UNKNOWN:
+      return WYRELOG_E_NOT_FOUND;
+    case WYL_SESSION_LOOKUP_TOMBSTONED:
+      return WYRELOG_E_OK;
+    case WYL_SESSION_LOOKUP_LIVE:
+      break;
+  }
+
+  if (live->state == WYL_SESSION_STATE_CLOSED) {
+    (void) wyl_handle_tombstone_session (handle, sid);
+    return WYRELOG_E_OK;
+  }
+
+  rc = wyl_session_close_with_request_id (handle, live, request_id);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  (void) wyl_handle_tombstone_session (handle, sid);
   return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
+wyl_session_logout (WylHandle *handle, wyl_session_id_t sid)
+{
+  return wyl_session_logout_with_request_id (handle, sid, NULL);
 }
 
 gchar *

--- a/wyrelog/wyl-session.c
+++ b/wyrelog/wyl-session.c
@@ -12,6 +12,14 @@ struct _WylSession
 {
   GObject parent_instance;
   wyl_id_t id;
+  /*
+   * Handle-scoped integer id assigned at the wyl_session_login success
+   * path through wyl_handle_register_session. Stable across the
+   * lifetime of the owning WylHandle and used by wyl_session_logout
+   * to resolve back to this session through the handle registry.
+   * Zero before registration; non-zero after.
+   */
+  wyl_session_id_t sid;
   gint64 created_at_us;
   gchar *username;
   gchar *tenant;
@@ -675,6 +683,11 @@ wyl_session_login (WylHandle *handle, const wyl_login_req_t *req,
     (void) wyl_audit_mirror_event (handle, session_ev);
 #endif
     session->state = WYL_SESSION_STATE_ACTIVE;
+    rc = wyl_handle_register_session (handle, session, &session->sid);
+    if (rc != WYRELOG_E_OK) {
+      g_object_unref (session);
+      return rc;
+    }
     *out_session = session;
     return WYRELOG_E_OK;
   }
@@ -707,6 +720,11 @@ wyl_session_login (WylHandle *handle, const wyl_login_req_t *req,
   }
   session->state = WYL_SESSION_STATE_ACTIVE;
 
+  rc = wyl_handle_register_session (handle, session, &session->sid);
+  if (rc != WYRELOG_E_OK) {
+    g_object_unref (session);
+    return rc;
+  }
   *out_session = session;
   return WYRELOG_E_OK;
 }
@@ -884,6 +902,14 @@ wyl_session_get_created_at_us (const WylSession *self)
 {
   g_return_val_if_fail (WYL_IS_SESSION (self), -1);
   return self->created_at_us;
+}
+
+wyl_session_id_t
+wyl_session_get_id (const WylSession *self)
+{
+  if (self == NULL || !WYL_IS_SESSION (self))
+    return 0;
+  return self->sid;
 }
 
 gchar *


### PR DESCRIPTION
## Summary

Replaces the audit-only `wyl_session_logout` placeholder with end-to-end durable teardown across the in-memory session registry, policy store, audit trail, access tokens, and refresh tokens. Driven by issue #271 (LoBAC release).

## Series shape

Six atomic commits:

1. **`session: register live sessions in a per-handle id registry`** — adds the `wyl_session_id_t -> WylSession*` map missing from the public API contract; `wyl_session_login` mints a non-zero sid on every success path; new public `wyl_session_get_id`. ABI-additive.
2. **`session: tear down durable session state on wyl_session_logout`** — replaces the audit-only stub with a four-cell state matrix (unknown -> `WYRELOG_E_NOT_FOUND`; tombstoned -> idempotent OK; live in `{idle,active,elevated,expiring}` -> FSM `LOGOUT` -> tombstone; live in `closed` -> tombstone). Adds `WYRELOG_E_NOT_FOUND` and `wyl_session_logout_with_request_id`.
3. **`session: document logout state matrix in public header`** — lifts the contract into `session.h` so external consumers see the matrix and the full return-code surface without reading the implementation.
4. **`daemon: revoke session tokens before driving HTTP logout FSM step`** — closes the access/refresh-token replay window by reordering the HTTP `logout_handler` to revoke refresh tokens, then access tokens, then drive the FSM. Fail-closed when the FSM step errors.
5. **`daemon: converge HTTP logout on the public session-logout API`** — swaps the HTTP FSM call from `wyl_session_close_with_request_id` to `wyl_session_logout_with_request_id` so HTTP and the core API share a single FSM call site. Adds a `revoked_session_tokens` gate on the HTTP context to refuse `store_access_token` / `store_refresh_token` for a session that has entered teardown, closing the residual race in which an `/auth/refresh` past the lock-protected revoked-state check could insert a fresh token after the snapshot revoke pass returned.
6. **`daemon: name revoked-session table after the token strings it keys`** — naming polish so the gate field, mark helper, and `WYL_TEST_DAEMON_HTTP`-only probe all agree on `session_token` for the UUID-string key, avoiding confusion with the integer `wyl_session_id_t`.

## Acceptance criteria coverage (issue #271)

| Criterion | Closed by |
|---|---|
| `wyl_session_logout` transitions through the FSM | C2 |
| Unknown / already-logged-out / expired explicit, tested behavior | C2 (state matrix) |
| HTTP logout invalidates access/refresh tokens consistently | C3 (revoke-before-FSM) + C4 (store gate) |
| Audit includes request/session ids correlatable with login | C2 (canonical UUID + `_with_request_id`) |
| Tests cover core API, HTTP bearer, refresh-after-logout, idempotent repeat | C1 + C2 + C3 + C4 |

## Test plan

- [x] `meson test -C builddir session-logout session-registry session-username session-username-lifecycle handle-engine-pair daemon-http-decide daemon-http-decide-audit` — all OK
- [x] `meson test -C builddir --suite wyrelog` — 54 OK / 1 SKIP / pre-existing flaky `decide` test passes in isolation under parallel-suite contention (unrelated to this series; same DuckDB-reopen race surfaced in #266 / #265 territory)
- [x] `./tools/gst-indent` clean on every changed file across the series
- [ ] CI on this PR

## Follow-up

- `WylDaemonHttpContext::revoked_session_tokens` is unbounded today (one ~37-byte session-token UUID per logout). Bound is operationally fine for v1 (growth proportional to actual logout volume; entries do not survive process restart) but should pick up TTL-pruning in a follow-up — eviction at `max(refresh_token_ttl, longest session lifetime)` is sufficient because no in-flight refresh can survive past that horizon.

Closes #271