### PR TITLE
wyctl: finish policy administration commands

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -141,6 +141,32 @@ if build_client
   test('wyctl-basic', test_wyctl_basic,
     depends : wyctl_exe,
   )
+
+  # End-to-end: drives wyctl as a subprocess against an in-process daemon
+  # so the policy mutation subcommands exercise the full client -> HTTP
+  # -> handler path, including bearer-only credentials and the privileged
+  # operator the daemon CLI cannot seed on its own.
+  test_wyctl_policy_daemon = executable('test-wyctl-policy-daemon',
+    'test-wyctl-policy-daemon.c',
+    '../wyrelog/daemon/http.c',
+    '../wyrelog/daemon/delta.c',
+    c_args : [
+      '-DWYL_HAS_DAEMON_HTTP',
+      '-DWYL_TEST_TEMPLATE_DIR="' + meson.project_source_root() / 'templates' / 'access' + '"',
+      '-DWYL_TEST_WYCTL_PATH="' + wyctl_exe.full_path() + '"',
+    ],
+    include_directories : [wyrelog_inc, include_directories('../wyrelog')],
+    dependencies : [
+      wyrelog_dep,
+      wyrelog_client_dep,
+      libsoup_dep,
+      sodium_dep,
+    ],
+  )
+
+  test('wyctl-policy-daemon', test_wyctl_policy_daemon,
+    depends : wyctl_exe,
+  )
 endif
 
 if host_machine.system() != 'windows' and build_client

--- a/tests/test-client-smoke.c
+++ b/tests/test-client-smoke.c
@@ -874,6 +874,64 @@ main (void)
           "Bearer access-ctl") != 0)
     return 209;
 
+  /*
+   * Bearer-only policy mutation: with no session_token set, the
+   * client must still emit the request using the access_token in the
+   * Authorization header and omit session_token from the URI query.
+   */
+  http.body = "{\"ok\":true}";
+  http.status = 0;
+  if (wyl_client_policy_permission_grant (local_client, "bearer subject",
+          "site.policy.read", "tenant/bearer", 321, "semi_trusted", 89)
+      != WYRELOG_E_OK)
+    return 220;
+  if (g_strcmp0 (http.last_method, "POST") != 0 ||
+      g_strcmp0 (http.last_path, "/policy/permissions/grant") != 0 ||
+      g_strcmp0 (http.last_subject, "bearer subject") != 0 ||
+      g_strcmp0 (http.last_perm, "site.policy.read") != 0 ||
+      g_strcmp0 (http.last_scope, "tenant/bearer") != 0 ||
+      g_strcmp0 (http.last_tenant, "__wr_default") != 0 ||
+      http.last_session_token != NULL ||
+      g_strcmp0 (http.last_authorization, "Bearer access-ctl") != 0 ||
+      g_strcmp0 (http.last_guard_timestamp, "321") != 0 ||
+      g_strcmp0 (http.last_guard_loc_class, "semi_trusted") != 0 ||
+      g_strcmp0 (http.last_guard_risk, "89") != 0)
+    return 221;
+  if (wyl_client_policy_permission_revoke (local_client, "bearer subject",
+          "site.policy.read", "tenant/bearer", 321, "semi_trusted", 89)
+      != WYRELOG_E_OK)
+    return 222;
+  if (g_strcmp0 (http.last_path, "/policy/permissions/revoke") != 0 ||
+      http.last_session_token != NULL ||
+      g_strcmp0 (http.last_authorization, "Bearer access-ctl") != 0)
+    return 223;
+  if (wyl_client_policy_role_grant (local_client, "bearer subject",
+          "site.reader", "tenant/bearer", 321, "semi_trusted", 89)
+      != WYRELOG_E_OK)
+    return 224;
+  if (g_strcmp0 (http.last_path, "/policy/roles/grant") != 0 ||
+      g_strcmp0 (http.last_role, "site.reader") != 0 ||
+      http.last_session_token != NULL ||
+      g_strcmp0 (http.last_authorization, "Bearer access-ctl") != 0)
+    return 225;
+  if (wyl_client_policy_role_revoke (local_client, "bearer subject",
+          "site.reader", "tenant/bearer", 321, "semi_trusted", 89)
+      != WYRELOG_E_OK)
+    return 226;
+  if (g_strcmp0 (http.last_path, "/policy/roles/revoke") != 0 ||
+      http.last_session_token != NULL ||
+      g_strcmp0 (http.last_authorization, "Bearer access-ctl") != 0)
+    return 227;
+  if (wyl_client_policy_permission_transition (local_client, "bearer subject",
+          "site.policy.read", "tenant/bearer", "grant", 321, "semi_trusted",
+          89) != WYRELOG_E_OK)
+    return 228;
+  if (g_strcmp0 (http.last_path, "/policy/permissions/transition") != 0 ||
+      g_strcmp0 (http.last_event, "grant") != 0 ||
+      http.last_session_token != NULL ||
+      g_strcmp0 (http.last_authorization, "Bearer access-ctl") != 0)
+    return 229;
+
   http.body = "{\"session_token\":\"session-relogin\",\"username\":\"alice\","
       "\"tenant\":\"__wr_default\",\"principal_state\":\"authenticated\","
       "\"session_state\":\"active\",\"access_token\":\"access-relogin\","

--- a/tests/test-wyctl-basic.c
+++ b/tests/test-wyctl-basic.c
@@ -3,6 +3,7 @@
 #include <glib/gstdio.h>
 #include <gio/gio.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #ifndef WYL_TEST_WYCTL_PATH
 #error "WYL_TEST_WYCTL_PATH is required"
@@ -1255,6 +1256,509 @@ test_audit_query (void)
   run_audit_query_case ("[]", "", 250 * 1000, "50", "100");
 }
 
+typedef struct
+{
+  GSocketListener *listener;
+  guint status;
+  const gchar *body;
+  gchar *request;
+} PolicyMutationServer;
+
+static gpointer
+policy_mutation_server_thread (gpointer data)
+{
+  PolicyMutationServer *server = data;
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GSocketConnection) conn =
+      g_socket_listener_accept (server->listener, NULL, NULL, &error);
+  if (conn == NULL)
+    return NULL;
+
+  gchar buffer[4096];
+  GInputStream *input = g_io_stream_get_input_stream (G_IO_STREAM (conn));
+  GOutputStream *output = g_io_stream_get_output_stream (G_IO_STREAM (conn));
+  gssize n = g_input_stream_read (input, buffer, sizeof buffer - 1, NULL, NULL);
+  if (n > 0) {
+    buffer[n] = '\0';
+    server->request = g_strdup (buffer);
+  }
+
+  const gchar *body = server->body != NULL ? server->body : "{}";
+  g_autofree gchar *response =
+      g_strdup_printf ("HTTP/1.1 %u OK\r\nContent-Type: application/json\r\n"
+      "Content-Length: %" G_GSIZE_FORMAT "\r\n\r\n%s",
+      server->status, strlen (body), body);
+  (void) g_output_stream_write (output, response, strlen (response), NULL,
+      NULL);
+  (void) g_io_stream_close (G_IO_STREAM (conn), NULL, NULL);
+  return NULL;
+}
+
+static void
+test_policy_permission_help (void)
+{
+  gchar *grant_argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "policy",
+    "permission-grant",
+    "--help",
+    NULL,
+  };
+  gchar *revoke_argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "policy",
+    "permission-revoke",
+    "--help",
+    NULL,
+  };
+  g_autofree gchar *stdout_buf = NULL;
+  g_autofree gchar *stderr_buf = NULL;
+  gint wait_status = 0;
+
+  run_child (grant_argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_assert_true (wait_status_is_success (wait_status));
+  g_assert_nonnull (g_strstr_len (stdout_buf, -1, "--subject"));
+  g_assert_nonnull (g_strstr_len (stdout_buf, -1, "--perm"));
+  g_assert_nonnull (g_strstr_len (stdout_buf, -1, "--scope"));
+  g_assert_nonnull (g_strstr_len (stdout_buf, -1, "--access-token-file"));
+  g_assert_nonnull (g_strstr_len (stdout_buf, -1, "--guard-timestamp"));
+  g_assert_nonnull (g_strstr_len (stdout_buf, -1, "--guard-loc-class"));
+  g_assert_nonnull (g_strstr_len (stdout_buf, -1, "--guard-risk"));
+  g_assert_null (g_strstr_len (stdout_buf, -1, "--tenant"));
+  g_assert_null (g_strstr_len (stdout_buf, -1, "--access-token "));
+  g_assert_cmpstr (stderr_buf, ==, "");
+
+  g_clear_pointer (&stdout_buf, g_free);
+  g_clear_pointer (&stderr_buf, g_free);
+  run_child (revoke_argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_assert_true (wait_status_is_success (wait_status));
+  g_assert_nonnull (g_strstr_len (stdout_buf, -1, "--subject"));
+  g_assert_nonnull (g_strstr_len (stdout_buf, -1, "--perm"));
+  g_assert_nonnull (g_strstr_len (stdout_buf, -1, "--scope"));
+  g_assert_nonnull (g_strstr_len (stdout_buf, -1, "--access-token-file"));
+  g_assert_cmpstr (stderr_buf, ==, "");
+}
+
+static void
+run_policy_permission_success_case (const gchar *command, const gchar *path)
+{
+  g_autofree gchar *token_path = NULL;
+  g_autoptr (GError) error = NULL;
+  gint fd = g_file_open_tmp ("wyctl-policy-perm-token-XXXXXX", &token_path,
+      &error);
+  g_assert_no_error (error);
+  g_assert_cmpint (fd, >=, 0);
+  g_assert_true (g_close (fd, NULL));
+  g_assert_true (g_file_set_contents (token_path, "token-1\n", -1, &error));
+  g_assert_no_error (error);
+
+  g_autoptr (GSocketListener) listener = NULL;
+  g_autofree gchar *daemon_url = listen_url_for_policy_server (&listener);
+  PolicyMutationServer server = {
+    .listener = listener,
+    .status = 200,
+    .body = "{}",
+  };
+  GThread *server_thread = g_thread_new ("policy-mutation",
+      policy_mutation_server_thread, &server);
+  gchar *argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "--daemon-url",
+    daemon_url,
+    "--timeout-ms",
+    "1000",
+    "policy",
+    (gchar *) command,
+    "--subject",
+    "alice",
+    "--perm",
+    "wr.audit.read",
+    "--scope",
+    "tenant/a",
+    "--access-token-file",
+    token_path,
+    "--guard-timestamp",
+    "123",
+    "--guard-loc-class",
+    "public",
+    "--guard-risk",
+    "69",
+    NULL,
+  };
+  g_autofree gchar *stdout_buf = NULL;
+  g_autofree gchar *stderr_buf = NULL;
+  gint wait_status = 0;
+
+  run_child (argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_thread_join (server_thread);
+
+  g_assert_true (wait_status_is_success (wait_status));
+  g_assert_cmpstr (stdout_buf, ==, "ok\n");
+  g_assert_cmpstr (stderr_buf, ==, "");
+  g_assert_nonnull (server.request);
+  g_autofree gchar *expected_request_line = g_strdup_printf ("POST %s?", path);
+  g_assert_nonnull (g_strstr_len (server.request, -1, expected_request_line));
+  g_assert_nonnull (g_strstr_len (server.request, -1, "subject=alice"));
+  g_assert_nonnull (g_strstr_len (server.request, -1, "perm=wr.audit.read"));
+  g_assert_nonnull (g_strstr_len (server.request, -1, "scope=tenant%2Fa"));
+  g_assert_nonnull (g_strstr_len (server.request, -1, "tenant=__wr_default"));
+  g_assert_nonnull (g_strstr_len (server.request, -1, "guard_timestamp=123"));
+  g_assert_nonnull (g_strstr_len (server.request, -1,
+          "guard_loc_class=public"));
+  g_assert_nonnull (g_strstr_len (server.request, -1, "guard_risk=69"));
+  g_assert_null (g_strstr_len (server.request, -1, "session_token="));
+  g_assert_nonnull (g_strstr_len (server.request, -1,
+          "Authorization: Bearer token-1"));
+
+  g_free (server.request);
+  g_unlink (token_path);
+}
+
+static void
+test_policy_permission_grant_success (void)
+{
+  run_policy_permission_success_case ("permission-grant",
+      "/policy/permissions/grant");
+}
+
+static void
+test_policy_permission_revoke_success (void)
+{
+  run_policy_permission_success_case ("permission-revoke",
+      "/policy/permissions/revoke");
+}
+
+static void
+run_policy_permission_status_case (const gchar *command, guint status,
+    gint expected_exit, const gchar *expected_stderr_marker)
+{
+  g_autofree gchar *token_path = NULL;
+  g_autoptr (GError) error = NULL;
+  gint fd = g_file_open_tmp ("wyctl-policy-perm-token-XXXXXX", &token_path,
+      &error);
+  g_assert_no_error (error);
+  g_assert_cmpint (fd, >=, 0);
+  g_assert_true (g_close (fd, NULL));
+  g_assert_true (g_file_set_contents (token_path, "token-1\n", -1, &error));
+  g_assert_no_error (error);
+
+  g_autoptr (GSocketListener) listener = NULL;
+  g_autofree gchar *daemon_url = listen_url_for_policy_server (&listener);
+  PolicyMutationServer server = {
+    .listener = listener,
+    .status = status,
+    .body = "{}",
+  };
+  GThread *server_thread = g_thread_new ("policy-mutation",
+      policy_mutation_server_thread, &server);
+  gchar *argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "--daemon-url",
+    daemon_url,
+    "--timeout-ms",
+    "1000",
+    "policy",
+    (gchar *) command,
+    "--subject",
+    "alice",
+    "--perm",
+    "wr.audit.read",
+    "--scope",
+    "tenant/a",
+    "--access-token-file",
+    token_path,
+    "--guard-timestamp",
+    "123",
+    "--guard-loc-class",
+    "public",
+    "--guard-risk",
+    "69",
+    NULL,
+  };
+  g_autofree gchar *stdout_buf = NULL;
+  g_autofree gchar *stderr_buf = NULL;
+  gint wait_status = 0;
+
+  run_child (argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_thread_join (server_thread);
+
+  g_assert_false (wait_status_is_success (wait_status));
+  g_assert_cmpint (WEXITSTATUS (wait_status), ==, expected_exit);
+  g_assert_cmpstr (stdout_buf, ==, "");
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1, expected_stderr_marker));
+
+  g_free (server.request);
+  g_unlink (token_path);
+}
+
+static void
+test_policy_permission_grant_status_errors (void)
+{
+  run_policy_permission_status_case ("permission-grant", 400, 3,
+      "wyctl: policy permission-grant failed: invalid_policy_mutation");
+  run_policy_permission_status_case ("permission-grant", 401, 6,
+      "wyctl: policy permission-grant failed: policy_auth_required");
+  run_policy_permission_status_case ("permission-grant", 403, 4,
+      "wyctl: policy permission-grant failed: policy_mutation_denied");
+  run_policy_permission_status_case ("permission-grant", 500, 5,
+      "wyctl: policy permission-grant failed: policy_mutation_failed");
+}
+
+static void
+test_policy_permission_revoke_status_errors (void)
+{
+  run_policy_permission_status_case ("permission-revoke", 400, 3,
+      "wyctl: policy permission-revoke failed: invalid_policy_mutation");
+  run_policy_permission_status_case ("permission-revoke", 401, 6,
+      "wyctl: policy permission-revoke failed: policy_auth_required");
+  run_policy_permission_status_case ("permission-revoke", 403, 4,
+      "wyctl: policy permission-revoke failed: policy_mutation_denied");
+  run_policy_permission_status_case ("permission-revoke", 500, 5,
+      "wyctl: policy permission-revoke failed: policy_mutation_failed");
+}
+
+static void
+test_policy_permission_validation (void)
+{
+  g_autofree gchar *token_path = NULL;
+  g_autoptr (GError) error = NULL;
+  gint fd = g_file_open_tmp ("wyctl-policy-perm-token-XXXXXX", &token_path,
+      &error);
+  g_assert_no_error (error);
+  g_assert_cmpint (fd, >=, 0);
+  g_assert_true (g_close (fd, NULL));
+  g_assert_true (g_file_set_contents (token_path, "token-1\n", -1, &error));
+  g_assert_no_error (error);
+
+  gchar *missing_subject_argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "--daemon-url",
+    "http://127.0.0.1:1",
+    "policy",
+    "permission-grant",
+    "--perm",
+    "wr.audit.read",
+    "--scope",
+    "tenant/a",
+    "--access-token-file",
+    token_path,
+    "--guard-timestamp",
+    "123",
+    "--guard-loc-class",
+    "public",
+    "--guard-risk",
+    "69",
+    NULL,
+  };
+  gchar *missing_perm_argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "--daemon-url",
+    "http://127.0.0.1:1",
+    "policy",
+    "permission-grant",
+    "--subject",
+    "alice",
+    "--scope",
+    "tenant/a",
+    "--access-token-file",
+    token_path,
+    "--guard-timestamp",
+    "123",
+    "--guard-loc-class",
+    "public",
+    "--guard-risk",
+    "69",
+    NULL,
+  };
+  gchar *missing_scope_argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "--daemon-url",
+    "http://127.0.0.1:1",
+    "policy",
+    "permission-grant",
+    "--subject",
+    "alice",
+    "--perm",
+    "wr.audit.read",
+    "--access-token-file",
+    token_path,
+    "--guard-timestamp",
+    "123",
+    "--guard-loc-class",
+    "public",
+    "--guard-risk",
+    "69",
+    NULL,
+  };
+  gchar *missing_token_argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "--daemon-url",
+    "http://127.0.0.1:1",
+    "policy",
+    "permission-grant",
+    "--subject",
+    "alice",
+    "--perm",
+    "wr.audit.read",
+    "--scope",
+    "tenant/a",
+    "--guard-timestamp",
+    "123",
+    "--guard-loc-class",
+    "public",
+    "--guard-risk",
+    "69",
+    NULL,
+  };
+  gchar *missing_timestamp_argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "--daemon-url",
+    "http://127.0.0.1:1",
+    "policy",
+    "permission-grant",
+    "--subject",
+    "alice",
+    "--perm",
+    "wr.audit.read",
+    "--scope",
+    "tenant/a",
+    "--access-token-file",
+    token_path,
+    "--guard-loc-class",
+    "public",
+    "--guard-risk",
+    "69",
+    NULL,
+  };
+  gchar *invalid_loc_argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "--daemon-url",
+    "http://127.0.0.1:1",
+    "policy",
+    "permission-grant",
+    "--subject",
+    "alice",
+    "--perm",
+    "wr.audit.read",
+    "--scope",
+    "tenant/a",
+    "--access-token-file",
+    token_path,
+    "--guard-timestamp",
+    "123",
+    "--guard-loc-class",
+    "unknown",
+    "--guard-risk",
+    "69",
+    NULL,
+  };
+  gchar *invalid_risk_argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "--daemon-url",
+    "http://127.0.0.1:1",
+    "policy",
+    "permission-grant",
+    "--subject",
+    "alice",
+    "--perm",
+    "wr.audit.read",
+    "--scope",
+    "tenant/a",
+    "--access-token-file",
+    token_path,
+    "--guard-timestamp",
+    "123",
+    "--guard-loc-class",
+    "public",
+    "--guard-risk",
+    "101",
+    NULL,
+  };
+  gchar *missing_daemon_argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "policy",
+    "permission-grant",
+    "--subject",
+    "alice",
+    "--perm",
+    "wr.audit.read",
+    "--scope",
+    "tenant/a",
+    "--access-token-file",
+    token_path,
+    "--guard-timestamp",
+    "123",
+    "--guard-loc-class",
+    "public",
+    "--guard-risk",
+    "69",
+    NULL,
+  };
+  g_autofree gchar *stdout_buf = NULL;
+  g_autofree gchar *stderr_buf = NULL;
+  gint wait_status = 0;
+
+  run_child (missing_subject_argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_assert_false (wait_status_is_success (wait_status));
+  g_assert_cmpstr (stdout_buf, ==, "");
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1, "wyctl: missing --subject"));
+
+  g_clear_pointer (&stdout_buf, g_free);
+  g_clear_pointer (&stderr_buf, g_free);
+  run_child (missing_perm_argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_assert_false (wait_status_is_success (wait_status));
+  g_assert_cmpstr (stdout_buf, ==, "");
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1, "wyctl: missing --perm"));
+
+  g_clear_pointer (&stdout_buf, g_free);
+  g_clear_pointer (&stderr_buf, g_free);
+  run_child (missing_scope_argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_assert_false (wait_status_is_success (wait_status));
+  g_assert_cmpstr (stdout_buf, ==, "");
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1, "wyctl: missing --scope"));
+
+  g_clear_pointer (&stdout_buf, g_free);
+  g_clear_pointer (&stderr_buf, g_free);
+  run_child (missing_token_argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_assert_false (wait_status_is_success (wait_status));
+  g_assert_cmpstr (stdout_buf, ==, "");
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1,
+          "wyctl: missing --access-token-file"));
+
+  g_clear_pointer (&stdout_buf, g_free);
+  g_clear_pointer (&stderr_buf, g_free);
+  run_child (missing_timestamp_argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_assert_false (wait_status_is_success (wait_status));
+  g_assert_cmpstr (stdout_buf, ==, "");
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1,
+          "wyctl: invalid --guard-timestamp"));
+
+  g_clear_pointer (&stdout_buf, g_free);
+  g_clear_pointer (&stderr_buf, g_free);
+  run_child (invalid_loc_argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_assert_false (wait_status_is_success (wait_status));
+  g_assert_cmpstr (stdout_buf, ==, "");
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1,
+          "wyctl: invalid --guard-loc-class"));
+
+  g_clear_pointer (&stdout_buf, g_free);
+  g_clear_pointer (&stderr_buf, g_free);
+  run_child (invalid_risk_argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_assert_false (wait_status_is_success (wait_status));
+  g_assert_cmpstr (stdout_buf, ==, "");
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1,
+          "wyctl: invalid --guard-risk"));
+
+  g_clear_pointer (&stdout_buf, g_free);
+  g_clear_pointer (&stderr_buf, g_free);
+  run_child (missing_daemon_argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_assert_false (wait_status_is_success (wait_status));
+  g_assert_cmpstr (stdout_buf, ==, "");
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1, "wyctl: missing daemon URL"));
+
+  g_unlink (token_path);
+}
+
 int
 main (int argc, char **argv)
 {
@@ -1276,6 +1780,18 @@ main (int argc, char **argv)
   g_test_add_func ("/wyctl/policy-help", test_policy_help);
   g_test_add_func ("/wyctl/policy-validation", test_policy_validation);
   g_test_add_func ("/wyctl/policy-check", test_policy_check);
+  g_test_add_func ("/wyctl/policy-permission-help",
+      test_policy_permission_help);
+  g_test_add_func ("/wyctl/policy-permission-validation",
+      test_policy_permission_validation);
+  g_test_add_func ("/wyctl/policy-permission-grant-success",
+      test_policy_permission_grant_success);
+  g_test_add_func ("/wyctl/policy-permission-revoke-success",
+      test_policy_permission_revoke_success);
+  g_test_add_func ("/wyctl/policy-permission-grant-status-errors",
+      test_policy_permission_grant_status_errors);
+  g_test_add_func ("/wyctl/policy-permission-revoke-status-errors",
+      test_policy_permission_revoke_status_errors);
   g_test_add_func ("/wyctl/audit-help", test_audit_help);
   g_test_add_func ("/wyctl/audit-validation", test_audit_validation);
   g_test_add_func ("/wyctl/audit-query", test_audit_query);

--- a/tests/test-wyctl-basic.c
+++ b/tests/test-wyctl-basic.c
@@ -1336,6 +1336,11 @@ test_policy_permission_help (void)
   g_assert_nonnull (g_strstr_len (stdout_buf, -1, "--perm"));
   g_assert_nonnull (g_strstr_len (stdout_buf, -1, "--scope"));
   g_assert_nonnull (g_strstr_len (stdout_buf, -1, "--access-token-file"));
+  g_assert_nonnull (g_strstr_len (stdout_buf, -1, "--guard-timestamp"));
+  g_assert_nonnull (g_strstr_len (stdout_buf, -1, "--guard-loc-class"));
+  g_assert_nonnull (g_strstr_len (stdout_buf, -1, "--guard-risk"));
+  g_assert_null (g_strstr_len (stdout_buf, -1, "--tenant"));
+  g_assert_null (g_strstr_len (stdout_buf, -1, "--access-token "));
   g_assert_cmpstr (stderr_buf, ==, "");
 }
 
@@ -1759,6 +1764,476 @@ test_policy_permission_validation (void)
   g_unlink (token_path);
 }
 
+static void
+test_policy_role_help (void)
+{
+  gchar *grant_argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "policy",
+    "role-grant",
+    "--help",
+    NULL,
+  };
+  gchar *revoke_argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "policy",
+    "role-revoke",
+    "--help",
+    NULL,
+  };
+  g_autofree gchar *stdout_buf = NULL;
+  g_autofree gchar *stderr_buf = NULL;
+  gint wait_status = 0;
+
+  run_child (grant_argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_assert_true (wait_status_is_success (wait_status));
+  g_assert_nonnull (g_strstr_len (stdout_buf, -1, "--subject"));
+  g_assert_nonnull (g_strstr_len (stdout_buf, -1, "--role"));
+  g_assert_nonnull (g_strstr_len (stdout_buf, -1, "--scope"));
+  g_assert_nonnull (g_strstr_len (stdout_buf, -1, "--access-token-file"));
+  g_assert_nonnull (g_strstr_len (stdout_buf, -1, "--guard-timestamp"));
+  g_assert_nonnull (g_strstr_len (stdout_buf, -1, "--guard-loc-class"));
+  g_assert_nonnull (g_strstr_len (stdout_buf, -1, "--guard-risk"));
+  g_assert_null (g_strstr_len (stdout_buf, -1, "--tenant"));
+  g_assert_null (g_strstr_len (stdout_buf, -1, "--access-token "));
+  g_assert_null (g_strstr_len (stdout_buf, -1, "--perm"));
+  g_assert_cmpstr (stderr_buf, ==, "");
+
+  g_clear_pointer (&stdout_buf, g_free);
+  g_clear_pointer (&stderr_buf, g_free);
+  run_child (revoke_argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_assert_true (wait_status_is_success (wait_status));
+  g_assert_nonnull (g_strstr_len (stdout_buf, -1, "--subject"));
+  g_assert_nonnull (g_strstr_len (stdout_buf, -1, "--role"));
+  g_assert_nonnull (g_strstr_len (stdout_buf, -1, "--scope"));
+  g_assert_nonnull (g_strstr_len (stdout_buf, -1, "--access-token-file"));
+  g_assert_nonnull (g_strstr_len (stdout_buf, -1, "--guard-timestamp"));
+  g_assert_nonnull (g_strstr_len (stdout_buf, -1, "--guard-loc-class"));
+  g_assert_nonnull (g_strstr_len (stdout_buf, -1, "--guard-risk"));
+  g_assert_null (g_strstr_len (stdout_buf, -1, "--tenant"));
+  g_assert_null (g_strstr_len (stdout_buf, -1, "--access-token "));
+  g_assert_null (g_strstr_len (stdout_buf, -1, "--perm"));
+  g_assert_cmpstr (stderr_buf, ==, "");
+}
+
+static void
+run_policy_role_success_case (const gchar *command, const gchar *path)
+{
+  g_autofree gchar *token_path = NULL;
+  g_autoptr (GError) error = NULL;
+  gint fd = g_file_open_tmp ("wyctl-policy-role-token-XXXXXX", &token_path,
+      &error);
+  g_assert_no_error (error);
+  g_assert_cmpint (fd, >=, 0);
+  g_assert_true (g_close (fd, NULL));
+  g_assert_true (g_file_set_contents (token_path, "token-1\n", -1, &error));
+  g_assert_no_error (error);
+
+  g_autoptr (GSocketListener) listener = NULL;
+  g_autofree gchar *daemon_url = listen_url_for_policy_server (&listener);
+  PolicyMutationServer server = {
+    .listener = listener,
+    .status = 200,
+    .body = "{}",
+  };
+  GThread *server_thread = g_thread_new ("policy-mutation",
+      policy_mutation_server_thread, &server);
+  gchar *argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "--daemon-url",
+    daemon_url,
+    "--timeout-ms",
+    "1000",
+    "policy",
+    (gchar *) command,
+    "--subject",
+    "alice",
+    "--role",
+    "wr.audit.reader",
+    "--scope",
+    "tenant/a",
+    "--access-token-file",
+    token_path,
+    "--guard-timestamp",
+    "123",
+    "--guard-loc-class",
+    "public",
+    "--guard-risk",
+    "69",
+    NULL,
+  };
+  g_autofree gchar *stdout_buf = NULL;
+  g_autofree gchar *stderr_buf = NULL;
+  gint wait_status = 0;
+
+  run_child (argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_thread_join (server_thread);
+
+  g_assert_true (wait_status_is_success (wait_status));
+  g_assert_cmpstr (stdout_buf, ==, "ok\n");
+  g_assert_cmpstr (stderr_buf, ==, "");
+  g_assert_nonnull (server.request);
+  g_autofree gchar *expected_request_line = g_strdup_printf ("POST %s?", path);
+  g_assert_nonnull (g_strstr_len (server.request, -1, expected_request_line));
+  g_assert_nonnull (g_strstr_len (server.request, -1, "subject=alice"));
+  g_assert_nonnull (g_strstr_len (server.request, -1, "role=wr.audit.reader"));
+  g_assert_nonnull (g_strstr_len (server.request, -1, "scope=tenant%2Fa"));
+  g_assert_nonnull (g_strstr_len (server.request, -1, "tenant=__wr_default"));
+  g_assert_nonnull (g_strstr_len (server.request, -1, "guard_timestamp=123"));
+  g_assert_nonnull (g_strstr_len (server.request, -1,
+          "guard_loc_class=public"));
+  g_assert_nonnull (g_strstr_len (server.request, -1, "guard_risk=69"));
+  g_assert_null (g_strstr_len (server.request, -1, "session_token="));
+  g_assert_nonnull (g_strstr_len (server.request, -1,
+          "Authorization: Bearer token-1"));
+
+  g_free (server.request);
+  g_unlink (token_path);
+}
+
+static void
+test_policy_role_grant_success (void)
+{
+  run_policy_role_success_case ("role-grant", "/policy/roles/grant");
+}
+
+static void
+test_policy_role_revoke_success (void)
+{
+  run_policy_role_success_case ("role-revoke", "/policy/roles/revoke");
+}
+
+static void
+run_policy_role_status_case (const gchar *command, guint status,
+    gint expected_exit, const gchar *expected_stderr_marker)
+{
+  g_autofree gchar *token_path = NULL;
+  g_autoptr (GError) error = NULL;
+  gint fd = g_file_open_tmp ("wyctl-policy-role-token-XXXXXX", &token_path,
+      &error);
+  g_assert_no_error (error);
+  g_assert_cmpint (fd, >=, 0);
+  g_assert_true (g_close (fd, NULL));
+  g_assert_true (g_file_set_contents (token_path, "token-1\n", -1, &error));
+  g_assert_no_error (error);
+
+  g_autoptr (GSocketListener) listener = NULL;
+  g_autofree gchar *daemon_url = listen_url_for_policy_server (&listener);
+  PolicyMutationServer server = {
+    .listener = listener,
+    .status = status,
+    .body = "{}",
+  };
+  GThread *server_thread = g_thread_new ("policy-mutation",
+      policy_mutation_server_thread, &server);
+  gchar *argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "--daemon-url",
+    daemon_url,
+    "--timeout-ms",
+    "1000",
+    "policy",
+    (gchar *) command,
+    "--subject",
+    "alice",
+    "--role",
+    "wr.audit.reader",
+    "--scope",
+    "tenant/a",
+    "--access-token-file",
+    token_path,
+    "--guard-timestamp",
+    "123",
+    "--guard-loc-class",
+    "public",
+    "--guard-risk",
+    "69",
+    NULL,
+  };
+  g_autofree gchar *stdout_buf = NULL;
+  g_autofree gchar *stderr_buf = NULL;
+  gint wait_status = 0;
+
+  run_child (argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_thread_join (server_thread);
+
+  g_assert_false (wait_status_is_success (wait_status));
+  g_assert_cmpint (WEXITSTATUS (wait_status), ==, expected_exit);
+  g_assert_cmpstr (stdout_buf, ==, "");
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1, expected_stderr_marker));
+
+  g_free (server.request);
+  g_unlink (token_path);
+}
+
+static void
+test_policy_role_grant_status_errors (void)
+{
+  run_policy_role_status_case ("role-grant", 400, 3,
+      "wyctl: policy role-grant failed: invalid_policy_mutation");
+  run_policy_role_status_case ("role-grant", 401, 6,
+      "wyctl: policy role-grant failed: policy_auth_required");
+  run_policy_role_status_case ("role-grant", 403, 4,
+      "wyctl: policy role-grant failed: policy_mutation_denied");
+  run_policy_role_status_case ("role-grant", 500, 5,
+      "wyctl: policy role-grant failed: policy_mutation_failed");
+}
+
+static void
+test_policy_role_revoke_status_errors (void)
+{
+  run_policy_role_status_case ("role-revoke", 400, 3,
+      "wyctl: policy role-revoke failed: invalid_policy_mutation");
+  run_policy_role_status_case ("role-revoke", 401, 6,
+      "wyctl: policy role-revoke failed: policy_auth_required");
+  run_policy_role_status_case ("role-revoke", 403, 4,
+      "wyctl: policy role-revoke failed: policy_mutation_denied");
+  run_policy_role_status_case ("role-revoke", 500, 5,
+      "wyctl: policy role-revoke failed: policy_mutation_failed");
+}
+
+static void
+test_policy_role_validation (void)
+{
+  g_autofree gchar *token_path = NULL;
+  g_autoptr (GError) error = NULL;
+  gint fd = g_file_open_tmp ("wyctl-policy-role-token-XXXXXX", &token_path,
+      &error);
+  g_assert_no_error (error);
+  g_assert_cmpint (fd, >=, 0);
+  g_assert_true (g_close (fd, NULL));
+  g_assert_true (g_file_set_contents (token_path, "token-1\n", -1, &error));
+  g_assert_no_error (error);
+
+  gchar *missing_subject_argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "--daemon-url",
+    "http://127.0.0.1:1",
+    "policy",
+    "role-grant",
+    "--role",
+    "wr.audit.reader",
+    "--scope",
+    "tenant/a",
+    "--access-token-file",
+    token_path,
+    "--guard-timestamp",
+    "123",
+    "--guard-loc-class",
+    "public",
+    "--guard-risk",
+    "69",
+    NULL,
+  };
+  gchar *missing_role_argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "--daemon-url",
+    "http://127.0.0.1:1",
+    "policy",
+    "role-grant",
+    "--subject",
+    "alice",
+    "--scope",
+    "tenant/a",
+    "--access-token-file",
+    token_path,
+    "--guard-timestamp",
+    "123",
+    "--guard-loc-class",
+    "public",
+    "--guard-risk",
+    "69",
+    NULL,
+  };
+  gchar *missing_scope_argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "--daemon-url",
+    "http://127.0.0.1:1",
+    "policy",
+    "role-grant",
+    "--subject",
+    "alice",
+    "--role",
+    "wr.audit.reader",
+    "--access-token-file",
+    token_path,
+    "--guard-timestamp",
+    "123",
+    "--guard-loc-class",
+    "public",
+    "--guard-risk",
+    "69",
+    NULL,
+  };
+  gchar *missing_token_argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "--daemon-url",
+    "http://127.0.0.1:1",
+    "policy",
+    "role-grant",
+    "--subject",
+    "alice",
+    "--role",
+    "wr.audit.reader",
+    "--scope",
+    "tenant/a",
+    "--guard-timestamp",
+    "123",
+    "--guard-loc-class",
+    "public",
+    "--guard-risk",
+    "69",
+    NULL,
+  };
+  gchar *missing_timestamp_argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "--daemon-url",
+    "http://127.0.0.1:1",
+    "policy",
+    "role-grant",
+    "--subject",
+    "alice",
+    "--role",
+    "wr.audit.reader",
+    "--scope",
+    "tenant/a",
+    "--access-token-file",
+    token_path,
+    "--guard-loc-class",
+    "public",
+    "--guard-risk",
+    "69",
+    NULL,
+  };
+  gchar *invalid_loc_argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "--daemon-url",
+    "http://127.0.0.1:1",
+    "policy",
+    "role-grant",
+    "--subject",
+    "alice",
+    "--role",
+    "wr.audit.reader",
+    "--scope",
+    "tenant/a",
+    "--access-token-file",
+    token_path,
+    "--guard-timestamp",
+    "123",
+    "--guard-loc-class",
+    "unknown",
+    "--guard-risk",
+    "69",
+    NULL,
+  };
+  gchar *invalid_risk_argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "--daemon-url",
+    "http://127.0.0.1:1",
+    "policy",
+    "role-grant",
+    "--subject",
+    "alice",
+    "--role",
+    "wr.audit.reader",
+    "--scope",
+    "tenant/a",
+    "--access-token-file",
+    token_path,
+    "--guard-timestamp",
+    "123",
+    "--guard-loc-class",
+    "public",
+    "--guard-risk",
+    "101",
+    NULL,
+  };
+  gchar *missing_daemon_argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "policy",
+    "role-grant",
+    "--subject",
+    "alice",
+    "--role",
+    "wr.audit.reader",
+    "--scope",
+    "tenant/a",
+    "--access-token-file",
+    token_path,
+    "--guard-timestamp",
+    "123",
+    "--guard-loc-class",
+    "public",
+    "--guard-risk",
+    "69",
+    NULL,
+  };
+  g_autofree gchar *stdout_buf = NULL;
+  g_autofree gchar *stderr_buf = NULL;
+  gint wait_status = 0;
+
+  run_child (missing_subject_argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_assert_false (wait_status_is_success (wait_status));
+  g_assert_cmpstr (stdout_buf, ==, "");
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1, "wyctl: missing --subject"));
+
+  g_clear_pointer (&stdout_buf, g_free);
+  g_clear_pointer (&stderr_buf, g_free);
+  run_child (missing_role_argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_assert_false (wait_status_is_success (wait_status));
+  g_assert_cmpstr (stdout_buf, ==, "");
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1, "wyctl: missing --role"));
+
+  g_clear_pointer (&stdout_buf, g_free);
+  g_clear_pointer (&stderr_buf, g_free);
+  run_child (missing_scope_argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_assert_false (wait_status_is_success (wait_status));
+  g_assert_cmpstr (stdout_buf, ==, "");
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1, "wyctl: missing --scope"));
+
+  g_clear_pointer (&stdout_buf, g_free);
+  g_clear_pointer (&stderr_buf, g_free);
+  run_child (missing_token_argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_assert_false (wait_status_is_success (wait_status));
+  g_assert_cmpstr (stdout_buf, ==, "");
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1,
+          "wyctl: missing --access-token-file"));
+
+  g_clear_pointer (&stdout_buf, g_free);
+  g_clear_pointer (&stderr_buf, g_free);
+  run_child (missing_timestamp_argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_assert_false (wait_status_is_success (wait_status));
+  g_assert_cmpstr (stdout_buf, ==, "");
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1,
+          "wyctl: invalid --guard-timestamp"));
+
+  g_clear_pointer (&stdout_buf, g_free);
+  g_clear_pointer (&stderr_buf, g_free);
+  run_child (invalid_loc_argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_assert_false (wait_status_is_success (wait_status));
+  g_assert_cmpstr (stdout_buf, ==, "");
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1,
+          "wyctl: invalid --guard-loc-class"));
+
+  g_clear_pointer (&stdout_buf, g_free);
+  g_clear_pointer (&stderr_buf, g_free);
+  run_child (invalid_risk_argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_assert_false (wait_status_is_success (wait_status));
+  g_assert_cmpstr (stdout_buf, ==, "");
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1,
+          "wyctl: invalid --guard-risk"));
+
+  g_clear_pointer (&stdout_buf, g_free);
+  g_clear_pointer (&stderr_buf, g_free);
+  run_child (missing_daemon_argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_assert_false (wait_status_is_success (wait_status));
+  g_assert_cmpstr (stdout_buf, ==, "");
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1, "wyctl: missing daemon URL"));
+
+  g_unlink (token_path);
+}
+
 int
 main (int argc, char **argv)
 {
@@ -1792,6 +2267,17 @@ main (int argc, char **argv)
       test_policy_permission_grant_status_errors);
   g_test_add_func ("/wyctl/policy-permission-revoke-status-errors",
       test_policy_permission_revoke_status_errors);
+  g_test_add_func ("/wyctl/policy-role-help", test_policy_role_help);
+  g_test_add_func ("/wyctl/policy-role-validation",
+      test_policy_role_validation);
+  g_test_add_func ("/wyctl/policy-role-grant-success",
+      test_policy_role_grant_success);
+  g_test_add_func ("/wyctl/policy-role-revoke-success",
+      test_policy_role_revoke_success);
+  g_test_add_func ("/wyctl/policy-role-grant-status-errors",
+      test_policy_role_grant_status_errors);
+  g_test_add_func ("/wyctl/policy-role-revoke-status-errors",
+      test_policy_role_revoke_status_errors);
   g_test_add_func ("/wyctl/audit-help", test_audit_help);
   g_test_add_func ("/wyctl/audit-validation", test_audit_validation);
   g_test_add_func ("/wyctl/audit-query", test_audit_query);

--- a/tests/test-wyctl-policy-daemon.c
+++ b/tests/test-wyctl-policy-daemon.c
@@ -1,0 +1,280 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+/*
+ * Drives wyctl as a child process against a wyrelogd HTTP server booted
+ * in-process. The four mutation subcommands (permission-grant,
+ * permission-revoke, role-grant, role-revoke) need a privileged
+ * operator on the policy-write / role-grant authorities, which the
+ * daemon CLI does not expose. The in-process pattern from
+ * test-daemon-http-decide is reused here: seed the admin via the
+ * library helpers, write its access token to a temp file, then exec
+ * wyctl with the documented flags and assert ok output.
+ */
+#include <glib.h>
+#include <glib/gstdio.h>
+#include <gio/gio.h>
+#include <string.h>
+#include <sys/wait.h>
+
+#include "daemon/delta.h"
+#include "daemon/http.h"
+#include "wyrelog/client.h"
+#include "wyrelog/policy/store-private.h"
+#include "wyrelog/wyl-handle-private.h"
+
+#ifndef WYL_TEST_TEMPLATE_DIR
+#error "WYL_TEST_TEMPLATE_DIR must be defined by the build."
+#endif
+
+#ifndef WYL_TEST_WYCTL_PATH
+#error "WYL_TEST_WYCTL_PATH must be defined by the build."
+#endif
+
+typedef struct
+{
+  SoupServer *server;
+  GMainLoop *loop;
+} TestHttpServer;
+
+static gpointer
+test_http_server_thread (gpointer data)
+{
+  TestHttpServer *http = data;
+
+  g_main_loop_run (http->loop);
+  return NULL;
+}
+
+static wyrelog_error_t
+grant_policy_write_authority (WylHandle *handle, const gchar *subject,
+    const gchar *scope)
+{
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  wyrelog_error_t rc = wyl_policy_store_grant_direct_permission (store, subject,
+      "wr.policy.write", scope);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_policy_store_set_session_state (store, scope, "active");
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_reload_engine_pair (handle);
+}
+
+static wyrelog_error_t
+grant_policy_role_authority (WylHandle *handle, const gchar *subject,
+    const gchar *scope)
+{
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  wyrelog_error_t rc = wyl_policy_store_grant_direct_permission (store, subject,
+      "wr.policy.grant_role", scope);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_policy_store_set_session_state (store, scope, "active");
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_reload_engine_pair (handle);
+}
+
+static gchar *
+write_token_file (const gchar *token)
+{
+  g_autoptr (GError) error = NULL;
+  gchar *token_path = NULL;
+  gint fd = g_file_open_tmp ("wyctl-policy-daemon-token-XXXXXX", &token_path,
+      &error);
+  g_assert_no_error (error);
+  g_assert_cmpint (fd, >=, 0);
+  g_assert_true (g_close (fd, NULL));
+  g_assert_true (g_file_set_contents (token_path, token, -1, &error));
+  g_assert_no_error (error);
+  return token_path;
+}
+
+static void
+run_wyctl (gchar **argv, gchar **stdout_buf, gchar **stderr_buf,
+    gint *wait_status)
+{
+  g_autoptr (GError) error = NULL;
+  g_assert_true (g_spawn_sync (NULL, argv, NULL, G_SPAWN_DEFAULT, NULL, NULL,
+          stdout_buf, stderr_buf, wait_status, &error));
+  g_assert_no_error (error);
+}
+
+static void
+assert_wyctl_ok (gchar **argv)
+{
+  g_autofree gchar *stdout_buf = NULL;
+  g_autofree gchar *stderr_buf = NULL;
+  gint wait_status = 0;
+  g_autoptr (GError) error = NULL;
+
+  run_wyctl (argv, &stdout_buf, &stderr_buf, &wait_status);
+
+  if (!g_spawn_check_wait_status (wait_status, &error)) {
+    g_printerr ("wyctl exited with status %d\nstdout: %s\nstderr: %s\n",
+        wait_status, stdout_buf ? stdout_buf : "(null)",
+        stderr_buf ? stderr_buf : "(null)");
+    g_clear_error (&error);
+    g_assert_not_reached ();
+  }
+  g_assert_cmpstr (stdout_buf, ==, "ok\n");
+  g_assert_cmpstr (stderr_buf, ==, "");
+}
+
+int
+main (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 1;
+
+  WylDaemonOptions opts = {
+    .template_dir = WYL_TEST_TEMPLATE_DIR,
+    .listen_port = 0,
+  };
+  WylDaemonRuntime runtime = {
+    .handle = handle,
+  };
+  if (wyl_daemon_start_delta_callbacks (handle, &runtime) != WYRELOG_E_OK)
+    return 2;
+
+  TestHttpServer http = { 0 };
+  http.loop = g_main_loop_new (NULL, FALSE);
+  g_autoptr (GError) error = NULL;
+  http.server = wyl_daemon_start_http_server_with_runtime (&opts, handle,
+      &runtime, &error);
+  if (http.server == NULL)
+    return 3;
+  GThread *thread = g_thread_new ("wyctl-policy-daemon",
+      test_http_server_thread, &http);
+
+  GSList *uris = soup_server_get_uris (http.server);
+  if (uris == NULL)
+    return 4;
+  g_autofree gchar *base_url = g_uri_to_string (uris->data);
+  g_slist_free_full (uris, (GDestroyNotify) g_uri_unref);
+
+  /* Login an operator with skip-mfa so we get a bearer access token, then
+   * grant it both authorities the daemon mutation handlers require:
+   * wr.policy.write for the permission grant/revoke handlers and
+   * wr.policy.grant_role for the role grant/revoke handlers. */
+  g_autoptr (WylClient) admin_client = NULL;
+  if (wyl_client_new (base_url, &admin_client) != WYRELOG_E_OK)
+    return 5;
+  wyl_handle_set_login_skip_mfa_allowed (handle, TRUE);
+  if (wyl_client_login_skip_mfa (admin_client, "wyctl-policy-admin")
+      != WYRELOG_E_OK) {
+    wyl_handle_set_login_skip_mfa_allowed (handle, FALSE);
+    return 6;
+  }
+  wyl_handle_set_login_skip_mfa_allowed (handle, FALSE);
+
+  g_autofree gchar *access_token = wyl_client_dup_access_token (admin_client);
+  if (access_token == NULL)
+    return 7;
+
+  if (grant_policy_write_authority (handle, "wyctl-policy-admin", "tenant-x")
+      != WYRELOG_E_OK)
+    return 8;
+  if (grant_policy_role_authority (handle, "wyctl-policy-admin", "tenant-x")
+      != WYRELOG_E_OK)
+    return 9;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (wyl_policy_store_upsert_permission (store, "site.wyctl.read",
+          "site wyctl read", "basic") != WYRELOG_E_OK)
+    return 10;
+  if (wyl_policy_store_upsert_role (store, "site.wyctl.reader",
+          "site wyctl reader") != WYRELOG_E_OK)
+    return 11;
+
+  g_autofree gchar *token_path = write_token_file (access_token);
+
+  /* Each mutation drives wyctl as a child against the in-process daemon. The
+   * scope parameter (tenant-x) matches the authority granted above; the
+   * guard-* triple is well below the deny threshold (loc=public, risk<=29
+   * for role, risk<=49 for permission per templates). */
+  gchar *permission_grant_argv[] = {
+    (gchar *) WYL_TEST_WYCTL_PATH,
+    "--daemon-url", (gchar *) base_url,
+    "policy", "permission-grant",
+    "--subject", "wyctl-target",
+    "--perm", "site.wyctl.read",
+    "--scope", "tenant-x",
+    "--access-token-file", token_path,
+    "--guard-timestamp", "123",
+    "--guard-loc-class", "public",
+    "--guard-risk", "29",
+    NULL,
+  };
+  assert_wyctl_ok (permission_grant_argv);
+  gboolean exists = FALSE;
+  if (wyl_policy_store_direct_permission_exists (store, "wyctl-target",
+          "site.wyctl.read", "tenant-x", &exists) != WYRELOG_E_OK || !exists)
+    return 12;
+
+  gchar *permission_revoke_argv[] = {
+    (gchar *) WYL_TEST_WYCTL_PATH,
+    "--daemon-url", (gchar *) base_url,
+    "policy", "permission-revoke",
+    "--subject", "wyctl-target",
+    "--perm", "site.wyctl.read",
+    "--scope", "tenant-x",
+    "--access-token-file", token_path,
+    "--guard-timestamp", "123",
+    "--guard-loc-class", "public",
+    "--guard-risk", "29",
+    NULL,
+  };
+  assert_wyctl_ok (permission_revoke_argv);
+  exists = TRUE;
+  if (wyl_policy_store_direct_permission_exists (store, "wyctl-target",
+          "site.wyctl.read", "tenant-x", &exists) != WYRELOG_E_OK || exists)
+    return 13;
+
+  gchar *role_grant_argv[] = {
+    (gchar *) WYL_TEST_WYCTL_PATH,
+    "--daemon-url", (gchar *) base_url,
+    "policy", "role-grant",
+    "--subject", "wyctl-target",
+    "--role", "site.wyctl.reader",
+    "--scope", "tenant-x",
+    "--access-token-file", token_path,
+    "--guard-timestamp", "123",
+    "--guard-loc-class", "public",
+    "--guard-risk", "29",
+    NULL,
+  };
+  assert_wyctl_ok (role_grant_argv);
+  exists = FALSE;
+  if (wyl_policy_store_role_membership_exists (store, "wyctl-target",
+          "site.wyctl.reader", "tenant-x", &exists) != WYRELOG_E_OK || !exists)
+    return 14;
+
+  gchar *role_revoke_argv[] = {
+    (gchar *) WYL_TEST_WYCTL_PATH,
+    "--daemon-url", (gchar *) base_url,
+    "policy", "role-revoke",
+    "--subject", "wyctl-target",
+    "--role", "site.wyctl.reader",
+    "--scope", "tenant-x",
+    "--access-token-file", token_path,
+    "--guard-timestamp", "123",
+    "--guard-loc-class", "public",
+    "--guard-risk", "29",
+    NULL,
+  };
+  assert_wyctl_ok (role_revoke_argv);
+  exists = TRUE;
+  if (wyl_policy_store_role_membership_exists (store, "wyctl-target",
+          "site.wyctl.reader", "tenant-x", &exists) != WYRELOG_E_OK || exists)
+    return 15;
+
+  g_unlink (token_path);
+
+  g_main_loop_quit (http.loop);
+  g_thread_join (thread);
+  soup_server_disconnect (http.server);
+  g_clear_object (&http.server);
+  g_clear_pointer (&http.loop, g_main_loop_unref);
+  return 0;
+}

--- a/wyrelog/wyctl/wyctl.c
+++ b/wyrelog/wyctl/wyctl.c
@@ -49,6 +49,17 @@ typedef struct
   gchar *guard_risk_arg;
 } WyctlPolicyPermissionOptions;
 
+typedef struct
+{
+  gchar *subject;
+  gchar *role;
+  gchar *scope;
+  gchar *access_token_file;
+  gchar *guard_timestamp_arg;
+  gchar *guard_loc_class;
+  gchar *guard_risk_arg;
+} WyctlPolicyRoleOptions;
+
 #define WYCTL_DEFAULT_TIMEOUT_MS 2000
 #define WYCTL_MAX_TIMEOUT_MS 60000
 #define WYCTL_AUDIT_DEFAULT_LIMIT 100
@@ -835,6 +846,133 @@ run_policy_permission_mutation_command (const WyctlOptions *global_opts,
 }
 
 static int
+run_policy_role_mutation_command (const WyctlOptions *global_opts,
+    const gchar *command, gint argc, gchar **argv)
+{
+  WyctlPolicyRoleOptions opts = { 0 };
+  GOptionEntry entries[] = {
+    {"subject", 0, 0, G_OPTION_ARG_STRING, &opts.subject,
+        "Mutation subject", "SUBJECT_ID"},
+    {"role", 0, 0, G_OPTION_ARG_STRING, &opts.role,
+        "Mutation role", "ROLE_ID"},
+    {"scope", 0, 0, G_OPTION_ARG_STRING, &opts.scope,
+        "Mutation scope", "SCOPE_ID"},
+    {"access-token-file", 0, 0, G_OPTION_ARG_STRING, &opts.access_token_file,
+        "Bearer access token file", "PATH"},
+    {"guard-timestamp", 0, 0, G_OPTION_ARG_STRING,
+        &opts.guard_timestamp_arg, "Guard timestamp", "US"},
+    {"guard-loc-class", 0, 0, G_OPTION_ARG_STRING, &opts.guard_loc_class,
+        "Guard location class", "CLASS"},
+    {"guard-risk", 0, 0, G_OPTION_ARG_STRING, &opts.guard_risk_arg,
+        "Guard risk score", "N"},
+    {NULL}
+  };
+  g_autoptr (GError) error = NULL;
+  g_autofree gchar *summary = g_strdup_printf ("- wyrelog policy %s", command);
+  g_autoptr (GOptionContext) context = g_option_context_new (summary);
+  g_option_context_add_main_entries (context, entries, NULL);
+
+  if (!g_option_context_parse (context, &argc, &argv, &error)) {
+    g_printerr ("wyctl: %s\n", error->message);
+    return 2;
+  }
+  if (argc > 1) {
+    g_printerr ("wyctl: unexpected policy %s argument: %s\n", command, argv[1]);
+    return 2;
+  }
+
+  if (opts.subject == NULL || opts.subject[0] == '\0') {
+    g_printerr ("wyctl: missing --subject\n");
+    return 2;
+  }
+  if (opts.role == NULL || opts.role[0] == '\0') {
+    g_printerr ("wyctl: missing --role\n");
+    return 2;
+  }
+  if (opts.scope == NULL || opts.scope[0] == '\0') {
+    g_printerr ("wyctl: missing --scope\n");
+    return 2;
+  }
+
+  if (global_opts->daemon_url == NULL || global_opts->daemon_url[0] == '\0') {
+    g_printerr ("wyctl: missing daemon URL\n");
+    return 2;
+  }
+  if (!daemon_url_is_valid (global_opts->daemon_url)) {
+    g_printerr ("wyctl: invalid daemon URL\n");
+    return 2;
+  }
+
+  guint timeout_ms = 0;
+  if (!parse_timeout_ms (global_opts->timeout_ms_arg, &timeout_ms)) {
+    g_printerr ("wyctl: invalid timeout\n");
+    return 2;
+  }
+
+  gint64 guard_timestamp = 0;
+  if (!parse_nonnegative_int64 (opts.guard_timestamp_arg, &guard_timestamp)) {
+    g_printerr ("wyctl: invalid --guard-timestamp\n");
+    return 2;
+  }
+  if (opts.guard_loc_class == NULL ||
+      !wyl_guard_loc_class_is_valid (opts.guard_loc_class)) {
+    g_printerr ("wyctl: invalid --guard-loc-class\n");
+    return 2;
+  }
+  gint64 guard_risk = 0;
+  if (!parse_nonnegative_int64 (opts.guard_risk_arg, &guard_risk) ||
+      guard_risk > 100) {
+    g_printerr ("wyctl: invalid --guard-risk\n");
+    return 2;
+  }
+
+  g_autofree gchar *access_token = NULL;
+  int token_rc = load_access_token_file (opts.access_token_file, &access_token);
+  if (token_rc != 0)
+    return token_rc;
+
+  g_autoptr (WylClient) client = NULL;
+  if (wyl_client_new (global_opts->daemon_url, &client) != WYRELOG_E_OK ||
+      wyl_client_set_bearer_credentials (client, access_token,
+          WYL_TENANT_DEFAULT) != WYRELOG_E_OK) {
+    g_printerr ("wyctl: invalid policy credentials\n");
+    return 2;
+  }
+  wyl_client_set_timeout_ms (client, timeout_ms);
+
+  wyrelog_error_t rc = WYRELOG_E_INVALID;
+  if (g_strcmp0 (command, "role-grant") == 0) {
+    rc = wyl_client_policy_role_grant (client, opts.subject, opts.role,
+        opts.scope, guard_timestamp, opts.guard_loc_class, guard_risk);
+  } else if (g_strcmp0 (command, "role-revoke") == 0) {
+    rc = wyl_client_policy_role_revoke (client, opts.subject, opts.role,
+        opts.scope, guard_timestamp, opts.guard_loc_class, guard_risk);
+  } else {
+    g_printerr ("wyctl: policy %s is not implemented\n", command);
+    return 3;
+  }
+
+  if (rc == WYRELOG_E_OK) {
+    g_print ("ok\n");
+    return 0;
+  }
+  if (rc == WYRELOG_E_INVALID) {
+    g_printerr ("wyctl: policy %s failed: invalid_policy_mutation\n", command);
+    return 3;
+  }
+  if (rc == WYRELOG_E_AUTH) {
+    g_printerr ("wyctl: policy %s failed: policy_auth_required\n", command);
+    return 6;
+  }
+  if (rc == WYRELOG_E_POLICY) {
+    g_printerr ("wyctl: policy %s failed: policy_mutation_denied\n", command);
+    return 4;
+  }
+  g_printerr ("wyctl: policy %s failed: policy_mutation_failed\n", command);
+  return 5;
+}
+
+static int
 run_policy (const WyctlOptions *global_opts, gint argc, gchar **argv)
 {
   if (argc < 2) {
@@ -848,6 +986,10 @@ run_policy (const WyctlOptions *global_opts, gint argc, gchar **argv)
   if (g_strcmp0 (argv[1], "permission-grant") == 0 ||
       g_strcmp0 (argv[1], "permission-revoke") == 0)
     return run_policy_permission_mutation_command (global_opts, argv[1],
+        argc - 1, argv + 1);
+  if (g_strcmp0 (argv[1], "role-grant") == 0 ||
+      g_strcmp0 (argv[1], "role-revoke") == 0)
+    return run_policy_role_mutation_command (global_opts, argv[1],
         argc - 1, argv + 1);
 
   g_printerr ("wyctl: unknown policy command: %s\n", argv[1]);

--- a/wyrelog/wyctl/wyctl.c
+++ b/wyrelog/wyctl/wyctl.c
@@ -38,6 +38,17 @@ typedef struct
   gchar *guard_risk_arg;
 } WyctlAuditOptions;
 
+typedef struct
+{
+  gchar *subject;
+  gchar *perm;
+  gchar *scope;
+  gchar *access_token_file;
+  gchar *guard_timestamp_arg;
+  gchar *guard_loc_class;
+  gchar *guard_risk_arg;
+} WyctlPolicyPermissionOptions;
+
 #define WYCTL_DEFAULT_TIMEOUT_MS 2000
 #define WYCTL_MAX_TIMEOUT_MS 60000
 #define WYCTL_AUDIT_DEFAULT_LIMIT 100
@@ -697,6 +708,133 @@ run_policy_decision_command (const WyctlOptions *global_opts,
 }
 
 static int
+run_policy_permission_mutation_command (const WyctlOptions *global_opts,
+    const gchar *command, gint argc, gchar **argv)
+{
+  WyctlPolicyPermissionOptions opts = { 0 };
+  GOptionEntry entries[] = {
+    {"subject", 0, 0, G_OPTION_ARG_STRING, &opts.subject,
+        "Mutation subject", "SUBJECT_ID"},
+    {"perm", 0, 0, G_OPTION_ARG_STRING, &opts.perm,
+        "Mutation permission", "PERMISSION_ID"},
+    {"scope", 0, 0, G_OPTION_ARG_STRING, &opts.scope,
+        "Mutation scope", "SCOPE_ID"},
+    {"access-token-file", 0, 0, G_OPTION_ARG_STRING, &opts.access_token_file,
+        "Bearer access token file", "PATH"},
+    {"guard-timestamp", 0, 0, G_OPTION_ARG_STRING,
+        &opts.guard_timestamp_arg, "Guard timestamp", "US"},
+    {"guard-loc-class", 0, 0, G_OPTION_ARG_STRING, &opts.guard_loc_class,
+        "Guard location class", "CLASS"},
+    {"guard-risk", 0, 0, G_OPTION_ARG_STRING, &opts.guard_risk_arg,
+        "Guard risk score", "N"},
+    {NULL}
+  };
+  g_autoptr (GError) error = NULL;
+  g_autofree gchar *summary = g_strdup_printf ("- wyrelog policy %s", command);
+  g_autoptr (GOptionContext) context = g_option_context_new (summary);
+  g_option_context_add_main_entries (context, entries, NULL);
+
+  if (!g_option_context_parse (context, &argc, &argv, &error)) {
+    g_printerr ("wyctl: %s\n", error->message);
+    return 2;
+  }
+  if (argc > 1) {
+    g_printerr ("wyctl: unexpected policy %s argument: %s\n", command, argv[1]);
+    return 2;
+  }
+
+  if (opts.subject == NULL || opts.subject[0] == '\0') {
+    g_printerr ("wyctl: missing --subject\n");
+    return 2;
+  }
+  if (opts.perm == NULL || opts.perm[0] == '\0') {
+    g_printerr ("wyctl: missing --perm\n");
+    return 2;
+  }
+  if (opts.scope == NULL || opts.scope[0] == '\0') {
+    g_printerr ("wyctl: missing --scope\n");
+    return 2;
+  }
+
+  if (global_opts->daemon_url == NULL || global_opts->daemon_url[0] == '\0') {
+    g_printerr ("wyctl: missing daemon URL\n");
+    return 2;
+  }
+  if (!daemon_url_is_valid (global_opts->daemon_url)) {
+    g_printerr ("wyctl: invalid daemon URL\n");
+    return 2;
+  }
+
+  guint timeout_ms = 0;
+  if (!parse_timeout_ms (global_opts->timeout_ms_arg, &timeout_ms)) {
+    g_printerr ("wyctl: invalid timeout\n");
+    return 2;
+  }
+
+  gint64 guard_timestamp = 0;
+  if (!parse_nonnegative_int64 (opts.guard_timestamp_arg, &guard_timestamp)) {
+    g_printerr ("wyctl: invalid --guard-timestamp\n");
+    return 2;
+  }
+  if (opts.guard_loc_class == NULL ||
+      !wyl_guard_loc_class_is_valid (opts.guard_loc_class)) {
+    g_printerr ("wyctl: invalid --guard-loc-class\n");
+    return 2;
+  }
+  gint64 guard_risk = 0;
+  if (!parse_nonnegative_int64 (opts.guard_risk_arg, &guard_risk) ||
+      guard_risk > 100) {
+    g_printerr ("wyctl: invalid --guard-risk\n");
+    return 2;
+  }
+
+  g_autofree gchar *access_token = NULL;
+  int token_rc = load_access_token_file (opts.access_token_file, &access_token);
+  if (token_rc != 0)
+    return token_rc;
+
+  g_autoptr (WylClient) client = NULL;
+  if (wyl_client_new (global_opts->daemon_url, &client) != WYRELOG_E_OK ||
+      wyl_client_set_bearer_credentials (client, access_token,
+          WYL_TENANT_DEFAULT) != WYRELOG_E_OK) {
+    g_printerr ("wyctl: invalid policy credentials\n");
+    return 2;
+  }
+  wyl_client_set_timeout_ms (client, timeout_ms);
+
+  wyrelog_error_t rc = WYRELOG_E_INVALID;
+  if (g_strcmp0 (command, "permission-grant") == 0) {
+    rc = wyl_client_policy_permission_grant (client, opts.subject, opts.perm,
+        opts.scope, guard_timestamp, opts.guard_loc_class, guard_risk);
+  } else if (g_strcmp0 (command, "permission-revoke") == 0) {
+    rc = wyl_client_policy_permission_revoke (client, opts.subject, opts.perm,
+        opts.scope, guard_timestamp, opts.guard_loc_class, guard_risk);
+  } else {
+    g_printerr ("wyctl: policy %s is not implemented\n", command);
+    return 3;
+  }
+
+  if (rc == WYRELOG_E_OK) {
+    g_print ("ok\n");
+    return 0;
+  }
+  if (rc == WYRELOG_E_INVALID) {
+    g_printerr ("wyctl: policy %s failed: invalid_policy_mutation\n", command);
+    return 3;
+  }
+  if (rc == WYRELOG_E_AUTH) {
+    g_printerr ("wyctl: policy %s failed: policy_auth_required\n", command);
+    return 6;
+  }
+  if (rc == WYRELOG_E_POLICY) {
+    g_printerr ("wyctl: policy %s failed: policy_mutation_denied\n", command);
+    return 4;
+  }
+  g_printerr ("wyctl: policy %s failed: policy_mutation_failed\n", command);
+  return 5;
+}
+
+static int
 run_policy (const WyctlOptions *global_opts, gint argc, gchar **argv)
 {
   if (argc < 2) {
@@ -707,6 +845,10 @@ run_policy (const WyctlOptions *global_opts, gint argc, gchar **argv)
   if (g_strcmp0 (argv[1], "check") == 0 || g_strcmp0 (argv[1], "explain") == 0)
     return run_policy_decision_command (global_opts, argv[1], argc - 1,
         argv + 1);
+  if (g_strcmp0 (argv[1], "permission-grant") == 0 ||
+      g_strcmp0 (argv[1], "permission-revoke") == 0)
+    return run_policy_permission_mutation_command (global_opts, argv[1],
+        argc - 1, argv + 1);
 
   g_printerr ("wyctl: unknown policy command: %s\n", argv[1]);
   return 2;

--- a/wyrelog/wyl-client.c
+++ b/wyrelog/wyl-client.c
@@ -427,10 +427,12 @@ client_policy_mutation_request (WylClient *client, const gchar *path,
     return WYRELOG_E_INVALID;
 
   g_autofree gchar *session_token = wyl_client_dup_session_token (client);
-  if (session_token == NULL || session_token[0] == '\0')
-    return WYRELOG_E_INVALID;
   g_autofree gchar *access_token = wyl_client_dup_access_token (client);
-  gboolean use_access_token = access_token != NULL && access_token[0] != '\0';
+  gboolean has_session = session_token != NULL && session_token[0] != '\0';
+  gboolean has_access = access_token != NULL && access_token[0] != '\0';
+  if (!has_session && !has_access)
+    return WYRELOG_E_INVALID;
+  gboolean use_access_token = has_access;
   g_autofree gchar *tenant = wyl_client_dup_tenant (client);
   if (tenant == NULL || tenant[0] == '\0')
     return WYRELOG_E_INVALID;


### PR DESCRIPTION
## Summary

Closes the LoBAC operator workflow gap on the wyctl side. Before this series, `wyctl policy check` and `wyctl policy explain` were the only policy verbs the CLI dispatched; any other verb hit `wyctl: unknown policy command`. The daemon HTTP routes (`/policy/permissions/{grant,revoke}`, `/policy/roles/{grant,revoke}`) and the public client helpers (`wyl_client_policy_permission_grant`/`_revoke`/`_role_grant`/`_role_revoke`) already existed but had no operator-facing entry point. This PR wires the four mutation subcommands with a frozen output and exit-code contract, fixes a client-helper bug that prevented bearer-only credentials, and lands an in-process integration test that drives the new wyctl commands against a live daemon.

## Series shape

Four atomic commits:

1. **`client: accept bearer-only credentials for policy mutation calls`** — the static helper `client_policy_mutation_request` short-circuited at the session_token guard before reaching the bearer URI-build branch, so callers that had only run `wyl_client_set_bearer_credentials` saw `WYRELOG_E_INVALID`. Replace the unconditional reject with a session-or-access guard. Adds a `tests/test-client-smoke.c` regression that drives all five mutation flavors with bearer-only credentials.

2. **`wyctl: add policy permission-grant and permission-revoke subcommands`** — wires the two subcommands through `run_policy`. Required flags: `--subject`, `--perm`, `--scope`, `--access-token-file`, `--guard-timestamp`, `--guard-loc-class`, `--guard-risk`. NO `--tenant` (v0 single-tenant per #273), NO inline `--access-token` (file-only, prevents process-listing leak). Frozen output: stdout `ok\n` exit 0; failure stderr `wyctl: policy <cmd> failed: <stable_code>` with exit codes 3/4/5/6 mapped from `WYRELOG_E_INVALID`/`POLICY`/`IO`/`AUTH`. Argument validation exits 2. NO client-side retry on 500. Tests cover help, validation, success path, and status-error mapping against a loopback HTTP server.

3. **`wyctl: add policy role-grant and role-revoke subcommands`** — mirrors C2's pattern with `--role` replacing `--perm`, routing to `wyl_client_policy_role_grant`/`_revoke`. Symmetrizes the C2 permission-revoke help-test assertions to match the grant block (full 7-flag inventory + `--tenant`/`--access-token` negatives) and adds the same coverage shape for role-grant/revoke.

4. **`tests: integrate wyctl policy mutations against an in-process daemon`** — a black-box shell driver was infeasible because `wyrelogd` has no CLI affordance to seed a privileged operator (skip-MFA login is gated by an in-process flag, no `member_of` facts in `bootstrap.dl`, the only path to grant `wr.policy.write` is the in-process helper). C4 instead boots an in-process daemon via `wyl_daemon_start_http_server_with_runtime`, performs a skip-MFA login to mint a real bearer access token, grants `wr.policy.write` and `wr.policy.grant_role` through the in-process policy-store helpers, and execs `wyctl` as a subprocess for each of the four mutation commands, asserting exit 0 + stdout `ok` + empty stderr.

## Acceptance criteria coverage (issue #274)

| Criterion | Closed by |
|---|---|
| permission-grant/revoke call daemon mutation API with subject/perm/scope/guard | C2 |
| role-grant/revoke call daemon role membership API | C3 |
| Bearer-token input consistent with policy check/explain | C2/C3 (`--access-token-file`); C1 unblocks the helper |
| Stable success/failure messages for scripts | C2/C3 (frozen contract: `ok\n` / `<stable_code>` exit 3/4/5/6) |
| Tests cover argument validation, request URI/body, bearer auth, daemon integration | C2/C3 unit-level + C4 in-process integration |

## v0 contract decisions

- **Hyphenated flat subcommands**: `permission-grant`, `permission-revoke`, `role-grant`, `role-revoke`. Flat `argv[1]` dispatch, no nested verb tree.
- **Required flags**: every flag listed above is mandatory; missing flags exit 2 with `wyctl: missing --<flag>`.
- **Bearer-only**: `--access-token-file` required, no inline `--access-token`, no fallback to URL-borne `session_token`.
- **No `--tenant`**: single-tenant v0 per just-merged #273; daemon rejects anything other than the canonical default.
- **No `permission-transition`**: separate follow-up issue; the public client helper exists but the issue body did not require it.

## Build matrix

- `meson setup` (default): clean.
- `meson setup -Denable_break_glass=true -Denable_audit=enabled`: clean.
- Both matrices pass the full wyrelog suite. The new `wyctl-policy-daemon` test runs in both.

## Test plan

- [x] `meson test -C builddir --suite wyrelog`: green on every C1–C4 commit.
- [x] `meson test -C /tmp/wy-bg-on --suite wyrelog`: green.
- [x] `tools/check-public-headers-no-novelty-tokens.sh`: clean across the series.
- [x] `./tools/gst-indent` clean on every changed C/H file.
- [x] `wyctl-policy-daemon` integration test: passes (~2s) on both matrices.
- [ ] CI on this PR.

## Out of scope (tracked for follow-up)

- `wyctl policy permission-transition` subcommand (the public client helper exists; not required by AC).
- A narrowly-scoped daemon test-seed mechanism (e.g., `--seed-policy-admin USER` flag) that would enable a black-box shell integration driver in addition to the current in-process C test.
- Process-substitution / FIFO support for `--access-token-file`; today the file must be a regular file.

Closes #274