### PR TITLE
engine: align with wirelog easy API rename

### DIFF
--- a/tests/test-engine-intern.c
+++ b/tests/test-engine-intern.c
@@ -354,14 +354,14 @@ test_intern_after_close (void)
 
   /* Simulate a closed engine: close the underlying session directly and
    * null the pointer so the engine object remains alive but sessionless. */
-  wl_easy_close (engine->session);
+  wirelog_easy_close (engine->session);
   engine->session = NULL;
 
   gint64 id = -999;
   rc = wyl_engine_intern_symbol (engine, "alice", &id);
 
   /* Release the engine. finalize will see session == NULL and skip
-   * wl_easy_close (g_clear_pointer is a no-op on NULL). */
+   * wirelog_easy_close (g_clear_pointer is a no-op on NULL). */
   g_object_unref (engine);
 
   if (rc != WYRELOG_E_INVALID) {

--- a/tests/test-engine-io.c
+++ b/tests/test-engine-io.c
@@ -537,7 +537,7 @@ test_delta_after_close (void)
 {
   WylEngine *engine = open_engine_from_test_templates ();
 
-  wl_easy_close (engine->session);
+  wirelog_easy_close (engine->session);
   engine->session = NULL;
 
   g_assert_cmpint (wyl_engine_set_delta_callback (engine, delta_expect_cb,
@@ -594,7 +594,7 @@ test_insert_after_close (void)
   WylEngine *engine = open_engine_from_test_templates ();
   gint64 row[3] = { 1, 2, 3 };
 
-  wl_easy_close (engine->session);
+  wirelog_easy_close (engine->session);
   engine->session = NULL;
 
   g_assert_cmpint (wyl_engine_insert (engine, "member_of", row, 3),
@@ -618,7 +618,7 @@ test_step_after_close (void)
 {
   WylEngine *engine = open_engine_from_test_templates ();
 
-  wl_easy_close (engine->session);
+  wirelog_easy_close (engine->session);
   engine->session = NULL;
 
   g_assert_cmpint (wyl_engine_step (engine), ==, WYRELOG_E_INVALID);
@@ -665,7 +665,7 @@ test_snapshot_after_close (void)
   WylEngine *engine = open_engine_from_test_templates ();
   guint seen = 0;
 
-  wl_easy_close (engine->session);
+  wirelog_easy_close (engine->session);
   engine->session = NULL;
 
   g_assert_cmpint (wyl_engine_snapshot (engine, "member_of",
@@ -722,7 +722,7 @@ test_remove_after_close (void)
   WylEngine *engine = open_engine_from_test_templates ();
   gint64 row[3] = { 1, 2, 3 };
 
-  wl_easy_close (engine->session);
+  wirelog_easy_close (engine->session);
   engine->session = NULL;
 
   g_assert_cmpint (wyl_engine_remove (engine, "member_of", row, 3),

--- a/wyrelog/wyl-engine-private.h
+++ b/wyrelog/wyl-engine-private.h
@@ -4,7 +4,7 @@
 #include <glib.h>
 #include <glib-object.h>
 
-#include <wirelog/wl_easy.h>
+#include <wirelog/wirelog-easy.h>
 
 #include "wyrelog/engine.h"
 #include "wyrelog/error.h"
@@ -41,7 +41,7 @@ typedef struct
 struct _WylEngine
 {
   GObject parent_instance;
-  wl_easy_session_t *session;
+  wirelog_easy_session_t *session;
   /* Logical path strings for diagnostic logging only; freed in finalize. */
   gchar *dl_src_logical_paths[WYL_ENGINE_TEMPLATE_COUNT];
   wyl_engine_mode_t mode;       /* Latched at first step or snapshot. */

--- a/wyrelog/wyl-engine.c
+++ b/wyrelog/wyl-engine.c
@@ -526,7 +526,7 @@ wyl_engine_finalize (GObject *object)
 {
   WylEngine *self = WYL_ENGINE (object);
 
-  g_clear_pointer (&self->session, wl_easy_close);
+  g_clear_pointer (&self->session, wirelog_easy_close);
   g_clear_pointer (&self->delta_cookie, g_free);
 
   for (gsize i = 0; i < WYL_ENGINE_TEMPLATE_COUNT; i++)
@@ -684,15 +684,15 @@ wyl_engine_open_with_options (const gchar *template_dir, guint32 num_workers,
   if (rc != WYRELOG_E_OK)
     return rc;
 
-  wl_easy_open_opts_t opts = {
+  wirelog_easy_open_opts_t opts = {
     .size = sizeof (opts),
     .num_workers = num_workers,
     .eager_build = true,
     ._reserved = NULL,
   };
 
-  wl_easy_session_t *session = NULL;
-  wirelog_error_t wl_rc = wl_easy_open_opts (dl_src, &opts, &session);
+  wirelog_easy_session_t *session = NULL;
+  wirelog_error_t wl_rc = wirelog_easy_open_opts (dl_src, &opts, &session);
 
   /* FC4: zero-fill the policy source buffer before freeing to avoid leaving
    * policy text in core dumps or swap.  Use the tracked length rather than
@@ -703,11 +703,11 @@ wyl_engine_open_with_options (const gchar *template_dir, guint32 num_workers,
   dl_src = NULL;
 
   if (wl_rc != WIRELOG_OK) {
-    /* wl_easy_open_opts sets *out to NULL on error per its contract,
+    /* wirelog_easy_open_opts sets *out to NULL on error per its contract,
      * but be defensive: close any partial session that may have been
      * returned despite the error. */
     if (session != NULL)
-      wl_easy_close (session);
+      wirelog_easy_close (session);
     return wyl_engine_map_wirelog_error (wl_rc);
   }
 
@@ -756,7 +756,7 @@ wyl_engine_intern_symbol_unchecked (WylEngine *self, const gchar *symbol,
   if (self->session == NULL)
     return WYRELOG_E_INVALID;
 
-  int64_t id = wl_easy_intern (self->session, symbol);
+  int64_t id = wirelog_easy_intern (self->session, symbol);
   if (id < 0) {
     WYL_LOG_ERROR (WYL_LOG_SECTION_POLICY,
         "engine: symbol interning failed for symbol of length %zu",
@@ -859,7 +859,7 @@ wyl_engine_insert_unchecked (WylEngine *self, const gchar *relation,
     return WYRELOG_E_INVALID;
 
   wirelog_error_t wl_rc =
-      wl_easy_insert (self->session, relation, (const int64_t *) row,
+      wirelog_easy_insert (self->session, relation, (const int64_t *) row,
       (uint32_t) ncols);
   wyrelog_error_t rc = wyl_engine_map_wirelog_error (wl_rc);
   if (rc != WYRELOG_E_OK) {
@@ -900,7 +900,7 @@ wyl_engine_step_unchecked (WylEngine *self)
   if (self->mode == WYL_ENGINE_MODE_SNAPSHOT)
     return WYRELOG_E_INVALID;
 
-  wirelog_error_t wl_rc = wl_easy_step (self->session);
+  wirelog_error_t wl_rc = wirelog_easy_step (self->session);
   wyrelog_error_t rc = wyl_engine_map_wirelog_error (wl_rc);
   if (rc == WYRELOG_E_OK) {
     self->mode = WYL_ENGINE_MODE_STEP;
@@ -945,8 +945,8 @@ wyl_engine_snapshot (WylEngine *self, const gchar *relation,
     return WYRELOG_E_INVALID;
 
   wyl_engine_tuple_cookie_t cookie = { cb, user_data };
-  wirelog_error_t wl_rc =
-      wl_easy_snapshot (self->session, relation, wyl_engine_tuple_trampoline,
+  wirelog_error_t wl_rc = wirelog_easy_snapshot (self->session, relation,
+      wyl_engine_tuple_trampoline,
       &cookie);
   wyrelog_error_t rc = wyl_engine_map_wirelog_error (wl_rc);
   if (rc == WYRELOG_E_OK) {
@@ -973,7 +973,8 @@ wyl_engine_set_delta_callback_unchecked (WylEngine *self, WylDeltaCallback cb,
 
   if (cb == NULL) {
     /* Clear the substrate hook before releasing the cookie it may reference. */
-    wirelog_error_t wl_rc = wl_easy_set_delta_cb (self->session, NULL, NULL);
+    wirelog_error_t wl_rc =
+        wirelog_easy_set_delta_cb (self->session, NULL, NULL);
     wyrelog_error_t rc = wyl_engine_map_wirelog_error (wl_rc);
     if (rc != WYRELOG_E_OK) {
       WYL_LOG_ERROR (WYL_LOG_SECTION_POLICY,
@@ -990,7 +991,7 @@ wyl_engine_set_delta_callback_unchecked (WylEngine *self, WylDeltaCallback cb,
   new_cookie->user_data = user_data;
 
   wirelog_error_t wl_rc =
-      wl_easy_set_delta_cb (self->session, wyl_engine_delta_trampoline,
+      wirelog_easy_set_delta_cb (self->session, wyl_engine_delta_trampoline,
       new_cookie);
   wyrelog_error_t rc = wyl_engine_map_wirelog_error (wl_rc);
   if (rc != WYRELOG_E_OK) {
@@ -1040,7 +1041,7 @@ wyl_engine_remove_unchecked (WylEngine *self, const gchar *relation,
     return WYRELOG_E_INVALID;
 
   wirelog_error_t wl_rc =
-      wl_easy_remove (self->session, relation, (const int64_t *) row,
+      wirelog_easy_remove (self->session, relation, (const int64_t *) row,
       (uint32_t) ncols);
   wyrelog_error_t rc = wyl_engine_map_wirelog_error (wl_rc);
   if (rc != WYRELOG_E_OK) {


### PR DESCRIPTION
## Summary

wirelog upstream renamed its public easy facade and moved the umbrella header path:

- `wl_easy_*` symbols (10 functions, 2 typedefs) -> `wirelog_easy_*`
- `<wirelog/wl_easy.h>` -> `<wirelog/wirelog-easy.h>`

This PR updates all consumer-side references in the engine wrapper and engine tests so wyrelog builds clean against current wirelog `main`.

## Changes

Single atomic commit touching four files:

- `wyrelog/wyl-engine-private.h` (header include + session field type)
- `wyrelog/wyl-engine.c` (14 call sites + struct typedef + opts typedef)
- `tests/test-engine-intern.c` (1 call to wl_easy_close in close-then-intern test)
- `tests/test-engine-io.c` (5 calls to wl_easy_close in delta-after-close coverage)

Total diff: 24 insertions, 23 deletions across 4 files.

## What is **not** affected

- The wirelog callback typedef renames (`wirelog_on_delta_fn`, `wirelog_on_tuple_fn`): wyrelog passes function pointers, not the typedef names.
- The wirelog I/O adapter framework rename (`wirelog_io_*`): wyrelog does not consume the I/O adapter API.
- The `WL_PUBLIC` -> `WIRELOG_PUBLIC` export-attribute rename: that's an internal wirelog concern.
- The `WL_STR_FN_*` enum constant rename: wyrelog does not use those enums.
- The `wl_intern_t` typedef rename on the public umbrella: wyrelog does not use that typedef.
- The `WL_LOG_FILE` env var: unchanged in wirelog; `tests/test-log.c` continues to set it as before.

## Test plan

- [x] `meson compile -C builddir` succeeds with current wirelog main
- [x] `meson test -C builddir --suite wyrelog` -> 58 OK / 0 fail / 1 skip locally
- [ ] CI Main on ubuntu, macos, windows