### PR TITLE
access: implement break-glass override path for LoBAC release

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -18,6 +18,18 @@ sodium_dep = dependency('libsodium', required : true)
 sqlite_dep = dependency('sqlite3', required : true)
 tss2_esys_dep = dependency('tss2-esys', required : get_option('enable_tpm'))
 enable_audit_opt = get_option('enable_audit')
+enable_break_glass_opt = get_option('enable_break_glass')
+if enable_break_glass_opt and not enable_audit_opt.allowed()
+  # The break-glass override path emits an audit event with a stable
+  # reason code on every arming and every override decision. Without
+  # the audit subsystem there is no place to record those events, so
+  # break-glass would silently bypass policy with no audit trail.
+  # Refuse the configuration at meson-setup time rather than ship a
+  # build that violates the meson.options:84-86 contract.
+  error('enable_break_glass=true requires enable_audit to be enabled '
+      + '(auto or enabled); the override path needs a durable audit '
+      + 'sink for reason-code emission.')
+endif
 if enable_audit_opt.allowed()
   duckdb_source = get_option('duckdb_source')
   if duckdb_source == 'prebuilt'

--- a/templates/access/bootstrap.dl
+++ b/templates/access/bootstrap.dl
@@ -186,7 +186,23 @@ tenant("__wr_default").
 // ---------------------------------------------------------------------------
 ttl("break_glass", 900).
 // `now/1` and `break_glass_used/1` are injected by the host at runtime;
-// the template does not write them.
+// the template does not write them. The injector is the per-decide
+// helper insert_break_glass_facts() in wyrelog/wyl-decide.c, which
+// stamps `now(now_secs)` on every break-glass-aware decide and adds
+// `break_glass_used(activated_at_secs)` once the activation has been
+// observed by at least one prior decide. The DL self-disable rule at
+// disabled_role("wr.break_glass") below uses these two facts together
+// with ttl("break_glass", 900) to retire the override after the
+// 900-second template horizon.
+//
+// The host also gates the per-arming activation through
+// wyl_handle_break_glass_is_active() in wyrelog/wyl-handle.c, which
+// applies the operator-supplied per-arm TTL (clamped at 900 by
+// WYL_BREAK_GLASS_DEFAULT_TTL_SECONDS in
+// wyrelog/access/break-glass-private.h). Because the per-arm TTL is
+// always less than or equal to the template horizon, the host-side
+// gate fires first; the DL self-disable rule is the durable backstop
+// when an in-memory activation outlives a single decide cycle.
 
 // ---------------------------------------------------------------------------
 // IDB: derivations

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -496,6 +496,21 @@ test_break_glass_arm = executable('test-break-glass-arm',
 
 test('break-glass-arm', test_break_glass_arm)
 
+if get_option('enable_break_glass') and get_option('enable_audit').allowed()
+  test_break_glass_decide = executable('test-break-glass-decide',
+    'test-break-glass-decide.c',
+    c_args : [
+      '-DWYL_HAS_BREAK_GLASS',
+      '-DWYL_HAS_AUDIT',
+      '-DWYL_TEST_TEMPLATE_DIR="' + meson.project_source_root() / 'templates' / 'access' + '"',
+    ],
+    include_directories : [wyrelog_inc, include_directories('../wyrelog')],
+    dependencies : [wyrelog_dep, wirelog_dep, duckdb_dep],
+  )
+
+  test('break-glass-decide', test_break_glass_decide)
+endif
+
 # NOTE: WYL_TEST_TEMPLATE_DIR points at the in-tree source layout
 # only. The installed layout (${datadir}/wyrelog/access) — produced
 # by install_subdir at the top-level meson.build — is not

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -481,6 +481,21 @@ test_break_glass_vocab = executable('test-break-glass-vocab',
 
 test('break-glass-vocab', test_break_glass_vocab)
 
+test_break_glass_arm_c_args = [
+  '-DWYL_TEST_TEMPLATE_DIR="' + meson.project_source_root() / 'templates' / 'access' + '"',
+]
+if get_option('enable_break_glass')
+  test_break_glass_arm_c_args += '-DWYL_HAS_BREAK_GLASS'
+endif
+
+test_break_glass_arm = executable('test-break-glass-arm',
+  'test-break-glass-arm.c',
+  c_args : test_break_glass_arm_c_args,
+  dependencies : [wyrelog_dep],
+)
+
+test('break-glass-arm', test_break_glass_arm)
+
 # NOTE: WYL_TEST_TEMPLATE_DIR points at the in-tree source layout
 # only. The installed layout (${datadir}/wyrelog/access) — produced
 # by install_subdir at the top-level meson.build — is not

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -473,6 +473,14 @@ test_session_registry = executable('test-session-registry',
 
 test('session-registry', test_session_registry)
 
+test_break_glass_vocab = executable('test-break-glass-vocab',
+  'test-break-glass-vocab.c',
+  include_directories : [wyrelog_inc, include_directories('../wyrelog')],
+  dependencies : [wyrelog_dep],
+)
+
+test('break-glass-vocab', test_break_glass_vocab)
+
 # NOTE: WYL_TEST_TEMPLATE_DIR points at the in-tree source layout
 # only. The installed layout (${datadir}/wyrelog/access) — produced
 # by install_subdir at the top-level meson.build — is not

--- a/tests/test-break-glass-arm.c
+++ b/tests/test-break-glass-arm.c
@@ -1,0 +1,216 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <glib.h>
+
+#include "wyrelog/wyrelog.h"
+
+#ifndef WYL_TEST_TEMPLATE_DIR
+#error "WYL_TEST_TEMPLATE_DIR must be defined by the build."
+#endif
+
+#ifdef WYL_HAS_BREAK_GLASS
+
+static gint
+check_arm_rejects_null_handle (void)
+{
+  if (wyl_handle_break_glass_arm (NULL,
+          WYL_BREAK_GLASS_REASON_INCIDENT_RESPONSE, 60)
+      != WYRELOG_E_INVALID)
+    return 1;
+  if (wyl_handle_break_glass_disarm (NULL) != WYRELOG_E_INVALID)
+    return 2;
+  if (wyl_handle_break_glass_is_active (NULL) != FALSE)
+    return 3;
+  return 0;
+}
+
+static gint
+check_arm_rejects_out_of_range_reason (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 10;
+
+  if (wyl_handle_break_glass_arm (handle,
+          (wyl_break_glass_reason_code_t) WYL_BREAK_GLASS_REASON_LAST_, 60)
+      != WYRELOG_E_INVALID)
+    return 11;
+  if (wyl_handle_break_glass_arm (handle,
+          (wyl_break_glass_reason_code_t) 99, 60)
+      != WYRELOG_E_INVALID)
+    return 12;
+  if (wyl_handle_break_glass_is_active (handle))
+    return 13;
+  return 0;
+}
+
+static gint
+check_arm_rejects_bad_ttl (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 20;
+
+  if (wyl_handle_break_glass_arm (handle,
+          WYL_BREAK_GLASS_REASON_INCIDENT_RESPONSE, 0)
+      != WYRELOG_E_INVALID)
+    return 21;
+  if (wyl_handle_break_glass_arm (handle,
+          WYL_BREAK_GLASS_REASON_INCIDENT_RESPONSE, -1)
+      != WYRELOG_E_INVALID)
+    return 22;
+  /* Strictly above the 900s ceiling rejected. */
+  if (wyl_handle_break_glass_arm (handle,
+          WYL_BREAK_GLASS_REASON_INCIDENT_RESPONSE, 901)
+      != WYRELOG_E_INVALID)
+    return 23;
+  if (wyl_handle_break_glass_arm (handle,
+          WYL_BREAK_GLASS_REASON_INCIDENT_RESPONSE, G_MAXINT64)
+      != WYRELOG_E_INVALID)
+    return 24;
+  if (wyl_handle_break_glass_is_active (handle))
+    return 25;
+  return 0;
+}
+
+static gint
+check_arm_then_active_then_disarm (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 30;
+
+  if (wyl_handle_break_glass_is_active (handle))
+    return 31;
+  if (wyl_handle_break_glass_arm (handle,
+          WYL_BREAK_GLASS_REASON_POLICY_CORRUPTION, 60)
+      != WYRELOG_E_OK)
+    return 32;
+  if (!wyl_handle_break_glass_is_active (handle))
+    return 33;
+  if (wyl_handle_break_glass_disarm (handle) != WYRELOG_E_OK)
+    return 34;
+  if (wyl_handle_break_glass_is_active (handle))
+    return 35;
+  /* Disarm is idempotent. */
+  if (wyl_handle_break_glass_disarm (handle) != WYRELOG_E_OK)
+    return 36;
+  return 0;
+}
+
+static gint
+check_double_arm_is_rejected (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 40;
+
+  if (wyl_handle_break_glass_arm (handle,
+          WYL_BREAK_GLASS_REASON_SERVICE_UNFREEZE, 60)
+      != WYRELOG_E_OK)
+    return 41;
+  /* Second arm before disarm: the operator must explicitly tear
+   * down the first activation before starting a fresh one. */
+  if (wyl_handle_break_glass_arm (handle,
+          WYL_BREAK_GLASS_REASON_INCIDENT_RESPONSE, 60)
+      != WYRELOG_E_INVALID)
+    return 42;
+  /* The original activation is still in effect after the rejected
+   * second arm; the rejection does not silently disarm. */
+  if (!wyl_handle_break_glass_is_active (handle))
+    return 43;
+  return 0;
+}
+
+static gint
+check_disarm_then_arm_succeeds (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 50;
+
+  if (wyl_handle_break_glass_arm (handle, WYL_BREAK_GLASS_REASON_OTHER, 60)
+      != WYRELOG_E_OK)
+    return 51;
+  if (wyl_handle_break_glass_disarm (handle) != WYRELOG_E_OK)
+    return 52;
+  if (wyl_handle_break_glass_arm (handle,
+          WYL_BREAK_GLASS_REASON_SECURITY_OFFICER_LOCKOUT, 60)
+      != WYRELOG_E_OK)
+    return 53;
+  if (!wyl_handle_break_glass_is_active (handle))
+    return 54;
+  return 0;
+}
+
+static gint
+check_isolation_across_handles (void)
+{
+  g_autoptr (WylHandle) ha = NULL;
+  g_autoptr (WylHandle) hb = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &ha) != WYRELOG_E_OK)
+    return 60;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &hb) != WYRELOG_E_OK)
+    return 61;
+
+  if (wyl_handle_break_glass_arm (ha,
+          WYL_BREAK_GLASS_REASON_INCIDENT_RESPONSE, 60)
+      != WYRELOG_E_OK)
+    return 62;
+  /* Activation on handle A must not be visible on handle B. */
+  if (wyl_handle_break_glass_is_active (hb))
+    return 63;
+  if (!wyl_handle_break_glass_is_active (ha))
+    return 64;
+  return 0;
+}
+
+#else /* !WYL_HAS_BREAK_GLASS */
+
+static gint
+check_arm_in_disabled_build_returns_disabled_error (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 70;
+
+  if (wyl_handle_break_glass_arm (handle,
+          WYL_BREAK_GLASS_REASON_INCIDENT_RESPONSE, 60)
+      != WYRELOG_E_BREAK_GLASS_DISABLED)
+    return 71;
+  if (wyl_handle_break_glass_disarm (handle)
+      != WYRELOG_E_BREAK_GLASS_DISABLED)
+    return 72;
+  if (wyl_handle_break_glass_is_active (handle))
+    return 73;
+  return 0;
+}
+
+#endif
+
+int
+main (void)
+{
+  gint rc;
+
+#ifdef WYL_HAS_BREAK_GLASS
+  if ((rc = check_arm_rejects_null_handle ()) != 0)
+    return rc;
+  if ((rc = check_arm_rejects_out_of_range_reason ()) != 0)
+    return rc;
+  if ((rc = check_arm_rejects_bad_ttl ()) != 0)
+    return rc;
+  if ((rc = check_arm_then_active_then_disarm ()) != 0)
+    return rc;
+  if ((rc = check_double_arm_is_rejected ()) != 0)
+    return rc;
+  if ((rc = check_disarm_then_arm_succeeds ()) != 0)
+    return rc;
+  if ((rc = check_isolation_across_handles ()) != 0)
+    return rc;
+#else
+  if ((rc = check_arm_in_disabled_build_returns_disabled_error ()) != 0)
+    return rc;
+#endif
+
+  return 0;
+}

--- a/tests/test-break-glass-decide.c
+++ b/tests/test-break-glass-decide.c
@@ -225,6 +225,118 @@ check_disarm_clears_used_and_active (void)
 }
 
 static gint
+check_ttl_expiry_disarm_and_rearm (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 70;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 71;
+  if (seed_armed_allow_fixture (handle, "bg-decide-user-4",
+          "wr.decide-permission-4", "bg-decide-resource-4") != WYRELOG_E_OK)
+    return 72;
+
+  /* Arm with a 1-second per-arm TTL. The host-side gate
+   * wyl_handle_break_glass_is_active applies this operator TTL, so
+   * a g_usleep past the horizon flips the gate to FALSE long before
+   * the 900-second DL self-disable horizon would fire. */
+  if (wyl_handle_break_glass_arm (handle,
+          WYL_BREAK_GLASS_REASON_INCIDENT_RESPONSE, 1) != WYRELOG_E_OK)
+    return 73;
+  if (!wyl_handle_break_glass_is_active (handle))
+    return 74;
+
+  g_autoptr (wyl_decide_req_t) req = wyl_decide_req_new ();
+  wyl_decide_req_set_subject_id (req, "bg-decide-user-4");
+  wyl_decide_req_set_action (req, "wr.decide-permission-4");
+  wyl_decide_req_set_resource_id (req, "bg-decide-resource-4");
+
+  g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
+  if (wyl_decide (handle, req, resp) != WYRELOG_E_OK)
+    return 75;
+  if (!wyl_handle_break_glass_has_been_used (handle))
+    return 76;
+
+  /* Sleep past the 1-second TTL and verify the host-side gate
+   * reports the activation has expired. */
+  g_usleep (G_USEC_PER_SEC + (G_USEC_PER_SEC / 2));
+  if (wyl_handle_break_glass_is_active (handle))
+    return 77;
+
+  /* Disarm is idempotent against an in-memory activation that has
+   * already passed its operator-TTL: the call still succeeds and
+   * tears the activation flag down so a subsequent arm starts from
+   * a clean slate. */
+  if (wyl_handle_break_glass_disarm (handle) != WYRELOG_E_OK)
+    return 78;
+  if (wyl_handle_break_glass_is_active (handle))
+    return 79;
+  if (wyl_handle_break_glass_has_been_used (handle))
+    return 80;
+
+  /* Re-arm with a fresh TTL and confirm the new activation is live;
+   * the prior expiry must not bleed into the new window. */
+  if (wyl_handle_break_glass_arm (handle,
+          WYL_BREAK_GLASS_REASON_INCIDENT_RESPONSE, 60) != WYRELOG_E_OK)
+    return 81;
+  if (!wyl_handle_break_glass_is_active (handle))
+    return 82;
+  if (wyl_handle_break_glass_has_been_used (handle))
+    return 83;
+  return 0;
+}
+
+static gint
+check_decide_fact_insert_failure_does_not_latch_used (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 90;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 91;
+  if (seed_armed_allow_fixture (handle, "bg-decide-user-5",
+          "wr.decide-permission-5", "bg-decide-resource-5") != WYRELOG_E_OK)
+    return 92;
+
+  if (wyl_handle_break_glass_arm (handle,
+          WYL_BREAK_GLASS_REASON_INCIDENT_RESPONSE, 60) != WYRELOG_E_OK)
+    return 93;
+  if (wyl_handle_break_glass_has_been_used (handle))
+    return 94;
+
+  /* Trip the next "now" insert so insert_break_glass_facts() returns
+   * non-OK before the engine_decide call. wyl_decide must propagate
+   * the failure and bypass both the audit-emit block and the
+   * mark-used latch: the audit-then-mark invariant requires that a
+   * decide which fails before audit commits leaves the used bit
+   * exactly as it was. */
+  wyl_handle_set_engine_insert_fault_once (handle, "now", WYRELOG_E_INVALID);
+
+  g_autoptr (wyl_decide_req_t) req = wyl_decide_req_new ();
+  wyl_decide_req_set_subject_id (req, "bg-decide-user-5");
+  wyl_decide_req_set_action (req, "wr.decide-permission-5");
+  wyl_decide_req_set_resource_id (req, "bg-decide-resource-5");
+
+  g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
+  if (wyl_decide (handle, req, resp) == WYRELOG_E_OK)
+    return 95;
+  if (wyl_handle_break_glass_has_been_used (handle))
+    return 96;
+
+  /* The activation itself remains intact: only the per-decide fact
+   * injection failed. A follow-up decide with no fault hook armed
+   * must succeed and now latch the used bit. */
+  g_autoptr (wyl_decide_resp_t) resp2 = wyl_decide_resp_new ();
+  if (wyl_decide (handle, req, resp2) != WYRELOG_E_OK)
+    return 97;
+  if (!wyl_handle_break_glass_has_been_used (handle))
+    return 98;
+  return 0;
+}
+
+static gint
 check_arm_writes_audit_row (void)
 {
   g_autoptr (WylHandle) handle = NULL;
@@ -284,6 +396,10 @@ main (void)
   if ((rc = check_decide_does_not_mark_when_inactive ()) != 0)
     return rc;
   if ((rc = check_disarm_clears_used_and_active ()) != 0)
+    return rc;
+  if ((rc = check_ttl_expiry_disarm_and_rearm ()) != 0)
+    return rc;
+  if ((rc = check_decide_fact_insert_failure_does_not_latch_used ()) != 0)
     return rc;
   if ((rc = check_arm_writes_audit_row ()) != 0)
     return rc;

--- a/tests/test-break-glass-decide.c
+++ b/tests/test-break-glass-decide.c
@@ -1,0 +1,292 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <glib.h>
+
+#include "wyrelog/wyrelog.h"
+
+#ifndef WYL_TEST_TEMPLATE_DIR
+#error "WYL_TEST_TEMPLATE_DIR must be defined by the build."
+#endif
+
+/*
+ * Decide-path coverage for the break-glass override surface.
+ * Compiled only when both enable_break_glass and enable_audit are on
+ * since the override path requires the audit conn for its arming
+ * trail; the meson registration mirrors that gate.
+ */
+
+#if defined(WYL_HAS_BREAK_GLASS) && defined(WYL_HAS_AUDIT)
+
+#include "access/break-glass-private.h"
+#include "wyl-handle-private.h"
+
+static wyrelog_error_t
+intern_symbol (WylHandle *handle, const gchar *symbol, gint64 *out_id)
+{
+  return wyl_handle_intern_engine_symbol (handle, symbol, out_id);
+}
+
+static wyrelog_error_t
+insert_symbol_row1 (WylHandle *handle, const gchar *relation,
+    const gchar *value)
+{
+  gint64 row[1];
+  wyrelog_error_t rc = intern_symbol (handle, value, &row[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_engine_insert (handle, relation, row, 1);
+}
+
+static wyrelog_error_t
+insert_symbol_row2 (WylHandle *handle, const gchar *relation,
+    const gchar *a, const gchar *b)
+{
+  gint64 row[2];
+  wyrelog_error_t rc = intern_symbol (handle, a, &row[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = intern_symbol (handle, b, &row[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_engine_insert (handle, relation, row, 2);
+}
+
+static wyrelog_error_t
+insert_symbol_row3 (WylHandle *handle, const gchar *relation,
+    const gchar *a, const gchar *b, const gchar *c)
+{
+  gint64 row[3];
+  wyrelog_error_t rc = intern_symbol (handle, a, &row[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = intern_symbol (handle, b, &row[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = intern_symbol (handle, c, &row[2]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_engine_insert (handle, relation, row, 3);
+}
+
+static wyrelog_error_t
+insert_symbol_row4 (WylHandle *handle, const gchar *relation,
+    const gchar *a, const gchar *b, const gchar *c, const gchar *d)
+{
+  gint64 row[4];
+  wyrelog_error_t rc = intern_symbol (handle, a, &row[0]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = intern_symbol (handle, b, &row[1]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = intern_symbol (handle, c, &row[2]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = intern_symbol (handle, d, &row[3]);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_engine_insert (handle, relation, row, 4);
+}
+
+static wyrelog_error_t
+seed_armed_allow_fixture (WylHandle *handle, const gchar *subject,
+    const gchar *action, const gchar *resource)
+{
+  wyrelog_error_t rc = insert_symbol_row2 (handle, "role_permission",
+      "wr.decide-role", action);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = insert_symbol_row3 (handle, "member_of", subject, "wr.decide-role",
+      resource);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = insert_symbol_row2 (handle, "principal_state", subject, "authenticated");
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = insert_symbol_row2 (handle, "session_state", resource, "active");
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = insert_symbol_row1 (handle, "session_active", "active");
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return insert_symbol_row4 (handle, "perm_state", subject, action, resource,
+      "armed");
+}
+
+static gint
+check_decide_marks_break_glass_used_when_armed (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 10;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 11;
+  if (seed_armed_allow_fixture (handle, "bg-decide-user-1",
+          "wr.decide-permission-1", "bg-decide-resource-1") != WYRELOG_E_OK)
+    return 12;
+
+  if (wyl_handle_break_glass_has_been_used (handle))
+    return 13;
+  if (wyl_handle_break_glass_arm (handle,
+          WYL_BREAK_GLASS_REASON_INCIDENT_RESPONSE, 60) != WYRELOG_E_OK)
+    return 14;
+  if (wyl_handle_break_glass_has_been_used (handle))
+    return 15;
+
+  g_autoptr (wyl_decide_req_t) req = wyl_decide_req_new ();
+  wyl_decide_req_set_subject_id (req, "bg-decide-user-1");
+  wyl_decide_req_set_action (req, "wr.decide-permission-1");
+  wyl_decide_req_set_resource_id (req, "bg-decide-resource-1");
+
+  g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
+  if (wyl_decide (handle, req, resp) != WYRELOG_E_OK)
+    return 16;
+  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_ALLOW)
+    return 17;
+  if (!wyl_handle_break_glass_has_been_used (handle))
+    return 18;
+  if (!wyl_handle_break_glass_is_active (handle))
+    return 19;
+
+  /* A second decide on the same activation keeps the used bit
+   * latched (no clear-and-reset semantics until disarm). */
+  g_autoptr (wyl_decide_resp_t) resp2 = wyl_decide_resp_new ();
+  if (wyl_decide (handle, req, resp2) != WYRELOG_E_OK)
+    return 20;
+  if (!wyl_handle_break_glass_has_been_used (handle))
+    return 21;
+  return 0;
+}
+
+static gint
+check_decide_does_not_mark_when_inactive (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 30;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 31;
+  if (seed_armed_allow_fixture (handle, "bg-decide-user-2",
+          "wr.decide-permission-2", "bg-decide-resource-2") != WYRELOG_E_OK)
+    return 32;
+
+  g_autoptr (wyl_decide_req_t) req = wyl_decide_req_new ();
+  wyl_decide_req_set_subject_id (req, "bg-decide-user-2");
+  wyl_decide_req_set_action (req, "wr.decide-permission-2");
+  wyl_decide_req_set_resource_id (req, "bg-decide-resource-2");
+
+  g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
+  if (wyl_decide (handle, req, resp) != WYRELOG_E_OK)
+    return 33;
+  if (wyl_decide_resp_get_decision (resp) != WYL_DECISION_ALLOW)
+    return 34;
+  /* Without an arming, the used bit remains FALSE through decide. */
+  if (wyl_handle_break_glass_has_been_used (handle))
+    return 35;
+  return 0;
+}
+
+static gint
+check_disarm_clears_used_and_active (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 40;
+  if (wyl_handle_open_engine_pair (handle, WYL_TEST_TEMPLATE_DIR)
+      != WYRELOG_E_OK)
+    return 41;
+  if (seed_armed_allow_fixture (handle, "bg-decide-user-3",
+          "wr.decide-permission-3", "bg-decide-resource-3") != WYRELOG_E_OK)
+    return 42;
+
+  if (wyl_handle_break_glass_arm (handle,
+          WYL_BREAK_GLASS_REASON_POLICY_CORRUPTION, 60) != WYRELOG_E_OK)
+    return 43;
+
+  g_autoptr (wyl_decide_req_t) req = wyl_decide_req_new ();
+  wyl_decide_req_set_subject_id (req, "bg-decide-user-3");
+  wyl_decide_req_set_action (req, "wr.decide-permission-3");
+  wyl_decide_req_set_resource_id (req, "bg-decide-resource-3");
+
+  g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
+  if (wyl_decide (handle, req, resp) != WYRELOG_E_OK)
+    return 44;
+  if (!wyl_handle_break_glass_has_been_used (handle))
+    return 45;
+
+  if (wyl_handle_break_glass_disarm (handle) != WYRELOG_E_OK)
+    return 46;
+  if (wyl_handle_break_glass_is_active (handle))
+    return 47;
+  if (wyl_handle_break_glass_has_been_used (handle))
+    return 48;
+  return 0;
+}
+
+static gint
+check_arm_writes_audit_row (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 50;
+
+  if (wyl_handle_break_glass_arm (handle,
+          WYL_BREAK_GLASS_REASON_SECURITY_OFFICER_LOCKOUT, 60) != WYRELOG_E_OK)
+    return 51;
+
+  wyl_audit_conn_t *conn = wyl_handle_get_audit_conn (handle);
+  g_autofree gchar *arm_json = NULL;
+  if (wyl_audit_conn_query_events_json (conn,
+          "action(\"break_glass_arm\")", &arm_json) != WYRELOG_E_OK)
+    return 52;
+  if (g_strstr_len (arm_json, -1, "\"action\":\"break_glass_arm\"") == NULL)
+    return 53;
+  if (g_strstr_len (arm_json, -1, "\"resource_id\":\"wr.break_glass\"")
+      == NULL)
+    return 54;
+  if (g_strstr_len (arm_json, -1,
+          "\"deny_reason\":\"security_officer_lockout\"") == NULL)
+    return 55;
+  if (g_strstr_len (arm_json, -1, "\"deny_origin\":\"break_glass\"") == NULL)
+    return 56;
+  if (g_strstr_len (arm_json, -1, "\"decision\":1") == NULL)
+    return 57;
+
+  if (wyl_handle_break_glass_disarm (handle) != WYRELOG_E_OK)
+    return 58;
+
+  g_autofree gchar *disarm_json = NULL;
+  if (wyl_audit_conn_query_events_json (conn,
+          "action(\"break_glass_disarm\")", &disarm_json) != WYRELOG_E_OK)
+    return 59;
+  if (g_strstr_len (disarm_json, -1, "\"action\":\"break_glass_disarm\"")
+      == NULL)
+    return 60;
+  if (g_strstr_len (disarm_json, -1, "\"resource_id\":\"wr.break_glass\"")
+      == NULL)
+    return 61;
+  if (g_strstr_len (disarm_json, -1, "\"deny_origin\":\"break_glass\"")
+      == NULL)
+    return 62;
+  return 0;
+}
+
+#endif /* WYL_HAS_BREAK_GLASS && WYL_HAS_AUDIT */
+
+int
+main (void)
+{
+#if defined(WYL_HAS_BREAK_GLASS) && defined(WYL_HAS_AUDIT)
+  gint rc;
+  if ((rc = check_decide_marks_break_glass_used_when_armed ()) != 0)
+    return rc;
+  if ((rc = check_decide_does_not_mark_when_inactive ()) != 0)
+    return rc;
+  if ((rc = check_disarm_clears_used_and_active ()) != 0)
+    return rc;
+  if ((rc = check_arm_writes_audit_row ()) != 0)
+    return rc;
+#endif
+  return 0;
+}

--- a/tests/test-break-glass-vocab.c
+++ b/tests/test-break-glass-vocab.c
@@ -1,0 +1,116 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <glib.h>
+#include <string.h>
+
+#include "wyrelog/wyrelog.h"
+#include "access/break-glass-private.h"
+
+static gint
+check_error_string_for_break_glass_disabled (void)
+{
+  const gchar *s = wyrelog_error_string (WYRELOG_E_BREAK_GLASS_DISABLED);
+  if (s == NULL || s[0] == '\0')
+    return 1;
+  if (strstr (s, "break-glass") == NULL)
+    return 2;
+  return 0;
+}
+
+static gint
+check_error_value_is_distinct_at_tail (void)
+{
+  /* The enumerator must append at the tail of wyrelog_error_t so the
+   * numeric values of every existing code remain stable. The previous
+   * tail was WYRELOG_E_NOT_FOUND = -9; the new tail is -10. Pin both
+   * values so a reorder is caught at compile time of this test. */
+  if ((int) WYRELOG_E_NOT_FOUND != -9)
+    return 10;
+  if ((int) WYRELOG_E_BREAK_GLASS_DISABLED != -10)
+    return 11;
+  return 0;
+}
+
+static gint
+check_reason_name_round_trip (void)
+{
+  for (guint i = 0; i < WYL_BREAK_GLASS_REASON_LAST_; i++) {
+    const gchar *name =
+        wyl_break_glass_reason_name ((wyl_break_glass_reason_code_t) i);
+    if (name == NULL || name[0] == '\0')
+      return 20;
+    wyl_break_glass_reason_code_t resolved = WYL_BREAK_GLASS_REASON_LAST_;
+    if (wyl_break_glass_reason_from_name (name, &resolved) != WYRELOG_E_OK)
+      return 21;
+    if ((guint) resolved != i)
+      return 22;
+  }
+  return 0;
+}
+
+static gint
+check_reason_name_unknown_returns_unknown_string (void)
+{
+  const gchar *s = wyl_break_glass_reason_name (WYL_BREAK_GLASS_REASON_LAST_);
+  if (g_strcmp0 (s, "unknown") != 0)
+    return 30;
+  return 0;
+}
+
+static gint
+check_reason_from_name_unknown_returns_not_found (void)
+{
+  wyl_break_glass_reason_code_t code = WYL_BREAK_GLASS_REASON_LAST_;
+  if (wyl_break_glass_reason_from_name ("definitely_not_a_reason", &code)
+      != WYRELOG_E_NOT_FOUND)
+    return 40;
+  return 0;
+}
+
+static gint
+check_reason_from_name_rejects_invalid_args (void)
+{
+  wyl_break_glass_reason_code_t code = WYL_BREAK_GLASS_REASON_LAST_;
+  if (wyl_break_glass_reason_from_name (NULL, &code) != WYRELOG_E_INVALID)
+    return 50;
+  if (wyl_break_glass_reason_from_name ("", &code) != WYRELOG_E_INVALID)
+    return 51;
+  if (wyl_break_glass_reason_from_name ("incident_response", NULL)
+      != WYRELOG_E_INVALID)
+    return 52;
+  return 0;
+}
+
+static gint
+check_default_ttl_matches_bootstrap_dl (void)
+{
+  /* templates/access/bootstrap.dl carries ttl("break_glass", 900); the
+   * compile-time ceiling exposed to the host must match so the
+   * host-side wall-clock gate cannot exceed the DL self-disable
+   * horizon. Pin the value so a divergence is caught here. */
+  if (WYL_BREAK_GLASS_DEFAULT_TTL_SECONDS != 900)
+    return 60;
+  return 0;
+}
+
+int
+main (void)
+{
+  gint rc;
+
+  if ((rc = check_error_string_for_break_glass_disabled ()) != 0)
+    return rc;
+  if ((rc = check_error_value_is_distinct_at_tail ()) != 0)
+    return rc;
+  if ((rc = check_reason_name_round_trip ()) != 0)
+    return rc;
+  if ((rc = check_reason_name_unknown_returns_unknown_string ()) != 0)
+    return rc;
+  if ((rc = check_reason_from_name_unknown_returns_not_found ()) != 0)
+    return rc;
+  if ((rc = check_reason_from_name_rejects_invalid_args ()) != 0)
+    return rc;
+  if ((rc = check_default_ttl_matches_bootstrap_dl ()) != 0)
+    return rc;
+
+  return 0;
+}

--- a/wyrelog/access/break-glass-private.h
+++ b/wyrelog/access/break-glass-private.h
@@ -1,0 +1,71 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+
+#include <glib.h>
+
+#include "wyrelog/error.h"
+
+G_BEGIN_DECLS;
+
+/*
+ * Closed enumeration of operator-supplied reason codes carried into
+ * the audit row when a break-glass override is armed or fired. The
+ * vocabulary is deliberately small so audit consumers can pivot
+ * dashboards on a stable string set; free-form reasons are rejected
+ * at the API boundary because they drift across releases and invite
+ * downstream-consumer breakage as well as audit-row injection.
+ *
+ * Adding a new code is a coordinated change: append a new
+ * enumerator BEFORE WYL_BREAK_GLASS_REASON_LAST_, extend the
+ * name table in access/break-glass.c, and document the addition in
+ * release notes so audit consumers can update their filters.
+ */
+typedef enum
+{
+  /* Active incident response — a host-side outage or attack that
+   * cannot be remediated through the standard policy-write surface
+   * because the legitimate operators have lost their access. */
+  WYL_BREAK_GLASS_REASON_INCIDENT_RESPONSE = 0,
+  /* The policy store has been corrupted or seeded with a bad
+   * grant set and the security officer must rebuild it. */
+  WYL_BREAK_GLASS_REASON_POLICY_CORRUPTION = 1,
+  /* The principal who normally holds wr.security_officer is
+   * locked out (lost MFA, departed, etc.) and a break-glass
+   * holder must re-establish the SoD counterweight. */
+  WYL_BREAK_GLASS_REASON_SECURITY_OFFICER_LOCKOUT = 2,
+  /* The service-side freeze guard has trapped a tenant in a
+   * frozen state that no normal grant can release. */
+  WYL_BREAK_GLASS_REASON_SERVICE_UNFREEZE = 3,
+  /* Reason is captured in the operator's incident docket rather
+   * than the audit-row reason code; reserved as a final fallback
+   * so the vocabulary can stay small without forcing the operator
+   * to misclassify. */
+  WYL_BREAK_GLASS_REASON_OTHER = 4,
+  WYL_BREAK_GLASS_REASON_LAST_,
+} wyl_break_glass_reason_code_t;
+
+/*
+ * Returns a stable, never-NULL human-readable name for |code|, or
+ * "unknown" when |code| is out of range. The string lives in static
+ * storage and must not be freed.
+ */
+const gchar *wyl_break_glass_reason_name (wyl_break_glass_reason_code_t code);
+
+/*
+ * Inverse of wyl_break_glass_reason_name: maps a stable name to its
+ * enumerator. Returns WYRELOG_E_OK and writes the resolved code on
+ * success, or WYRELOG_E_NOT_FOUND when |name| does not match any
+ * known reason. NULL or empty |name| returns WYRELOG_E_INVALID.
+ */
+wyrelog_error_t wyl_break_glass_reason_from_name (const gchar * name,
+    wyl_break_glass_reason_code_t * out_code);
+
+/*
+ * Compile-time ceiling on the per-arming TTL. Mirrors the
+ * ttl("break_glass", 900) row in templates/access/bootstrap.dl so
+ * the host-side TTL gate cannot exceed the DL self-disable horizon
+ * that templates/access/bootstrap.dl:223-227 enforces.
+ */
+#define WYL_BREAK_GLASS_DEFAULT_TTL_SECONDS 900
+
+G_END_DECLS;

--- a/wyrelog/access/break-glass-private.h
+++ b/wyrelog/access/break-glass-private.h
@@ -40,4 +40,50 @@ wyrelog_error_t wyl_break_glass_reason_from_name (const gchar * name,
  */
 #define WYL_BREAK_GLASS_DEFAULT_TTL_SECONDS 900
 
+#ifdef WYL_HAS_BREAK_GLASS
+
+/*
+ * Forward declaration so the helpers below can name WylHandle
+ * without forcing every include path through handle-private.h.
+ */
+typedef struct _WylHandle WylHandle;
+
+/*
+ * Returns the operator-supplied reason code for the current
+ * activation. |out_reason| is written only when the handle is in
+ * an active break-glass window; on a NULL handle, an inactive
+ * handle, or an expired activation the call returns
+ * WYRELOG_E_INVALID and |*out_reason| is left untouched.
+ */
+wyrelog_error_t wyl_handle_break_glass_get_reason (WylHandle * handle,
+    wyl_break_glass_reason_code_t * out_reason);
+
+/*
+ * Returns the wall-clock microsecond timestamp at which the
+ * current activation was registered. NULL or inactive handle
+ * returns WYRELOG_E_INVALID and leaves |*out_activated_at_us|
+ * untouched.
+ */
+wyrelog_error_t wyl_handle_break_glass_get_activated_at_us (WylHandle * handle,
+    gint64 * out_activated_at_us);
+
+/*
+ * Records that the active break-glass window has been observed by
+ * a decide call so subsequent decides inject break_glass_used/1
+ * for the DL self-disable rule. Idempotent; further calls after
+ * the first do not advance the timestamp. Safe to call when the
+ * handle is inactive: the call becomes a no-op.
+ */
+void wyl_handle_break_glass_mark_used (WylHandle * handle);
+
+/*
+ * Returns TRUE iff the handle has observed a break-glass-arm
+ * decide at least once since the last disarm. Used by the decide
+ * path to decide whether to inject break_glass_used/1 into the
+ * engine.
+ */
+gboolean wyl_handle_break_glass_has_been_used (WylHandle * handle);
+
+#endif
+
 G_END_DECLS;

--- a/wyrelog/access/break-glass-private.h
+++ b/wyrelog/access/break-glass-private.h
@@ -3,46 +3,18 @@
 
 #include <glib.h>
 
+#include "wyrelog/break-glass.h"
 #include "wyrelog/error.h"
 
 G_BEGIN_DECLS;
 
 /*
- * Closed enumeration of operator-supplied reason codes carried into
- * the audit row when a break-glass override is armed or fired. The
- * vocabulary is deliberately small so audit consumers can pivot
- * dashboards on a stable string set; free-form reasons are rejected
- * at the API boundary because they drift across releases and invite
- * downstream-consumer breakage as well as audit-row injection.
- *
- * Adding a new code is a coordinated change: append a new
- * enumerator BEFORE WYL_BREAK_GLASS_REASON_LAST_, extend the
- * name table in access/break-glass.c, and document the addition in
- * release notes so audit consumers can update their filters.
+ * The closed reason-code enumeration lives in the public header
+ * wyrelog/break-glass.h so callers and audit consumers see one
+ * authoritative vocabulary. This private header pulls it in for
+ * library-internal helpers and adds the host-only ceilings and
+ * lookup helpers the public surface does not need to expose.
  */
-typedef enum
-{
-  /* Active incident response — a host-side outage or attack that
-   * cannot be remediated through the standard policy-write surface
-   * because the legitimate operators have lost their access. */
-  WYL_BREAK_GLASS_REASON_INCIDENT_RESPONSE = 0,
-  /* The policy store has been corrupted or seeded with a bad
-   * grant set and the security officer must rebuild it. */
-  WYL_BREAK_GLASS_REASON_POLICY_CORRUPTION = 1,
-  /* The principal who normally holds wr.security_officer is
-   * locked out (lost MFA, departed, etc.) and a break-glass
-   * holder must re-establish the SoD counterweight. */
-  WYL_BREAK_GLASS_REASON_SECURITY_OFFICER_LOCKOUT = 2,
-  /* The service-side freeze guard has trapped a tenant in a
-   * frozen state that no normal grant can release. */
-  WYL_BREAK_GLASS_REASON_SERVICE_UNFREEZE = 3,
-  /* Reason is captured in the operator's incident docket rather
-   * than the audit-row reason code; reserved as a final fallback
-   * so the vocabulary can stay small without forcing the operator
-   * to misclassify. */
-  WYL_BREAK_GLASS_REASON_OTHER = 4,
-  WYL_BREAK_GLASS_REASON_LAST_,
-} wyl_break_glass_reason_code_t;
 
 /*
  * Returns a stable, never-NULL human-readable name for |code|, or

--- a/wyrelog/access/break-glass.c
+++ b/wyrelog/access/break-glass.c
@@ -1,0 +1,39 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "break-glass-private.h"
+
+#include <string.h>
+
+static const gchar *const reason_names[] = {
+  [WYL_BREAK_GLASS_REASON_INCIDENT_RESPONSE] = "incident_response",
+  [WYL_BREAK_GLASS_REASON_POLICY_CORRUPTION] = "policy_corruption",
+  [WYL_BREAK_GLASS_REASON_SECURITY_OFFICER_LOCKOUT] =
+      "security_officer_lockout",
+  [WYL_BREAK_GLASS_REASON_SERVICE_UNFREEZE] = "service_unfreeze",
+  [WYL_BREAK_GLASS_REASON_OTHER] = "other",
+};
+
+G_STATIC_ASSERT (G_N_ELEMENTS (reason_names) == WYL_BREAK_GLASS_REASON_LAST_);
+
+const gchar *
+wyl_break_glass_reason_name (wyl_break_glass_reason_code_t code)
+{
+  if ((guint) code >= WYL_BREAK_GLASS_REASON_LAST_)
+    return "unknown";
+  return reason_names[code];
+}
+
+wyrelog_error_t
+wyl_break_glass_reason_from_name (const gchar *name,
+    wyl_break_glass_reason_code_t *out_code)
+{
+  if (name == NULL || name[0] == '\0' || out_code == NULL)
+    return WYRELOG_E_INVALID;
+
+  for (guint i = 0; i < WYL_BREAK_GLASS_REASON_LAST_; i++) {
+    if (g_strcmp0 (name, reason_names[i]) == 0) {
+      *out_code = (wyl_break_glass_reason_code_t) i;
+      return WYRELOG_E_OK;
+    }
+  }
+  return WYRELOG_E_NOT_FOUND;
+}

--- a/wyrelog/break-glass.h
+++ b/wyrelog/break-glass.h
@@ -1,0 +1,86 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+
+#include <glib.h>
+
+#include "wyrelog/error.h"
+#include "wyrelog/handle.h"
+
+G_BEGIN_DECLS;
+
+/*
+ * Operator-supplied reason carried into the audit row when a
+ * break-glass override is activated and emitted again on each
+ * override decision. The vocabulary is closed; passing a value
+ * outside the listed set returns WYRELOG_E_INVALID. Stable string
+ * names accompanying each enumerator are the durable identifier
+ * downstream audit consumers should pivot on.
+ *
+ *   - WYL_BREAK_GLASS_REASON_INCIDENT_RESPONSE: active outage or
+ *     attack that the standard policy-write surface cannot
+ *     remediate because the legitimate operators are locked out.
+ *   - WYL_BREAK_GLASS_REASON_POLICY_CORRUPTION: the policy store
+ *     has been seeded with a bad grant set and the security
+ *     officer must rebuild it.
+ *   - WYL_BREAK_GLASS_REASON_SECURITY_OFFICER_LOCKOUT: the
+ *     principal who normally holds wr.security_officer is locked
+ *     out and a break-glass holder must re-establish the SoD
+ *     counterweight.
+ *   - WYL_BREAK_GLASS_REASON_SERVICE_UNFREEZE: the service-side
+ *     freeze guard has trapped a tenant in a frozen state that no
+ *     normal grant can release.
+ *   - WYL_BREAK_GLASS_REASON_OTHER: reserved final fallback so
+ *     operators are not forced to misclassify; the textual reason
+ *     belongs in the operator's incident docket, not the audit
+ *     row's stable code.
+ */
+typedef enum
+{
+  WYL_BREAK_GLASS_REASON_INCIDENT_RESPONSE = 0,
+  WYL_BREAK_GLASS_REASON_POLICY_CORRUPTION = 1,
+  WYL_BREAK_GLASS_REASON_SECURITY_OFFICER_LOCKOUT = 2,
+  WYL_BREAK_GLASS_REASON_SERVICE_UNFREEZE = 3,
+  WYL_BREAK_GLASS_REASON_OTHER = 4,
+  WYL_BREAK_GLASS_REASON_LAST_,
+} wyl_break_glass_reason_code_t;
+
+/*
+ * Activate the break-glass override on |handle| with the given
+ * |reason| and a TTL of |ttl_seconds|. The TTL is capped at the
+ * compile-time ceiling that matches the bootstrap policy template;
+ * passing a larger value or a non-positive value returns
+ * WYRELOG_E_INVALID. A reason outside the closed enumeration
+ * returns WYRELOG_E_INVALID. A second call before
+ * wyl_handle_break_glass_disarm returns WYRELOG_E_INVALID so an
+ * operator cannot extend the wall-clock window by re-arming.
+ *
+ * Builds without -Denable_break_glass=true return
+ * WYRELOG_E_BREAK_GLASS_DISABLED so callers can detect that the
+ * override path is absent rather than receive a false positive.
+ *
+ * The activation is handle-scoped: a second WylHandle in the same
+ * process or in a separate process is unaffected. The activation
+ * does not survive process restart by design; an operator must
+ * present a fresh activation request after restart.
+ */
+wyrelog_error_t wyl_handle_break_glass_arm (WylHandle * handle,
+    wyl_break_glass_reason_code_t reason, gint64 ttl_seconds);
+
+/*
+ * Cancels an in-progress activation on |handle|. Returns
+ * WYRELOG_E_OK whether or not the handle was active so callers can
+ * use it idempotently from a teardown path. Builds without
+ * -Denable_break_glass=true return WYRELOG_E_BREAK_GLASS_DISABLED.
+ */
+wyrelog_error_t wyl_handle_break_glass_disarm (WylHandle * handle);
+
+/*
+ * Returns TRUE iff the break-glass override is currently active on
+ * |handle| and its TTL has not elapsed. Returns FALSE for a NULL
+ * handle, an inactive handle, an expired activation, or a build
+ * without the override path. Strictly read-only; does not advance
+ * the activation's used flag or otherwise mutate state.
+ */
+gboolean wyl_handle_break_glass_is_active (WylHandle * handle);
+
+G_END_DECLS;

--- a/wyrelog/error.h
+++ b/wyrelog/error.h
@@ -34,6 +34,20 @@ typedef enum wyrelog_error_t
    * sid the handle has never registered.
    */
   WYRELOG_E_NOT_FOUND = -9,
+  /*
+   * Break-glass override surface is not available in this build or
+   * has not been activated for the current handle. Returned by the
+   * override-aware paths when WYL_HAS_BREAK_GLASS was not set at
+   * compile time, when the operator-supplied reason is missing or
+   * out of vocabulary, when the requested TTL exceeds the
+   * compile-time ceiling, or when the calling code attempts to use
+   * an override that the runtime activation state does not
+   * authorise. Distinct from WYRELOG_E_POLICY (load-time policy
+   * fault) and WYRELOG_E_INVALID (argument-shape failure) so
+   * operators can triage "build does not ship the override path"
+   * from genuine misuse.
+   */
+  WYRELOG_E_BREAK_GLASS_DISABLED = -10,
 } wyrelog_error_t;
 
 const gchar *wyrelog_error_string (wyrelog_error_t err);

--- a/wyrelog/meson.build
+++ b/wyrelog/meson.build
@@ -14,6 +14,7 @@ wyrelog_public_headers = files(
 )
 
 wyrelog_sources = files(
+  'access/break-glass.c',
   'access/decision.c',
   'auth/jwt.c',
   'audit/event.c',
@@ -66,6 +67,10 @@ if get_option('enable_audit').allowed()
   wyrelog_sources += files('audit/conn.c')
   wyrelog_deps += duckdb_dep
   wyrelog_c_args += '-DWYL_HAS_AUDIT'
+endif
+
+if get_option('enable_break_glass')
+  wyrelog_c_args += '-DWYL_HAS_BREAK_GLASS'
 endif
 
 libwyrelog = library('wyrelog',
@@ -135,6 +140,9 @@ endif
 if get_option('enable_audit').allowed()
   wyrelogd_deps += duckdb_dep
   wyrelogd_c_args += '-DWYL_HAS_AUDIT'
+endif
+if get_option('enable_break_glass')
+  wyrelogd_c_args += '-DWYL_HAS_BREAK_GLASS'
 endif
 
 wyrelogd_exe = executable('wyrelogd',

--- a/wyrelog/meson.build
+++ b/wyrelog/meson.build
@@ -2,6 +2,7 @@ wyrelog_inc = include_directories('..')
 
 wyrelog_public_headers = files(
   'audit.h',
+  'break-glass.h',
   'decide.h',
   'engine.h',
   'error.h',

--- a/wyrelog/wyl-decide.c
+++ b/wyrelog/wyl-decide.c
@@ -3,6 +3,7 @@
 
 #include "wyrelog/wyrelog.h"
 
+#include "access/break-glass-private.h"
 #include "access/decision-private.h"
 #include "wyl-handle-compound-private.h"
 #include "wyl-handle-private.h"
@@ -530,6 +531,78 @@ fail_closed_for_audit (wyl_decide_resp_t *resp)
 }
 #endif
 
+#ifdef WYL_HAS_BREAK_GLASS
+typedef struct
+{
+  gint64 now_row[1];
+  gint64 used_row[1];
+  gboolean now_inserted;
+  gboolean used_inserted;
+} break_glass_eval_facts_t;
+
+static wyrelog_error_t
+remove_break_glass_facts (WylHandle *handle,
+    const break_glass_eval_facts_t *facts)
+{
+  wyrelog_error_t first_rc = WYRELOG_E_OK;
+  if (facts->used_inserted) {
+    wyrelog_error_t rc = wyl_handle_engine_remove (handle, "break_glass_used",
+        facts->used_row, 1);
+    if (first_rc == WYRELOG_E_OK)
+      first_rc = rc;
+  }
+  if (facts->now_inserted) {
+    wyrelog_error_t rc = wyl_handle_engine_remove (handle, "now",
+        facts->now_row, 1);
+    if (first_rc == WYRELOG_E_OK)
+      first_rc = rc;
+  }
+  return first_rc;
+}
+
+/*
+ * Inserts the host-supplied EDB rows that templates/access/bootstrap.dl
+ * declares as runtime-only (now/1 and break_glass_used/1) so the
+ * self-disable rule disabled_role("wr.break_glass") can fire when the
+ * activation outlives its TTL. The facts are inserted lock-free under
+ * the per-decide critical section the caller already owns; on any
+ * insertion failure the partially-inserted facts are removed before
+ * returning so the engine state is restored to its pre-call shape.
+ *
+ * The injection happens unconditionally on every break-glass-aware
+ * decide so a handle whose break-glass window has expired since the
+ * previous decide does not need a separate host-side gate to surface
+ * the deny. now/1 is always injected; break_glass_used/1 is injected
+ * only when the handle has observed at least one armed decide.
+ */
+static wyrelog_error_t
+insert_break_glass_facts (WylHandle *handle, break_glass_eval_facts_t *facts)
+{
+  facts->now_row[0] = g_get_real_time () / G_USEC_PER_SEC;
+  wyrelog_error_t rc = wyl_handle_engine_insert (handle, "now",
+      facts->now_row, 1);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  facts->now_inserted = TRUE;
+
+  if (wyl_handle_break_glass_has_been_used (handle)) {
+    gint64 activated_at_us = 0;
+    if (wyl_handle_break_glass_get_activated_at_us (handle, &activated_at_us)
+        == WYRELOG_E_OK) {
+      facts->used_row[0] = activated_at_us / G_USEC_PER_SEC;
+      rc = wyl_handle_engine_insert (handle, "break_glass_used",
+          facts->used_row, 1);
+      if (rc != WYRELOG_E_OK) {
+        (void) remove_break_glass_facts (handle, facts);
+        return rc;
+      }
+      facts->used_inserted = TRUE;
+    }
+  }
+  return WYRELOG_E_OK;
+}
+#endif
+
 wyrelog_error_t
 wyl_decide (WylHandle *handle, const wyl_decide_req_t *req,
     wyl_decide_resp_t *resp)
@@ -570,6 +643,10 @@ wyl_decide (WylHandle *handle, const wyl_decide_req_t *req,
 
     gboolean allowed = FALSE;
     guard_eval_facts_t guard_facts = { 0 };
+#ifdef WYL_HAS_BREAK_GLASS
+    break_glass_eval_facts_t break_glass_facts = { 0 };
+    gboolean break_glass_active_now = wyl_handle_break_glass_is_active (handle);
+#endif
     const wyl_guard_expr_t *guard =
         wyl_perm_arm_rule_lookup (wyl_decide_req_get_action (req));
     if (guard != NULL) {
@@ -588,11 +665,24 @@ wyl_decide (WylHandle *handle, const wyl_decide_req_t *req,
       if (rc != WYRELOG_E_OK)
         return rc;
     }
+#ifdef WYL_HAS_BREAK_GLASS
+    if (break_glass_active_now) {
+      rc = insert_break_glass_facts (handle, &break_glass_facts);
+      if (rc != WYRELOG_E_OK) {
+        if (guard_facts.eval_guard_inserted)
+          (void) remove_guard_eval_facts (handle, &guard_facts);
+        return rc;
+      }
+    }
+#endif
 
     rc = wyl_handle_engine_decide (handle, row, &allowed);
     if (rc != WYRELOG_E_OK) {
       if (guard_facts.eval_guard_inserted)
         (void) remove_guard_eval_facts (handle, &guard_facts);
+#ifdef WYL_HAS_BREAK_GLASS
+      (void) remove_break_glass_facts (handle, &break_glass_facts);
+#endif
       return rc;
     }
     if (allowed) {
@@ -603,6 +693,9 @@ wyl_decide (WylHandle *handle, const wyl_decide_req_t *req,
       if (rc != WYRELOG_E_OK) {
         if (guard_facts.eval_guard_inserted)
           (void) remove_guard_eval_facts (handle, &guard_facts);
+#ifdef WYL_HAS_BREAK_GLASS
+        (void) remove_break_glass_facts (handle, &break_glass_facts);
+#endif
         return rc;
       }
       deny_reason = wyl_deny_reason_name (code);
@@ -614,9 +707,15 @@ wyl_decide (WylHandle *handle, const wyl_decide_req_t *req,
         wyl_decide_resp_set_decision (resp, WYL_DECISION_DENY);
         wyl_decide_resp_set_deny_tags (resp, "guard_cleanup_failed",
             "eval_guard");
+#ifdef WYL_HAS_BREAK_GLASS
+        (void) remove_break_glass_facts (handle, &break_glass_facts);
+#endif
         return rc;
       }
     }
+#ifdef WYL_HAS_BREAK_GLASS
+    (void) remove_break_glass_facts (handle, &break_glass_facts);
+#endif
   }
   wyl_decide_resp_set_deny_tags (resp, deny_reason, deny_origin);
 emit_audit:
@@ -640,6 +739,16 @@ emit_audit:
   wyl_audit_event_set_decision (ev, wyl_decide_resp_get_decision (resp));
   if (wyl_audit_emit (handle, ev) != WYRELOG_E_OK)
     fail_closed_for_audit (resp);
+#endif
+
+#ifdef WYL_HAS_BREAK_GLASS
+  /*
+   * Mark the activation observed AFTER the audit row has committed
+   * so a fail-closed audit emit does not falsely register a usage
+   * the operator's incident docket cannot see. The mark is a no-op
+   * when the handle is not currently in an activation window.
+   */
+  wyl_handle_break_glass_mark_used (handle);
 #endif
 
   return WYRELOG_E_OK;

--- a/wyrelog/wyl-error.c
+++ b/wyrelog/wyl-error.c
@@ -25,6 +25,9 @@ wyrelog_error_string (wyrelog_error_t err)
       return "policy evaluation runtime fault";
     case WYRELOG_E_NOT_FOUND:
       return "no entity registered for the supplied identifier";
+    case WYRELOG_E_BREAK_GLASS_DISABLED:
+      return "break-glass override is disabled in this build or not "
+          "armed at runtime";
   }
   return "unknown error";
 }

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -3,6 +3,7 @@
 
 #include <string.h>
 
+#include "access/break-glass-private.h"
 #include "access/decision-private.h"
 #include "wyrelog/engine.h"
 #include "wyl-engine-private.h"
@@ -81,6 +82,24 @@ struct _WylHandle
   GMutex sessions_lock;
   GHashTable *sessions_by_id;
   guint64 next_session_id;
+#ifdef WYL_HAS_BREAK_GLASS
+  /*
+   * Handle-scoped break-glass override state. The override path is
+   * gated on the build option to keep the bypass surface absent
+   * from default builds; off-builds expose the public API as
+   * stubs returning WYRELOG_E_BREAK_GLASS_DISABLED. Activation is
+   * single-shot per handle: a second arm before disarm fails so
+   * an operator cannot extend the wall-clock window by re-arming.
+   * Live fields are read under break_glass_lock so a concurrent
+   * decide cannot observe a torn state.
+   */
+  GMutex break_glass_lock;
+  gboolean break_glass_active;
+  wyl_break_glass_reason_code_t break_glass_reason;
+  gint64 break_glass_activated_at_us;
+  gint64 break_glass_ttl_seconds;
+  gboolean break_glass_used;
+#endif
 #ifdef WYL_HAS_AUDIT
   wyl_audit_conn_t *audit_conn;
 #endif
@@ -152,6 +171,9 @@ wyl_handle_finalize (GObject *object)
   g_clear_pointer (&self->policy_store, wyl_policy_store_close);
   g_clear_pointer (&self->sessions_by_id, g_hash_table_unref);
   g_mutex_clear (&self->sessions_lock);
+#ifdef WYL_HAS_BREAK_GLASS
+  g_mutex_clear (&self->break_glass_lock);
+#endif
 #ifdef WYL_HAS_AUDIT
   /* NULL-safe: if wyl_shutdown already closed the conn the pointer
    * was reset to NULL there; otherwise this is the only close site
@@ -196,6 +218,11 @@ wyl_handle_init (WylHandle *self)
   self->sessions_by_id = g_hash_table_new_full (g_int64_hash, g_int64_equal,
       g_free, wyl_session_registry_entry_free);
   self->next_session_id = 1;
+#ifdef WYL_HAS_BREAK_GLASS
+  g_mutex_init (&self->break_glass_lock);
+  self->break_glass_active = FALSE;
+  self->break_glass_used = FALSE;
+#endif
 }
 
 wyrelog_error_t
@@ -832,6 +859,88 @@ wyl_handle_get_login_skip_mfa_allowed (WylHandle *self)
           &deployment_mode) != WYRELOG_E_OK)
     return FALSE;
   return g_strcmp0 (deployment_mode, "production") != 0;
+}
+
+wyrelog_error_t
+wyl_handle_break_glass_arm (WylHandle *handle,
+    wyl_break_glass_reason_code_t reason, gint64 ttl_seconds)
+{
+#ifdef WYL_HAS_BREAK_GLASS
+  if (handle == NULL || !WYL_IS_HANDLE (handle))
+    return WYRELOG_E_INVALID;
+  if ((guint) reason >= WYL_BREAK_GLASS_REASON_LAST_)
+    return WYRELOG_E_INVALID;
+  if (ttl_seconds <= 0 || ttl_seconds > WYL_BREAK_GLASS_DEFAULT_TTL_SECONDS)
+    return WYRELOG_E_INVALID;
+
+  g_mutex_lock (&handle->break_glass_lock);
+  if (handle->break_glass_active) {
+    g_mutex_unlock (&handle->break_glass_lock);
+    /*
+     * Single-shot per handle: a second arm before disarm is a
+     * misuse, not a TTL extension. Returning E_INVALID forces
+     * the caller through the explicit disarm path so the
+     * activation event log records both the prior teardown and
+     * the fresh activation rather than a silent overwrite.
+     */
+    return WYRELOG_E_INVALID;
+  }
+  handle->break_glass_active = TRUE;
+  handle->break_glass_reason = reason;
+  handle->break_glass_activated_at_us = g_get_real_time ();
+  handle->break_glass_ttl_seconds = ttl_seconds;
+  handle->break_glass_used = FALSE;
+  g_mutex_unlock (&handle->break_glass_lock);
+  return WYRELOG_E_OK;
+#else
+  (void) handle;
+  (void) reason;
+  (void) ttl_seconds;
+  return WYRELOG_E_BREAK_GLASS_DISABLED;
+#endif
+}
+
+wyrelog_error_t
+wyl_handle_break_glass_disarm (WylHandle *handle)
+{
+#ifdef WYL_HAS_BREAK_GLASS
+  if (handle == NULL || !WYL_IS_HANDLE (handle))
+    return WYRELOG_E_INVALID;
+
+  g_mutex_lock (&handle->break_glass_lock);
+  handle->break_glass_active = FALSE;
+  handle->break_glass_used = FALSE;
+  g_mutex_unlock (&handle->break_glass_lock);
+  return WYRELOG_E_OK;
+#else
+  (void) handle;
+  return WYRELOG_E_BREAK_GLASS_DISABLED;
+#endif
+}
+
+gboolean
+wyl_handle_break_glass_is_active (WylHandle *handle)
+{
+#ifdef WYL_HAS_BREAK_GLASS
+  if (handle == NULL || !WYL_IS_HANDLE (handle))
+    return FALSE;
+
+  gboolean active;
+  g_mutex_lock (&handle->break_glass_lock);
+  if (!handle->break_glass_active) {
+    active = FALSE;
+  } else {
+    gint64 now_us = g_get_real_time ();
+    gint64 expiry_us = handle->break_glass_activated_at_us
+        + handle->break_glass_ttl_seconds * G_USEC_PER_SEC;
+    active = (now_us < expiry_us);
+  }
+  g_mutex_unlock (&handle->break_glass_lock);
+  return active;
+#else
+  (void) handle;
+  return FALSE;
+#endif
 }
 
 static GHashTable *

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -891,6 +891,26 @@ wyl_handle_break_glass_arm (WylHandle *handle,
   handle->break_glass_ttl_seconds = ttl_seconds;
   handle->break_glass_used = FALSE;
   g_mutex_unlock (&handle->break_glass_lock);
+
+#ifdef WYL_HAS_AUDIT
+  /*
+   * Emit the arm event outside the lock: the audit conn has its
+   * own write serialisation, and a failure to land the row must
+   * not be allowed to roll back the in-memory activation. The
+   * activation has already happened from the operator's point of
+   * view; an audit-write failure is a fail-closed signal for the
+   * operator's external incident docket, not a reason to silently
+   * disarm and pretend the arming never occurred.
+   */
+  g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
+  wyl_audit_event_set_action (ev, "break_glass_arm");
+  wyl_audit_event_set_resource_id (ev, "wr.break_glass");
+  wyl_audit_event_set_deny_reason (ev, wyl_break_glass_reason_name (reason));
+  wyl_audit_event_set_deny_origin (ev, "break_glass");
+  wyl_audit_event_set_decision (ev, WYL_DECISION_ALLOW);
+  (void) wyl_audit_emit (handle, ev);
+#endif
+
   return WYRELOG_E_OK;
 #else
   (void) handle;
@@ -911,6 +931,22 @@ wyl_handle_break_glass_disarm (WylHandle *handle)
   handle->break_glass_active = FALSE;
   handle->break_glass_used = FALSE;
   g_mutex_unlock (&handle->break_glass_lock);
+
+#ifdef WYL_HAS_AUDIT
+  /*
+   * Disarm is idempotent and always emits a row; a disarm against
+   * an already-inactive handle still records the operator's
+   * intent so the audit log captures the teardown signal even
+   * when no activation was outstanding.
+   */
+  g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
+  wyl_audit_event_set_action (ev, "break_glass_disarm");
+  wyl_audit_event_set_resource_id (ev, "wr.break_glass");
+  wyl_audit_event_set_deny_origin (ev, "break_glass");
+  wyl_audit_event_set_decision (ev, WYL_DECISION_ALLOW);
+  (void) wyl_audit_emit (handle, ev);
+#endif
+
   return WYRELOG_E_OK;
 #else
   (void) handle;
@@ -942,6 +978,67 @@ wyl_handle_break_glass_is_active (WylHandle *handle)
   return FALSE;
 #endif
 }
+
+#ifdef WYL_HAS_BREAK_GLASS
+wyrelog_error_t
+wyl_handle_break_glass_get_reason (WylHandle *handle,
+    wyl_break_glass_reason_code_t *out_reason)
+{
+  if (handle == NULL || out_reason == NULL || !WYL_IS_HANDLE (handle))
+    return WYRELOG_E_INVALID;
+
+  wyrelog_error_t rc = WYRELOG_E_INVALID;
+  g_mutex_lock (&handle->break_glass_lock);
+  if (handle->break_glass_active) {
+    *out_reason = handle->break_glass_reason;
+    rc = WYRELOG_E_OK;
+  }
+  g_mutex_unlock (&handle->break_glass_lock);
+  return rc;
+}
+
+wyrelog_error_t
+wyl_handle_break_glass_get_activated_at_us (WylHandle *handle,
+    gint64 *out_activated_at_us)
+{
+  if (handle == NULL || out_activated_at_us == NULL || !WYL_IS_HANDLE (handle))
+    return WYRELOG_E_INVALID;
+
+  wyrelog_error_t rc = WYRELOG_E_INVALID;
+  g_mutex_lock (&handle->break_glass_lock);
+  if (handle->break_glass_active) {
+    *out_activated_at_us = handle->break_glass_activated_at_us;
+    rc = WYRELOG_E_OK;
+  }
+  g_mutex_unlock (&handle->break_glass_lock);
+  return rc;
+}
+
+void
+wyl_handle_break_glass_mark_used (WylHandle *handle)
+{
+  if (handle == NULL || !WYL_IS_HANDLE (handle))
+    return;
+
+  g_mutex_lock (&handle->break_glass_lock);
+  if (handle->break_glass_active)
+    handle->break_glass_used = TRUE;
+  g_mutex_unlock (&handle->break_glass_lock);
+}
+
+gboolean
+wyl_handle_break_glass_has_been_used (WylHandle *handle)
+{
+  if (handle == NULL || !WYL_IS_HANDLE (handle))
+    return FALSE;
+
+  gboolean used;
+  g_mutex_lock (&handle->break_glass_lock);
+  used = handle->break_glass_active && handle->break_glass_used;
+  g_mutex_unlock (&handle->break_glass_lock);
+  return used;
+}
+#endif
 
 static GHashTable *
 new_engine_symbol_map (void)

--- a/wyrelog/wyrelog.h
+++ b/wyrelog/wyrelog.h
@@ -17,4 +17,5 @@
 #include "wyrelog/audit.h"
 #include "wyrelog/decide.h"
 #include "wyrelog/perm.h"
+#include "wyrelog/break-glass.h"
 #include "wyrelog/version.h"


### PR DESCRIPTION
## Summary

Wires the `wr.break_glass` override path that `meson.options:76-87` and `templates/access/bootstrap.dl` had described but not yet wired. v0 ships a host-side programmatic surface only — daemon HTTP `/auth/break-glass-arm` route + Ed25519 signed-credential ingress are deferred to a follow-up issue per the AC out-clause "v0 release explicitly rejects unsupported break-glass use".

## Series shape

Four atomic commits:

1. **`access: foundation symbols for break-glass override path`** — configure-time gate (`enable_break_glass=true && !enable_audit.allowed()` → meson error), `WYRELOG_E_BREAK_GLASS_DISABLED = -10` at the enum tail, `WYL_HAS_BREAK_GLASS` define propagated to libwyrelog and wyrelogd, closed reason vocab in `access/break-glass-private.h` + `break-glass.c` (`wyl_break_glass_reason_code_t` with five values: `incident_response` / `policy_corruption` / `security_officer_lockout` / `service_unfreeze` / `other`), plus `WYL_BREAK_GLASS_DEFAULT_TTL_SECONDS = 900` matching `templates/access/bootstrap.dl:187`.
2. **`access: handle-scoped break-glass arming surface`** — public `wyrelog/break-glass.h` exposing `wyl_handle_break_glass_arm(handle, reason, ttl)` / `_disarm` / `_is_active`. Single-shot per handle (no double-arm without disarm), TTL bounded above by 900s, in-memory state on `WylHandle` under a dedicated mutex. Off-builds compile every public function as a stub returning `WYRELOG_E_BREAK_GLASS_DISABLED`.
3. **`access: wire break-glass arm into decide-path engine facts and audit`** — `wyl_decide` injects `now/1` always and `break_glass_used/1` when latched; removes both rows on every cleanup path so the engine state is restored regardless of ALLOW / DENY / guard fault. Mark-used latches AFTER the audit row commits so a fail-closed audit emit does not falsely register a usage. Arm/disarm emit audit rows carrying the stable operator reason name, action `break_glass_arm` / `break_glass_disarm`, and `decision=ALLOW`.
4. **`access: enforce break-glass TTL self-disable and fault-injection invariants`** — TTL expiry / disarm / re-arm test, fault-injection test asserting `mark_used` does NOT latch when `insert_break_glass_facts` returns early, and a comment block in `templates/access/bootstrap.dl` cross-referencing `insert_break_glass_facts()` and `wyl_handle_break_glass_is_active()` as the runtime injector and host-side TTL gate respectively.

## Acceptance criteria coverage (issue #272)

| Criterion | Closed by |
|---|---|
| Distinct runtime auth path (not skip-MFA) | C2 (separate symbol triple, no skip-MFA reuse) |
| Operator reason + audit + stable code | C1 (closed enum) + C3 (arm audit emission) |
| Bypass only intended decision points; never suppresses audit | v0 has NO DENY→ALLOW flip (AC out-clause); audit-emit invariant preserved by mark-after-audit at `wyl-decide.c:751` |
| Self-disable / TTL enforced | C2 host-side TTL gate + C3 DL `now`/`break_glass_used` injection |
| Tests: allow / deny / expiry / missing reason / audit / disabled-build | C1+C2+C3+C4 |

## Build matrix

- `meson setup -Denable_break_glass=true -Denable_audit=disabled` — refused at configure time with a self-documenting `meson.build:29` error.
- `meson setup -Denable_break_glass=false` (default) — both library and daemon compile clean; public symbols return `WYRELOG_E_BREAK_GLASS_DISABLED` / `FALSE` from stubs.
- `meson setup -Denable_break_glass=true -Denable_audit=enabled` — full surface compiles clean; `tests/test-break-glass-vocab`, `test-break-glass-arm`, `test-break-glass-decide` all gated and registered.

## Test plan

- [x] `meson test -C builddir --suite wyrelog` (off): 56 OK, 0 fail, 1 skip.
- [x] `meson test -C /tmp/wy-bg-on --suite wyrelog` (on): 57 OK, 0 fail, 1 skip.
- [x] `tools/check-public-headers-no-novelty-tokens.sh`: OK (no forbidden tokens in any installed public header).
- [x] `./tools/gst-indent` clean on every changed `.c` / `.h` across the series.
- [ ] CI on this PR.

## Out of scope

Tracked for follow-up issues:

- Daemon HTTP `/auth/break-glass-arm` route + Ed25519 signed-credential ingress (carries the replay / trust-root / signed-reason / cross-tenant concerns).
- Pre-existing `return rc` audit-skip paths in `wyl_decide` that bypass `emit_audit:` on shape errors (predates #272; visible in several places above the `emit_audit:` label).
- Arm/disarm audit-emit failure log surface (`g_warning` or counter) so a permanent audit-conn-down state is observable from the operator side.
- Multi-handle durable arming (cross-handle visibility through the policy store).
- Full bypass-scope enumeration (DENY→ALLOW flip for `disabled_role` deny on `wr.break_glass` role-holders).

Closes #272