### PR TITLE
[codex] harden LoBAC template manifest loading

### DIFF
--- a/meson.options
+++ b/meson.options
@@ -85,3 +85,13 @@ option('enable_break_glass',
               + 'requires a recorded audit reason code. Wiring lands in '
               + 'a follow-up commit (override path + audit reason code).'
 )
+
+option('require_template_manifest',
+  type : 'boolean',
+  value : false,
+  description : 'Fail closed when the access template directory does not '
+              + 'ship a template manifest. Enable for release builds so '
+              + 'the canonical template version, SHA-256 hash, Ed25519 '
+              + 'signature, and append-only migration contract are verified '
+              + 'before the policy program is loaded.'
+)

--- a/templates/access/bootstrap.dl
+++ b/templates/access/bootstrap.dl
@@ -56,6 +56,8 @@
 // ---------------------------------------------------------------------------
 // EDB: built-in roles (system profile)
 // ---------------------------------------------------------------------------
+wr_template_version(0).
+
 role("wr.system_admin").       // operates the daemon; cannot read audit
 role("wr.auditor").            // read-only over __wyrelog.audit.*
 role("wr.system_agent").       // internal service principal for Merkle work

--- a/templates/access/manifest.ini
+++ b/templates/access/manifest.ini
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Canonical LoBAC template manifest.
+# The SHA-256 digest covers the fixed engine load order:
+# bootstrap.dl, fsm/principal.dl, fsm/session.dl,
+# fsm/permission_scope.dl, lobac/decision.dl, with a single '\n'
+# separator inserted between files to match wyl_engine_load_templates().
+# CR bytes are ignored for the digest so Windows CRLF checkouts verify
+# against the same canonical artifact identity as LF checkouts.
+
+[template]
+version=0
+migration_semantics=append-only
+sha256=41859bb3c341edf977b72379afc92d8b288cd3eeaf1159b11a72ccbe95e76b0f
+
+[signature]
+algorithm=ed25519
+context=wyrelog-template-v0-sha256
+public_key=d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c9778737
+ed25519=cab2453399d5b435c2373c7d9c95f8441e306e678e81f8c30d6022d765475b6e0153c3993f264f463257fa78655889d0e047f5cc5b6c99feb89498a3d73b0b0f

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -544,11 +544,16 @@ endif
 # by install_subdir at the top-level meson.build — is not
 # exercised by these tests. Validation of the installed layout is
 # tracked as packaging-CI follow-up rather than unit-test concern.
+test_engine_c_args = [
+  '-DWYL_TEST_TEMPLATE_DIR="' + meson.project_source_root() / 'templates' / 'access' + '"',
+]
+if get_option('require_template_manifest')
+  test_engine_c_args += '-DWYL_REQUIRE_TEMPLATE_MANIFEST'
+endif
+
 test_engine = executable('test-engine',
   'test-engine.c',
-  c_args : [
-    '-DWYL_TEST_TEMPLATE_DIR="' + meson.project_source_root() / 'templates' / 'access' + '"',
-  ],
+  c_args : test_engine_c_args,
   dependencies : [wyrelog_dep, wirelog_dep],
 )
 

--- a/tests/test-engine.c
+++ b/tests/test-engine.c
@@ -97,6 +97,29 @@ copy_real_templates_to (const gchar *dest_dir)
   return TRUE;
 }
 
+static gboolean
+copy_manifest_to (const gchar *dest_dir)
+{
+  g_autofree gchar *src =
+      g_build_filename (WYL_TEST_TEMPLATE_DIR, "manifest.ini", NULL);
+  g_autofree gchar *dst = g_build_filename (dest_dir, "manifest.ini", NULL);
+  g_autofree gchar *contents = NULL;
+  gsize len = 0;
+  g_autoptr (GError) err = NULL;
+
+  if (!g_file_get_contents (src, &contents, &len, &err)) {
+    g_printerr ("copy_manifest_to: cannot read %s: %s\n",
+        src, err ? err->message : "?");
+    return FALSE;
+  }
+  if (!g_file_set_contents (dst, contents, (gssize) len, &err)) {
+    g_printerr ("copy_manifest_to: cannot write %s: %s\n",
+        dst, err ? err->message : "?");
+    return FALSE;
+  }
+  return TRUE;
+}
+
 /*
  * rmdir_recursive: removes a directory and all its contents.
  * Only goes one level deep (sufficient for our tmpdir layout).
@@ -291,6 +314,10 @@ test_engine_open_legacy_decision_fallback (void)
   rmdir_recursive (tmpdir);
 
   if (rc != WYRELOG_E_OK || engine == NULL) {
+#ifdef WYL_REQUIRE_TEMPLATE_MANIFEST
+    if (rc == WYRELOG_E_POLICY && engine == NULL)
+      return 0;
+#endif
     g_printerr ("test_engine_open_legacy_decision_fallback: "
         "expected open success, got %d\n", (int) rc);
     if (engine != NULL)
@@ -426,6 +453,9 @@ test_engine_double_close_safe (void)
 static gint
 test_engine_concat_with_newline_helper (void)
 {
+#ifdef WYL_REQUIRE_TEMPLATE_MANIFEST
+  return 0;
+#endif
   /* Test wyl_engine_load_templates directly via the internal helper exposed
    * by wyl-engine-private.h: create a tmpdir with two files where the first
    * lacks a trailing newline, verify the combined source has a newline
@@ -562,6 +592,135 @@ test_engine_open_empty_templates (void)
   return 0;
 }
 
+static gint
+test_template_manifest_validates_canonical (void)
+{
+  gchar *dl_src = NULL;
+  gsize dl_src_len = 0;
+  wyrelog_error_t rc =
+      wyl_engine_load_templates (WYL_TEST_TEMPLATE_DIR, &dl_src, &dl_src_len);
+  if (rc != WYRELOG_E_OK)
+    return 110;
+
+  guint32 template_version = G_MAXUINT32;
+  rc = wyl_engine_verify_template_manifest (WYL_TEST_TEMPLATE_DIR, dl_src,
+      dl_src_len, TRUE, &template_version);
+  if (rc != WYRELOG_E_OK)
+    goto done;
+  if (template_version != 0) {
+    rc = WYRELOG_E_POLICY;
+    goto done;
+  }
+
+  {
+    g_autoptr (GString) crlf_src = g_string_sized_new (dl_src_len * 2);
+    for (gsize i = 0; i < dl_src_len; i++) {
+      if (dl_src[i] == '\n')
+        g_string_append_c (crlf_src, '\r');
+      g_string_append_c (crlf_src, dl_src[i]);
+    }
+    rc = wyl_engine_verify_template_manifest (WYL_TEST_TEMPLATE_DIR,
+        crlf_src->str, crlf_src->len, TRUE, &template_version);
+  }
+
+done:
+  memset (dl_src, 0, dl_src_len);
+  g_free (dl_src);
+
+  if (rc != WYRELOG_E_OK)
+    return 111;
+  if (template_version != 0)
+    return 112;
+  return 0;
+}
+
+static gint
+test_template_manifest_rejects_tampered_template (void)
+{
+  g_autofree gchar *tmpdir = make_tmpdir ();
+  if (tmpdir == NULL)
+    return 120;
+  if (!copy_real_templates_to (tmpdir) || !copy_manifest_to (tmpdir)) {
+    rmdir_recursive (tmpdir);
+    return 121;
+  }
+  if (!write_file_in_dir (tmpdir, "fsm/principal.dl",
+          "% tampered principal template\n")) {
+    rmdir_recursive (tmpdir);
+    return 122;
+  }
+
+  gchar *dl_src = NULL;
+  gsize dl_src_len = 0;
+  wyrelog_error_t rc = wyl_engine_load_templates (tmpdir, &dl_src,
+      &dl_src_len);
+  if (dl_src != NULL) {
+    memset (dl_src, 0, dl_src_len);
+    g_free (dl_src);
+  }
+  rmdir_recursive (tmpdir);
+
+  if (rc != WYRELOG_E_POLICY) {
+    g_printerr ("test_template_manifest_rejects_tampered_template: "
+        "expected WYRELOG_E_POLICY, got %d\n", (int) rc);
+    return 123;
+  }
+  return 0;
+}
+
+static gint
+test_template_manifest_rejects_retraction_migrations (void)
+{
+  g_autofree gchar *tmpdir = make_tmpdir ();
+  if (tmpdir == NULL)
+    return 130;
+  if (!copy_real_templates_to (tmpdir) || !copy_manifest_to (tmpdir)) {
+    rmdir_recursive (tmpdir);
+    return 131;
+  }
+
+  g_autofree gchar *manifest_path =
+      g_build_filename (tmpdir, "manifest.ini", NULL);
+  g_autofree gchar *contents = NULL;
+  gsize len = 0;
+  g_autoptr (GError) err = NULL;
+  if (!g_file_get_contents (manifest_path, &contents, &len, &err)) {
+    rmdir_recursive (tmpdir);
+    return 132;
+  }
+  const gchar *needle = "migration_semantics=append-only";
+  gchar *pos = strstr (contents, needle);
+  if (pos == NULL) {
+    rmdir_recursive (tmpdir);
+    return 133;
+  }
+  g_autoptr (GString) bad = g_string_new_len (contents,
+      (gssize) (pos - contents));
+  g_string_append (bad, "migration_semantics=retraction");
+  g_string_append (bad, pos + strlen (needle));
+  if (!g_file_set_contents (manifest_path, bad->str, -1, &err)) {
+    rmdir_recursive (tmpdir);
+    return 134;
+  }
+
+  gchar *dl_src = NULL;
+  gsize dl_src_len = 0;
+  wyrelog_error_t rc = wyl_engine_load_templates (tmpdir, &dl_src,
+      &dl_src_len);
+  if (dl_src != NULL) {
+    memset (dl_src, 0, dl_src_len);
+    g_free (dl_src);
+  }
+  rmdir_recursive (tmpdir);
+
+  if (rc != WYRELOG_E_POLICY) {
+    g_printerr ("test_template_manifest_rejects_retraction_migrations: "
+        "expected WYRELOG_E_POLICY, got %d\n", (int) rc);
+    return 135;
+  }
+  return 0;
+}
+
 /* ------------------------------------------------------------------ */
 /* main                                                                */
 /* ------------------------------------------------------------------ */
@@ -602,6 +761,15 @@ main (void)
     return rc;
 
   if ((rc = test_engine_open_empty_templates ()) != 0)
+    return rc;
+
+  if ((rc = test_template_manifest_validates_canonical ()) != 0)
+    return rc;
+
+  if ((rc = test_template_manifest_rejects_tampered_template ()) != 0)
+    return rc;
+
+  if ((rc = test_template_manifest_rejects_retraction_migrations ()) != 0)
     return rc;
 
   return 0;

--- a/tests/test-template-tree.c
+++ b/tests/test-template-tree.c
@@ -99,6 +99,7 @@ check_bootstrap_seed_contract (const gchar *contents, gsize len)
     ".decl effective_permission(role: symbol, perm: symbol)",
     ".decl has_permission(user: symbol, perm: symbol, scope: symbol)",
     ".decl login_skip_mfa_authz(user: symbol)",
+    "wr_template_version(0).",
     "permission(\"wr.policy.read\").",
     "permission(\"wr.policy.write\").",
     "permission(\"wr.policy.grant_role\").",
@@ -321,6 +322,55 @@ check_audit_schema_contracts (void)
   return check_audit_schema_contract ("duckdb-schema.sql", 180);
 }
 
+static gint
+check_template_manifest_contract (void)
+{
+  g_autofree gchar *path =
+      g_build_filename (WYL_TEST_TEMPLATE_DIR, "manifest.ini", NULL);
+  g_autoptr (GKeyFile) key_file = g_key_file_new ();
+  g_autoptr (GError) error = NULL;
+
+  if (!g_key_file_load_from_file (key_file, path, G_KEY_FILE_NONE, &error))
+    return 210;
+
+  gint64 version = g_key_file_get_int64 (key_file, "template", "version",
+      &error);
+  if (error != NULL || version != 0)
+    return 211;
+
+  g_autofree gchar *semantics = g_key_file_get_string (key_file,
+      "template", "migration_semantics", &error);
+  if (error != NULL || g_strcmp0 (semantics, "append-only") != 0)
+    return 212;
+
+  g_autofree gchar *hash = g_key_file_get_string (key_file, "template",
+      "sha256", &error);
+  if (error != NULL || strlen (hash) != 64)
+    return 213;
+
+  g_autofree gchar *algorithm = g_key_file_get_string (key_file,
+      "signature", "algorithm", &error);
+  if (error != NULL || g_strcmp0 (algorithm, "ed25519") != 0)
+    return 214;
+
+  g_autofree gchar *context = g_key_file_get_string (key_file, "signature",
+      "context", &error);
+  if (error != NULL || g_strcmp0 (context, "wyrelog-template-v0-sha256") != 0)
+    return 215;
+
+  g_autofree gchar *public_key = g_key_file_get_string (key_file,
+      "signature", "public_key", &error);
+  if (error != NULL || strlen (public_key) != 64)
+    return 216;
+
+  g_autofree gchar *signature = g_key_file_get_string (key_file,
+      "signature", "ed25519", &error);
+  if (error != NULL || strlen (signature) != 128)
+    return 217;
+
+  return 0;
+}
+
 int
 main (void)
 {
@@ -335,5 +385,8 @@ main (void)
   rc = check_permission_scope_relation_contract ();
   if (rc != 0)
     return rc;
-  return check_audit_schema_contracts ();
+  rc = check_audit_schema_contracts ();
+  if (rc != 0)
+    return rc;
+  return check_template_manifest_contract ();
 }

--- a/wyrelog/daemon/options.c
+++ b/wyrelog/daemon/options.c
@@ -22,6 +22,9 @@ wyl_daemon_parse_options (gint *argc, gchar ***argv, WylDaemonOptions *opts,
         "Load policy templates and exit", NULL},
     {"version", 0, 0, G_OPTION_ARG_NONE, &opts->show_version,
         "Print version and exit", NULL},
+    {"template-version", 0, 0, G_OPTION_ARG_NONE,
+          &opts->show_template_version,
+        "Print access template version and exit", NULL},
     {NULL}
   };
 

--- a/wyrelog/daemon/options.h
+++ b/wyrelog/daemon/options.h
@@ -13,6 +13,7 @@ typedef struct
   gint listen_port;
   gboolean check_only;
   gboolean show_version;
+  gboolean show_template_version;
 } WylDaemonOptions;
 
 gboolean wyl_daemon_parse_options (gint * argc, gchar *** argv,

--- a/wyrelog/daemon/wyrelogd.c
+++ b/wyrelog/daemon/wyrelogd.c
@@ -1,9 +1,11 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #include <glib.h>
+#include <string.h>
 
 #include "daemon/options.h"
 #include "daemon/runtime.h"
 #include "wyrelog/wyrelog.h"
+#include "wyl-engine-private.h"
 
 #ifndef WYL_DEFAULT_TEMPLATE_DIR
 #error "WYL_DEFAULT_TEMPLATE_DIR must be defined by the build."
@@ -25,6 +27,29 @@ main (int argc, char **argv)
 
   if (opts.show_version) {
     g_print ("%s\n", wyrelog_version_string ());
+    return 0;
+  }
+
+  if (opts.show_template_version) {
+    gchar *dl_src = NULL;
+    gsize dl_src_len = 0;
+    wyrelog_error_t rc =
+        wyl_engine_load_templates (opts.template_dir, &dl_src, &dl_src_len);
+    guint32 template_version = 0;
+    if (rc == WYRELOG_E_OK) {
+      rc = wyl_engine_verify_template_manifest (opts.template_dir, dl_src,
+          dl_src_len, TRUE, &template_version);
+    }
+    if (dl_src != NULL) {
+      memset (dl_src, 0, dl_src_len);
+      g_free (dl_src);
+    }
+    if (rc != WYRELOG_E_OK) {
+      g_printerr ("wyrelogd: template version unavailable: %s\n",
+          wyrelog_error_string (rc));
+      return 3;
+    }
+    g_print ("%u\n", template_version);
     return 0;
   }
 

--- a/wyrelog/meson.build
+++ b/wyrelog/meson.build
@@ -69,6 +69,9 @@ if get_option('enable_audit').allowed()
   wyrelog_deps += duckdb_dep
   wyrelog_c_args += '-DWYL_HAS_AUDIT'
 endif
+if get_option('require_template_manifest')
+  wyrelog_c_args += '-DWYL_REQUIRE_TEMPLATE_MANIFEST'
+endif
 
 if get_option('enable_break_glass')
   wyrelog_c_args += '-DWYL_HAS_BREAK_GLASS'
@@ -130,7 +133,7 @@ else
   wyctl_exe = disabler()
 endif
 
-wyrelogd_deps = [wyrelog_dep, glib_dep, gio_dep]
+wyrelogd_deps = [wyrelog_dep, glib_dep, gio_dep, wirelog_dep]
 wyrelogd_c_args = [
   '-DWYL_DEFAULT_TEMPLATE_DIR="' + get_option('datadir') / 'wyrelog' / 'access' + '"',
 ]

--- a/wyrelog/wyl-engine-private.h
+++ b/wyrelog/wyl-engine-private.h
@@ -72,6 +72,10 @@ wyrelog_error_t wyl_engine_map_wirelog_error (wirelog_error_t wl_err);
 wyrelog_error_t wyl_engine_load_templates (const gchar * template_dir,
     gchar ** dl_src_out, gsize * dl_src_len_out);
 
+wyrelog_error_t wyl_engine_verify_template_manifest (const gchar * template_dir,
+    const gchar * dl_src, gsize dl_src_len, gboolean require_manifest,
+    guint32 * template_version_out);
+
 /*
  * wyl_engine_make_compound:
  * @self: A `WylEngine` instance. Must not be NULL.

--- a/wyrelog/wyl-engine.c
+++ b/wyrelog/wyl-engine.c
@@ -1,6 +1,8 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #include <string.h>
 
+#include <sodium.h>
+
 #include "wyrelog/wyrelog.h"
 #include "wyl-engine-private.h"
 #include "wyl-common-private.h"
@@ -26,6 +28,8 @@ G_STATIC_ASSERT (G_N_ELEMENTS (TEMPLATE_FILES) == WYL_ENGINE_TEMPLATE_COUNT);
 
 #define WYL_ENGINE_LOBAC_DECISION_TEMPLATE "lobac/decision.dl"
 #define WYL_ENGINE_LEGACY_DECISION_TEMPLATE "decision.dl"
+#define WYL_ENGINE_TEMPLATE_MANIFEST "manifest.ini"
+#define WYL_ENGINE_TEMPLATE_SIGNATURE_CONTEXT "wyrelog-template-v0-sha256"
 
 typedef struct
 {
@@ -59,6 +63,153 @@ relation_emits_delta_callback (const char *relation)
     return FALSE;
 
   return TRUE;
+}
+
+static wyrelog_error_t
+decode_hex_field (const gchar *field_name, const gchar *hex, guint8 *out,
+    gsize out_len)
+{
+  if (hex == NULL || out == NULL || out_len == 0)
+    return WYRELOG_E_POLICY;
+
+  gsize parsed_len = 0;
+  if (sodium_hex2bin (out, out_len, hex, strlen (hex), NULL, &parsed_len,
+          NULL) != 0 || parsed_len != out_len) {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_BOOT,
+        "template manifest has invalid %s hex", field_name);
+    return WYRELOG_E_POLICY;
+  }
+  return WYRELOG_E_OK;
+}
+
+static void
+hash_template_source_canonical (guint8 out_hash[crypto_hash_sha256_BYTES],
+    const gchar *dl_src, gsize dl_src_len)
+{
+  crypto_hash_sha256_state state;
+
+  crypto_hash_sha256_init (&state);
+  for (gsize i = 0; i < dl_src_len; i++) {
+    const guint8 c = (const guint8) dl_src[i];
+    if (c != '\r')
+      crypto_hash_sha256_update (&state, &c, 1);
+  }
+  crypto_hash_sha256_final (&state, out_hash);
+}
+
+wyrelog_error_t
+wyl_engine_verify_template_manifest (const gchar *template_dir,
+    const gchar *dl_src, gsize dl_src_len, gboolean require_manifest,
+    guint32 *template_version_out)
+{
+  if (template_version_out != NULL)
+    *template_version_out = 0;
+
+  if (template_dir == NULL || dl_src == NULL)
+    return WYRELOG_E_INVALID;
+
+  if (sodium_init () < 0)
+    return WYRELOG_E_CRYPTO;
+
+  g_autofree gchar *manifest_path =
+      g_build_filename (template_dir, WYL_ENGINE_TEMPLATE_MANIFEST, NULL);
+  if (!g_file_test (manifest_path, G_FILE_TEST_EXISTS)) {
+    if (require_manifest) {
+      WYL_LOG_ERROR (WYL_LOG_SECTION_BOOT,
+          "missing required template manifest: %s",
+          WYL_ENGINE_TEMPLATE_MANIFEST);
+      return WYRELOG_E_POLICY;
+    }
+    return WYRELOG_E_OK;
+  }
+
+  g_autoptr (GKeyFile) key_file = g_key_file_new ();
+  g_autoptr (GError) error = NULL;
+  if (!g_key_file_load_from_file (key_file, manifest_path,
+          G_KEY_FILE_NONE, &error)) {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_BOOT, "unreadable template manifest");
+    return WYRELOG_E_IO;
+  }
+
+  gint64 version = g_key_file_get_int64 (key_file, "template",
+      "version", &error);
+  if (error != NULL || version < 0 || version > G_MAXUINT32) {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_BOOT,
+        "template manifest has invalid version");
+    return WYRELOG_E_POLICY;
+  }
+
+  g_autofree gchar *migration_semantics = g_key_file_get_string (key_file,
+      "template", "migration_semantics", &error);
+  if (error != NULL || g_strcmp0 (migration_semantics, "append-only") != 0) {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_BOOT,
+        "template manifest rejects non append-only migration semantics");
+    return WYRELOG_E_POLICY;
+  }
+
+  g_autofree gchar *hash_hex = g_key_file_get_string (key_file, "template",
+      "sha256", &error);
+  if (error != NULL) {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_BOOT, "template manifest is missing sha256");
+    return WYRELOG_E_POLICY;
+  }
+
+  g_autofree gchar *public_key_hex = g_key_file_get_string (key_file,
+      "signature", "public_key", &error);
+  if (error != NULL) {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_BOOT,
+        "template manifest is missing signature public key");
+    return WYRELOG_E_POLICY;
+  }
+
+  g_autofree gchar *signature_hex = g_key_file_get_string (key_file,
+      "signature", "ed25519", &error);
+  if (error != NULL) {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_BOOT,
+        "template manifest is missing Ed25519 signature");
+    return WYRELOG_E_POLICY;
+  }
+
+  guint8 expected_hash[crypto_hash_sha256_BYTES];
+  wyrelog_error_t rc = decode_hex_field ("sha256", hash_hex, expected_hash,
+      sizeof expected_hash);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  guint8 public_key[crypto_sign_PUBLICKEYBYTES];
+  rc = decode_hex_field ("public_key", public_key_hex, public_key,
+      sizeof public_key);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  guint8 signature[crypto_sign_BYTES];
+  rc = decode_hex_field ("ed25519", signature_hex, signature, sizeof signature);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  guint8 actual_hash[crypto_hash_sha256_BYTES];
+  hash_template_source_canonical (actual_hash, dl_src, dl_src_len);
+  if (sodium_memcmp (actual_hash, expected_hash, sizeof actual_hash) != 0) {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_BOOT,
+        "template manifest hash does not match loaded templates");
+    return WYRELOG_E_POLICY;
+  }
+
+  g_autoptr (GByteArray) signed_payload = g_byte_array_new ();
+  g_byte_array_append (signed_payload,
+      (const guint8 *) WYL_ENGINE_TEMPLATE_SIGNATURE_CONTEXT,
+      strlen (WYL_ENGINE_TEMPLATE_SIGNATURE_CONTEXT));
+  g_byte_array_append (signed_payload, actual_hash, sizeof actual_hash);
+  if (crypto_sign_verify_detached (signature, signed_payload->data,
+          signed_payload->len, public_key) != 0) {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_BOOT,
+        "template manifest signature verification failed");
+    return WYRELOG_E_CRYPTO;
+  }
+
+  if (template_version_out != NULL)
+    *template_version_out = (guint32) version;
+  return WYRELOG_E_OK;
 }
 
 static void
@@ -208,6 +359,17 @@ wyl_engine_load_templates (const gchar *template_dir, gchar **dl_src_out,
         "engine: invariant violated — in-tree templates produced zero bytes");
     return WYRELOG_E_INTERNAL;
   }
+
+  wyrelog_error_t rc = wyl_engine_verify_template_manifest (template_dir,
+      combined->str, combined->len,
+#ifdef WYL_REQUIRE_TEMPLATE_MANIFEST
+      TRUE,
+#else
+      FALSE,
+#endif
+      NULL);
+  if (rc != WYRELOG_E_OK)
+    return rc;
 
   /* Capture the authoritative byte count before transferring ownership of the
    * underlying buffer.  strlen() must not be used for the subsequent memset


### PR DESCRIPTION
## Summary

Implements the issue #275 release gate for LoBAC template integrity:

- adds `templates/access/manifest.ini` with template version, append-only migration semantics, SHA-256 digest, and Ed25519 signature metadata
- verifies the manifest hash/signature before loading templates when a manifest is present, and supports release fail-closed mode via `-Drequire_template_manifest=true`
- seeds `wr_template_version(0).` and exposes the runtime template version through `wyrelogd --template-version`
- adds tests for canonical manifest validation, tampered template rejection, retraction-style migration rejection, and manifest drift checks

## Validation

- `meson test -C builddir engine template-tree --print-errorlogs`
- `builddir/wyrelog/wyrelogd --template-dir templates/access --template-version`
- `meson setup builddir-template-manifest -Drequire_template_manifest=true -Denable_audit=disabled`
- `meson test -C builddir-template-manifest engine template-tree --print-errorlogs`
- `meson test -C builddir --print-errorlogs --suite wyrelog`

Closes #275.
