### PR TITLE
tenant: enforce LoBAC v0 single-tenant contract

### DIFF
--- a/docs/lobac-v0-tenant-contract.md
+++ b/docs/lobac-v0-tenant-contract.md
@@ -1,0 +1,113 @@
+# LoBAC v0 Single-Tenant Contract
+
+## Overview
+
+LoBAC v0 ships as a **single-tenant** access-intelligence runtime. The
+public wire surface, the public C API, and the bootstrap policy template
+all share one canonical tenant identity. Multi-tenant capabilities
+described in the parent design (#5) and the profile-separation work (#2)
+are deferred to v1.
+
+## Canonical tenant
+
+The only accepted tenant value is the literal:
+
+```
+__wr_default
+```
+
+This value is exposed internally as the `WYL_TENANT_DEFAULT` constant
+(`wyrelog/wyl-common-private.h`) and is the only value the daemon and
+client library will accept across every surface that takes a tenant:
+
+- `wyl_session_login` (and the libwyrelog session minting path)
+- `POST /auth/login` (HTTP login surface)
+- `POST /decide` (decision surface)
+- `GET  /policy` (policy read surface)
+- `GET  /audit` (audit query surface)
+- JWT bearer-token `claims.tenant`
+- `wyl_client_tenant_select` (C API tenant selector)
+
+Any other literal — including the empty string, an unknown identifier,
+or a foreign-looking literal such as `evil-co` — is rejected.
+
+## Wire-format error codes
+
+The HTTP gate emits two stable string codes scoped exclusively to the
+tenant check. These are defined in `wyrelog/daemon/http.c` as
+`WYL_DAEMON_ERR_TENANT_INVALID` and `WYL_DAEMON_ERR_TENANT_DENIED`:
+
+| Code              | HTTP status | Meaning                                                                                                  |
+|-------------------|-------------|----------------------------------------------------------------------------------------------------------|
+| `tenant_invalid`  | 400         | The request declares a tenant value the daemon does not recognise. In v0 anything other than `__wr_default` is unknown. |
+| `tenant_denied`   | 403         | The authenticated principal's tenant does not match the tenant declared on the request.                  |
+
+`tenant_invalid` is also emitted with HTTP 401 by the bearer-token
+verifier when a JWT carries a `claims.tenant` the daemon does not
+recognise. Status differs because the failure surfaces during auth, not
+on a malformed request body.
+
+The two codes are wire strings only; the existing `wyrelog_error_t`
+enum is unchanged. Clients keying on these codes can distinguish a
+malformed-tenant request from a credential/tenant mismatch without
+relying on handler-specific generic shape codes.
+
+## Defense in depth
+
+The bearer-token verifier enforces `claims.tenant == __wr_default`
+**directly**, independent of the transitive session check. Verification
+order in `resolve_bearer_session`:
+
+1. Verify JWT signature.
+2. Resolve the live session referenced by the token.
+3. **Direct check**: `wyl_daemon_tenant_is_known(claims.tenant)` —
+   reject with `tenant_invalid` (HTTP 401) on any non-canonical value.
+4. Equality check: `claims.tenant == session.tenant`.
+
+The direct check is redundant with the session-mint gate today, but it
+stops a future relaxation upstream (for example, a multi-tenant prep
+change to `login_tenant_is_valid`) from silently relaxing JWT
+acceptance. The session-token auth path does not carry a per-token
+tenant claim and is gated by `ensure_auth_context_request_tenant`
+through the request query parameter, so no analogous check is needed
+there.
+
+## Public API surface
+
+The following public symbols exist and remain stable across v0 → v1
+for forward compatibility, but in v0 they reject any non-canonical
+value with `WYRELOG_E_INVALID`:
+
+- `wyl_client_tenant_select` (`wyrelog/client.h`)
+- `wyl_client_dup_tenant`     (`wyrelog/client.h`)
+- `wyl_login_req_set_tenant`  (`wyrelog/session.h`)
+- `wyl_login_req_get_tenant`  (`wyrelog/session.h`)
+- `wyl_session_dup_tenant`    (`wyrelog/session.h`)
+
+Callers written against the v0 wire contract will keep compiling once
+the multi-tenant widening lands; only the runtime accept-set widens.
+
+## What is NOT shipped in v0
+
+The following are explicitly out of scope for v0 and tracked as
+follow-up work against the parent multi-tenant design (#5) and the
+profile-separation issue (#2):
+
+- Tenant registry storage (no per-tenant rows in the policy store).
+- Tenant CRUD admin API (no `POST /tenants`, no listing surface).
+- Per-tenant data-encryption keys / TPM-sealed scope per tenant.
+- Cross-tenant isolation regression suite.
+- Audit-row tenant column and per-tenant audit partitioning.
+
+A v0 deployment that needs a second tenant must wait for v1; there is
+no supported workaround through configuration, environment, or runtime
+flag.
+
+## SemVer note
+
+Single-tenant is a **pre-1.0 contract**. Widening the runtime
+accept-set to admit additional tenants is an API/wire behavior change
+and requires a major-version bump (v1). Until then, both the bootstrap
+DL template (`templates/access/bootstrap.dl`) and the daemon's
+`wyl_daemon_tenant_is_known` predicate are the source of truth for the
+single accepted value.

--- a/templates/access/bootstrap.dl
+++ b/templates/access/bootstrap.dl
@@ -179,6 +179,21 @@ inherits("wr.service_admin", "wr.operator").
 // ---------------------------------------------------------------------------
 // EDB: default tenant for single-tenant installs
 // ---------------------------------------------------------------------------
+// v0 ships single-tenant; the only accepted tenant value across the
+// daemon's HTTP surface, the client library, JWT claims, and every
+// `wr.*` fact in this template is the canonical default below.
+// `wr.break_glass` and the rest of the seeded `role/`, `permission/`,
+// and `role_permission/` rows are scoped to this single tenant.
+//
+// Adding additional `tenant(...)` rows here is reserved for v1 and
+// has no effect at runtime in v0: the daemon's HTTP gate
+// (`wyl_daemon_tenant_is_known` in wyrelog/daemon/http.c) rejects any
+// request bearing a tenant value other than the canonical default
+// with the stable wire-format error code `tenant_invalid` (HTTP 400)
+// or `tenant_denied` (HTTP 403). See docs/lobac-v0-tenant-contract.md
+// for the full contract, including the JWT claims defense-in-depth
+// check and the public-API surface that rejects non-canonical values
+// with `WYRELOG_E_INVALID`.
 tenant("__wr_default").
 
 // ---------------------------------------------------------------------------

--- a/tests/test-client-smoke.c
+++ b/tests/test-client-smoke.c
@@ -285,6 +285,15 @@ main (void)
     return 138;
   if (wyl_client_tenant_select (local_client, "unknown") != WYRELOG_E_INVALID)
     return 90;
+  /*
+   * Single-tenant v0 contract: every tenant literal other than the
+   * canonical default must fail closed with WYRELOG_E_INVALID. Pin a
+   * distinct foreign-looking literal here so a regression that
+   * silently widens the accept set on wyl_client_tenant_select is
+   * caught by the smoke suite.
+   */
+  if (wyl_client_tenant_select (local_client, "evil-co") != WYRELOG_E_INVALID)
+    return 96;
   if (wyl_client_tenant_select (local_client, "__wr_default") != WYRELOG_E_OK)
     return 91;
   http.body = "{\"ok\":true}";

--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -2938,7 +2938,7 @@ check_tenant_gate_codes_contract (void)
   /* Pass: NULL request tenant falls back to the default, matches auth. */
   g_clear_pointer (&code, g_free);
   status = 0;
-  if (!wyl_daemon_http_check_request_tenant_for_test ("__wr_default", NULL,
+  if (!wyl_daemon_http_check_request_tenant_for_test (NULL, "__wr_default",
           &status, &code))
     return 1902;
   if (status != 0 || code != NULL)
@@ -2947,8 +2947,8 @@ check_tenant_gate_codes_contract (void)
   /* Reject: request tenant is not the known default. 400 tenant_invalid. */
   g_clear_pointer (&code, g_free);
   status = 0;
-  if (wyl_daemon_http_check_request_tenant_for_test ("__wr_default",
-          "unknown", &status, &code))
+  if (wyl_daemon_http_check_request_tenant_for_test ("unknown",
+          "__wr_default", &status, &code))
     return 1904;
   if (status != 400 || g_strcmp0 (code, "tenant_invalid") != 0)
     return 1905;
@@ -2956,7 +2956,7 @@ check_tenant_gate_codes_contract (void)
   /* Reject: empty request tenant. 400 tenant_invalid. */
   g_clear_pointer (&code, g_free);
   status = 0;
-  if (wyl_daemon_http_check_request_tenant_for_test ("__wr_default", "",
+  if (wyl_daemon_http_check_request_tenant_for_test ("", "__wr_default",
           &status, &code))
     return 1906;
   if (status != 400 || g_strcmp0 (code, "tenant_invalid") != 0)
@@ -2972,8 +2972,8 @@ check_tenant_gate_codes_contract (void)
    */
   g_clear_pointer (&code, g_free);
   status = 0;
-  if (wyl_daemon_http_check_request_tenant_for_test ("other-tenant",
-          "__wr_default", &status, &code))
+  if (wyl_daemon_http_check_request_tenant_for_test ("__wr_default",
+          "other-tenant", &status, &code))
     return 1908;
   if (status != 403 || g_strcmp0 (code, "tenant_denied") != 0)
     return 1909;
@@ -2981,7 +2981,7 @@ check_tenant_gate_codes_contract (void)
   /* Reject: missing auth tenant on a default-tenant request. 403 tenant_denied. */
   g_clear_pointer (&code, g_free);
   status = 0;
-  if (wyl_daemon_http_check_request_tenant_for_test (NULL, "__wr_default",
+  if (wyl_daemon_http_check_request_tenant_for_test ("__wr_default", NULL,
           &status, &code))
     return 1910;
   if (status != 403 || g_strcmp0 (code, "tenant_denied") != 0)

--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -518,7 +518,8 @@ check_request_id_header_contract (const gchar *base_url)
 }
 
 static gint
-check_raw_decide_contract (WylHandle *handle, const gchar *base_url)
+check_raw_decide_contract (SoupServer *server, WylHandle *handle,
+    const gchar *base_url)
 {
   g_autoptr (SoupSession) session = soup_session_new ();
   guint status = 0;
@@ -706,6 +707,55 @@ check_raw_decide_contract (WylHandle *handle, const gchar *base_url)
    */
   if (status != 400 || strstr (body, "\"tenant_invalid\"") == NULL)
     return 1812;
+
+#ifdef WYL_HAS_AUDIT
+  /*
+   * Defense-in-depth tenant gate on the JWT claims themselves
+   * (issue #273). Forge a token with the daemon's secret carrying
+   * a foreign tenant in the access claims; the signature verifies
+   * but resolve_bearer_session must reject the token because the
+   * claims tenant is not WYL_TENANT_DEFAULT. Today this rejection
+   * is also reachable transitively via the live_tenant comparison
+   * (every wyl_session_login() session carries the default tenant,
+   * so claims.tenant != live_tenant), but the direct claims gate
+   * makes the contract explicit so a future relaxation cannot
+   * silently widen the JWT-acceptance surface. The wire code is
+   * "tenant_invalid" with HTTP 401 (auth boundary).
+   */
+  g_autofree gchar *foreign_tenant_token = NULL;
+  guint8 secret[32];
+  if (wyl_daemon_http_copy_access_token_secret (server, secret, sizeof secret)
+      != WYRELOG_E_OK)
+    return 1824;
+  wyl_jwt_issue_input_t foreign_tenant_input = {
+    .key_id = "__wr_default_hs256",
+    .jti = "foreign-tenant-jti",
+    .subject = "http-guard-user",
+    .issuer = "wyrelogd",
+    .audience = "wyrelog-client",
+    .tenant = "evil-co",
+    .principal_state_at_issue = "authenticated",
+    .session_id = "foreign-tenant-session",
+    .issued_at = g_get_real_time () / G_USEC_PER_SEC,
+    .ttl_seconds = WYL_JWT_ACCESS_TTL_SECONDS,
+  };
+  wyrelog_error_t sign_rc = wyl_jwt_sign_hs256 (&foreign_tenant_input, secret,
+      sizeof secret, &foreign_tenant_token);
+  memset (secret, 0, sizeof secret);
+  if (sign_rc != WYRELOG_E_OK)
+    return 1825;
+
+  g_clear_pointer (&body, g_free);
+  rc = send_raw_decide_bearer (session, "POST", base_url, "http-guard-user",
+      "wr.audit.read", "http-guard-scope", NULL, foreign_tenant_token,
+      &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 401 || strstr (body, "\"tenant_invalid\"") == NULL)
+    return 1826;
+#else
+  (void) server;
+#endif
 
   return 0;
 }
@@ -3065,7 +3115,7 @@ main (void)
   if (request_id_rc != 0)
     return request_id_rc;
 
-  gint raw_rc = check_raw_decide_contract (handle, base_url);
+  gint raw_rc = check_raw_decide_contract (http.server, handle, base_url);
   if (raw_rc != 0)
     return raw_rc;
   gint decision = -1;
@@ -3169,7 +3219,7 @@ main (void)
   /* Seed http.not_armed (http-deny-user) and other negative-decide audit
    * events that the audit_event_present series below relies on. The full
    * raw decide protocol contract is exercised in the non-audit variant. */
-  gint raw_rc = check_raw_decide_contract (handle, base_url);
+  gint raw_rc = check_raw_decide_contract (http.server, handle, base_url);
   if (raw_rc != 0)
     return raw_rc;
   gint decision = -1;

--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -708,6 +708,24 @@ check_raw_decide_contract (SoupServer *server, WylHandle *handle,
   if (status != 400 || strstr (body, "\"tenant_invalid\"") == NULL)
     return 1812;
 
+  /*
+   * The single-tenant v0 contract rejects every tenant value other
+   * than the canonical default, including foreign-looking literals
+   * such as "evil-co". This pins the rejection through the full
+   * /decide HTTP path (in addition to the JWT-claims gate exercised
+   * below) so a regression that silently widens the accept set
+   * cannot escape detection.
+   */
+  g_clear_pointer (&body, g_free);
+  rc = send_raw_decide_bearer (session, "POST", base_url, "http-guard-user",
+      "wr.audit.read", "http-guard-scope",
+      "tenant=evil-co&guard_timestamp=123&guard_loc_class=public"
+      "&guard_risk=69", guard_access_token, &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 400 || strstr (body, "\"tenant_invalid\"") == NULL)
+    return 1813;
+
 #ifdef WYL_HAS_AUDIT
   /*
    * Defense-in-depth tenant gate on the JWT claims themselves
@@ -1325,6 +1343,22 @@ check_raw_login_contract (SoupServer *server, WylHandle *handle,
     return rc;
   if (status != 400 || strstr (body, "\"tenant_invalid\"") == NULL)
     return 484;
+  g_clear_pointer (&body, g_free);
+
+  /*
+   * Single-tenant v0 contract: a foreign-looking tenant literal on
+   * the /auth/login surface must fail closed with the stable wire
+   * code "tenant_invalid" and HTTP 400, mirroring the /decide gate
+   * above. Pinning a distinct literal here (in addition to the
+   * existing "unknown" coverage) makes the foreign-tenant rejection
+   * unambiguous on the login surface.
+   */
+  rc = send_raw_login (session, "POST", base_url,
+      "username=login-user&tenant=evil-co", &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 400 || strstr (body, "\"tenant_invalid\"") == NULL)
+    return 513;
   g_clear_pointer (&body, g_free);
 
   rc = send_raw_login (session, "POST", base_url, "username=login-user",

--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -699,7 +699,12 @@ check_raw_decide_contract (WylHandle *handle, const gchar *base_url)
       "&guard_risk=69", guard_access_token, &status, &body);
   if (rc != 0)
     return rc;
-  if (status != 400 || strstr (body, "\"invalid_decide_request\"") == NULL)
+  /*
+   * Tenant gate emits the stable wire code "tenant_invalid" rather
+   * than the surrounding handler's generic shape error so callers
+   * can recognise tenant rejections regardless of endpoint family.
+   */
+  if (status != 400 || strstr (body, "\"tenant_invalid\"") == NULL)
     return 1812;
 
   return 0;
@@ -1268,7 +1273,7 @@ check_raw_login_contract (SoupServer *server, WylHandle *handle,
       "username=login-user&tenant=unknown", &status, &body);
   if (rc != 0)
     return rc;
-  if (status != 400 || strstr (body, "\"invalid_login_request\"") == NULL)
+  if (status != 400 || strstr (body, "\"tenant_invalid\"") == NULL)
     return 484;
   g_clear_pointer (&body, g_free);
 
@@ -1998,7 +2003,7 @@ check_policy_permission_mutation_contract (WylHandle *handle,
       "/policy/permissions/grant", unknown_tenant_query, &status, &body);
   if (rc != 0)
     return rc;
-  if (status != 400 || strstr (body, "\"invalid_policy_auth\"") == NULL)
+  if (status != 400 || strstr (body, "\"tenant_invalid\"") == NULL)
     return 187;
   if (direct_permission_exists (handle, "target", "site.policy.read",
           "tenant-a")) {
@@ -2675,7 +2680,7 @@ check_raw_audit_contract (SoupServer *server, WylHandle *handle,
       access_token, &status, &body);
   if (rc != 0)
     return rc;
-  if (status != 400 || strstr (body, "\"invalid_audit_auth\"") == NULL)
+  if (status != 400 || strstr (body, "\"tenant_invalid\"") == NULL)
     return 163;
 
   g_clear_pointer (&body, g_free);
@@ -2910,6 +2915,82 @@ check_audit_event_present (WylClient *client, const gchar *filter,
 #endif
 
 /*
+ * Unit-style coverage for the v0 tenant-gate wire codes (issue #273).
+ * Drives the http.c decision helper through the WYL_TEST_DAEMON_HTTP
+ * seam so that both gate arms are exercised even though the
+ * tenant_denied arm is unreachable end-to-end in v0 single-tenant mode
+ * (every wyl_session_login() session today carries the default
+ * tenant, so the request_tenant != auth_tenant arm fires only against
+ * a synthesised auth context).
+ */
+static gint
+check_tenant_gate_codes_contract (void)
+{
+  /* Pass: matching default tenant on both sides. */
+  guint status = 0;
+  g_autofree gchar *code = NULL;
+  if (!wyl_daemon_http_check_request_tenant_for_test ("__wr_default",
+          "__wr_default", &status, &code))
+    return 1900;
+  if (status != 0 || code != NULL)
+    return 1901;
+
+  /* Pass: NULL request tenant falls back to the default, matches auth. */
+  g_clear_pointer (&code, g_free);
+  status = 0;
+  if (!wyl_daemon_http_check_request_tenant_for_test ("__wr_default", NULL,
+          &status, &code))
+    return 1902;
+  if (status != 0 || code != NULL)
+    return 1903;
+
+  /* Reject: request tenant is not the known default. 400 tenant_invalid. */
+  g_clear_pointer (&code, g_free);
+  status = 0;
+  if (wyl_daemon_http_check_request_tenant_for_test ("__wr_default",
+          "unknown", &status, &code))
+    return 1904;
+  if (status != 400 || g_strcmp0 (code, "tenant_invalid") != 0)
+    return 1905;
+
+  /* Reject: empty request tenant. 400 tenant_invalid. */
+  g_clear_pointer (&code, g_free);
+  status = 0;
+  if (wyl_daemon_http_check_request_tenant_for_test ("__wr_default", "",
+          &status, &code))
+    return 1906;
+  if (status != 400 || g_strcmp0 (code, "tenant_invalid") != 0)
+    return 1907;
+
+  /*
+   * Reject: request tenant is the known default but the authenticated
+   * principal carries a different tenant. 403 tenant_denied. This is
+   * the arm that is currently unreachable end-to-end in v0 because
+   * wyl_session_login() only mints sessions for __wr_default; the
+   * unit-style check covers the wire contract ahead of C3, which
+   * adds a direct JWT-claims tenant check that can reach this arm.
+   */
+  g_clear_pointer (&code, g_free);
+  status = 0;
+  if (wyl_daemon_http_check_request_tenant_for_test ("other-tenant",
+          "__wr_default", &status, &code))
+    return 1908;
+  if (status != 403 || g_strcmp0 (code, "tenant_denied") != 0)
+    return 1909;
+
+  /* Reject: missing auth tenant on a default-tenant request. 403 tenant_denied. */
+  g_clear_pointer (&code, g_free);
+  status = 0;
+  if (wyl_daemon_http_check_request_tenant_for_test (NULL, "__wr_default",
+          &status, &code))
+    return 1910;
+  if (status != 403 || g_strcmp0 (code, "tenant_denied") != 0)
+    return 1911;
+
+  return 0;
+}
+
+/*
  * The daemon-http-decide test surface has been split across two binaries
  * compiled from this single translation unit:
  *
@@ -2933,6 +3014,10 @@ check_audit_event_present (WylClient *client, const gchar *filter,
 int
 main (void)
 {
+  gint tenant_gate_rc = check_tenant_gate_codes_contract ();
+  if (tenant_gate_rc != 0)
+    return tenant_gate_rc;
+
   g_autoptr (WylHandle) handle = NULL;
   if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
     return 1;
@@ -3033,6 +3118,10 @@ main (void)
 int
 main (void)
 {
+  gint tenant_gate_rc = check_tenant_gate_codes_contract ();
+  if (tenant_gate_rc != 0)
+    return tenant_gate_rc;
+
   g_autoptr (WylHandle) handle = NULL;
   if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
     return 1;

--- a/tests/test-session-username.c
+++ b/tests/test-session-username.c
@@ -3,6 +3,7 @@
 #include <string.h>
 
 #include "wyrelog/wyrelog.h"
+#include "wyrelog/wyl-common-private.h"
 #include "wyrelog/wyl-handle-private.h"
 
 #ifndef WYL_TEST_TEMPLATE_DIR
@@ -414,6 +415,52 @@ check_login_rejects_unknown_tenant_before_skip_mfa (void)
     return 44;
   if (session != NULL)
     return 45;
+  return 0;
+}
+
+/*
+ * The single-tenant v0 contract rejects every tenant value other than
+ * the canonical default, so a foreign-looking literal like "evil-co"
+ * must fail closed at wyl_session_login with WYRELOG_E_INVALID and
+ * leave the out-session NULL. Pinning a distinct literal here (in
+ * addition to the existing "unknown" coverage) makes the foreign-
+ * tenant rejection unambiguous and guards against a regression that
+ * silently widens the accept set. The accept side is exercised
+ * symbolically by binding wyl_login_req_set_tenant to
+ * WYL_TENANT_DEFAULT and asserting WYRELOG_E_OK; this makes the
+ * "only the default constant is accepted" rule fail loudly if either
+ * the constant or the comparison drifts.
+ */
+static gint
+check_login_rejects_evil_co_tenant (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (NULL, &handle) != WYRELOG_E_OK)
+    return 46;
+
+  g_autoptr (wyl_login_req_t) reject_req = wyl_login_req_new ();
+  wyl_login_req_set_username (reject_req, "tenant-user");
+  wyl_login_req_set_tenant (reject_req, "evil-co");
+
+  g_autoptr (WylSession) reject_session = NULL;
+  if (wyl_session_login (handle, reject_req, &reject_session)
+      != WYRELOG_E_INVALID)
+    return 47;
+  if (reject_session != NULL)
+    return 48;
+
+  g_autoptr (wyl_login_req_t) accept_req = wyl_login_req_new ();
+  wyl_login_req_set_username (accept_req, "tenant-user");
+  wyl_login_req_set_tenant (accept_req, WYL_TENANT_DEFAULT);
+
+  g_autoptr (WylSession) accept_session = NULL;
+  if (wyl_session_login (handle, accept_req, &accept_session) != WYRELOG_E_OK)
+    return 49;
+  if (accept_session == NULL)
+    return 50;
+  g_autofree gchar *bound_tenant = wyl_session_dup_tenant (accept_session);
+  if (g_strcmp0 (bound_tenant, WYL_TENANT_DEFAULT) != 0)
+    return 51;
   return 0;
 }
 
@@ -1885,6 +1932,8 @@ main (void)
   if ((rc = check_login_rejects_unknown_tenant ()) != 0)
     return rc;
   if ((rc = check_login_rejects_unknown_tenant_before_skip_mfa ()) != 0)
+    return rc;
+  if ((rc = check_login_rejects_evil_co_tenant ()) != 0)
     return rc;
   if ((rc = check_request_buffer_independent_of_session ()) != 0)
     return rc;

--- a/wyrelog/client.h
+++ b/wyrelog/client.h
@@ -50,6 +50,15 @@ wyrelog_error_t wyl_client_set_bearer_credentials (WylClient * client,
 gchar *wyl_client_dup_session_token (const WylClient * client);
 gchar *wyl_client_dup_access_token (const WylClient * client);
 gchar *wyl_client_dup_username (const WylClient * client);
+/*
+ * Returns a heap-allocated copy of the tenant currently bound to
+ * |client|. v0 contract: single-tenant; the only value that can ever
+ * be observed here is the canonical default ("__wr_default"). The
+ * tenant accessor is retained on the public surface so callers
+ * written against the v0 wire contract keep compiling once
+ * multi-tenant support lands as a follow-up. Caller frees with
+ * g_free or g_autofree.
+ */
 gchar *wyl_client_dup_tenant (const WylClient * client);
 gchar *wyl_client_dup_principal_state (const WylClient * client);
 gchar *wyl_client_dup_session_state (const WylClient * client);
@@ -134,6 +143,16 @@ wyrelog_error_t wyl_audit_iter_next (WylAuditIter * iter,
     gboolean * out_has_next);
 
 /* Tenant / event */
+/*
+ * Binds |client| to the named tenant for subsequent guarded HTTP
+ * calls. v0 contract: single-tenant; the only value accepted is the
+ * canonical default ("__wr_default"). Every other literal fails
+ * closed with WYRELOG_E_INVALID and leaves the client's tenant
+ * binding unchanged. Multi-tenant support is tracked as a follow-up;
+ * the entry point is retained on the public surface so callers
+ * written against the v0 wire contract keep compiling once that
+ * widening lands.
+ */
 wyrelog_error_t wyl_client_tenant_select (WylClient * client,
     const gchar * tenant);
 wyrelog_error_t wyl_client_event_emit (WylClient * client,

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -9,6 +9,7 @@
 #include "daemon/delta.h"
 #include "wyrelog/wyrelog.h"
 #include "wyrelog/auth/jwt-private.h"
+#include "wyrelog/wyl-common-private.h"
 #include "wyrelog/wyl-handle-private.h"
 #include "wyrelog/wyl-id-private.h"
 #include "wyrelog/wyl-request-id-private.h"
@@ -18,7 +19,6 @@
 #define WYL_DAEMON_JWT_ISSUER "wyrelogd"
 #define WYL_DAEMON_JWT_AUDIENCE "wyrelog-client"
 #define WYL_DAEMON_JWT_KEY_ID "__wr_default_hs256"
-#define WYL_DAEMON_DEFAULT_TENANT "__wr_default"
 #define WYL_DAEMON_JWT_KEY_LEN 32
 #define WYL_DAEMON_REFRESH_TTL_SECONDS 86400
 #define WYL_DAEMON_REFRESH_GRACE_SECONDS 30
@@ -35,7 +35,7 @@
  *   tenant_invalid  - 400. The request carries a tenant query
  *                     parameter (or login body field) whose value is
  *                     not a tenant this daemon recognises. In v0 the
- *                     only known tenant is WYL_DAEMON_DEFAULT_TENANT.
+ *                     only known tenant is WYL_TENANT_DEFAULT.
  *   tenant_denied   - 403. The authenticated principal's tenant does
  *                     not match the tenant declared on the request.
  *                     Distinct from tenant_invalid so callers can
@@ -121,7 +121,7 @@ static void set_json_error (SoupServerMessage * msg, guint status,
 static gboolean
 wyl_daemon_tenant_is_known (const gchar *tenant)
 {
-  return g_strcmp0 (tenant, WYL_DAEMON_DEFAULT_TENANT) == 0;
+  return g_strcmp0 (tenant, WYL_TENANT_DEFAULT) == 0;
 }
 
 static void
@@ -846,7 +846,7 @@ lookup_request_tenant (GHashTable *query)
 {
   if (query != NULL && g_hash_table_contains (query, "tenant"))
     return g_hash_table_lookup (query, "tenant");
-  return WYL_DAEMON_DEFAULT_TENANT;
+  return WYL_TENANT_DEFAULT;
 }
 
 /*
@@ -906,8 +906,8 @@ ensure_auth_context_request_tenant (SoupServerMessage *msg, GHashTable *query,
 
 #ifdef WYL_TEST_DAEMON_HTTP
 gboolean
-wyl_daemon_http_check_request_tenant_for_test (const gchar *auth_tenant,
-    const gchar *request_tenant, guint *out_status, gchar **out_code)
+wyl_daemon_http_check_request_tenant_for_test (const gchar *request_tenant,
+    const gchar *auth_tenant, guint *out_status, gchar **out_code)
 {
   /*
    * Mirrors lookup_request_tenant()'s NULL-query fallback: if the
@@ -916,7 +916,7 @@ wyl_daemon_http_check_request_tenant_for_test (const gchar *auth_tenant,
    * lookup_request_tenant() does inside a real handler.
    */
   const gchar *effective = request_tenant != NULL ? request_tenant
-      : WYL_DAEMON_DEFAULT_TENANT;
+      : WYL_TENANT_DEFAULT;
   const gchar *code = NULL;
   guint status = decide_request_tenant_gate (effective, auth_tenant, &code);
   if (out_status != NULL)
@@ -1634,7 +1634,7 @@ login_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
   }
 
   const gchar *username = NULL;
-  const gchar *tenant = WYL_DAEMON_DEFAULT_TENANT;
+  const gchar *tenant = WYL_TENANT_DEFAULT;
   const gchar *skip_mfa = NULL;
   const gchar *password = NULL;
   if (query != NULL) {

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -754,10 +754,32 @@ lookup_bearer_token (SoupServerMessage *msg)
   return token;
 }
 
+/*
+ * Bearer-token auth resolver. Defense-in-depth tenant gate: after
+ * the signature/issuer/audience/exp verifier passes and the access
+ * claims are parsed, we directly require that the JWT's tenant
+ * claim is one of the daemon's known tenants (today, only
+ * WYL_TENANT_DEFAULT). This check is REDUNDANT with the live-session
+ * comparison below, by design: today wyl_session_login() only mints
+ * sessions on the default tenant, so a foreign-tenant JWT would
+ * already be caught by the live_tenant != claims.tenant arm. The
+ * direct check here makes the contract explicit so a future
+ * relaxation upstream (e.g., letting the live session carry a
+ * non-default tenant) cannot silently widen the JWT-acceptance
+ * surface. On miss, we surface the stable wire code
+ * WYL_DAEMON_ERR_TENANT_INVALID through *out_auth_error_code so the
+ * caller can emit it instead of the generic auth_required code.
+ * out_auth_error_code may be NULL; callers that don't need the
+ * specific reason still get WYRELOG_E_POLICY and can fall back to
+ * their handler-family auth_required code.
+ */
 static wyrelog_error_t
 resolve_bearer_session (SoupServer *server, WylDaemonHttpContext *ctx,
-    const gchar *token, WylDaemonAuthContext *out_auth)
+    const gchar *token, WylDaemonAuthContext *out_auth,
+    const gchar **out_auth_error_code)
 {
+  if (out_auth_error_code != NULL)
+    *out_auth_error_code = NULL;
   if (ctx == NULL || token == NULL || out_auth == NULL)
     return WYRELOG_E_INVALID;
   wyl_daemon_auth_context_clear (out_auth);
@@ -780,6 +802,19 @@ resolve_bearer_session (SoupServer *server, WylDaemonHttpContext *ctx,
   rc = wyl_jwt_parse_access_claims_json (payload, &claims);
   if (rc != WYRELOG_E_OK)
     return WYRELOG_E_POLICY;
+  /*
+   * Direct JWT-claims tenant gate (defense-in-depth, see function
+   * header comment). Runs immediately after signature verify and
+   * BEFORE the live-session comparison so a foreign-tenant claim
+   * is rejected as a tenant violation even if the transitive check
+   * below would also reject it.
+   */
+  if (!wyl_daemon_tenant_is_known (claims.tenant)) {
+    if (out_auth_error_code != NULL)
+      *out_auth_error_code = WYL_DAEMON_ERR_TENANT_INVALID;
+    wyl_jwt_access_claims_clear (&claims);
+    return WYRELOG_E_POLICY;
+  }
   if (g_strcmp0 (claims.principal_state_at_issue, "authenticated") != 0) {
     wyl_jwt_access_claims_clear (&claims);
     return WYRELOG_E_POLICY;
@@ -815,10 +850,21 @@ resolve_bearer_session (SoupServer *server, WylDaemonHttpContext *ctx,
   return WYRELOG_E_OK;
 }
 
+/*
+ * Session-token (cookie-equivalent) auth resolver. Same
+ * defense-in-depth tenant gate as resolve_bearer_session: the
+ * live session's tenant must be one of the daemon's known tenants.
+ * Today wyl_session_login() only mints WYL_TENANT_DEFAULT sessions,
+ * so this check is redundant; it stays as an explicit gate so a
+ * future relaxation upstream cannot let a non-default tenant slip
+ * through to a privileged handler. out_auth_error_code may be NULL.
+ */
 static wyrelog_error_t
 resolve_session_token_auth (SoupServer *server, const gchar *session_token,
-    WylDaemonAuthContext *out_auth)
+    WylDaemonAuthContext *out_auth, const gchar **out_auth_error_code)
 {
+  if (out_auth_error_code != NULL)
+    *out_auth_error_code = NULL;
   if (server == NULL || session_token == NULL || out_auth == NULL)
     return WYRELOG_E_INVALID;
   wyl_daemon_auth_context_clear (out_auth);
@@ -833,6 +879,11 @@ resolve_session_token_auth (SoupServer *server, const gchar *session_token,
   if (username == NULL || username[0] == '\0' || tenant == NULL ||
       tenant[0] == '\0')
     return WYRELOG_E_POLICY;
+  if (!wyl_daemon_tenant_is_known (tenant)) {
+    if (out_auth_error_code != NULL)
+      *out_auth_error_code = WYL_DAEMON_ERR_TENANT_INVALID;
+    return WYRELOG_E_POLICY;
+  }
 
   out_auth->session_id = g_strdup (session_token);
   out_auth->actor = g_steal_pointer (&username);
@@ -1216,18 +1267,22 @@ authorize_guarded_session_action (SoupServer *server, SoupServerMessage *msg,
   }
 
   g_auto (WylDaemonAuthContext) auth = { 0 };
+  const gchar *auth_tenant_error = NULL;
   if (has_session_token) {
     wyrelog_error_t auth_rc =
-        resolve_session_token_auth (server, session_token, &auth);
+        resolve_session_token_auth (server, session_token, &auth,
+        &auth_tenant_error);
     if (auth_rc != WYRELOG_E_OK) {
-      set_json_error (msg, 401, auth_required_code);
+      set_json_error (msg, 401,
+          auth_tenant_error != NULL ? auth_tenant_error : auth_required_code);
       return FALSE;
     }
   } else {
     wyrelog_error_t auth_rc = resolve_bearer_session (server, ctx,
-        bearer_token, &auth);
+        bearer_token, &auth, &auth_tenant_error);
     if (auth_rc != WYRELOG_E_OK) {
-      set_json_error (msg, 401, auth_required_code);
+      set_json_error (msg, 401,
+          auth_tenant_error != NULL ? auth_tenant_error : auth_required_code);
       return FALSE;
     }
   }
@@ -1871,10 +1926,12 @@ logout_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
   WylDaemonHttpContext *ctx = user_data;
   g_auto (WylDaemonAuthContext) bearer_auth = { 0 };
   if (has_bearer_token) {
+    const gchar *auth_tenant_error = NULL;
     wyrelog_error_t auth_rc = resolve_bearer_session (server, ctx,
-        bearer_token, &bearer_auth);
+        bearer_token, &bearer_auth, &auth_tenant_error);
     if (auth_rc != WYRELOG_E_OK) {
-      set_json_error (msg, 401, "logout_auth_required");
+      set_json_error (msg, 401, auth_tenant_error != NULL
+          ? auth_tenant_error : "logout_auth_required");
       return;
     }
     session_token = bearer_auth.session_id;
@@ -1987,10 +2044,12 @@ decide_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
     return;
   }
   g_auto (WylDaemonAuthContext) auth = { 0 };
+  const gchar *auth_tenant_error = NULL;
   wyrelog_error_t auth_rc = resolve_bearer_session (server, ctx,
-      bearer_token, &auth);
+      bearer_token, &auth, &auth_tenant_error);
   if (auth_rc != WYRELOG_E_OK) {
-    set_json_error (msg, 401, "decide_auth_required");
+    set_json_error (msg, 401, auth_tenant_error != NULL
+        ? auth_tenant_error : "decide_auth_required");
     return;
   }
   if (!ensure_auth_context_request_tenant (msg, query, &auth))

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -26,6 +26,28 @@
 #define WYL_DAEMON_REQUEST_ID_DATA "wyl-daemon-request-id"
 #define WYL_DAEMON_REQUEST_ID_ATTEMPTED_DATA "wyl-daemon-request-id-attempted"
 
+/*
+ * Stable HTTP wire-format error codes for the tenant gate. Both are
+ * emitted as the "error" field of the JSON error body produced by
+ * set_json_error(). They are part of the v0 single-tenant contract
+ * tracked in issue #273:
+ *
+ *   tenant_invalid  - 400. The request carries a tenant query
+ *                     parameter (or login body field) whose value is
+ *                     not a tenant this daemon recognises. In v0 the
+ *                     only known tenant is WYL_DAEMON_DEFAULT_TENANT.
+ *   tenant_denied   - 403. The authenticated principal's tenant does
+ *                     not match the tenant declared on the request.
+ *                     Distinct from tenant_invalid so callers can
+ *                     distinguish "your request was malformed" from
+ *                     "your credentials are not for this tenant".
+ *
+ * These constants are HTTP wire strings only; they intentionally do
+ * NOT extend the wyrelog_error_t enum.
+ */
+#define WYL_DAEMON_ERR_TENANT_INVALID "tenant_invalid"
+#define WYL_DAEMON_ERR_TENANT_DENIED  "tenant_denied"
+
 typedef struct
 {
   gchar *jti;
@@ -827,26 +849,83 @@ lookup_request_tenant (GHashTable *query)
   return WYL_DAEMON_DEFAULT_TENANT;
 }
 
-static gboolean
-ensure_auth_context_request_tenant (SoupServerMessage *msg, GHashTable *query,
-    const WylDaemonAuthContext *auth, const gchar *invalid_code,
-    const gchar *denied_code)
+/*
+ * Pure-decision form of the tenant gate: takes the request tenant and
+ * the authenticated principal's tenant and returns 0 on pass, or the
+ * HTTP status (400 / 403) that the gate would emit on failure. On
+ * failure, *out_code points to one of the stable wire-format error
+ * code constants (WYL_DAEMON_ERR_TENANT_INVALID /
+ * WYL_DAEMON_ERR_TENANT_DENIED). Used by both the SoupServerMessage
+ * wrapper below and the WYL_TEST_DAEMON_HTTP test seam.
+ */
+static guint
+decide_request_tenant_gate (const gchar *request_tenant,
+    const gchar *auth_tenant, const gchar **out_code)
 {
-  const gchar *request_tenant = lookup_request_tenant (query);
   if (request_tenant == NULL || request_tenant[0] == '\0' ||
       !wyl_daemon_tenant_is_known (request_tenant)) {
-    set_json_error (msg, 400, invalid_code);
-    return FALSE;
+    if (out_code != NULL)
+      *out_code = WYL_DAEMON_ERR_TENANT_INVALID;
+    return 400;
   }
 
-  if (auth == NULL || auth->tenant == NULL ||
-      g_strcmp0 (auth->tenant, request_tenant) != 0) {
-    set_json_error (msg, 403, denied_code);
-    return FALSE;
+  if (auth_tenant == NULL || g_strcmp0 (auth_tenant, request_tenant) != 0) {
+    if (out_code != NULL)
+      *out_code = WYL_DAEMON_ERR_TENANT_DENIED;
+    return 403;
   }
 
-  return TRUE;
+  if (out_code != NULL)
+    *out_code = NULL;
+  return 0;
 }
+
+/*
+ * Cross-check the request's declared tenant against the authenticated
+ * principal's tenant and emit the stable tenant gate error codes
+ * (WYL_DAEMON_ERR_TENANT_INVALID / WYL_DAEMON_ERR_TENANT_DENIED) on
+ * failure. The codes are wire strings independent of the surrounding
+ * handler family (decide / audit / policy / login) so that clients can
+ * recognise a tenant-gate rejection regardless of which endpoint
+ * produced it.
+ */
+static gboolean
+ensure_auth_context_request_tenant (SoupServerMessage *msg, GHashTable *query,
+    const WylDaemonAuthContext *auth)
+{
+  const gchar *request_tenant = lookup_request_tenant (query);
+  const gchar *auth_tenant = (auth != NULL) ? auth->tenant : NULL;
+  const gchar *code = NULL;
+  guint status = decide_request_tenant_gate (request_tenant, auth_tenant,
+      &code);
+  if (status == 0)
+    return TRUE;
+  set_json_error (msg, status, code);
+  return FALSE;
+}
+
+#ifdef WYL_TEST_DAEMON_HTTP
+gboolean
+wyl_daemon_http_check_request_tenant_for_test (const gchar *auth_tenant,
+    const gchar *request_tenant, guint *out_status, gchar **out_code)
+{
+  /*
+   * Mirrors lookup_request_tenant()'s NULL-query fallback: if the
+   * caller passes request_tenant=NULL we treat that as "no tenant
+   * query parameter" and fall back to the default tenant, exactly as
+   * lookup_request_tenant() does inside a real handler.
+   */
+  const gchar *effective = request_tenant != NULL ? request_tenant
+      : WYL_DAEMON_DEFAULT_TENANT;
+  const gchar *code = NULL;
+  guint status = decide_request_tenant_gate (effective, auth_tenant, &code);
+  if (out_status != NULL)
+    *out_status = status;
+  if (out_code != NULL)
+    *out_code = code != NULL ? g_strdup (code) : NULL;
+  return status == 0;
+}
+#endif
 
 static const gchar *
 ensure_request_id_header (SoupServerMessage *msg)
@@ -1152,8 +1231,7 @@ authorize_guarded_session_action (SoupServer *server, SoupServerMessage *msg,
       return FALSE;
     }
   }
-  if (!ensure_auth_context_request_tenant (msg, query, &auth, invalid_code,
-          denied_code))
+  if (!ensure_auth_context_request_tenant (msg, query, &auth))
     return FALSE;
 
   g_autoptr (wyl_decide_req_t) req = wyl_decide_req_new ();
@@ -1572,7 +1650,7 @@ login_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
   }
   if (tenant == NULL || tenant[0] == '\0' ||
       !wyl_daemon_tenant_is_known (tenant)) {
-    set_json_error (msg, 400, "invalid_login_request");
+    set_json_error (msg, 400, WYL_DAEMON_ERR_TENANT_INVALID);
     return;
   }
   if (password != NULL) {
@@ -1890,7 +1968,7 @@ decide_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
   const gchar *tenant = lookup_request_tenant (query);
   if (tenant == NULL || tenant[0] == '\0' ||
       !wyl_daemon_tenant_is_known (tenant)) {
-    set_json_error (msg, 400, "invalid_decide_request");
+    set_json_error (msg, 400, WYL_DAEMON_ERR_TENANT_INVALID);
     return;
   }
   gboolean has_guard_context =
@@ -1915,8 +1993,7 @@ decide_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
     set_json_error (msg, 401, "decide_auth_required");
     return;
   }
-  if (!ensure_auth_context_request_tenant (msg, query, &auth,
-          "invalid_decide_request", "decide_denied"))
+  if (!ensure_auth_context_request_tenant (msg, query, &auth))
     return;
   if (g_strcmp0 (auth.actor, user) != 0) {
     set_json_error (msg, 403, "decide_denied");

--- a/wyrelog/daemon/http.h
+++ b/wyrelog/daemon/http.h
@@ -27,5 +27,18 @@ gboolean wyl_daemon_http_expire_refresh_grace_for_test (SoupServer * server,
     const gchar * refresh_token);
 gboolean wyl_daemon_http_session_is_revoked (SoupServer * server,
     const gchar * session_token);
+/*
+ * Test seam: drive the tenant-gate cross-check between a synthesised
+ * authenticated principal tenant (auth_tenant, may be NULL) and the
+ * tenant declared by the request (request_tenant, may be NULL meaning
+ * "no tenant query param", which causes lookup_request_tenant() to
+ * fall back to the default tenant). Returns TRUE on pass and FALSE on
+ * rejection; on rejection out_status / out_code (caller-owned, copy
+ * via g_strdup) are populated with the wire-format response that the
+ * helper would have set on a real SoupServerMessage.
+ */
+gboolean wyl_daemon_http_check_request_tenant_for_test
+    (const gchar * auth_tenant, const gchar * request_tenant,
+    guint * out_status, gchar ** out_code);
 #endif
 #endif

--- a/wyrelog/daemon/http.h
+++ b/wyrelog/daemon/http.h
@@ -28,17 +28,19 @@ gboolean wyl_daemon_http_expire_refresh_grace_for_test (SoupServer * server,
 gboolean wyl_daemon_http_session_is_revoked (SoupServer * server,
     const gchar * session_token);
 /*
- * Test seam: drive the tenant-gate cross-check between a synthesised
- * authenticated principal tenant (auth_tenant, may be NULL) and the
- * tenant declared by the request (request_tenant, may be NULL meaning
- * "no tenant query param", which causes lookup_request_tenant() to
- * fall back to the default tenant). Returns TRUE on pass and FALSE on
- * rejection; on rejection out_status / out_code (caller-owned, copy
- * via g_strdup) are populated with the wire-format response that the
- * helper would have set on a real SoupServerMessage.
+ * Test seam: drive the tenant-gate cross-check between the tenant
+ * declared by the request (request_tenant, may be NULL meaning "no
+ * tenant query param", which causes lookup_request_tenant() to fall
+ * back to the default tenant) and a synthesised authenticated
+ * principal tenant (auth_tenant, may be NULL). Parameter order
+ * mirrors decide_request_tenant_gate(): (request_tenant, auth_tenant).
+ * Returns TRUE on pass and FALSE on rejection; on rejection out_status
+ * / out_code (caller-owned, copy via g_strdup) are populated with the
+ * wire-format response that the helper would have set on a real
+ * SoupServerMessage.
  */
 gboolean wyl_daemon_http_check_request_tenant_for_test
-    (const gchar * auth_tenant, const gchar * request_tenant,
+    (const gchar * request_tenant, const gchar * auth_tenant,
     guint * out_status, gchar ** out_code);
 #endif
 #endif

--- a/wyrelog/session.h
+++ b/wyrelog/session.h
@@ -67,7 +67,24 @@ gboolean wyl_login_req_get_skip_mfa (const wyl_login_req_t * req);
 void wyl_login_req_set_request_id (wyl_login_req_t * req,
     const gchar * request_id);
 const gchar *wyl_login_req_get_request_id (const wyl_login_req_t * req);
+/*
+ * Sets the tenant carried by |req|. v0 contract: single-tenant;
+ * wyl_session_login accepts only the canonical default
+ * ("__wr_default") and fails closed with WYRELOG_E_INVALID for every
+ * other literal. The setter itself does not validate the value (it
+ * only stores the caller-supplied string); the rejection lands at
+ * login time. Passing NULL clears the field, which wyl_session_login
+ * treats as "use the default tenant". Multi-tenant support is
+ * tracked as a follow-up.
+ */
 void wyl_login_req_set_tenant (wyl_login_req_t * req, const gchar * tenant);
+/*
+ * Returns the borrowed tenant carried by |req|, or NULL when unset.
+ * The pointer is owned by the request and remains valid until the
+ * next set call or until the request is freed. v0 contract:
+ * single-tenant; on a successful login the bound tenant is always
+ * the canonical default ("__wr_default").
+ */
 const gchar *wyl_login_req_get_tenant (const wyl_login_req_t * req);
 
 wyrelog_error_t wyl_session_login (WylHandle * handle,
@@ -172,6 +189,15 @@ wyl_session_id_t wyl_session_get_id (const WylSession * self);
  * Caller frees with g_free or g_autofree.
  */
 gchar *wyl_session_dup_username (const WylSession * self);
+/*
+ * Returns a heap-allocated copy of the tenant carried into |self|
+ * by wyl_session_login. v0 contract: single-tenant; the only value
+ * that can ever be observed here is the canonical default
+ * ("__wr_default") because wyl_session_login fails closed for every
+ * other tenant literal. Returns NULL when |self| is NULL or not a
+ * WylSession. Caller frees with g_free or g_autofree. Multi-tenant
+ * support is tracked as a follow-up.
+ */
 gchar *wyl_session_dup_tenant (const WylSession * self);
 
 G_END_DECLS;

--- a/wyrelog/wyctl/wyctl.c
+++ b/wyrelog/wyctl/wyctl.c
@@ -9,6 +9,7 @@
 #include "wyrelog/decide.h"
 #include "wyrelog/version.h"
 #include "wyrelog/wyl-client-private.h"
+#include "wyrelog/wyl-common-private.h"
 #include "wyrelog/wyl-permission-scope-private.h"
 
 typedef struct
@@ -576,7 +577,7 @@ run_policy_decide_request (const WyctlOptions *global_opts,
   g_autoptr (WylClient) client = NULL;
   if (wyl_client_new (global_opts->daemon_url, &client) != WYRELOG_E_OK ||
       wyl_client_set_bearer_credentials (client, access_token,
-          "__wr_default") != WYRELOG_E_OK) {
+          WYL_TENANT_DEFAULT) != WYRELOG_E_OK) {
     g_printerr ("wyctl: invalid policy credentials\n");
     return 2;
   }
@@ -789,7 +790,7 @@ run_audit_query (const WyctlOptions *global_opts, gint argc, gchar **argv)
   g_autoptr (WylClient) client = NULL;
   if (wyl_client_new (global_opts->daemon_url, &client) != WYRELOG_E_OK ||
       wyl_client_set_bearer_credentials (client, access_token,
-          "__wr_default") != WYRELOG_E_OK) {
+          WYL_TENANT_DEFAULT) != WYRELOG_E_OK) {
     g_printerr ("wyctl: invalid audit credentials\n");
     return 2;
   }

--- a/wyrelog/wyl-client.c
+++ b/wyrelog/wyl-client.c
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #include "wyrelog/wyl-client-private.h"
+#include "wyrelog/wyl-common-private.h"
 #include "wyrelog/wyl-permission-scope-private.h"
 
 struct _WylClient
@@ -1071,7 +1072,7 @@ wyl_client_tenant_select (WylClient *client, const gchar *tenant)
   if (client == NULL || !WYL_IS_CLIENT (client) || tenant == NULL ||
       tenant[0] == '\0')
     return WYRELOG_E_INVALID;
-  if (client->tenant == NULL || g_strcmp0 (tenant, "__wr_default") != 0 ||
+  if (client->tenant == NULL || g_strcmp0 (tenant, WYL_TENANT_DEFAULT) != 0 ||
       g_strcmp0 (client->tenant, tenant) != 0)
     return WYRELOG_E_INVALID;
 

--- a/wyrelog/wyl-common-private.h
+++ b/wyrelog/wyl-common-private.h
@@ -5,3 +5,19 @@
 
 #include "wyrelog/error.h"
 #include "wyl-log-private.h"
+
+/*
+ * Single source of truth for the wyrelog v0 default tenant identifier.
+ *
+ * The v0 single-tenant contract (issue #273) keeps wyrelog deliberately
+ * single-tenant: every authenticated principal is bound to this tenant
+ * and the daemon's tenant gate accepts no other value. Callers that
+ * mint, validate, or compare tenant strings MUST use this constant
+ * rather than re-typing the literal so that any future widening of the
+ * contract changes a single point.
+ *
+ * Wire format note: this string also appears in JWT claim bodies, in
+ * HTTP request query parameters (?tenant=...), and in client-side
+ * comparisons. Changing the value is an ABI / wire-compat break.
+ */
+#define WYL_TENANT_DEFAULT "__wr_default"

--- a/wyrelog/wyl-session.c
+++ b/wyrelog/wyl-session.c
@@ -2,6 +2,7 @@
 #include "wyrelog/wyrelog.h"
 
 #include "audit/event-private.h"
+#include "wyl-common-private.h"
 #include "wyl-fsm-principal-private.h"
 #include "wyl-fsm-session-private.h"
 #include "wyl-handle-private.h"
@@ -75,7 +76,7 @@ reload_session_snapshot (WylHandle *handle)
 static gboolean
 login_tenant_is_valid (const gchar *tenant)
 {
-  return tenant != NULL && g_strcmp0 (tenant, "__wr_default") == 0;
+  return tenant != NULL && g_strcmp0 (tenant, WYL_TENANT_DEFAULT) == 0;
 }
 
 static wyrelog_error_t
@@ -585,7 +586,7 @@ wyl_session_login (WylHandle *handle, const wyl_login_req_t *req,
   if (handle == NULL)
     return WYRELOG_E_INVALID;
 
-  const gchar *tenant = "__wr_default";
+  const gchar *tenant = WYL_TENANT_DEFAULT;
   if (req != NULL && wyl_login_req_get_tenant (req) != NULL)
     tenant = wyl_login_req_get_tenant (req);
   if (!login_tenant_is_valid (tenant))


### PR DESCRIPTION
## Summary

Locks the LoBAC v0 tenant contract as **single-tenant only** with explicit, documented rejection of any non-canonical tenant value. The client, daemon, audit iterator, JWT claims, and request APIs already carried a tenant field but the daemon recognized only `__wr_default`; rejection paths returned generic shape-error codes that downstream consumers could not distinguish from any other input failure.

Per the AC out-clause "v0 release explicitly rejects unsupported break-glass use" pattern (already used for issues #271 and #272), this PR ships **path A**: explicit single-tenant v0 with stable wire codes, defense-in-depth JWT validation, regression coverage on every gate, and a release doc capturing the contract. Multi-tenant work — registry storage, CRUD admin API, per-tenant DEK, isolation tests, audit-row tenant column — is deferred to v1 and tracked in `docs/lobac-v0-tenant-contract.md`.

## Series shape

Five atomic commits:

1. **`daemon: emit stable tenant error codes on the HTTP gate`** — introduces wire-format strings `tenant_invalid` (HTTP 400/401, malformed/unknown tenant) and `tenant_denied` (HTTP 403, auth-context tenant ≠ request tenant). Refactors `ensure_auth_context_request_tenant` into a pure decider `decide_request_tenant_gate` with a `WYL_TEST_DAEMON_HTTP`-gated test seam. Wire-format change is intentional (pre-1.0 LoBAC v0).
2. **`access: lift default tenant literal to a single private constant`** — replaces the duplicated `"__wr_default"` literal across `wyl-session.c`, `wyl-client.c`, `daemon/http.c`, `wyctl/wyctl.c`, and the prior `WYL_DAEMON_DEFAULT_TENANT` macro with `WYL_TENANT_DEFAULT` in `wyrelog/wyl-common-private.h`. Aligns the test-seam parameter order with the internal decider. Behavior byte-identical.
3. **`daemon: enforce JWT tenant claim against the canonical default directly`** — adds defense-in-depth: `resolve_bearer_session` and `resolve_session_token_auth` now run `wyl_daemon_tenant_is_known(claims.tenant)` directly, before the live-session comparison. A future relaxation of `login_tenant_is_valid` cannot silently relax JWT acceptance. Regression test forges a valid-signature JWT with `"tenant":"evil-co"` against a default-tenant session; verified to fail without the impl change and pass with it (proving the new gate is exercised, not just the transitive arm).
4. **`tenant: cover single-tenant fail-closed paths and document v0 contract`** — regression suite covering `wyl_session_login` foreign tenant rejection, HTTP `/decide?tenant=evil-co`, HTTP `/auth/login` body tenant, and `wyl_client_tenant_select(c, "evil-co")`. Public-API docstrings on `wyl_client_tenant_select`, `wyl_client_dup_tenant`, `wyl_login_req_set/get_tenant`, `wyl_session_dup_tenant` now state the v0 contract explicitly. No symbol removed; no deprecation annotation.
5. **`docs: document the LoBAC v0 single-tenant contract`** — `docs/lobac-v0-tenant-contract.md` (canonical tenant, error codes, defense-in-depth, public API surface, v1 follow-up list, SemVer note). `templates/access/bootstrap.dl` gets a comment-only cross-reference above the `tenant("__wr_default").` seed.

## Acceptance criteria coverage (issue #273)

| Criterion | Closed by |
|---|---|
| Release docs and API behavior state v0 single-tenant | C5 + docstrings in C4 |
| Single-tenant: reject unknown tenants with documented error codes | C1 + C2 |
| Mark misleading multi-tenant CLI/API affordances | C4 docstrings (no removal; ABI-stable) |
| JWT/session tenant checks remain fail-closed and are tested | C3 (direct check) + C4 (regression suite) |

## Build matrix

- `meson setup` (default, `enable_break_glass=false`, `enable_audit=auto`) — clean.
- `meson setup -Denable_break_glass=true -Denable_audit=enabled` — clean.
- Both matrices pass the full wyrelog suite. Pre-existing parallel-suite timeouts (`session-username`, `wyrelogd-healthz`, `client-audit-daemon`) under sanitizer + parallelism are unrelated to this series and pass when run in isolation; tracked under the daemon-http-decide split work (commit `5aa6cfb` upstream).

## Test plan

- [x] `meson test -C builddir --suite wyrelog` (default): green on every C1–C5 commit.
- [x] `meson test -C /tmp/wy-bg-on --suite wyrelog` (break-glass on): green on every C1–C5 commit.
- [x] `tools/check-public-headers-no-novelty-tokens.sh`: clean across the series.
- [x] `./tools/gst-indent` clean on every changed C/H file.
- [x] C3 regression test verified to FAIL without the impl change (commenting out the direct gate makes the new test exit 34/1826) — proving the test exercises the new defense-in-depth code path.
- [ ] CI on this PR.

## Out of scope (tracked for v1)

Per `docs/lobac-v0-tenant-contract.md`:

- Tenant registry storage (per-tenant rows in the policy store).
- Tenant CRUD admin API (`POST /tenants`, `DELETE /tenants`, etc.) plus the super-admin RBAC needed to gate it.
- Per-tenant DEK / TPM seal scope.
- Cross-tenant isolation regression suite.
- Audit-row tenant column with non-null default `__wr_default` so a v1 schema migration is non-breaking.
- Per-tenant audit partitioning.

These reference parent design `#5` and profile separation `#2`.

Closes #273