### PR TITLE
[codex] add production runtime gates

### DIFF
--- a/meson.options
+++ b/meson.options
@@ -24,13 +24,11 @@ option('enable_client',
 option('require_tpm',
   type : 'boolean',
   value : true,
-  description : 'Runtime fail-closed gate for the hardware-backed key '
-              + 'provider. When true, wyrelog refuses to start if the '
-              + 'tss2-esys provider cannot be initialised, even if the '
-              + 'development stub is compiled in. Set to false only for '
-              + 'host development environments where running against the '
-              + 'dev key provider is acceptable. Wiring lands in a '
-              + 'follow-up commit (runtime gate in wyl_init).'
+  description : 'Release intent for hardware-backed key provider '
+              + 'requirements. Production daemon startup fails closed when '
+              + 'only the development KeyProvider is available; set this '
+              + 'false only for host development configurations that are '
+              + 'not expected to satisfy production key custody.'
 )
 
 option('enable_audit',
@@ -39,9 +37,7 @@ option('enable_audit',
   description : 'Build the DuckDB-backed audit subsystem that records '
               + 'access decisions to a local analytic store. Disabled by '
               + 'default pending dependency stabilisation; set to enabled '
-              + 'to opt in once the DuckDB integration is ready. Wiring '
-              + 'lands in a follow-up commit (audit sink + DuckDB '
-              + 'linkage).'
+              + 'to opt in to the DuckDB-backed audit sink.'
 )
 
 option('duckdb_source',
@@ -82,8 +78,7 @@ option('enable_break_glass',
               + 'enable for builds that ship the corresponding signed '
               + 'override credential. Must not be enabled unless '
               + 'enable_audit is also enabled, since the override path '
-              + 'requires a recorded audit reason code. Wiring lands in '
-              + 'a follow-up commit (override path + audit reason code).'
+              + 'requires a recorded audit reason code.'
 )
 
 option('require_template_manifest',

--- a/tests/check-wyrelogd-production-gates.sh
+++ b/tests/check-wyrelogd-production-gates.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+set -eu
+
+WYRELOGD=$1
+TEMPLATE_DIR=$2
+PYTHON=$3
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT INT TERM
+
+"$PYTHON" - "$TEMPLATE_DIR" "$TMPDIR/access-no-manifest" <<'PY'
+import pathlib
+import shutil
+import sys
+
+src = pathlib.Path(sys.argv[1])
+dst = pathlib.Path(sys.argv[2])
+shutil.copytree(src, dst)
+(dst / "manifest.ini").unlink()
+PY
+
+"$WYRELOGD" --template-dir "$TMPDIR/access-no-manifest" \
+  --policy-db "$TMPDIR/nonprod.sqlite" --check
+
+if "$WYRELOGD" --production --template-dir "$TMPDIR/access-no-manifest" \
+    --policy-db "$TMPDIR/prod-missing-manifest.sqlite" --check; then
+  echo "production mode accepted templates without a manifest" >&2
+  exit 1
+fi
+
+if "$WYRELOGD" --production --template-dir "$TEMPLATE_DIR" \
+    --policy-db "$TMPDIR/prod-dev-keyprovider.sqlite" --check; then
+  echo "production mode accepted the development KeyProvider" >&2
+  exit 1
+fi

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -21,7 +21,18 @@ test('wyrelogd-check', wyrelogd_exe,
 )
 
 if host_machine.system() != 'windows'
+  python3 = find_program('python3')
   sh = find_program('sh')
+  test('wyrelogd-production-gates', sh,
+    args : [
+      meson.current_source_dir() / 'check-wyrelogd-production-gates.sh',
+      wyrelogd_exe.full_path(),
+      meson.project_source_root() / 'templates' / 'access',
+      python3.full_path(),
+    ],
+    depends : wyrelogd_exe,
+  )
+
   wyrelogd_sigterm_cmd = '"' + wyrelogd_exe.full_path()
   wyrelogd_sigterm_cmd += '" --template-dir "'
   wyrelogd_sigterm_cmd += meson.project_source_root() / 'templates' / 'access'
@@ -39,7 +50,6 @@ if host_machine.system() != 'windows'
   )
 
   if build_client
-    python3 = find_program('python3')
     wyrelogd_healthz_expect_audit = '0'
     if get_option('enable_audit').allowed()
       wyrelogd_healthz_expect_audit = '1'

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -481,7 +481,9 @@ endif
 test_decide = executable('test-decide',
   'test-decide.c',
   c_args : test_decide_c_args,
-  dependencies : [wyrelog_dep, wirelog_dep],
+  dependencies : [wyrelog_dep, wirelog_dep] + (get_option('enable_audit').allowed()
+      ? [duckdb_dep]
+      : []),
 )
 
 test('decide', test_decide)

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -471,11 +471,16 @@ test_revoke_req = executable('test-revoke-req',
 
 test('revoke-req', test_revoke_req)
 
+test_decide_c_args = [
+  '-DWYL_TEST_TEMPLATE_DIR="' + meson.project_source_root() / 'templates' / 'access' + '"',
+]
+if get_option('enable_audit').allowed()
+  test_decide_c_args += '-DWYL_HAS_AUDIT'
+endif
+
 test_decide = executable('test-decide',
   'test-decide.c',
-  c_args : [
-    '-DWYL_TEST_TEMPLATE_DIR="' + meson.project_source_root() / 'templates' / 'access' + '"',
-  ],
+  c_args : test_decide_c_args,
   dependencies : [wyrelog_dep, wirelog_dep],
 )
 

--- a/wyrelog/daemon/options.c
+++ b/wyrelog/daemon/options.c
@@ -20,6 +20,8 @@ wyl_daemon_parse_options (gint *argc, gchar ***argv, WylDaemonOptions *opts,
 #endif
     {"check", 0, 0, G_OPTION_ARG_NONE, &opts->check_only,
         "Load policy templates and exit", NULL},
+    {"production", 0, 0, G_OPTION_ARG_NONE, &opts->production_mode,
+        "Enable production fail-closed startup gates", NULL},
     {"version", 0, 0, G_OPTION_ARG_NONE, &opts->show_version,
         "Print version and exit", NULL},
     {"template-version", 0, 0, G_OPTION_ARG_NONE,

--- a/wyrelog/daemon/options.h
+++ b/wyrelog/daemon/options.h
@@ -12,6 +12,7 @@ typedef struct
 #endif
   gint listen_port;
   gboolean check_only;
+  gboolean production_mode;
   gboolean show_version;
   gboolean show_template_version;
 } WylDaemonOptions;

--- a/wyrelog/daemon/runtime.c
+++ b/wyrelog/daemon/runtime.c
@@ -16,6 +16,8 @@ open_runtime_handle (const WylDaemonOptions *opts, WylHandle **out_handle)
   WylHandleOpenOptions open_opts = {
     .template_dir = opts->template_dir,
     .policy_store_path = opts->policy_store_path,
+    .production_mode = opts->production_mode,
+    .require_template_manifest = opts->production_mode,
 #ifdef WYL_HAS_AUDIT
     .audit_store_path = opts->audit_store_path,
 #endif
@@ -31,6 +33,8 @@ open_readiness_handle (const WylDaemonOptions *opts, WylHandle **out_handle)
    * exercise mutation paths and must not seed configured authority data. */
   WylHandleOpenOptions open_opts = {
     .template_dir = opts->template_dir,
+    .production_mode = opts->production_mode,
+    .require_template_manifest = opts->production_mode,
   };
 
   return wyl_handle_open_with_options (&open_opts, out_handle);

--- a/wyrelog/wyl-engine-private.h
+++ b/wyrelog/wyl-engine-private.h
@@ -75,6 +75,8 @@ wyrelog_error_t wyl_engine_load_templates (const gchar * template_dir,
 wyrelog_error_t wyl_engine_verify_template_manifest (const gchar * template_dir,
     const gchar * dl_src, gsize dl_src_len, gboolean require_manifest,
     guint32 * template_version_out);
+wyrelog_error_t wyl_engine_open_with_options (const gchar * template_dir,
+    guint32 num_workers, gboolean require_template_manifest, WylEngine ** out);
 
 /*
  * wyl_engine_make_compound:

--- a/wyrelog/wyl-engine.c
+++ b/wyrelog/wyl-engine.c
@@ -306,8 +306,9 @@ wyl_engine_map_wirelog_error (wirelog_error_t wl_err)
   }
 }
 
-wyrelog_error_t
-wyl_engine_load_templates (const gchar *template_dir, gchar **dl_src_out,
+static wyrelog_error_t
+load_templates_internal (const gchar *template_dir,
+    gboolean require_template_manifest, gchar **dl_src_out,
     gsize *dl_src_len_out)
 {
   g_autoptr (GString) combined = g_string_new (NULL);
@@ -361,12 +362,7 @@ wyl_engine_load_templates (const gchar *template_dir, gchar **dl_src_out,
   }
 
   wyrelog_error_t rc = wyl_engine_verify_template_manifest (template_dir,
-      combined->str, combined->len,
-#ifdef WYL_REQUIRE_TEMPLATE_MANIFEST
-      TRUE,
-#else
-      FALSE,
-#endif
+      combined->str, combined->len, require_template_manifest,
       NULL);
   if (rc != WYRELOG_E_OK)
     return rc;
@@ -379,11 +375,24 @@ wyl_engine_load_templates (const gchar *template_dir, gchar **dl_src_out,
   return WYRELOG_E_OK;
 }
 
+wyrelog_error_t
+wyl_engine_load_templates (const gchar *template_dir, gchar **dl_src_out,
+    gsize *dl_src_len_out)
+{
+  return load_templates_internal (template_dir,
+#ifdef WYL_REQUIRE_TEMPLATE_MANIFEST
+      TRUE,
+#else
+      FALSE,
+#endif
+      dl_src_out, dl_src_len_out);
+}
+
 /* --- Public API ---------------------------------------------------- */
 
 wyrelog_error_t
-wyl_engine_open (const gchar *template_dir, guint32 num_workers,
-    WylEngine **out)
+wyl_engine_open_with_options (const gchar *template_dir, guint32 num_workers,
+    gboolean require_template_manifest, WylEngine **out)
 {
   /* Set out-param to NULL at entry; every failure path leaves it NULL. */
   if (out != NULL)
@@ -397,8 +406,8 @@ wyl_engine_open (const gchar *template_dir, guint32 num_workers,
 
   gchar *dl_src = NULL;
   gsize dl_src_len = 0;
-  wyrelog_error_t rc =
-      wyl_engine_load_templates (template_dir, &dl_src, &dl_src_len);
+  wyrelog_error_t rc = load_templates_internal (template_dir,
+      require_template_manifest, &dl_src, &dl_src_len);
   if (rc != WYRELOG_E_OK)
     return rc;
 
@@ -440,6 +449,19 @@ wyl_engine_open (const gchar *template_dir, guint32 num_workers,
 
   *out = engine;
   return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
+wyl_engine_open (const gchar *template_dir, guint32 num_workers,
+    WylEngine **out)
+{
+  return wyl_engine_open_with_options (template_dir, num_workers,
+#ifdef WYL_REQUIRE_TEMPLATE_MANIFEST
+      TRUE,
+#else
+      FALSE,
+#endif
+      out);
 }
 
 void

--- a/wyrelog/wyl-handle-private.h
+++ b/wyrelog/wyl-handle-private.h
@@ -22,6 +22,8 @@ typedef struct
 #ifdef WYL_HAS_AUDIT
   const gchar *audit_store_path;
 #endif
+  gboolean production_mode;
+  gboolean require_template_manifest;
 } WylHandleOpenOptions;
 
 /*

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -72,6 +72,7 @@ struct _WylHandle
   wyl_policy_store_t *policy_store;
   gboolean login_skip_mfa_allowed;
   gboolean engine_pair_poisoned;
+  gboolean require_template_manifest;
   /*
    * Per-handle registry mapping wyl_session_id_t to live WylSession*.
    * Strong references; sessions stay alive at least until handle
@@ -577,6 +578,8 @@ wyl_handle_open_with_options (const WylHandleOpenOptions *opts,
     return WYRELOG_E_INVALID;
 
   WylHandle *self = g_object_new (WYL_TYPE_HANDLE, NULL);
+  self->require_template_manifest = opts->require_template_manifest
+      || opts->production_mode;
 
   wyrelog_error_t rc =
       wyl_policy_store_open (opts->policy_store_path, &self->policy_store);
@@ -617,6 +620,29 @@ wyl_handle_open_with_options (const WylHandleOpenOptions *opts,
     return rc;
   }
 #endif
+
+  if (opts->production_mode) {
+#if defined(WYL_HAS_BREAK_GLASS) && !defined(WYL_HAS_AUDIT)
+    WYL_LOG_ERROR (WYL_LOG_SECTION_BOOT,
+        "production mode requires audit when break-glass is compiled in");
+    g_object_unref (self);
+    return WYRELOG_E_POLICY;
+#endif
+#if defined(WYL_HAS_BREAK_GLASS) && defined(WYL_HAS_AUDIT)
+    if (opts->audit_store_path == NULL || opts->audit_store_path[0] == '\0') {
+      WYL_LOG_ERROR (WYL_LOG_SECTION_BOOT,
+          "production mode requires a durable audit store for break-glass");
+      g_object_unref (self);
+      return WYRELOG_E_POLICY;
+    }
+#endif
+#ifndef WYL_HAS_PRODUCTION_KEYPROVIDER
+    WYL_LOG_ERROR (WYL_LOG_SECTION_BOOT,
+        "production mode requires a non-development KeyProvider");
+    g_object_unref (self);
+    return WYRELOG_E_POLICY;
+#endif
+  }
 
   *out_handle = self;
   return WYRELOG_E_OK;
@@ -1315,12 +1341,14 @@ replace_engine_pair (WylHandle *self, const gchar *template_dir)
   gchar *old_template_dir = self->template_dir;
 
   WylEngine *new_read_engine = NULL;
-  rc = wyl_engine_open (template_dir, 1, &new_read_engine);
+  rc = wyl_engine_open_with_options (template_dir, 1,
+      self->require_template_manifest, &new_read_engine);
   if (rc != WYRELOG_E_OK)
     return rc;
 
   WylEngine *new_delta_engine = NULL;
-  rc = wyl_engine_open (template_dir, 1, &new_delta_engine);
+  rc = wyl_engine_open_with_options (template_dir, 1,
+      self->require_template_manifest, &new_delta_engine);
   if (rc != WYRELOG_E_OK) {
     g_object_unref (new_read_engine);
     return rc;


### PR DESCRIPTION
## Summary

- add a `wyrelogd --production` startup mode for fail-closed production gates
- require signed template manifest verification in production mode
- reject production startup when only the development KeyProvider is available
- reject unsafe break-glass/audit production combinations
- add a daemon-level production gate regression test

## Notes

This keeps development behavior unchanged: non-production daemon checks can still run with development-only key handling and without a template manifest when the build does not require one. Production mode is explicit and fails before serving traffic when required safety gates are not satisfied.

## Validation

- `meson test -C builddir wyrelogd-production-gates engine wyrelogd-check --print-errorlogs`
- `meson test -C builddir --print-errorlogs --suite wyrelog`
- `meson test -C builddir wyrelogd-production-gates --print-errorlogs`
