### PR TITLE
auth: bind JWT keys to boot epochs

### DIFF
--- a/docs/auth-session-restart-model.md
+++ b/docs/auth-session-restart-model.md
@@ -1,0 +1,46 @@
+# LoBAC Auth Restart and JWT Key Model
+
+LoBAC v0 uses a restart-invalidates-all auth/session model.
+
+## Restart Semantics
+
+Daemon restart invalidates every in-memory HTTP session, access token,
+refresh token, refresh successor, refresh reuse marker, and logout tombstone.
+Clients must treat any authentication failure after restart as a full
+reauthentication requirement.
+
+Stable wire errors after restart:
+
+- Bearer-protected endpoints return their existing `*_auth_required` code.
+- `/auth/refresh` returns `refresh_auth_required`.
+- Tenant mismatch remains fail-closed through `tenant_invalid` or
+  `tenant_denied` before endpoint-specific authorization continues.
+
+This model intentionally does not persist refresh-token state. A restart
+cannot resurrect a logged-out session or revoked refresh token because no
+previous token state is reloaded.
+
+## JWT Signing Key Custody
+
+Production JWT signing key material is rooted in the configured production
+KeyProvider path. On each daemon boot, the daemon derives a JWT root secret
+from the KeyProvider and mixes in a random boot epoch before issuing tokens.
+The boot epoch is reflected in the JWT `kid`, so tokens from a previous
+process epoch fail the key-id gate before they can bind to live token state.
+
+Non-production mode continues to use process-local random JWT key material.
+
+## Rotation Behavior
+
+JWT signing-key rotation is epoch rotation. Rotating the epoch clears active
+access-token and refresh-token state and changes the JWT `kid`. Existing
+session handles remain in memory, but clients must login again because old
+access and refresh tokens no longer authenticate.
+
+Operator runbook:
+
+1. Rotate the production KeyProvider material if the root must change.
+2. Restart the daemon to create a new boot epoch.
+3. Expect all clients to receive `*_auth_required` or
+   `refresh_auth_required` and perform a fresh login.
+4. Confirm `/readyz` returns ready before admitting traffic.

--- a/tests/check-wyrelogd-production-gates.sh
+++ b/tests/check-wyrelogd-production-gates.sh
@@ -35,3 +35,15 @@ if "$WYRELOGD" --production --template-dir "$TEMPLATE_DIR" \
   echo "production mode accepted the development KeyProvider" >&2
   exit 1
 fi
+
+"$PYTHON" - "$TMPDIR/prod.key" <<'PY'
+import os
+import sys
+
+with open(sys.argv[1], "wb") as f:
+    f.write(os.urandom(32))
+PY
+
+"$WYRELOGD" --production --template-dir "$TEMPLATE_DIR" \
+  --policy-db "$TMPDIR/prod.sqlite" \
+  --policy-keyprovider "$TMPDIR/prod.key" --check

--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -745,8 +745,12 @@ check_raw_decide_contract (SoupServer *server, WylHandle *handle,
   if (wyl_daemon_http_copy_access_token_secret (server, secret, sizeof secret)
       != WYRELOG_E_OK)
     return 1824;
+  g_autofree gchar *foreign_tenant_key_id =
+      wyl_daemon_http_dup_access_token_key_id (server);
+  if (foreign_tenant_key_id == NULL)
+    return 1827;
   wyl_jwt_issue_input_t foreign_tenant_input = {
-    .key_id = "__wr_default_hs256",
+    .key_id = foreign_tenant_key_id,
     .jti = "foreign-tenant-jti",
     .subject = "http-guard-user",
     .issuer = "wyrelogd",
@@ -891,12 +895,14 @@ verify_login_access_token (const gchar *body, const gchar *session_token,
 
   g_autoptr (GBytes) payload = NULL;
   gint64 now = g_get_real_time () / G_USEC_PER_SEC;
+  g_autofree gchar *key_id = wyl_daemon_http_dup_access_token_key_id (server);
+  if (key_id == NULL)
+    return 532;
   wyrelog_error_t rc = wyl_jwt_verify_hs256_access_token (access_token, secret,
-      sizeof secret, "__wr_default_hs256", "wyrelogd", "wyrelog-client", now,
-      &payload);
+      sizeof secret, key_id, "wyrelogd", "wyrelog-client", now, &payload);
   memset (secret, 0, sizeof secret);
   if (rc != WYRELOG_E_OK)
-    return 532;
+    return 536;
 
   gsize payload_len = 0;
   const gchar *payload_data = g_bytes_get_data (payload, &payload_len);
@@ -913,10 +919,10 @@ verify_login_access_token (const gchar *body, const gchar *session_token,
       strstr (payload_text, expected_state) == NULL ||
       strstr (payload_text, expected_session) == NULL ||
       strstr (payload_text, expected_tenant) == NULL)
-    return 533;
+    return 537;
   g_autofree gchar *jti = extract_json_string (payload_text, "jti");
   if (jti == NULL || g_strcmp0 (jti, session_token) == 0)
-    return 534;
+    return 538;
   return 0;
 }
 
@@ -936,9 +942,14 @@ sign_test_access_token_with_jti (SoupServer *server, const gchar *jti,
       wyl_daemon_http_copy_access_token_secret (server, secret, sizeof secret);
   if (rc != WYRELOG_E_OK)
     return rc;
+  g_autofree gchar *key_id = wyl_daemon_http_dup_access_token_key_id (server);
+  if (key_id == NULL) {
+    memset (secret, 0, sizeof secret);
+    return WYRELOG_E_INTERNAL;
+  }
 
   wyl_jwt_issue_input_t input = {
-    .key_id = "__wr_default_hs256",
+    .key_id = key_id,
     .jti = jti,
     .subject = subject,
     .issuer = issuer,
@@ -1098,6 +1109,74 @@ session_state_expect_cb (const gchar *session_id, const gchar *state,
       g_strcmp0 (state, expect->state) == 0)
     expect->matches++;
   return WYRELOG_E_OK;
+}
+
+static gint
+check_jwt_epoch_rotation_contract (SoupServer *server, WylHandle *handle,
+    const gchar *base_url)
+{
+  g_autoptr (SoupSession) session = soup_session_new ();
+  guint status = 0;
+  g_autofree gchar *body = NULL;
+
+  g_autofree gchar *key_id_before =
+      wyl_daemon_http_dup_access_token_key_id (server);
+  if (key_id_before == NULL)
+    return 1840;
+
+  wyl_handle_set_login_skip_mfa_allowed (handle, TRUE);
+  gint rc = send_raw_login (session, "POST", base_url,
+      "username=rotation-user&skip_mfa=true", &status, &body);
+  wyl_handle_set_login_skip_mfa_allowed (handle, FALSE);
+  if (rc != 0)
+    return rc;
+  if (status != 200)
+    return 1841;
+
+  g_autofree gchar *session_token = extract_json_string (body,
+      "session_token");
+  g_autofree gchar *access_token = extract_json_string (body, "access_token");
+  g_autofree gchar *refresh_token = extract_json_string (body,
+      "refresh_token");
+  if (session_token == NULL || access_token == NULL || refresh_token == NULL)
+    return 1842;
+
+  g_clear_pointer (&body, g_free);
+  rc = send_raw_decide_bearer (session, "POST", base_url, "rotation-user",
+      "site.rotation.read", "rotation-scope", NULL, access_token, &status,
+      &body);
+  if (rc != 0)
+    return rc;
+  if (status != 200)
+    return 1843;
+
+  if (wyl_daemon_http_rotate_access_token_key_for_test (server)
+      != WYRELOG_E_OK)
+    return 1844;
+
+  g_autofree gchar *key_id_after =
+      wyl_daemon_http_dup_access_token_key_id (server);
+  if (key_id_after == NULL || g_strcmp0 (key_id_before, key_id_after) == 0)
+    return 1845;
+
+  g_clear_pointer (&body, g_free);
+  rc = send_raw_decide_bearer (session, "POST", base_url, "rotation-user",
+      "site.rotation.read", "rotation-scope", NULL, access_token, &status,
+      &body);
+  if (rc != 0)
+    return rc;
+  if (status != 401 || strstr (body, "\"decide_auth_required\"") == NULL)
+    return 1846;
+
+  g_clear_pointer (&body, g_free);
+  rc = send_raw_refresh (session, "POST", base_url, refresh_token, &status,
+      &body);
+  if (rc != 0)
+    return rc;
+  if (status != 401 || strstr (body, "\"refresh_auth_required\"") == NULL)
+    return 1847;
+
+  return 0;
 }
 
 static gint
@@ -3188,6 +3267,9 @@ main (void)
     return 13;
 
   raw_rc = check_raw_login_contract (http.server, handle, base_url);
+  if (raw_rc != 0)
+    return raw_rc;
+  raw_rc = check_jwt_epoch_rotation_contract (http.server, handle, base_url);
   if (raw_rc != 0)
     return raw_rc;
 

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -12,6 +12,7 @@
 #include "wyrelog/wyl-common-private.h"
 #include "wyrelog/wyl-handle-private.h"
 #include "wyrelog/wyl-id-private.h"
+#include "wyrelog/wyl-keyprovider-file-private.h"
 #include "wyrelog/wyl-request-id-private.h"
 #include "wyrelog/wyl-fsm-permission-scope-private.h"
 #include "wyrelog/wyl-permission-scope-private.h"
@@ -20,6 +21,9 @@
 #define WYL_DAEMON_JWT_AUDIENCE "wyrelog-client"
 #define WYL_DAEMON_JWT_KEY_ID "__wr_default_hs256"
 #define WYL_DAEMON_JWT_KEY_LEN 32
+#define WYL_DAEMON_JWT_EPOCH_LEN 16
+#define WYL_DAEMON_JWT_KEYPROVIDER_LABEL "wyrelog.jwt.hs256.root.v1"
+#define WYL_DAEMON_JWT_BOOT_EPOCH_CONTEXT "wyrelog.jwt.hs256.boot_epoch.v1"
 #define WYL_DAEMON_REFRESH_TTL_SECONDS 86400
 #define WYL_DAEMON_REFRESH_GRACE_SECONDS 30
 #define WYL_DAEMON_REQUEST_ID_HEADER "X-Wyrelog-Request-Id"
@@ -93,7 +97,10 @@ typedef struct
   WylHandle *handle;
   WylDaemonRuntime *runtime;
   guint8 access_token_secret[WYL_DAEMON_JWT_KEY_LEN];
+  gchar *access_token_key_id;
   gboolean access_token_secret_ready;
+  gboolean production_mode;
+  gchar *policy_keyprovider_path;
   GHashTable *sessions_by_token;
   GHashTable *access_tokens_by_jti;
   GHashTable *refresh_tokens_by_token;
@@ -180,6 +187,8 @@ wyl_daemon_http_context_free (gpointer data)
     return;
 
   sodium_memzero (ctx->access_token_secret, sizeof ctx->access_token_secret);
+  g_free (ctx->access_token_key_id);
+  g_free (ctx->policy_keyprovider_path);
   g_hash_table_unref (ctx->sessions_by_token);
   g_hash_table_unref (ctx->access_tokens_by_jti);
   g_hash_table_unref (ctx->refresh_tokens_by_token);
@@ -189,17 +198,110 @@ wyl_daemon_http_context_free (gpointer data)
   g_free (ctx);
 }
 
+static wyrelog_error_t
+derive_access_token_secret (const WylDaemonOptions *opts,
+    guint8 out_secret[WYL_DAEMON_JWT_KEY_LEN], gchar **out_key_id)
+{
+  if (opts == NULL || out_secret == NULL || out_key_id == NULL)
+    return WYRELOG_E_INVALID;
+  *out_key_id = NULL;
+
+  if (sodium_init () < 0)
+    return WYRELOG_E_CRYPTO;
+
+  guint8 epoch[WYL_DAEMON_JWT_EPOCH_LEN];
+  randombytes_buf (epoch, sizeof epoch);
+  g_autofree gchar *epoch_hex = g_malloc0 ((sizeof epoch * 2) + 1);
+  sodium_bin2hex (epoch_hex, (sizeof epoch * 2) + 1, epoch, sizeof epoch);
+
+  if (!opts->production_mode) {
+    randombytes_buf (out_secret, WYL_DAEMON_JWT_KEY_LEN);
+    *out_key_id = g_strdup_printf ("%s.%s", WYL_DAEMON_JWT_KEY_ID, epoch_hex);
+    sodium_memzero (epoch, sizeof epoch);
+    return WYRELOG_E_OK;
+  }
+
+  if (opts->policy_keyprovider_path == NULL
+      || opts->policy_keyprovider_path[0] == '\0') {
+    sodium_memzero (epoch, sizeof epoch);
+    return WYRELOG_E_POLICY;
+  }
+
+  g_autoptr (wyl_keyprovider_file_t) keyprovider =
+      wyl_keyprovider_file_new (opts->policy_keyprovider_path);
+  if (keyprovider == NULL) {
+    sodium_memzero (epoch, sizeof epoch);
+    return WYRELOG_E_CRYPTO;
+  }
+
+  const wyl_keyprovider_vtable_t *vt = wyl_keyprovider_file_get_vtable ();
+  guint8 root[WYL_DAEMON_JWT_KEY_LEN];
+  wyrelog_error_t rc = vt->derive (keyprovider,
+      WYL_DAEMON_JWT_KEYPROVIDER_LABEL, root, sizeof root);
+  if (rc != WYRELOG_E_OK) {
+    sodium_memzero (epoch, sizeof epoch);
+    return rc;
+  }
+
+  crypto_generichash_state state;
+  if (crypto_generichash_init (&state, root, sizeof root,
+          WYL_DAEMON_JWT_KEY_LEN) != 0) {
+    sodium_memzero (root, sizeof root);
+    sodium_memzero (epoch, sizeof epoch);
+    return WYRELOG_E_CRYPTO;
+  }
+  crypto_generichash_update (&state,
+      (const guint8 *) WYL_DAEMON_JWT_BOOT_EPOCH_CONTEXT,
+      strlen (WYL_DAEMON_JWT_BOOT_EPOCH_CONTEXT));
+  crypto_generichash_update (&state, epoch, sizeof epoch);
+  crypto_generichash_final (&state, out_secret, WYL_DAEMON_JWT_KEY_LEN);
+
+  sodium_memzero (root, sizeof root);
+  sodium_memzero (epoch, sizeof epoch);
+  *out_key_id = g_strdup_printf ("%s.%s", WYL_DAEMON_JWT_KEY_ID, epoch_hex);
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+wyl_daemon_http_context_rotate_access_token_key (WylDaemonHttpContext *ctx)
+{
+  if (ctx == NULL)
+    return WYRELOG_E_INVALID;
+
+  WylDaemonOptions opts = {
+    .production_mode = ctx->production_mode,
+    .policy_keyprovider_path = ctx->policy_keyprovider_path,
+  };
+  guint8 next_secret[WYL_DAEMON_JWT_KEY_LEN];
+  g_autofree gchar *next_key_id = NULL;
+  wyrelog_error_t rc = derive_access_token_secret (&opts, next_secret,
+      &next_key_id);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  g_mutex_lock (&ctx->lock);
+  sodium_memzero (ctx->access_token_secret, sizeof ctx->access_token_secret);
+  memcpy (ctx->access_token_secret, next_secret, sizeof next_secret);
+  g_clear_pointer (&ctx->access_token_key_id, g_free);
+  ctx->access_token_key_id = g_steal_pointer (&next_key_id);
+  ctx->access_token_secret_ready = TRUE;
+  g_hash_table_remove_all (ctx->access_tokens_by_jti);
+  g_hash_table_remove_all (ctx->refresh_tokens_by_token);
+  g_mutex_unlock (&ctx->lock);
+  sodium_memzero (next_secret, sizeof next_secret);
+  return WYRELOG_E_OK;
+}
+
 static WylDaemonHttpContext *
-wyl_daemon_http_context_new (WylHandle *handle, WylDaemonRuntime *runtime)
+wyl_daemon_http_context_new (const WylDaemonOptions *opts, WylHandle *handle,
+    WylDaemonRuntime *runtime, GError **error)
 {
   WylDaemonHttpContext *ctx = g_new0 (WylDaemonHttpContext, 1);
 
   ctx->handle = handle;
   ctx->runtime = runtime;
-  if (sodium_init () >= 0) {
-    randombytes_buf (ctx->access_token_secret, sizeof ctx->access_token_secret);
-    ctx->access_token_secret_ready = TRUE;
-  }
+  ctx->production_mode = opts->production_mode;
+  ctx->policy_keyprovider_path = g_strdup (opts->policy_keyprovider_path);
   ctx->sessions_by_token =
       g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_object_unref);
   ctx->access_tokens_by_jti = g_hash_table_new_full (g_str_hash, g_str_equal,
@@ -210,6 +312,13 @@ wyl_daemon_http_context_new (WylHandle *handle, WylDaemonRuntime *runtime)
       g_free, NULL);
   g_mutex_init (&ctx->lock);
   g_mutex_init (&ctx->policy_mutation_lock);
+  wyrelog_error_t rc = wyl_daemon_http_context_rotate_access_token_key (ctx);
+  if (rc != WYRELOG_E_OK) {
+    g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_FAILED,
+        "JWT signing key initialization failed: %s", wyrelog_error_string (rc));
+    wyl_daemon_http_context_free (ctx);
+    return NULL;
+  }
   return ctx;
 }
 
@@ -334,7 +443,7 @@ wyl_daemon_http_context_access_token_is_active (WylDaemonHttpContext *ctx,
       && g_strcmp0 (state->session_id, claims->session_id) == 0
       && g_strcmp0 (state->subject, claims->subject) == 0
       && g_strcmp0 (state->tenant, claims->tenant) == 0
-      && g_strcmp0 (state->key_id, WYL_DAEMON_JWT_KEY_ID) == 0
+      && g_strcmp0 (state->key_id, ctx->access_token_key_id) == 0
       && state->expires_at == claims->expires_at;
   g_mutex_unlock (&ctx->lock);
   return active;
@@ -430,8 +539,30 @@ wyl_daemon_http_copy_access_token_secret (SoupServer *server,
   if (!ctx->access_token_secret_ready)
     return WYRELOG_E_INTERNAL;
 
+  g_mutex_lock (&ctx->lock);
   memcpy (out_secret, ctx->access_token_secret, WYL_DAEMON_JWT_KEY_LEN);
+  g_mutex_unlock (&ctx->lock);
   return WYRELOG_E_OK;
+}
+
+gchar *
+wyl_daemon_http_dup_access_token_key_id (SoupServer *server)
+{
+  WylDaemonHttpContext *ctx = wyl_daemon_http_get_context (server);
+  if (ctx == NULL)
+    return NULL;
+
+  g_mutex_lock (&ctx->lock);
+  gchar *key_id = g_strdup (ctx->access_token_key_id);
+  g_mutex_unlock (&ctx->lock);
+  return key_id;
+}
+
+wyrelog_error_t
+wyl_daemon_http_rotate_access_token_key_for_test (SoupServer *server)
+{
+  WylDaemonHttpContext *ctx = wyl_daemon_http_get_context (server);
+  return wyl_daemon_http_context_rotate_access_token_key (ctx);
 }
 
 gboolean
@@ -643,7 +774,9 @@ copy_access_token_secret (WylDaemonHttpContext *ctx,
     return WYRELOG_E_INVALID;
   if (!ctx->access_token_secret_ready)
     return WYRELOG_E_INTERNAL;
+  g_mutex_lock (&ctx->lock);
   memcpy (out_secret, ctx->access_token_secret, WYL_DAEMON_JWT_KEY_LEN);
+  g_mutex_unlock (&ctx->lock);
   return WYRELOG_E_OK;
 }
 
@@ -677,7 +810,7 @@ issue_access_token (WylDaemonHttpContext *ctx, const gchar *session_token,
     return WYRELOG_E_INVALID;
   }
   wyl_jwt_issue_input_t input = {
-    .key_id = WYL_DAEMON_JWT_KEY_ID,
+    .key_id = ctx->access_token_key_id,
     .jti = token_id,
     .subject = username,
     .issuer = WYL_DAEMON_JWT_ISSUER,
@@ -693,7 +826,7 @@ issue_access_token (WylDaemonHttpContext *ctx, const gchar *session_token,
   if (rc != WYRELOG_E_OK)
     return rc;
   if (!wyl_daemon_http_context_store_access_token (ctx, token_id,
-          session_token, username, tenant, WYL_DAEMON_JWT_KEY_ID,
+          session_token, username, tenant, ctx->access_token_key_id,
           issued_at + ttl)) {
     g_clear_pointer (out_token, g_free);
     return WYRELOG_E_INTERNAL;
@@ -792,7 +925,7 @@ resolve_bearer_session (SoupServer *server, WylDaemonHttpContext *ctx,
   g_autoptr (GBytes) payload = NULL;
   gint64 now = g_get_real_time () / G_USEC_PER_SEC;
   rc = wyl_jwt_verify_hs256_access_token (token, secret, sizeof secret,
-      WYL_DAEMON_JWT_KEY_ID, WYL_DAEMON_JWT_ISSUER,
+      ctx->access_token_key_id, WYL_DAEMON_JWT_ISSUER,
       WYL_DAEMON_JWT_AUDIENCE, now, &payload);
   sodium_memzero (secret, sizeof secret);
   if (rc != WYRELOG_E_OK)
@@ -2110,7 +2243,12 @@ wyl_daemon_start_http_server_with_runtime (const WylDaemonOptions *opts,
   }
 
   SoupServer *server = soup_server_new (NULL, NULL);
-  WylDaemonHttpContext *ctx = wyl_daemon_http_context_new (handle, runtime);
+  WylDaemonHttpContext *ctx =
+      wyl_daemon_http_context_new (opts, handle, runtime, error);
+  if (ctx == NULL) {
+    g_object_unref (server);
+    return NULL;
+  }
   g_object_set_data_full (G_OBJECT (server), "wyl-daemon-http-context", ctx,
       wyl_daemon_http_context_free);
   soup_server_add_handler (server, "/healthz", healthz_handler, NULL, NULL);

--- a/wyrelog/daemon/http.h
+++ b/wyrelog/daemon/http.h
@@ -21,6 +21,9 @@ WylSession *wyl_daemon_http_ref_session (SoupServer * server,
 #ifdef WYL_TEST_DAEMON_HTTP
 wyrelog_error_t wyl_daemon_http_copy_access_token_secret (SoupServer * server,
     guint8 * out_secret, gsize out_len);
+gchar *wyl_daemon_http_dup_access_token_key_id (SoupServer * server);
+wyrelog_error_t wyl_daemon_http_rotate_access_token_key_for_test
+    (SoupServer * server);
 gboolean wyl_daemon_http_remove_session_for_test (SoupServer * server,
     const gchar * session_token);
 gboolean wyl_daemon_http_expire_refresh_grace_for_test (SoupServer * server,

--- a/wyrelog/daemon/runtime.c
+++ b/wyrelog/daemon/runtime.c
@@ -2,6 +2,7 @@
 #include "daemon/runtime.h"
 
 #include <glib.h>
+#include <glib/gstdio.h>
 
 #include "daemon/checks.h"
 #include "daemon/delta.h"
@@ -9,6 +10,19 @@
 #include "daemon/signals.h"
 #include "wyrelog/wyrelog.h"
 #include "wyrelog/wyl-handle-private.h"
+
+static void
+cleanup_readiness_policy_db (gpointer data)
+{
+  gchar *path = data;
+  if (path == NULL)
+    return;
+
+  g_autofree gchar *clear_path = g_strdup_printf ("%s.clear", path);
+  (void) g_remove (path);
+  (void) g_remove (clear_path);
+  g_free (path);
+}
 
 static wyrelog_error_t
 open_runtime_handle (const WylDaemonOptions *opts, WylHandle **out_handle)
@@ -30,16 +44,38 @@ open_runtime_handle (const WylDaemonOptions *opts, WylHandle **out_handle)
 static wyrelog_error_t
 open_readiness_handle (const WylDaemonOptions *opts, WylHandle **out_handle)
 {
+  if (out_handle == NULL)
+    return WYRELOG_E_INVALID;
+  *out_handle = NULL;
+
+  g_autofree gchar *scratch_policy_store = NULL;
+  if (opts->production_mode) {
+    g_autoptr (GError) error = NULL;
+    gint fd = g_file_open_tmp ("wyrelog-readiness-policy-XXXXXX.sqlite",
+        &scratch_policy_store, &error);
+    if (fd < 0)
+      return WYRELOG_E_IO;
+    (void) g_close (fd, NULL);
+    (void) g_remove (scratch_policy_store);
+  }
+
   /* Readiness probes intentionally run against scratch stores: the checks
    * exercise mutation paths and must not seed configured authority data. */
   WylHandleOpenOptions open_opts = {
     .template_dir = opts->template_dir,
+    .policy_store_path = scratch_policy_store,
     .policy_keyprovider_path = opts->policy_keyprovider_path,
     .production_mode = opts->production_mode,
     .require_template_manifest = opts->production_mode,
   };
 
-  return wyl_handle_open_with_options (&open_opts, out_handle);
+  wyrelog_error_t rc = wyl_handle_open_with_options (&open_opts, out_handle);
+  if (rc == WYRELOG_E_OK && scratch_policy_store != NULL) {
+    g_object_set_data_full (G_OBJECT (*out_handle),
+        "wyl-readiness-policy-db", g_steal_pointer (&scratch_policy_store),
+        cleanup_readiness_policy_db);
+  }
+  return rc;
 }
 
 static gboolean

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -604,7 +604,7 @@ wyl_handle_open_with_options (const WylHandleOpenOptions *opts,
       return WYRELOG_E_CRYPTO;
     }
     store_open_opts.keyprovider_vtable = wyl_keyprovider_file_get_vtable ();
-    store_open_opts.keyprovider_state = keyprovider_state;
+    store_open_opts.keyprovider_state = g_steal_pointer (&keyprovider_state);
     store_open_opts.keyprovider_state_free =
         (void (*)(gpointer)) wyl_keyprovider_file_free;
   }


### PR DESCRIPTION
## Summary

- document the LoBAC v0 auth restart model as restart-invalidates-all
- derive production JWT signing material from the configured KeyProvider path and bind issued tokens to a per-boot epoch `kid`
- rotate JWT epochs by clearing access and refresh token state, making old bearer and refresh tokens fail closed
- fix production readiness/check scratch policy DB handling so encrypted production gates can run with a real KeyProvider
- add coverage for JWT epoch rotation invalidating old access and refresh tokens, plus a positive production KeyProvider gate

## Test plan

- `meson compile -C builddir`
- `meson test -C builddir daemon-http-decide jwt wyrelogd-production-gates --print-errorlogs`
- `meson test -C builddir --suite wyrelog --print-errorlogs`