### PR TITLE
ci: exclude subprojects and builddir from CodeQL

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -3,3 +3,6 @@ name: Wyrelog CodeQL
 paths:
   - tests
   - wyrelog
+paths-ignore:
+  - subprojects/**
+  - builddir/**


### PR DESCRIPTION
## Summary

- Add `paths-ignore` to `.github/codeql/codeql-config.yml` so CodeQL alerts no longer surface from `subprojects/**` (vendored wirelog, libchronoid, DuckDB) or `builddir/**` (generated artifacts).
- The existing allowlist (`paths: [tests, wyrelog]`) is retained for first-party scope.

## Why

CodeQL's `paths` filter for compiled languages classifies results based on what the build invokes, not on directory traversal. Meson builds the wirelog, libchronoid, and DuckDB subprojects in-tree, so their .c files appear in Security tab alerts even though they are upstream code we vendor unchanged. Explicit `paths-ignore` filters those out post-analysis.

## Test plan

- [ ] CodeQL workflow runs on push and reports no alerts under `subprojects/` or `builddir/`
- [ ] First-party paths under `wyrelog/` and `tests/` continue to be scanned