### PR TITLE
[codex] Package operator readiness path

### DIFF
--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -1,0 +1,156 @@
+# Wyrelog Operator Runbook
+
+This runbook closes the supported Linux production path for a packaged
+Wyrelog application service deployment. It assumes the package installs
+`wyrelogd`, `wyctl`, the access-control template tree, and the systemd
+support files from `packaging/`.
+
+## Installed Layout
+
+- Binaries: `/usr/bin/wyrelogd`, `/usr/bin/wyctl`
+- Templates: `/usr/share/wyrelog/access`
+- Daemon environment: `/etc/wyrelog/wyrelogd.env`
+- Policy KeyProvider state: `/etc/wyrelog/policy.key`
+- Policy store: `/var/lib/wyrelog/policy.sqlite`
+- Audit store: `/var/log/wyrelog/audit.duckdb`
+- Runtime directory: `/run/wyrelog`
+- HTTP listen port: `127.0.0.1:8765` unless overridden by the service file
+- Production log policy: compile release builds with
+  `-Dwyrelog_log_max_level=warn`; packaged runtime defaults set
+  `WYL_LOG=warn`
+
+## First Install
+
+1. Install the package and create managed users/directories:
+
+   ```sh
+   systemd-sysusers /usr/lib/sysusers.d/wyrelog.conf
+   systemd-tmpfiles --create /usr/lib/tmpfiles.d/wyrelog.conf
+   ```
+
+2. Create the production KeyProvider state once:
+
+   ```sh
+   install -m 0640 -o root -g wyrelog /dev/null /etc/wyrelog/policy.key
+   python3 - <<'PY'
+import os
+with open("/etc/wyrelog/policy.key", "wb") as f:
+    f.write(os.urandom(32))
+PY
+   chown root:wyrelog /etc/wyrelog/policy.key
+   chmod 0640 /etc/wyrelog/policy.key
+   ```
+
+3. Validate package readiness before starting the daemon:
+
+   ```sh
+   wyrelogd --production \
+     --template-dir /usr/share/wyrelog/access \
+     --policy-db /var/lib/wyrelog/policy.sqlite \
+     --policy-keyprovider /etc/wyrelog/policy.key \
+     --audit-db /var/log/wyrelog/audit.duckdb \
+     --check
+   wyrelogd --template-info --template-dir /usr/share/wyrelog/access
+   wyctl key status --keyprovider /etc/wyrelog/policy.key
+   ```
+
+4. Start and verify service readiness:
+
+   ```sh
+   systemctl enable --now wyrelog.service
+   wyctl --daemon-url http://127.0.0.1:8765 status
+   wyctl --daemon-url http://127.0.0.1:8765 status --readiness
+   ```
+
+## Day-2 Operations
+
+- Template validation:
+
+  ```sh
+  wyrelogd --template-info --template-dir /usr/share/wyrelog/access
+  wyrelogd --production --template-dir /usr/share/wyrelog/access \
+    --policy-db /var/lib/wyrelog/policy.sqlite \
+    --policy-keyprovider /etc/wyrelog/policy.key \
+    --audit-db /var/log/wyrelog/audit.duckdb --check
+  ```
+
+- Policy grant/revoke:
+
+  ```sh
+  wyctl --daemon-url http://127.0.0.1:8765 policy permission-grant \
+    --subject alice --permission site.policy.read --scope tenant-a \
+    --access-token-file /run/wyrelog/operator.token
+  wyctl --daemon-url http://127.0.0.1:8765 policy permission-revoke \
+    --subject alice --permission site.policy.read --scope tenant-a \
+    --access-token-file /run/wyrelog/operator.token
+  ```
+
+- Audit query:
+
+  ```sh
+  wyctl --daemon-url http://127.0.0.1:8765 audit query \
+    --filter 'decision=deny' --limit 50 \
+    --access-token-file /run/wyrelog/operator.token
+  ```
+
+- Restart:
+
+  ```sh
+  systemctl restart wyrelog.service
+  wyctl --daemon-url http://127.0.0.1:8765 status --readiness
+  ```
+
+  Access and refresh tokens are invalidated by daemon restart. Operators
+  must obtain fresh credentials after restart.
+
+## Backup And Restore
+
+1. Stop the daemon:
+
+   ```sh
+   systemctl stop wyrelog.service
+   ```
+
+2. Back up `/etc/wyrelog/policy.key`,
+   `/var/lib/wyrelog/policy.sqlite`, `/var/log/wyrelog/audit.duckdb`,
+   and the output of `wyrelogd --template-info`.
+
+3. Restore the files with the same ownership and modes, then run the
+   production `--check` command before restarting.
+
+## Template Upgrade
+
+1. Install the new package without starting the daemon.
+2. Run `wyrelogd --template-info` and record version, hash, migration
+   count, and latest migration version.
+3. Run production `--check` against the existing policy and audit stores.
+4. Restart the service.
+5. If readiness fails, roll back the package and restore the previous
+   template tree and policy store backup.
+
+## Key Rotation
+
+1. Stop the daemon.
+2. Back up the current key and policy store together.
+3. Replace `/etc/wyrelog/policy.key` with a new 32-byte file using mode
+   `0640`, owner `root`, and group `wyrelog`.
+4. Run `wyctl key status --keyprovider /etc/wyrelog/policy.key`.
+5. Run production `--check`, then start the daemon.
+
+Changing the KeyProvider root invalidates sealed policy-store material
+that was written under the previous root. Perform root rotation only with
+a coordinated restore or migration plan.
+
+## Emergency Break-Glass
+
+Break-glass builds must be compiled with audit enabled. Before enabling
+the build flag, verify that audit readiness passes and that the emergency
+principal and expiry policy are documented for the deployment. Every
+override must leave an audit reason code.
+
+## Rollback
+
+Rollback requires the previous package, template identity, policy store,
+audit store, and KeyProvider state. Stop the daemon, restore the previous
+artifacts, run production `--check`, start the service, and verify
+readiness with `wyctl status --readiness`.

--- a/meson.build
+++ b/meson.build
@@ -92,6 +92,23 @@ install_subdir(
   install_dir : join_paths(get_option('datadir'), 'wyrelog'),
 )
 
+install_data(
+  'packaging/systemd/wyrelog.service',
+  install_dir : join_paths(get_option('prefix'), 'lib', 'systemd', 'system'),
+)
+install_data(
+  'packaging/sysusers.d/wyrelog.conf',
+  install_dir : join_paths(get_option('prefix'), 'lib', 'sysusers.d'),
+)
+install_data(
+  'packaging/tmpfiles.d/wyrelog.conf',
+  install_dir : join_paths(get_option('prefix'), 'lib', 'tmpfiles.d'),
+)
+install_data(
+  'packaging/wyrelogd.env',
+  install_dir : join_paths(get_option('sysconfdir'), 'wyrelog'),
+)
+
 # Install git pre-commit hook for code style checking
 git_hook_script = find_program('hooks/pre-commit.hook')
 git_dir = join_paths(meson.project_source_root(), '.git')

--- a/packaging/systemd/wyrelog.service
+++ b/packaging/systemd/wyrelog.service
@@ -1,0 +1,31 @@
+[Unit]
+Description=Wyrelog application service
+Documentation=man:wyrelogd(1)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=wyrelog
+Group=wyrelog
+Environment=WYL_LOG=warn
+EnvironmentFile=-/etc/wyrelog/wyrelogd.env
+ExecStart=/usr/bin/wyrelogd --production --template-dir /usr/share/wyrelog/access --policy-db /var/lib/wyrelog/policy.sqlite --policy-keyprovider /etc/wyrelog/policy.key --audit-db /var/log/wyrelog/audit.duckdb --listen-port 8765
+Restart=on-failure
+RestartSec=5s
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
+ProtectSystem=strict
+ReadOnlyPaths=/etc/wyrelog /usr/share/wyrelog
+ReadWritePaths=/var/lib/wyrelog /var/log/wyrelog /run/wyrelog
+RuntimeDirectory=wyrelog
+RuntimeDirectoryMode=0750
+StateDirectory=wyrelog
+StateDirectoryMode=0750
+LogsDirectory=wyrelog
+LogsDirectoryMode=0750
+UMask=0077
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/sysusers.d/wyrelog.conf
+++ b/packaging/sysusers.d/wyrelog.conf
@@ -1,0 +1,1 @@
+u wyrelog - "Wyrelog daemon" /var/lib/wyrelog /usr/sbin/nologin

--- a/packaging/tmpfiles.d/wyrelog.conf
+++ b/packaging/tmpfiles.d/wyrelog.conf
@@ -1,0 +1,5 @@
+d /etc/wyrelog 0750 root wyrelog -
+d /var/lib/wyrelog 0750 wyrelog wyrelog -
+d /var/log/wyrelog 0750 wyrelog wyrelog -
+d /run/wyrelog 0750 wyrelog wyrelog -
+z /etc/wyrelog 0750 root wyrelog -

--- a/packaging/wyrelogd.env
+++ b/packaging/wyrelogd.env
@@ -1,0 +1,4 @@
+# Optional overrides for packaged wyrelogd deployments.
+# Keep this file free of key material; /etc/wyrelog/policy.key is read
+# directly by the KeyProvider path configured in the systemd unit.
+WYL_LOG=warn

--- a/tests/check-packaged-install-readiness.sh
+++ b/tests/check-packaged-install-readiness.sh
@@ -1,0 +1,132 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+set -eu
+
+WYRELOGD=$1
+WYCTL=$2
+TEMPLATE_DIR=$3
+SOURCE_ROOT=$4
+PYTHON=$5
+
+PORT=$("$PYTHON" - <<'PY'
+import socket
+
+with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+    sock.bind(("127.0.0.1", 0))
+    print(sock.getsockname()[1])
+PY
+)
+
+TMPDIR=$(mktemp -d)
+PID=
+
+cleanup() {
+  if [ -n "$PID" ]; then
+    kill "$PID" 2>/dev/null || true
+  fi
+  rm -rf "$TMPDIR"
+}
+trap cleanup EXIT INT TERM
+
+for path in \
+  "$SOURCE_ROOT/packaging/systemd/wyrelog.service" \
+  "$SOURCE_ROOT/packaging/sysusers.d/wyrelog.conf" \
+  "$SOURCE_ROOT/packaging/tmpfiles.d/wyrelog.conf" \
+  "$SOURCE_ROOT/packaging/wyrelogd.env" \
+  "$SOURCE_ROOT/docs/operator-runbook.md"; do
+  test -s "$path"
+done
+
+if ! grep -q -- "--production" \
+    "$SOURCE_ROOT/packaging/systemd/wyrelog.service"; then
+  echo "service unit does not enable production gates" >&2
+  exit 1
+fi
+if ! grep -q "WYL_LOG=warn" \
+    "$SOURCE_ROOT/packaging/systemd/wyrelog.service"; then
+  echo "service unit does not set production log ceiling" >&2
+  exit 1
+fi
+
+INSTALL_ROOT="$TMPDIR/install"
+mkdir -p "$INSTALL_ROOT/usr/share/wyrelog" \
+  "$INSTALL_ROOT/etc/wyrelog" \
+  "$INSTALL_ROOT/var/lib/wyrelog" \
+  "$INSTALL_ROOT/var/log/wyrelog" \
+  "$INSTALL_ROOT/run/wyrelog"
+cp -R "$TEMPLATE_DIR" "$INSTALL_ROOT/usr/share/wyrelog/access"
+
+"$PYTHON" - "$INSTALL_ROOT/etc/wyrelog/policy.key" <<'PY'
+import os
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+path.write_bytes(os.urandom(32))
+PY
+
+TEMPLATE_INSTALL="$INSTALL_ROOT/usr/share/wyrelog/access"
+POLICY_DB="$INSTALL_ROOT/var/lib/wyrelog/policy.sqlite"
+AUDIT_DB="$INSTALL_ROOT/var/log/wyrelog/audit.duckdb"
+KEY="$INSTALL_ROOT/etc/wyrelog/policy.key"
+BASE_URL="http://127.0.0.1:$PORT"
+
+"$WYCTL" key status --keyprovider "$KEY" >"$TMPDIR/key.out"
+if [ "$(cat "$TMPDIR/key.out")" != "status=ready type=file bytes=32" ]; then
+  echo "unexpected key status output" >&2
+  cat "$TMPDIR/key.out" >&2
+  exit 1
+fi
+
+"$WYRELOGD" --template-info --template-dir "$TEMPLATE_INSTALL" \
+  >"$TMPDIR/template-info.out"
+grep -q '^version=' "$TMPDIR/template-info.out"
+grep -q '^sha256=' "$TMPDIR/template-info.out"
+grep -q '^migrations=' "$TMPDIR/template-info.out"
+
+"$WYRELOGD" --production \
+  --template-dir "$TEMPLATE_INSTALL" \
+  --policy-db "$POLICY_DB" \
+  --policy-keyprovider "$KEY" \
+  --audit-db "$AUDIT_DB" \
+  --check
+
+"$WYRELOGD" --production \
+  --template-dir "$TEMPLATE_INSTALL" \
+  --policy-db "$POLICY_DB" \
+  --policy-keyprovider "$KEY" \
+  --audit-db "$AUDIT_DB" \
+  --listen-port "$PORT" &
+PID=$!
+
+i=0
+while [ "$i" -lt 150 ]; do
+  i=$((i + 1))
+  if "$WYCTL" --daemon-url "$BASE_URL" --timeout-ms 500 status \
+      >"$TMPDIR/status.out" 2>"$TMPDIR/status.err"; then
+    if [ "$(cat "$TMPDIR/status.out")" != "ok" ]; then
+      echo "unexpected status output" >&2
+      cat "$TMPDIR/status.out" >&2
+      cat "$TMPDIR/status.err" >&2
+      exit 1
+    fi
+    "$WYCTL" --daemon-url "$BASE_URL" --timeout-ms 500 status \
+      --readiness >"$TMPDIR/ready.out" 2>"$TMPDIR/ready.err"
+    if [ "$(cat "$TMPDIR/ready.out")" != "status=ready" ]; then
+      echo "unexpected readiness output" >&2
+      cat "$TMPDIR/ready.out" >&2
+      cat "$TMPDIR/ready.err" >&2
+      exit 1
+    fi
+    kill -TERM "$PID"
+    wait "$PID"
+    PID=
+    exit 0
+  fi
+  sleep 0.1
+done
+
+echo "packaged install smoke did not reach live daemon" >&2
+cat "$TMPDIR/status.err" >&2 || true
+exit 1

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -193,6 +193,18 @@ if host_machine.system() != 'windows' and build_client
     depends : [wyctl_exe, wyrelogd_exe],
   )
 
+  test('packaged-install-readiness', sh,
+    args : [
+      meson.current_source_dir() / 'check-packaged-install-readiness.sh',
+      wyrelogd_exe.full_path(),
+      wyctl_exe.full_path(),
+      meson.project_source_root() / 'templates' / 'access',
+      meson.project_source_root(),
+      python3.full_path(),
+    ],
+    depends : [wyctl_exe, wyrelogd_exe],
+  )
+
   test('client-audit-daemon', sh,
     args : [
       meson.current_source_dir() / 'check-client-audit-daemon.sh',

--- a/wyrelog/daemon/options.c
+++ b/wyrelog/daemon/options.c
@@ -13,10 +13,8 @@ wyl_daemon_parse_options (gint *argc, gchar ***argv, WylDaemonOptions *opts,
     {"policy-keyprovider", 0, 0, G_OPTION_ARG_STRING,
           &opts->policy_keyprovider_path,
         "Path to policy database key provider state", "PATH"},
-#ifdef WYL_HAS_AUDIT
     {"audit-db", 0, 0, G_OPTION_ARG_STRING, &opts->audit_store_path,
         "Runtime audit sink database path", "PATH"},
-#endif
 #ifdef WYL_HAS_DAEMON_HTTP
     {"listen-port", 0, 0, G_OPTION_ARG_INT, &opts->listen_port,
         "HTTP listen port", "PORT"},

--- a/wyrelog/daemon/options.h
+++ b/wyrelog/daemon/options.h
@@ -8,9 +8,7 @@ typedef struct
   const gchar *template_dir;
   const gchar *policy_store_path;
   const gchar *policy_keyprovider_path;
-#ifdef WYL_HAS_AUDIT
   const gchar *audit_store_path;
-#endif
   gint listen_port;
   gboolean check_only;
   gboolean production_mode;

--- a/wyrelog/wyctl/wyctl.c
+++ b/wyrelog/wyctl/wyctl.c
@@ -60,10 +60,16 @@ typedef struct
   gchar *guard_risk_arg;
 } WyctlPolicyRoleOptions;
 
+typedef struct
+{
+  gchar *keyprovider_path;
+} WyctlKeyOptions;
+
 #define WYCTL_DEFAULT_TIMEOUT_MS 2000
 #define WYCTL_MAX_TIMEOUT_MS 60000
 #define WYCTL_AUDIT_DEFAULT_LIMIT 100
 #define WYCTL_AUDIT_MAX_LIMIT 100
+#define WYCTL_KEYPROVIDER_FILE_BYTES 32
 
 typedef struct
 {
@@ -1130,6 +1136,64 @@ run_audit (const WyctlOptions *global_opts, gint argc, gchar **argv)
   return 2;
 }
 
+static int
+run_key_status (gint argc, gchar **argv)
+{
+  WyctlKeyOptions opts = { 0 };
+  GOptionEntry entries[] = {
+    {"keyprovider", 0, 0, G_OPTION_ARG_STRING, &opts.keyprovider_path,
+        "Policy KeyProvider state file", "PATH"},
+    {NULL}
+  };
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GOptionContext) context =
+      g_option_context_new ("- wyrelog key status");
+  g_option_context_add_main_entries (context, entries, NULL);
+
+  if (!g_option_context_parse (context, &argc, &argv, &error)) {
+    g_printerr ("wyctl: %s\n", error->message);
+    return 2;
+  }
+  if (argc > 1) {
+    g_printerr ("wyctl: unexpected key status argument: %s\n", argv[1]);
+    return 2;
+  }
+  if (opts.keyprovider_path == NULL || opts.keyprovider_path[0] == '\0') {
+    g_printerr ("wyctl: missing --keyprovider\n");
+    return 2;
+  }
+
+  g_autofree gchar *contents = NULL;
+  gsize len = 0;
+  if (!g_file_get_contents (opts.keyprovider_path, &contents, &len, NULL)) {
+    g_printerr ("wyctl: keyprovider unreadable\n");
+    return 1;
+  }
+  if (len != WYCTL_KEYPROVIDER_FILE_BYTES) {
+    g_printerr ("wyctl: keyprovider invalid\n");
+    return 1;
+  }
+
+  g_print ("status=ready type=file bytes=%u\n",
+      (guint) WYCTL_KEYPROVIDER_FILE_BYTES);
+  return 0;
+}
+
+static int
+run_key (gint argc, gchar **argv)
+{
+  if (argc < 2) {
+    g_printerr ("wyctl: missing key command\n");
+    return 2;
+  }
+
+  if (g_strcmp0 (argv[1], "status") == 0)
+    return run_key_status (argc - 1, argv + 1);
+
+  g_printerr ("wyctl: unknown key command: %s\n", argv[1]);
+  return 2;
+}
+
 int
 main (int argc, char **argv)
 {
@@ -1171,6 +1235,8 @@ main (int argc, char **argv)
     return run_policy (&opts, argc - 1, argv + 1);
   if (g_strcmp0 (argv[1], "audit") == 0)
     return run_audit (&opts, argc - 1, argv + 1);
+  if (g_strcmp0 (argv[1], "key") == 0)
+    return run_key (argc - 1, argv + 1);
 
   g_printerr ("wyctl: unknown command: %s\n", argv[1]);
   return 2;


### PR DESCRIPTION
## Summary

- Add Linux packaging support files for the daemon service, sysusers, tmpfiles, and packaged runtime environment defaults.
- Add an operator runbook covering first install, readiness validation, backup/restore, restart behavior, template upgrade, key rotation, emergency break-glass, and rollback.
- Add `wyctl key status` for non-secret KeyProvider state inspection and keep `wyrelogd --audit-db` accepted across audit-enabled and audit-disabled builds.
- Add a packaged install readiness smoke test that starts from an empty install root, validates template/key state, runs production `--check`, starts the daemon, and verifies health/readiness.
- Align the Wyrelog engine wrapper with the current Wirelog easy API names so the refreshed dependency builds cleanly.

## Validation

- `meson compile -C builddir`
- `meson test -C builddir packaged-install-readiness wyctl-basic wyctl-status-daemon wyrelogd-production-gates --print-errorlogs`
- `meson test -C builddir --suite wyrelog --print-errorlogs`
