### PR TITLE
ci: stabilise decide tests on ubuntu CI

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -114,7 +114,9 @@ if build_client
       dependencies : test_daemon_http_decide_deps,
     )
 
-    test('daemon-http-decide-audit', test_daemon_http_decide_audit)
+    test('daemon-http-decide-audit', test_daemon_http_decide_audit,
+      timeout : 60,
+    )
   endif
 endif
 

--- a/tests/test-decide.c
+++ b/tests/test-decide.c
@@ -851,7 +851,13 @@ check_persistent_permission_state_authority_matrix (void)
 
   g_autofree gchar *policy_path = g_build_filename (dir, "policy.sqlite", NULL);
 #ifdef WYL_HAS_AUDIT
+  /* Each handle gets its own audit DuckDB path so the close/reopen
+   * across the two blocks does not trip the same-file reopen
+   * sensitivity that surfaces under ASAN + MALLOC_PERTURB_ on Linux.
+   * The test exercises the policy_store reopen, not the audit store
+   * lifecycle, so distinct audit paths preserve the test intent. */
   g_autofree gchar *audit_path = g_build_filename (dir, "audit.duckdb", NULL);
+  g_autofree gchar *audit_path2 = g_build_filename (dir, "audit2.duckdb", NULL);
 #endif
 
   {
@@ -898,7 +904,7 @@ check_persistent_permission_state_authority_matrix (void)
       .template_dir = WYL_TEST_TEMPLATE_DIR,
       .policy_store_path = policy_path,
 #ifdef WYL_HAS_AUDIT
-      .audit_store_path = audit_path,
+      .audit_store_path = audit_path2,
 #endif
     };
     if (wyl_handle_open_with_options (&opts, &handle) != WYRELOG_E_OK)
@@ -958,6 +964,7 @@ check_persistent_permission_state_authority_matrix (void)
 
 #ifdef WYL_HAS_AUDIT
   g_remove (audit_path);
+  g_remove (audit_path2);
 #endif
   g_remove (policy_path);
   g_rmdir (dir);


### PR DESCRIPTION
## Summary

Two distinct flakes have been hitting `CI Main / build-ubuntu-latest` since 2026-05-09:

- `wyrelog / decide` — exit 167 / "signal 39 SIGinvalid" at ~4.5s. Maps to `tests/test-decide.c:905`, the second of two `WylHandle` opens in `check_persistent_permission_state_authority_matrix`. Both opens shared the same `audit.duckdb` path; under ASAN + `MALLOC_PERTURB_=70` on Linux the same-file reopen sometimes fails. macOS and Windows runners pass.
- `wyrelog / daemon-http-decide-audit` — TIMEOUT at 30.02-30.03s SIGTERM on two consecutive runs. The audit variant runs a serial chain of HTTP decides + 11 audit-event projections and was running just over the meson default 30s timeout under CI load.

## Changes

Two atomic commits:

1. `tests: isolate audit DuckDB paths in persistent-permission state matrix` — give each handle in the test its own audit DuckDB file (`audit.duckdb` and `audit2.duckdb`). The test asserts on the policy_store reopen, so distinct audit paths preserve the original intent while removing the same-file reopen sensitivity.
2. `tests: raise daemon-http-decide-audit meson timeout to 60s` — adds `timeout : 60` to the test declaration. The handle-engine-pair test already uses the same kwarg at 120s for the same reason. The split commit (`3bd72a3`) already moved the lighter half out; the audit variant is intrinsically serial.

## Why this is the right scope

The exit-167 path is **not** a production bug for normal usage: real operators do not open and close the same `audit.duckdb` file repeatedly inside one process. The fragile pattern lives in this one test. Hardening the test removes the flake without papering over a daemon defect.

The 30s timeout was simply too tight for the audit-variant chain; the bump matches the documented split intent.

## Test plan

- [ ] CI Main on ubuntu passes `wyrelog / decide` and `wyrelog / daemon-http-decide-audit`
- [ ] CodeQL still green
- [ ] macOS and Windows builds remain green