### PR TITLE
template: validate migration artifacts

### DIFF
--- a/templates/access/manifest.ini
+++ b/templates/access/manifest.ini
@@ -11,6 +11,7 @@
 [template]
 version=0
 migration_semantics=append-only
+migration_path=migrations
 sha256=41859bb3c341edf977b72379afc92d8b288cd3eeaf1159b11a72ccbe95e76b0f
 
 [signature]

--- a/templates/access/migrations/0000-baseline.ini
+++ b/templates/access/migrations/0000-baseline.ini
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Baseline LoBAC template migration artifact.
+# The hash covers the canonical migration payload assembled from the
+# [migration] fields below, excluding this file's comments and signature block.
+
+[migration]
+id=0000-baseline
+sequence=0
+from_version=0
+to_version=0
+semantics=append-only
+operation=baseline
+reserved_namespace=wr.
+sha256=4da70b605e672afa9598d3de30cb546a3ea8ea0794e9112dbb5c459cc09afc95
+
+[signature]
+algorithm=ed25519
+context=wyrelog-template-migration-v0-sha256
+public_key=01e9516027b8564147359113e4b6592fdee4315da9d04ac873d88b3c0df1e2ee
+ed25519=20a1ca2c395f93da6c2f4f79127ed5eb7846318aa18d989479000075e688c6b834d74052ade2e022a2bcacf365100ac3a7a26082fdc0bf21d456cdbf79ab6406

--- a/tests/test-engine.c
+++ b/tests/test-engine.c
@@ -120,6 +120,32 @@ copy_manifest_to (const gchar *dest_dir)
   return TRUE;
 }
 
+static gboolean
+copy_migrations_to (const gchar *dest_dir)
+{
+  g_autofree gchar *dst_dir = g_build_filename (dest_dir, "migrations", NULL);
+  if (g_mkdir (dst_dir, 0755) != 0)
+    return FALSE;
+
+  g_autofree gchar *src = g_build_filename (WYL_TEST_TEMPLATE_DIR,
+      "migrations", "0000-baseline.ini", NULL);
+  g_autofree gchar *dst = g_build_filename (dst_dir, "0000-baseline.ini",
+      NULL);
+  g_autofree gchar *contents = NULL;
+  gsize len = 0;
+  g_autoptr (GError) err = NULL;
+
+  if (!g_file_get_contents (src, &contents, &len, &err))
+    return FALSE;
+  return g_file_set_contents (dst, contents, (gssize) len, &err);
+}
+
+static gboolean
+copy_template_artifacts_to (const gchar *dest_dir)
+{
+  return copy_manifest_to (dest_dir) && copy_migrations_to (dest_dir);
+}
+
 /*
  * rmdir_recursive: removes a directory and all its contents.
  * Only goes one level deep (sufficient for our tmpdir layout).
@@ -640,7 +666,7 @@ test_template_manifest_rejects_tampered_template (void)
   g_autofree gchar *tmpdir = make_tmpdir ();
   if (tmpdir == NULL)
     return 120;
-  if (!copy_real_templates_to (tmpdir) || !copy_manifest_to (tmpdir)) {
+  if (!copy_real_templates_to (tmpdir) || !copy_template_artifacts_to (tmpdir)) {
     rmdir_recursive (tmpdir);
     return 121;
   }
@@ -674,7 +700,7 @@ test_template_manifest_rejects_retraction_migrations (void)
   g_autofree gchar *tmpdir = make_tmpdir ();
   if (tmpdir == NULL)
     return 130;
-  if (!copy_real_templates_to (tmpdir) || !copy_manifest_to (tmpdir)) {
+  if (!copy_real_templates_to (tmpdir) || !copy_template_artifacts_to (tmpdir)) {
     rmdir_recursive (tmpdir);
     return 131;
   }
@@ -718,6 +744,198 @@ test_template_manifest_rejects_retraction_migrations (void)
         "expected WYRELOG_E_POLICY, got %d\n", (int) rc);
     return 135;
   }
+  return 0;
+}
+
+static gint
+test_template_artifact_info_reports_identity (void)
+{
+  gchar *dl_src = NULL;
+  gsize dl_src_len = 0;
+  wyrelog_error_t rc =
+      wyl_engine_load_templates (WYL_TEST_TEMPLATE_DIR, &dl_src, &dl_src_len);
+  if (rc != WYRELOG_E_OK)
+    return 140;
+
+  WylTemplateArtifactInfo info = { 0 };
+  rc = wyl_engine_inspect_template_artifact (WYL_TEST_TEMPLATE_DIR, dl_src,
+      dl_src_len, TRUE, &info);
+
+  memset (dl_src, 0, dl_src_len);
+  g_free (dl_src);
+
+  if (rc != WYRELOG_E_OK)
+    return 141;
+  if (info.version != 0 || info.migration_count != 1 ||
+      info.latest_migration_version != 0)
+    return 142;
+  if (g_strcmp0 (info.sha256_hex,
+          "41859bb3c341edf977b72379afc92d8b288cd3eeaf1159b11a72ccbe95e76b0f")
+      != 0)
+    return 143;
+  return 0;
+}
+
+static gint
+test_template_artifact_rejects_missing_migration (void)
+{
+  g_autofree gchar *tmpdir = make_tmpdir ();
+  if (tmpdir == NULL)
+    return 150;
+  if (!copy_real_templates_to (tmpdir) || !copy_manifest_to (tmpdir)) {
+    rmdir_recursive (tmpdir);
+    return 151;
+  }
+
+  gchar *dl_src = NULL;
+  gsize dl_src_len = 0;
+  wyrelog_error_t rc = wyl_engine_load_templates (tmpdir, &dl_src,
+      &dl_src_len);
+  if (dl_src != NULL) {
+    memset (dl_src, 0, dl_src_len);
+    g_free (dl_src);
+  }
+  rmdir_recursive (tmpdir);
+
+  if (rc != WYRELOG_E_POLICY) {
+    g_printerr ("test_template_artifact_rejects_missing_migration: "
+        "expected WYRELOG_E_POLICY, got %d\n", (int) rc);
+    return 152;
+  }
+  return 0;
+}
+
+static gint
+test_template_artifact_rejects_duplicate_migration (void)
+{
+  g_autofree gchar *tmpdir = make_tmpdir ();
+  if (tmpdir == NULL)
+    return 160;
+  if (!copy_real_templates_to (tmpdir) || !copy_template_artifacts_to (tmpdir)) {
+    rmdir_recursive (tmpdir);
+    return 161;
+  }
+  g_autofree gchar *src = g_build_filename (tmpdir, "migrations",
+      "0000-baseline.ini", NULL);
+  g_autofree gchar *dst = g_build_filename (tmpdir, "migrations",
+      "0001-duplicate.ini", NULL);
+  g_autofree gchar *contents = NULL;
+  gsize len = 0;
+  g_autoptr (GError) err = NULL;
+  if (!g_file_get_contents (src, &contents, &len, &err)
+      || !g_file_set_contents (dst, contents, (gssize) len, &err)) {
+    rmdir_recursive (tmpdir);
+    return 162;
+  }
+
+  gchar *dl_src = NULL;
+  gsize dl_src_len = 0;
+  wyrelog_error_t rc = wyl_engine_load_templates (tmpdir, &dl_src,
+      &dl_src_len);
+  if (dl_src != NULL) {
+    memset (dl_src, 0, dl_src_len);
+    g_free (dl_src);
+  }
+  rmdir_recursive (tmpdir);
+
+  if (rc != WYRELOG_E_POLICY)
+    return 163;
+  return 0;
+}
+
+static gint
+test_template_artifact_rejects_tampered_migration_signature (void)
+{
+  g_autofree gchar *tmpdir = make_tmpdir ();
+  if (tmpdir == NULL)
+    return 170;
+  if (!copy_real_templates_to (tmpdir) || !copy_template_artifacts_to (tmpdir)) {
+    rmdir_recursive (tmpdir);
+    return 171;
+  }
+  g_autofree gchar *path = g_build_filename (tmpdir, "migrations",
+      "0000-baseline.ini", NULL);
+  g_autofree gchar *contents = NULL;
+  gsize len = 0;
+  g_autoptr (GError) err = NULL;
+  if (!g_file_get_contents (path, &contents, &len, &err)) {
+    rmdir_recursive (tmpdir);
+    return 172;
+  }
+  gchar *pos = strstr (contents, "operation=baseline");
+  if (pos == NULL) {
+    rmdir_recursive (tmpdir);
+    return 173;
+  }
+  g_autoptr (GString) bad = g_string_new_len (contents,
+      (gssize) (pos - contents));
+  g_string_append (bad, "operation=additive");
+  g_string_append (bad, pos + strlen ("operation=baseline"));
+  if (!g_file_set_contents (path, bad->str, -1, &err)) {
+    rmdir_recursive (tmpdir);
+    return 174;
+  }
+
+  gchar *dl_src = NULL;
+  gsize dl_src_len = 0;
+  wyrelog_error_t rc = wyl_engine_load_templates (tmpdir, &dl_src,
+      &dl_src_len);
+  if (dl_src != NULL) {
+    memset (dl_src, 0, dl_src_len);
+    g_free (dl_src);
+  }
+  rmdir_recursive (tmpdir);
+
+  if (rc != WYRELOG_E_POLICY)
+    return 175;
+  return 0;
+}
+
+static gint
+test_template_artifact_rejects_reserved_namespace_violation (void)
+{
+  g_autofree gchar *tmpdir = make_tmpdir ();
+  if (tmpdir == NULL)
+    return 180;
+  if (!copy_real_templates_to (tmpdir) || !copy_template_artifacts_to (tmpdir)) {
+    rmdir_recursive (tmpdir);
+    return 181;
+  }
+  g_autofree gchar *path = g_build_filename (tmpdir, "migrations",
+      "0000-baseline.ini", NULL);
+  g_autofree gchar *contents = NULL;
+  gsize len = 0;
+  g_autoptr (GError) err = NULL;
+  if (!g_file_get_contents (path, &contents, &len, &err)) {
+    rmdir_recursive (tmpdir);
+    return 182;
+  }
+  gchar *pos = strstr (contents, "reserved_namespace=wr.");
+  if (pos == NULL) {
+    rmdir_recursive (tmpdir);
+    return 183;
+  }
+  g_autoptr (GString) bad = g_string_new_len (contents,
+      (gssize) (pos - contents));
+  g_string_append (bad, "reserved_namespace=customer.");
+  g_string_append (bad, pos + strlen ("reserved_namespace=wr."));
+  if (!g_file_set_contents (path, bad->str, -1, &err)) {
+    rmdir_recursive (tmpdir);
+    return 184;
+  }
+
+  gchar *dl_src = NULL;
+  gsize dl_src_len = 0;
+  wyrelog_error_t rc = wyl_engine_load_templates (tmpdir, &dl_src,
+      &dl_src_len);
+  if (dl_src != NULL) {
+    memset (dl_src, 0, dl_src_len);
+    g_free (dl_src);
+  }
+  rmdir_recursive (tmpdir);
+
+  if (rc != WYRELOG_E_POLICY)
+    return 185;
   return 0;
 }
 
@@ -770,6 +988,23 @@ main (void)
     return rc;
 
   if ((rc = test_template_manifest_rejects_retraction_migrations ()) != 0)
+    return rc;
+
+  if ((rc = test_template_artifact_info_reports_identity ()) != 0)
+    return rc;
+
+  if ((rc = test_template_artifact_rejects_missing_migration ()) != 0)
+    return rc;
+
+  if ((rc = test_template_artifact_rejects_duplicate_migration ()) != 0)
+    return rc;
+
+  if ((rc =
+          test_template_artifact_rejects_tampered_migration_signature ()) != 0)
+    return rc;
+
+  if ((rc =
+          test_template_artifact_rejects_reserved_namespace_violation ()) != 0)
     return rc;
 
   return 0;

--- a/tests/test-template-tree.c
+++ b/tests/test-template-tree.c
@@ -343,6 +343,11 @@ check_template_manifest_contract (void)
   if (error != NULL || g_strcmp0 (semantics, "append-only") != 0)
     return 212;
 
+  g_autofree gchar *migration_path = g_key_file_get_string (key_file,
+      "template", "migration_path", &error);
+  if (error != NULL || g_strcmp0 (migration_path, "migrations") != 0)
+    return 218;
+
   g_autofree gchar *hash = g_key_file_get_string (key_file, "template",
       "sha256", &error);
   if (error != NULL || strlen (hash) != 64)
@@ -371,6 +376,76 @@ check_template_manifest_contract (void)
   return 0;
 }
 
+static gint
+check_template_migration_contract (void)
+{
+  g_autofree gchar *path = g_build_filename (WYL_TEST_TEMPLATE_DIR,
+      "migrations", "0000-baseline.ini", NULL);
+  g_autoptr (GKeyFile) key_file = g_key_file_new ();
+  g_autoptr (GError) error = NULL;
+
+  if (!g_key_file_load_from_file (key_file, path, G_KEY_FILE_NONE, &error))
+    return 230;
+
+  g_autofree gchar *id = g_key_file_get_string (key_file, "migration", "id",
+      &error);
+  if (error != NULL || g_strcmp0 (id, "0000-baseline") != 0)
+    return 231;
+
+  gint64 sequence = g_key_file_get_int64 (key_file, "migration", "sequence",
+      &error);
+  if (error != NULL || sequence != 0)
+    return 232;
+
+  gint64 from_version = g_key_file_get_int64 (key_file, "migration",
+      "from_version", &error);
+  if (error != NULL || from_version != 0)
+    return 233;
+
+  gint64 to_version = g_key_file_get_int64 (key_file, "migration",
+      "to_version", &error);
+  if (error != NULL || to_version != 0)
+    return 234;
+
+  g_autofree gchar *semantics = g_key_file_get_string (key_file, "migration",
+      "semantics", &error);
+  if (error != NULL || g_strcmp0 (semantics, "append-only") != 0)
+    return 235;
+
+  g_autofree gchar *operation = g_key_file_get_string (key_file, "migration",
+      "operation", &error);
+  if (error != NULL || g_strcmp0 (operation, "baseline") != 0)
+    return 236;
+
+  g_autofree gchar *reserved_namespace = g_key_file_get_string (key_file,
+      "migration", "reserved_namespace", &error);
+  if (error != NULL || g_strcmp0 (reserved_namespace, "wr.") != 0)
+    return 237;
+
+  g_autofree gchar *hash = g_key_file_get_string (key_file, "migration",
+      "sha256", &error);
+  if (error != NULL || strlen (hash) != 64)
+    return 238;
+
+  g_autofree gchar *context = g_key_file_get_string (key_file, "signature",
+      "context", &error);
+  if (error != NULL
+      || g_strcmp0 (context, "wyrelog-template-migration-v0-sha256") != 0)
+    return 239;
+
+  g_autofree gchar *public_key = g_key_file_get_string (key_file,
+      "signature", "public_key", &error);
+  if (error != NULL || strlen (public_key) != 64)
+    return 240;
+
+  g_autofree gchar *signature = g_key_file_get_string (key_file,
+      "signature", "ed25519", &error);
+  if (error != NULL || strlen (signature) != 128)
+    return 241;
+
+  return 0;
+}
+
 int
 main (void)
 {
@@ -388,5 +463,8 @@ main (void)
   rc = check_audit_schema_contracts ();
   if (rc != 0)
     return rc;
-  return check_template_manifest_contract ();
+  rc = check_template_manifest_contract ();
+  if (rc != 0)
+    return rc;
+  return check_template_migration_contract ();
 }

--- a/wyrelog/daemon/options.c
+++ b/wyrelog/daemon/options.c
@@ -30,6 +30,8 @@ wyl_daemon_parse_options (gint *argc, gchar ***argv, WylDaemonOptions *opts,
     {"template-version", 0, 0, G_OPTION_ARG_NONE,
           &opts->show_template_version,
         "Print access template version and exit", NULL},
+    {"template-info", 0, 0, G_OPTION_ARG_NONE, &opts->show_template_info,
+        "Print access template artifact identity and exit", NULL},
     {NULL}
   };
 

--- a/wyrelog/daemon/options.h
+++ b/wyrelog/daemon/options.h
@@ -16,6 +16,7 @@ typedef struct
   gboolean production_mode;
   gboolean show_version;
   gboolean show_template_version;
+  gboolean show_template_info;
 } WylDaemonOptions;
 
 gboolean wyl_daemon_parse_options (gint * argc, gchar *** argv,

--- a/wyrelog/daemon/wyrelogd.c
+++ b/wyrelog/daemon/wyrelogd.c
@@ -53,5 +53,31 @@ main (int argc, char **argv)
     return 0;
   }
 
+  if (opts.show_template_info) {
+    gchar *dl_src = NULL;
+    gsize dl_src_len = 0;
+    wyrelog_error_t rc =
+        wyl_engine_load_templates (opts.template_dir, &dl_src, &dl_src_len);
+    WylTemplateArtifactInfo info = { 0 };
+    if (rc == WYRELOG_E_OK) {
+      rc = wyl_engine_inspect_template_artifact (opts.template_dir, dl_src,
+          dl_src_len, TRUE, &info);
+    }
+    if (dl_src != NULL) {
+      memset (dl_src, 0, dl_src_len);
+      g_free (dl_src);
+    }
+    if (rc != WYRELOG_E_OK) {
+      g_printerr ("wyrelogd: template info unavailable: %s\n",
+          wyrelog_error_string (rc));
+      return 3;
+    }
+    g_print
+        ("version=%u\nsha256=%s\nmigrations=%u\nlatest_migration_version=%u\n",
+        info.version, info.sha256_hex, info.migration_count,
+        info.latest_migration_version);
+    return 0;
+  }
+
   return wyl_daemon_run_runtime (&opts);
 }

--- a/wyrelog/wyl-engine-private.h
+++ b/wyrelog/wyl-engine-private.h
@@ -30,6 +30,14 @@ typedef enum
 
 typedef struct _WylDeltaCookie WylDeltaCookie;
 
+typedef struct
+{
+  guint32 version;
+  gchar sha256_hex[65];
+  guint32 migration_count;
+  guint32 latest_migration_version;
+} WylTemplateArtifactInfo;
+
 struct _WylEngine
 {
   GObject parent_instance;
@@ -75,6 +83,9 @@ wyrelog_error_t wyl_engine_load_templates (const gchar * template_dir,
 wyrelog_error_t wyl_engine_verify_template_manifest (const gchar * template_dir,
     const gchar * dl_src, gsize dl_src_len, gboolean require_manifest,
     guint32 * template_version_out);
+wyrelog_error_t wyl_engine_inspect_template_artifact (const gchar *
+    template_dir, const gchar * dl_src, gsize dl_src_len,
+    gboolean require_manifest, WylTemplateArtifactInfo * info_out);
 wyrelog_error_t wyl_engine_open_with_options (const gchar * template_dir,
     guint32 num_workers, gboolean require_template_manifest, WylEngine ** out);
 

--- a/wyrelog/wyl-engine.c
+++ b/wyrelog/wyl-engine.c
@@ -30,6 +30,9 @@ G_STATIC_ASSERT (G_N_ELEMENTS (TEMPLATE_FILES) == WYL_ENGINE_TEMPLATE_COUNT);
 #define WYL_ENGINE_LEGACY_DECISION_TEMPLATE "decision.dl"
 #define WYL_ENGINE_TEMPLATE_MANIFEST "manifest.ini"
 #define WYL_ENGINE_TEMPLATE_SIGNATURE_CONTEXT "wyrelog-template-v0-sha256"
+#define WYL_ENGINE_TEMPLATE_MIGRATION_DIR "migrations"
+#define WYL_ENGINE_TEMPLATE_MIGRATION_SIGNATURE_CONTEXT \
+  "wyrelog-template-migration-v0-sha256"
 
 typedef struct
 {
@@ -97,13 +100,254 @@ hash_template_source_canonical (guint8 out_hash[crypto_hash_sha256_BYTES],
   crypto_hash_sha256_final (&state, out_hash);
 }
 
-wyrelog_error_t
-wyl_engine_verify_template_manifest (const gchar *template_dir,
-    const gchar *dl_src, gsize dl_src_len, gboolean require_manifest,
-    guint32 *template_version_out)
+static gchar *
+hex_encode (const guint8 *data, gsize len)
 {
-  if (template_version_out != NULL)
-    *template_version_out = 0;
+  gchar *hex = g_malloc0 ((len * 2) + 1);
+  sodium_bin2hex (hex, (len * 2) + 1, data, len);
+  return hex;
+}
+
+static gchar *
+canonical_migration_payload (const gchar *id, guint64 sequence,
+    guint64 from_version, guint64 to_version, const gchar *semantics,
+    const gchar *operation, const gchar *reserved_namespace)
+{
+  return g_strdup_printf ("id=%s\nsequence=%" G_GUINT64_FORMAT
+      "\nfrom_version=%" G_GUINT64_FORMAT "\nto_version=%" G_GUINT64_FORMAT
+      "\nsemantics=%s\noperation=%s\n" "reserved_namespace=%s\n", id, sequence,
+      from_version, to_version, semantics, operation, reserved_namespace);
+}
+
+static gboolean
+migration_operation_is_append_only (const gchar *operation)
+{
+  return g_strcmp0 (operation, "baseline") == 0
+      || g_strcmp0 (operation, "additive") == 0
+      || g_strcmp0 (operation, "supersession") == 0;
+}
+
+static gint
+compare_string_ptr (gconstpointer a, gconstpointer b)
+{
+  const gchar *const *sa = a;
+  const gchar *const *sb = b;
+  return g_strcmp0 (*sa, *sb);
+}
+
+static wyrelog_error_t
+verify_migration_artifact (const gchar *path, const gchar *name,
+    guint32 expected_sequence, guint32 expected_from_version,
+    GHashTable *seen_ids, GHashTable *seen_sequences, guint32 *to_version_out)
+{
+  g_autoptr (GKeyFile) key_file = g_key_file_new ();
+  g_autoptr (GError) error = NULL;
+  if (!g_key_file_load_from_file (key_file, path, G_KEY_FILE_NONE, &error)) {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_BOOT,
+        "unreadable template migration artifact: %s", name);
+    return WYRELOG_E_IO;
+  }
+
+  gint64 sequence = g_key_file_get_int64 (key_file, "migration", "sequence",
+      &error);
+  if (error != NULL || sequence < 0 || sequence > G_MAXUINT32
+      || (guint32) sequence != expected_sequence) {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_BOOT,
+        "template migration artifact has invalid sequence: %s", name);
+    return WYRELOG_E_POLICY;
+  }
+
+  gchar expected_prefix[16];
+  g_snprintf (expected_prefix, sizeof expected_prefix, "%04u-",
+      (guint) expected_sequence);
+  if (!g_str_has_prefix (name, expected_prefix)) {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_BOOT,
+        "template migration artifact order does not match filename: %s", name);
+    return WYRELOG_E_POLICY;
+  }
+
+  g_autofree gchar *id = g_key_file_get_string (key_file, "migration", "id",
+      &error);
+  if (error != NULL || id == NULL || id[0] == '\0') {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_BOOT,
+        "template migration artifact has invalid id: %s", name);
+    return WYRELOG_E_POLICY;
+  }
+
+  if (g_hash_table_contains (seen_ids, id)
+      || g_hash_table_contains (seen_sequences, GUINT_TO_POINTER ((guint)
+              sequence))) {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_BOOT,
+        "template migration artifact is duplicated: %s", name);
+    return WYRELOG_E_POLICY;
+  }
+
+  gint64 from_version = g_key_file_get_int64 (key_file, "migration",
+      "from_version", &error);
+  if (error != NULL || from_version < 0 || from_version > G_MAXUINT32
+      || (guint32) from_version != expected_from_version) {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_BOOT,
+        "template migration artifact has invalid from_version: %s", name);
+    return WYRELOG_E_POLICY;
+  }
+
+  gint64 to_version = g_key_file_get_int64 (key_file, "migration",
+      "to_version", &error);
+  if (error != NULL || to_version < from_version || to_version > G_MAXUINT32) {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_BOOT,
+        "template migration artifact has invalid to_version: %s", name);
+    return WYRELOG_E_POLICY;
+  }
+
+  g_autofree gchar *semantics = g_key_file_get_string (key_file, "migration",
+      "semantics", &error);
+  if (error != NULL || g_strcmp0 (semantics, "append-only") != 0) {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_BOOT,
+        "template migration artifact rejects append-only semantics: %s", name);
+    return WYRELOG_E_POLICY;
+  }
+
+  g_autofree gchar *operation = g_key_file_get_string (key_file, "migration",
+      "operation", &error);
+  if (error != NULL || !migration_operation_is_append_only (operation)) {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_BOOT,
+        "template migration artifact has non append-only operation: %s", name);
+    return WYRELOG_E_POLICY;
+  }
+
+  g_autofree gchar *reserved_namespace = g_key_file_get_string (key_file,
+      "migration", "reserved_namespace", &error);
+  if (error != NULL || g_strcmp0 (reserved_namespace, "wr.") != 0) {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_BOOT,
+        "template migration artifact violates reserved namespace: %s", name);
+    return WYRELOG_E_POLICY;
+  }
+
+  g_autofree gchar *hash_hex = g_key_file_get_string (key_file, "migration",
+      "sha256", &error);
+  g_autofree gchar *public_key_hex = g_key_file_get_string (key_file,
+      "signature", "public_key", &error);
+  g_autofree gchar *signature_hex = g_key_file_get_string (key_file,
+      "signature", "ed25519", &error);
+  if (error != NULL) {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_BOOT,
+        "template migration artifact is missing signed identity: %s", name);
+    return WYRELOG_E_POLICY;
+  }
+
+  guint8 expected_hash[crypto_hash_sha256_BYTES];
+  wyrelog_error_t rc = decode_hex_field ("migration sha256", hash_hex,
+      expected_hash, sizeof expected_hash);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  g_autofree gchar *payload = canonical_migration_payload (id,
+      (guint64) sequence, (guint64) from_version, (guint64) to_version,
+      semantics, operation, reserved_namespace);
+  guint8 actual_hash[crypto_hash_sha256_BYTES];
+  crypto_hash_sha256 (actual_hash, (const guint8 *) payload, strlen (payload));
+  if (sodium_memcmp (actual_hash, expected_hash, sizeof actual_hash) != 0) {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_BOOT,
+        "template migration artifact hash mismatch: %s", name);
+    return WYRELOG_E_POLICY;
+  }
+
+  guint8 public_key[crypto_sign_PUBLICKEYBYTES];
+  rc = decode_hex_field ("migration public_key", public_key_hex, public_key,
+      sizeof public_key);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  guint8 signature[crypto_sign_BYTES];
+  rc = decode_hex_field ("migration ed25519", signature_hex, signature,
+      sizeof signature);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  g_autoptr (GByteArray) signed_payload = g_byte_array_new ();
+  g_byte_array_append (signed_payload,
+      (const guint8 *) WYL_ENGINE_TEMPLATE_MIGRATION_SIGNATURE_CONTEXT,
+      strlen (WYL_ENGINE_TEMPLATE_MIGRATION_SIGNATURE_CONTEXT));
+  g_byte_array_append (signed_payload, actual_hash, sizeof actual_hash);
+  if (crypto_sign_verify_detached (signature, signed_payload->data,
+          signed_payload->len, public_key) != 0) {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_BOOT,
+        "template migration artifact signature verification failed: %s", name);
+    return WYRELOG_E_CRYPTO;
+  }
+
+  g_hash_table_add (seen_ids, g_strdup (id));
+  g_hash_table_add (seen_sequences, GUINT_TO_POINTER ((guint) sequence));
+  *to_version_out = (guint32) to_version;
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+verify_template_migrations (const gchar *template_dir,
+    const gchar *migration_path, guint32 template_version,
+    guint32 *migration_count_out, guint32 *latest_migration_version_out)
+{
+  *migration_count_out = 0;
+  *latest_migration_version_out = template_version;
+
+  if (migration_path == NULL || migration_path[0] == '\0')
+    return WYRELOG_E_OK;
+  if (g_path_is_absolute (migration_path)
+      || strstr (migration_path, "..") != NULL) {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_BOOT,
+        "template manifest has invalid migration path");
+    return WYRELOG_E_POLICY;
+  }
+
+  g_autofree gchar *dir_path = g_build_filename (template_dir,
+      migration_path, NULL);
+  g_autoptr (GDir) dir = g_dir_open (dir_path, 0, NULL);
+  if (dir == NULL) {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_BOOT,
+        "missing template migration directory: %s", migration_path);
+    return WYRELOG_E_POLICY;
+  }
+
+  g_autoptr (GPtrArray) names = g_ptr_array_new_with_free_func (g_free);
+  const gchar *entry = NULL;
+  while ((entry = g_dir_read_name (dir)) != NULL) {
+    if (g_str_has_suffix (entry, ".ini"))
+      g_ptr_array_add (names, g_strdup (entry));
+  }
+  if (names->len == 0) {
+    WYL_LOG_ERROR (WYL_LOG_SECTION_BOOT,
+        "template migration directory is empty: %s", migration_path);
+    return WYRELOG_E_POLICY;
+  }
+  g_ptr_array_sort (names, compare_string_ptr);
+
+  g_autoptr (GHashTable) seen_ids = g_hash_table_new_full (g_str_hash,
+      g_str_equal, g_free, NULL);
+  g_autoptr (GHashTable) seen_sequences = g_hash_table_new (g_direct_hash,
+      g_direct_equal);
+  guint32 expected_from_version = template_version;
+  for (guint i = 0; i < names->len; i++) {
+    const gchar *name = g_ptr_array_index (names, i);
+    g_autofree gchar *path = g_build_filename (dir_path, name, NULL);
+    guint32 to_version = 0;
+    wyrelog_error_t rc = verify_migration_artifact (path, name, i,
+        expected_from_version, seen_ids, seen_sequences, &to_version);
+    if (rc != WYRELOG_E_OK)
+      return rc;
+    expected_from_version = to_version;
+  }
+
+  *migration_count_out = names->len;
+  *latest_migration_version_out = expected_from_version;
+  return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
+wyl_engine_inspect_template_artifact (const gchar *template_dir,
+    const gchar *dl_src, gsize dl_src_len, gboolean require_manifest,
+    WylTemplateArtifactInfo *info_out)
+{
+  if (info_out != NULL)
+    memset (info_out, 0, sizeof *info_out);
 
   if (template_dir == NULL || dl_src == NULL)
     return WYRELOG_E_INVALID;
@@ -147,6 +391,8 @@ wyl_engine_verify_template_manifest (const gchar *template_dir,
     return WYRELOG_E_POLICY;
   }
 
+  g_autofree gchar *migration_path = g_key_file_get_string (key_file,
+      "template", "migration_path", NULL);
   g_autofree gchar *hash_hex = g_key_file_get_string (key_file, "template",
       "sha256", &error);
   if (error != NULL) {
@@ -207,9 +453,36 @@ wyl_engine_verify_template_manifest (const gchar *template_dir,
     return WYRELOG_E_CRYPTO;
   }
 
-  if (template_version_out != NULL)
-    *template_version_out = (guint32) version;
+  guint32 migration_count = 0;
+  guint32 latest_migration_version = 0;
+  rc = verify_template_migrations (template_dir, migration_path,
+      (guint32) version, &migration_count, &latest_migration_version);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  if (info_out != NULL) {
+    info_out->version = (guint32) version;
+    info_out->migration_count = migration_count;
+    info_out->latest_migration_version = latest_migration_version;
+    g_autofree gchar *actual_hash_hex = hex_encode (actual_hash,
+        sizeof actual_hash);
+    g_strlcpy (info_out->sha256_hex, actual_hash_hex,
+        sizeof info_out->sha256_hex);
+  }
   return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
+wyl_engine_verify_template_manifest (const gchar *template_dir,
+    const gchar *dl_src, gsize dl_src_len, gboolean require_manifest,
+    guint32 *template_version_out)
+{
+  WylTemplateArtifactInfo info = { 0 };
+  wyrelog_error_t rc = wyl_engine_inspect_template_artifact (template_dir,
+      dl_src, dl_src_len, require_manifest, &info);
+  if (rc == WYRELOG_E_OK && template_version_out != NULL)
+    *template_version_out = info.version;
+  return rc;
 }
 
 static void


### PR DESCRIPTION
## Summary

- add a signed baseline migration artifact under the access template tree
- validate template migration ordering, append-only semantics, hashes, signatures, and reserved namespace before engine load
- add `wyrelogd --template-info` for operator-visible template version/hash/migration identity
- cover valid identity, missing/duplicate migrations, tampered migration content, reserved namespace violations, and template tree contract checks

## Test plan

- `meson compile -C builddir`
- `meson test -C builddir template-tree engine wyrelogd-check wyrelogd-production-gates --print-errorlogs`
- `meson test -C builddir --suite wyrelog --print-errorlogs`
- `builddir/wyrelog/wyrelogd --template-dir templates/access --template-info`