### PR TITLE
[codex] Split daemon profiles

### DIFF
--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -10,14 +10,44 @@ support files from `packaging/`.
 - Binaries: `/usr/bin/wyrelogd`, `/usr/bin/wyctl`
 - Templates: `/usr/share/wyrelog/access`
 - Daemon environment: `/etc/wyrelog/wyrelogd.env`
-- Policy KeyProvider state: `/etc/wyrelog/policy.key`
-- Policy store: `/var/lib/wyrelog/policy.sqlite`
-- Audit store: `/var/log/wyrelog/audit.duckdb`
+- System KeyProvider state: `/etc/wyrelog/system/policy.key`
+- System policy store: `/var/lib/wyrelog/system/policy.sqlite`
+- System audit store: `/var/log/wyrelog/system/audit.duckdb`
+- Service KeyProvider state: `/etc/wyrelog/service/policy.key`
+- Service policy store: `/var/lib/wyrelog/service/policy.sqlite`
+- Service audit store: `/var/log/wyrelog/service/audit.duckdb`
 - Runtime directory: `/run/wyrelog`
 - HTTP listen port: `127.0.0.1:8765` unless overridden by the service file
 - Production log policy: compile release builds with
   `-Dwyrelog_log_max_level=warn`; packaged runtime defaults set
   `WYL_LOG=warn`
+
+## Profiles
+
+Wyrelog ships two daemon profiles:
+
+- `system`: the authority profile for policy, keys, audit aggregation,
+  and operator control.
+- `service`: the application-facing profile for user decisions. It uses
+  independent policy/key/audit paths and a bounded disk spool for events
+  that cannot yet be forwarded to the system profile.
+
+Packaged profile paths:
+
+- System policy store: `/var/lib/wyrelog/system/policy.sqlite`
+- System KeyProvider state: `/etc/wyrelog/system/policy.key`
+- System audit store: `/var/log/wyrelog/system/audit.duckdb`
+- Service policy store: `/var/lib/wyrelog/service/policy.sqlite`
+- Service KeyProvider state: `/etc/wyrelog/service/policy.key`
+- Service audit store: `/var/log/wyrelog/service/audit.duckdb`
+- Service event spool: `/var/lib/wyrelog/service/event-spool`
+
+Inspect the resolved profile contract with:
+
+```sh
+wyrelogd --profile=system --profile-info --production
+wyrelogd --profile=service --profile-info --production
+```
 
 ## First Install
 
@@ -31,35 +61,39 @@ support files from `packaging/`.
 2. Create the production KeyProvider state once:
 
    ```sh
-   install -m 0640 -o root -g wyrelog /dev/null /etc/wyrelog/policy.key
+   install -m 0640 -o root -g wyrelog /dev/null /etc/wyrelog/system/policy.key
    python3 - <<'PY'
 import os
-with open("/etc/wyrelog/policy.key", "wb") as f:
+with open("/etc/wyrelog/system/policy.key", "wb") as f:
     f.write(os.urandom(32))
 PY
-   chown root:wyrelog /etc/wyrelog/policy.key
-   chmod 0640 /etc/wyrelog/policy.key
+   chown root:wyrelog /etc/wyrelog/system/policy.key
+   chmod 0640 /etc/wyrelog/system/policy.key
    ```
 
 3. Validate package readiness before starting the daemon:
 
    ```sh
    wyrelogd --production \
+     --profile system \
      --template-dir /usr/share/wyrelog/access \
-     --policy-db /var/lib/wyrelog/policy.sqlite \
-     --policy-keyprovider /etc/wyrelog/policy.key \
-     --audit-db /var/log/wyrelog/audit.duckdb \
+     --policy-db /var/lib/wyrelog/system/policy.sqlite \
+     --policy-keyprovider /etc/wyrelog/system/policy.key \
+     --audit-db /var/log/wyrelog/system/audit.duckdb \
      --check
    wyrelogd --template-info --template-dir /usr/share/wyrelog/access
-   wyctl key status --keyprovider /etc/wyrelog/policy.key
+   wyctl key status --keyprovider /etc/wyrelog/system/policy.key
    ```
 
 4. Start and verify service readiness:
 
    ```sh
-   systemctl enable --now wyrelog.service
+   systemctl enable --now wyrelog-system.service
+   systemctl enable --now wyrelog-service.service
    wyctl --daemon-url http://127.0.0.1:8765 status
    wyctl --daemon-url http://127.0.0.1:8765 status --readiness
+   wyctl --daemon-url http://127.0.0.1:8766 status
+   wyctl --daemon-url http://127.0.0.1:8766 status --readiness
    ```
 
 ## Day-2 Operations
@@ -69,9 +103,10 @@ PY
   ```sh
   wyrelogd --template-info --template-dir /usr/share/wyrelog/access
   wyrelogd --production --template-dir /usr/share/wyrelog/access \
-    --policy-db /var/lib/wyrelog/policy.sqlite \
-    --policy-keyprovider /etc/wyrelog/policy.key \
-    --audit-db /var/log/wyrelog/audit.duckdb --check
+    --profile system \
+    --policy-db /var/lib/wyrelog/system/policy.sqlite \
+    --policy-keyprovider /etc/wyrelog/system/policy.key \
+    --audit-db /var/log/wyrelog/system/audit.duckdb --check
   ```
 
 - Policy grant/revoke:
@@ -96,24 +131,40 @@ PY
 - Restart:
 
   ```sh
-  systemctl restart wyrelog.service
+  systemctl restart wyrelog-system.service
+  systemctl restart wyrelog-service.service
   wyctl --daemon-url http://127.0.0.1:8765 status --readiness
+  wyctl --daemon-url http://127.0.0.1:8766 status --readiness
   ```
 
   Access and refresh tokens are invalidated by daemon restart. Operators
   must obtain fresh credentials after restart.
+
+- Profile status:
+
+  ```sh
+  curl -fsS http://127.0.0.1:8765/profile/status
+  curl -fsS http://127.0.0.1:8766/profile/status
+  ```
+
+  Service-profile event forwarding targets
+  `http://127.0.0.1:8765/profile/events`. If the system profile is not
+  reachable, the service profile keeps its local decision path isolated
+  and uses the configured event spool directory as the bounded recovery
+  surface.
 
 ## Backup And Restore
 
 1. Stop the daemon:
 
    ```sh
-   systemctl stop wyrelog.service
+   systemctl stop wyrelog-service.service
+   systemctl stop wyrelog-system.service
    ```
 
-2. Back up `/etc/wyrelog/policy.key`,
-   `/var/lib/wyrelog/policy.sqlite`, `/var/log/wyrelog/audit.duckdb`,
-   and the output of `wyrelogd --template-info`.
+2. Back up the active profile's KeyProvider state, policy store, audit
+   store, event spool when present, and the output of
+   `wyrelogd --template-info`.
 
 3. Restore the files with the same ownership and modes, then run the
    production `--check` command before restarting.
@@ -132,9 +183,9 @@ PY
 
 1. Stop the daemon.
 2. Back up the current key and policy store together.
-3. Replace `/etc/wyrelog/policy.key` with a new 32-byte file using mode
-   `0640`, owner `root`, and group `wyrelog`.
-4. Run `wyctl key status --keyprovider /etc/wyrelog/policy.key`.
+3. Replace the active profile's `policy.key` with a new 32-byte file
+   using mode `0640`, owner `root`, and group `wyrelog`.
+4. Run `wyctl key status --keyprovider PATH`.
 5. Run production `--check`, then start the daemon.
 
 Changing the KeyProvider root invalidates sealed policy-store material

--- a/meson.build
+++ b/meson.build
@@ -63,12 +63,17 @@ wirelog_proj = subproject(
   'wirelog',
   default_options : ['tests=false', 'documentation=false'],
 )
+wirelog_consumer_args = []
+if host_machine.system() == 'windows'
+  wirelog_consumer_args += ['-DWIRELOG_BUILDING']
+endif
 wirelog_dep = declare_dependency(
   link_with : wirelog_proj.get_variable('wirelog_lib'),
   include_directories : [
     wirelog_proj.get_variable('wirelog_inc'),
     wirelog_proj.get_variable('wirelog_src_inc'),
   ],
+  compile_args : wirelog_consumer_args,
 )
 
 libchronoid_proj = subproject(
@@ -94,6 +99,8 @@ install_subdir(
 
 install_data(
   'packaging/systemd/wyrelog.service',
+  'packaging/systemd/wyrelog-system.service',
+  'packaging/systemd/wyrelog-service.service',
   install_dir : join_paths(get_option('prefix'), 'lib', 'systemd', 'system'),
 )
 install_data(
@@ -106,6 +113,8 @@ install_data(
 )
 install_data(
   'packaging/wyrelogd.env',
+  'packaging/system.env',
+  'packaging/service.env',
   install_dir : join_paths(get_option('sysconfdir'), 'wyrelog'),
 )
 

--- a/packaging/service.env
+++ b/packaging/service.env
@@ -1,0 +1,2 @@
+# Optional overrides for the packaged service-profile service.
+WYL_LOG=warn

--- a/packaging/system.env
+++ b/packaging/system.env
@@ -1,0 +1,2 @@
+# Optional overrides for the packaged system-profile service.
+WYL_LOG=warn

--- a/packaging/systemd/wyrelog-service.service
+++ b/packaging/systemd/wyrelog-service.service
@@ -1,0 +1,31 @@
+[Unit]
+Description=Wyrelog service profile service
+Documentation=man:wyrelogd(1)
+After=network-online.target wyrelog-system.service
+Wants=network-online.target wyrelog-system.service
+
+[Service]
+Type=simple
+User=wyrelog
+Group=wyrelog
+Environment=WYL_LOG=warn
+EnvironmentFile=-/etc/wyrelog/service.env
+ExecStart=/usr/bin/wyrelogd --production --profile=service --template-dir /usr/share/wyrelog/access --policy-db /var/lib/wyrelog/service/policy.sqlite --policy-keyprovider /etc/wyrelog/service/policy.key --audit-db /var/log/wyrelog/service/audit.duckdb --system-url http://127.0.0.1:8765 --event-spool-dir /var/lib/wyrelog/service/event-spool --event-queue-limit 1024 --listen-port 8766
+Restart=on-failure
+RestartSec=5s
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
+ProtectSystem=strict
+ReadOnlyPaths=/etc/wyrelog /usr/share/wyrelog
+ReadWritePaths=/var/lib/wyrelog/service /var/log/wyrelog/service /run/wyrelog
+RuntimeDirectory=wyrelog
+RuntimeDirectoryMode=0750
+StateDirectory=wyrelog
+StateDirectoryMode=0750
+LogsDirectory=wyrelog
+LogsDirectoryMode=0750
+UMask=0077
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/systemd/wyrelog-system.service
+++ b/packaging/systemd/wyrelog-system.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Wyrelog application service
+Description=Wyrelog system profile service
 Documentation=man:wyrelogd(1)
 After=network-online.target
 Wants=network-online.target
@@ -9,7 +9,7 @@ Type=simple
 User=wyrelog
 Group=wyrelog
 Environment=WYL_LOG=warn
-EnvironmentFile=-/etc/wyrelog/wyrelogd.env
+EnvironmentFile=-/etc/wyrelog/system.env
 ExecStart=/usr/bin/wyrelogd --production --profile=system --template-dir /usr/share/wyrelog/access --policy-db /var/lib/wyrelog/system/policy.sqlite --policy-keyprovider /etc/wyrelog/system/policy.key --audit-db /var/log/wyrelog/system/audit.duckdb --listen-port 8765
 Restart=on-failure
 RestartSec=5s

--- a/packaging/tmpfiles.d/wyrelog.conf
+++ b/packaging/tmpfiles.d/wyrelog.conf
@@ -1,5 +1,12 @@
 d /etc/wyrelog 0750 root wyrelog -
+d /etc/wyrelog/system 0750 root wyrelog -
+d /etc/wyrelog/service 0750 root wyrelog -
 d /var/lib/wyrelog 0750 wyrelog wyrelog -
+d /var/lib/wyrelog/system 0750 wyrelog wyrelog -
+d /var/lib/wyrelog/service 0750 wyrelog wyrelog -
+d /var/lib/wyrelog/service/event-spool 0700 wyrelog wyrelog -
 d /var/log/wyrelog 0750 wyrelog wyrelog -
+d /var/log/wyrelog/system 0750 wyrelog wyrelog -
+d /var/log/wyrelog/service 0750 wyrelog wyrelog -
 d /run/wyrelog 0750 wyrelog wyrelog -
 z /etc/wyrelog 0750 root wyrelog -

--- a/packaging/wyrelogd.env
+++ b/packaging/wyrelogd.env
@@ -1,4 +1,4 @@
 # Optional overrides for packaged wyrelogd deployments.
-# Keep this file free of key material; /etc/wyrelog/policy.key is read
-# directly by the KeyProvider path configured in the systemd unit.
+# Keep this file free of key material; profile-specific policy.key files
+# are read directly by the KeyProvider path configured in the systemd unit.
 WYL_LOG=warn

--- a/tests/check-packaged-install-readiness.sh
+++ b/tests/check-packaged-install-readiness.sh
@@ -31,9 +31,13 @@ trap cleanup EXIT INT TERM
 
 for path in \
   "$SOURCE_ROOT/packaging/systemd/wyrelog.service" \
+  "$SOURCE_ROOT/packaging/systemd/wyrelog-system.service" \
+  "$SOURCE_ROOT/packaging/systemd/wyrelog-service.service" \
   "$SOURCE_ROOT/packaging/sysusers.d/wyrelog.conf" \
   "$SOURCE_ROOT/packaging/tmpfiles.d/wyrelog.conf" \
   "$SOURCE_ROOT/packaging/wyrelogd.env" \
+  "$SOURCE_ROOT/packaging/system.env" \
+  "$SOURCE_ROOT/packaging/service.env" \
   "$SOURCE_ROOT/docs/operator-runbook.md"; do
   test -s "$path"
 done
@@ -41,6 +45,16 @@ done
 if ! grep -q -- "--production" \
     "$SOURCE_ROOT/packaging/systemd/wyrelog.service"; then
   echo "service unit does not enable production gates" >&2
+  exit 1
+fi
+if ! grep -q -- "--profile=system" \
+    "$SOURCE_ROOT/packaging/systemd/wyrelog-system.service"; then
+  echo "system unit does not select the system profile" >&2
+  exit 1
+fi
+if ! grep -q -- "--profile=service" \
+    "$SOURCE_ROOT/packaging/systemd/wyrelog-service.service"; then
+  echo "service unit does not select the service profile" >&2
   exit 1
 fi
 if ! grep -q "WYL_LOG=warn" \
@@ -52,12 +66,18 @@ fi
 INSTALL_ROOT="$TMPDIR/install"
 mkdir -p "$INSTALL_ROOT/usr/share/wyrelog" \
   "$INSTALL_ROOT/etc/wyrelog" \
+  "$INSTALL_ROOT/etc/wyrelog/system" \
+  "$INSTALL_ROOT/etc/wyrelog/service" \
   "$INSTALL_ROOT/var/lib/wyrelog" \
+  "$INSTALL_ROOT/var/lib/wyrelog/system" \
+  "$INSTALL_ROOT/var/lib/wyrelog/service" \
   "$INSTALL_ROOT/var/log/wyrelog" \
+  "$INSTALL_ROOT/var/log/wyrelog/system" \
+  "$INSTALL_ROOT/var/log/wyrelog/service" \
   "$INSTALL_ROOT/run/wyrelog"
 cp -R "$TEMPLATE_DIR" "$INSTALL_ROOT/usr/share/wyrelog/access"
 
-"$PYTHON" - "$INSTALL_ROOT/etc/wyrelog/policy.key" <<'PY'
+"$PYTHON" - "$INSTALL_ROOT/etc/wyrelog/system/policy.key" <<'PY'
 import os
 import pathlib
 import sys
@@ -67,9 +87,9 @@ path.write_bytes(os.urandom(32))
 PY
 
 TEMPLATE_INSTALL="$INSTALL_ROOT/usr/share/wyrelog/access"
-POLICY_DB="$INSTALL_ROOT/var/lib/wyrelog/policy.sqlite"
-AUDIT_DB="$INSTALL_ROOT/var/log/wyrelog/audit.duckdb"
-KEY="$INSTALL_ROOT/etc/wyrelog/policy.key"
+POLICY_DB="$INSTALL_ROOT/var/lib/wyrelog/system/policy.sqlite"
+AUDIT_DB="$INSTALL_ROOT/var/log/wyrelog/system/audit.duckdb"
+KEY="$INSTALL_ROOT/etc/wyrelog/system/policy.key"
 BASE_URL="http://127.0.0.1:$PORT"
 
 "$WYCTL" key status --keyprovider "$KEY" >"$TMPDIR/key.out"
@@ -86,6 +106,7 @@ grep -q '^sha256=' "$TMPDIR/template-info.out"
 grep -q '^migrations=' "$TMPDIR/template-info.out"
 
 "$WYRELOGD" --production \
+  --profile system \
   --template-dir "$TEMPLATE_INSTALL" \
   --policy-db "$POLICY_DB" \
   --policy-keyprovider "$KEY" \
@@ -93,6 +114,7 @@ grep -q '^migrations=' "$TMPDIR/template-info.out"
   --check
 
 "$WYRELOGD" --production \
+  --profile system \
   --template-dir "$TEMPLATE_INSTALL" \
   --policy-db "$POLICY_DB" \
   --policy-keyprovider "$KEY" \
@@ -119,6 +141,18 @@ while [ "$i" -lt 150 ]; do
       cat "$TMPDIR/ready.err" >&2
       exit 1
     fi
+    "$PYTHON" - "$BASE_URL" <<'PY'
+import json
+import sys
+import urllib.request
+
+body = urllib.request.urlopen(f"{sys.argv[1]}/profile/status", timeout=1).read()
+status = json.loads(body.decode())
+if status.get("profile") != "system":
+    raise SystemExit(status)
+if status.get("event_queue_limit") != 1024:
+    raise SystemExit(status)
+PY
     kill -TERM "$PID"
     wait "$PID"
     PID=

--- a/tests/check-wyrelogd-profiles.sh
+++ b/tests/check-wyrelogd-profiles.sh
@@ -1,0 +1,217 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+set -eu
+
+WYRELOGD=$1
+TEMPLATE_DIR=$2
+PYTHON=$3
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT INT TERM
+
+"$PYTHON" - "$TMPDIR/system.key" "$TMPDIR/service.key" <<'PY'
+import os
+import pathlib
+import sys
+
+for raw in sys.argv[1:]:
+    pathlib.Path(raw).write_bytes(os.urandom(32))
+PY
+
+if "$WYRELOGD" --profile=nope --check >/dev/null 2>"$TMPDIR/bad.err"; then
+  echo "invalid profile was accepted" >&2
+  exit 1
+fi
+if ! grep -q "profile must be system or service" "$TMPDIR/bad.err"; then
+  echo "invalid profile did not report a stable error" >&2
+  cat "$TMPDIR/bad.err" >&2
+  exit 1
+fi
+
+"$WYRELOGD" --production --profile=system \
+  --template-dir "$TEMPLATE_DIR" \
+  --policy-db "$TMPDIR/system/policy.sqlite" \
+  --policy-keyprovider "$TMPDIR/system.key" \
+  --audit-db "$TMPDIR/system/audit.duckdb" \
+  --check
+
+"$WYRELOGD" --production --profile=service \
+  --template-dir "$TEMPLATE_DIR" \
+  --policy-db "$TMPDIR/service/policy.sqlite" \
+  --policy-keyprovider "$TMPDIR/service.key" \
+  --audit-db "$TMPDIR/service/audit.duckdb" \
+  --system-url "http://127.0.0.1:1" \
+  --event-spool-dir "$TMPDIR/service/event-spool" \
+  --event-queue-limit 8 \
+  --check
+
+if [ ! -d "$TMPDIR/service/event-spool" ]; then
+  echo "service profile did not create the event spool" >&2
+  exit 1
+fi
+
+"$WYRELOGD" --profile=service \
+  --template-dir "$TEMPLATE_DIR" \
+  --system-url "http://127.0.0.1:1" \
+  --event-spool-dir "$TMPDIR/service/run-spool" \
+  --event-queue-limit 2 \
+  --listen-port 0 \
+  >"$TMPDIR/service-run.out" 2>"$TMPDIR/service-run.err" &
+SERVICE_PID=$!
+SPOOLED=0
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  if find "$TMPDIR/service/run-spool" -name '*.event' -print -quit \
+      2>/dev/null | grep -q .; then
+    SPOOLED=1
+    break
+  fi
+  if ! kill -0 "$SERVICE_PID" 2>/dev/null; then
+    break
+  fi
+  sleep 1
+done
+kill "$SERVICE_PID" 2>/dev/null || true
+wait "$SERVICE_PID" 2>/dev/null || true
+if [ "$SPOOLED" -ne 1 ]; then
+  echo "service profile did not spool an event during system outage" >&2
+  cat "$TMPDIR/service-run.err" >&2
+  exit 1
+fi
+
+mkdir -p "$TMPDIR/service/full-spool"
+printf '{"profile":"service","event":"existing"}' \
+  >"$TMPDIR/service/full-spool/existing.event"
+if "$WYRELOGD" --profile=service \
+    --template-dir "$TEMPLATE_DIR" \
+    --system-url "http://127.0.0.1:1" \
+    --event-spool-dir "$TMPDIR/service/full-spool" \
+    --event-queue-limit 1 \
+    --listen-port 0 \
+    >/dev/null 2>"$TMPDIR/full-spool.err"; then
+  echo "full event spool was accepted" >&2
+  exit 1
+fi
+if ! grep -q "event spool queue limit reached" "$TMPDIR/full-spool.err"; then
+  echo "full event spool did not report a stable error" >&2
+  cat "$TMPDIR/full-spool.err" >&2
+  exit 1
+fi
+
+"$PYTHON" - "$TMPDIR/http.port" "$TMPDIR/http.requests" <<'PY' &
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import pathlib
+import sys
+
+port_path = pathlib.Path(sys.argv[1])
+requests_path = pathlib.Path(sys.argv[2])
+seen = 0
+
+class Handler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        global seen
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length).decode("utf-8")
+        with requests_path.open("a", encoding="utf-8") as out:
+            out.write(body + "\n")
+        seen += 1
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(b'{"ok":true}')
+
+    def log_message(self, fmt, *args):
+        return
+
+server = HTTPServer(("127.0.0.1", 0), Handler)
+port_path.write_text(str(server.server_port), encoding="utf-8")
+while seen < 2:
+    server.handle_request()
+PY
+HTTP_PID=$!
+for _ in 1 2 3 4 5; do
+  [ -s "$TMPDIR/http.port" ] && break
+  sleep 1
+done
+if [ ! -s "$TMPDIR/http.port" ]; then
+  echo "test HTTP endpoint did not start" >&2
+  kill "$HTTP_PID" 2>/dev/null || true
+  exit 1
+fi
+HTTP_PORT=$(cat "$TMPDIR/http.port")
+
+mkdir -p "$TMPDIR/service/drain-spool"
+printf '{"profile":"service","event":"existing"}' \
+  >"$TMPDIR/service/drain-spool/existing.event"
+"$WYRELOGD" --profile=service \
+  --template-dir "$TEMPLATE_DIR" \
+  --system-url "http://127.0.0.1:$HTTP_PORT" \
+  --event-spool-dir "$TMPDIR/service/drain-spool" \
+  --event-queue-limit 8 \
+  --listen-port 0 \
+  >"$TMPDIR/service-drain.out" 2>"$TMPDIR/service-drain.err" &
+SERVICE_PID=$!
+HTTP_DONE=0
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  if ! kill -0 "$HTTP_PID" 2>/dev/null; then
+    HTTP_DONE=1
+    break
+  fi
+  if ! kill -0 "$SERVICE_PID" 2>/dev/null; then
+    break
+  fi
+  sleep 1
+done
+kill "$SERVICE_PID" 2>/dev/null || true
+kill "$HTTP_PID" 2>/dev/null || true
+wait "$SERVICE_PID" 2>/dev/null || true
+wait "$HTTP_PID" 2>/dev/null || true
+if [ "$HTTP_DONE" -ne 1 ]; then
+  echo "service profile did not drain and forward events" >&2
+  cat "$TMPDIR/service-drain.err" >&2
+  exit 1
+fi
+if find "$TMPDIR/service/drain-spool" -name '*.event' -print -quit \
+    | grep -q .; then
+  echo "service profile left drained events in the spool" >&2
+  exit 1
+fi
+if [ "$(grep -c '"profile":"service"' "$TMPDIR/http.requests")" -ne 2 ]; then
+  echo "service profile did not forward the expected event count" >&2
+  cat "$TMPDIR/http.requests" >&2
+  exit 1
+fi
+
+if "$WYRELOGD" --profile=service --event-queue-limit 0 \
+    --check >/dev/null 2>"$TMPDIR/limit.err"; then
+  echo "zero event queue limit was accepted" >&2
+  exit 1
+fi
+if ! grep -q "event queue limit must be a positive integer" \
+    "$TMPDIR/limit.err"; then
+  echo "invalid event queue limit did not report a stable error" >&2
+  cat "$TMPDIR/limit.err" >&2
+  exit 1
+fi
+
+cat >"$TMPDIR/service.ini" <<EOF
+[daemon]
+profile=service
+template_dir=$TEMPLATE_DIR
+policy_db=$TMPDIR/config/policy.sqlite
+policy_keyprovider=$TMPDIR/service.key
+audit_db=$TMPDIR/config/audit.duckdb
+system_url=http://127.0.0.1:8765
+event_spool_dir=$TMPDIR/config/event-spool
+event_queue_limit=9
+listen_port=9876
+production=true
+EOF
+
+"$WYRELOGD" --config "$TMPDIR/service.ini" --profile-info \
+  >"$TMPDIR/profile.out"
+grep -q '^profile=service$' "$TMPDIR/profile.out"
+grep -q "^policy_db=$TMPDIR/config/policy.sqlite$" "$TMPDIR/profile.out"
+grep -q "^event_spool_dir=$TMPDIR/config/event-spool$" "$TMPDIR/profile.out"
+grep -q '^event_queue_limit=9$' "$TMPDIR/profile.out"
+grep -q '^listen_port=9876$' "$TMPDIR/profile.out"

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -33,6 +33,16 @@ if host_machine.system() != 'windows'
     depends : wyrelogd_exe,
   )
 
+  test('wyrelogd-profiles', sh,
+    args : [
+      meson.current_source_dir() / 'check-wyrelogd-profiles.sh',
+      wyrelogd_exe.full_path(),
+      meson.project_source_root() / 'templates' / 'access',
+      python3.full_path(),
+    ],
+    depends : wyrelogd_exe,
+  )
+
   wyrelogd_sigterm_cmd = '"' + wyrelogd_exe.full_path()
   wyrelogd_sigterm_cmd += '" --template-dir "'
   wyrelogd_sigterm_cmd += meson.project_source_root() / 'templates' / 'access'

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -100,7 +100,11 @@ typedef struct
   gchar *access_token_key_id;
   gboolean access_token_secret_ready;
   gboolean production_mode;
+  WylDaemonProfile profile;
   gchar *policy_keyprovider_path;
+  gchar *system_url;
+  gchar *event_spool_dir;
+  guint event_queue_limit;
   GHashTable *sessions_by_token;
   GHashTable *access_tokens_by_jti;
   GHashTable *refresh_tokens_by_token;
@@ -124,6 +128,7 @@ typedef struct
 static WylDaemonHttpContext *wyl_daemon_http_get_context (SoupServer * server);
 static void set_json_error (SoupServerMessage * msg, guint status,
     const gchar * code);
+static void set_json_ok (SoupServerMessage * msg);
 
 static gboolean
 wyl_daemon_tenant_is_known (const gchar *tenant)
@@ -189,6 +194,8 @@ wyl_daemon_http_context_free (gpointer data)
   sodium_memzero (ctx->access_token_secret, sizeof ctx->access_token_secret);
   g_free (ctx->access_token_key_id);
   g_free (ctx->policy_keyprovider_path);
+  g_free (ctx->system_url);
+  g_free (ctx->event_spool_dir);
   g_hash_table_unref (ctx->sessions_by_token);
   g_hash_table_unref (ctx->access_tokens_by_jti);
   g_hash_table_unref (ctx->refresh_tokens_by_token);
@@ -301,7 +308,11 @@ wyl_daemon_http_context_new (const WylDaemonOptions *opts, WylHandle *handle,
   ctx->handle = handle;
   ctx->runtime = runtime;
   ctx->production_mode = opts->production_mode;
+  ctx->profile = opts->profile;
   ctx->policy_keyprovider_path = g_strdup (opts->policy_keyprovider_path);
+  ctx->system_url = g_strdup (opts->system_url);
+  ctx->event_spool_dir = g_strdup (opts->event_spool_dir);
+  ctx->event_queue_limit = opts->event_queue_limit;
   ctx->sessions_by_token =
       g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_object_unref);
   ctx->access_tokens_by_jti = g_hash_table_new_full (g_str_hash, g_str_equal,
@@ -1351,6 +1362,59 @@ readyz_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
       strlen (body));
 }
 
+static void
+profile_status_handler (SoupServer *server, SoupServerMessage *msg,
+    const char *path, GHashTable *query, gpointer user_data)
+{
+  (void) server;
+  (void) path;
+  (void) query;
+
+  WylDaemonHttpContext *ctx = user_data;
+  const gchar *profile =
+      ctx->profile == WYL_DAEMON_PROFILE_SERVICE ? "service" : "system";
+  g_autoptr (GString) body = g_string_new ("{\"profile\":");
+  append_json_string (body, profile);
+  g_string_append (body, ",\"system_url\":");
+  if (ctx->system_url == NULL)
+    g_string_append (body, "null");
+  else
+    append_json_string (body, ctx->system_url);
+  g_string_append (body, ",\"event_spool_dir\":");
+  if (ctx->event_spool_dir == NULL)
+    g_string_append (body, "null");
+  else
+    append_json_string (body, ctx->event_spool_dir);
+  g_string_append_printf (body, ",\"event_queue_limit\":%u}",
+      ctx->event_queue_limit);
+
+  attach_request_id_header (msg);
+  soup_server_message_set_status (msg, 200, NULL);
+  soup_server_message_set_response (msg, "application/json",
+      SOUP_MEMORY_COPY, body->str, body->len);
+}
+
+static void
+profile_events_handler (SoupServer *server, SoupServerMessage *msg,
+    const char *path, GHashTable *query, gpointer user_data)
+{
+  (void) server;
+  (void) path;
+  (void) query;
+
+  WylDaemonHttpContext *ctx = user_data;
+  if (g_strcmp0 (soup_server_message_get_method (msg), "POST") != 0) {
+    set_json_error (msg, 405, "method_not_allowed");
+    return;
+  }
+  if (ctx->profile != WYL_DAEMON_PROFILE_SYSTEM) {
+    set_json_error (msg, 403, "profile_event_ingest_denied");
+    return;
+  }
+
+  set_json_ok (msg);
+}
+
 static gboolean
 authorize_guarded_session_action (SoupServer *server, SoupServerMessage *msg,
     GHashTable *query, WylDaemonHttpContext *ctx, const gchar *action,
@@ -2253,6 +2317,10 @@ wyl_daemon_start_http_server_with_runtime (const WylDaemonOptions *opts,
       wyl_daemon_http_context_free);
   soup_server_add_handler (server, "/healthz", healthz_handler, NULL, NULL);
   soup_server_add_handler (server, "/readyz", readyz_handler, ctx, NULL);
+  soup_server_add_handler (server, "/profile/status", profile_status_handler,
+      ctx, NULL);
+  soup_server_add_handler (server, "/profile/events", profile_events_handler,
+      ctx, NULL);
   soup_server_add_handler (server, "/auth/login", login_handler, ctx, NULL);
   soup_server_add_handler (server, "/auth/refresh", refresh_handler, ctx, NULL);
   soup_server_add_handler (server, "/auth/logout", logout_handler, ctx, NULL);

--- a/wyrelog/daemon/options.c
+++ b/wyrelog/daemon/options.c
@@ -1,11 +1,149 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #include "daemon/options.h"
 
+#include <errno.h>
+#include <string.h>
+
+#define WYL_DAEMON_DEFAULT_EVENT_QUEUE_LIMIT 1024
+
+const gchar *
+wyl_daemon_profile_name (WylDaemonProfile profile)
+{
+  switch (profile) {
+    case WYL_DAEMON_PROFILE_SYSTEM:
+      return "system";
+    case WYL_DAEMON_PROFILE_SERVICE:
+      return "service";
+  }
+  return "unknown";
+}
+
+static gboolean
+parse_profile (const gchar *value, WylDaemonProfile *out_profile)
+{
+  if (value == NULL || value[0] == '\0' || out_profile == NULL)
+    return FALSE;
+  if (g_strcmp0 (value, "system") == 0) {
+    *out_profile = WYL_DAEMON_PROFILE_SYSTEM;
+    return TRUE;
+  }
+  if (g_strcmp0 (value, "service") == 0) {
+    *out_profile = WYL_DAEMON_PROFILE_SERVICE;
+    return TRUE;
+  }
+  return FALSE;
+}
+
+static gboolean
+parse_uint_arg (const gchar *value, guint min_value, guint max_value,
+    guint *out_value)
+{
+  if (out_value == NULL)
+    return FALSE;
+  if (value == NULL || value[0] == '\0')
+    return FALSE;
+
+  errno = 0;
+  gchar *end = NULL;
+  guint64 parsed = g_ascii_strtoull (value, &end, 10);
+  if (errno != 0 || end == value || *end != '\0' || parsed < min_value ||
+      parsed > max_value)
+    return FALSE;
+
+  *out_value = (guint) parsed;
+  return TRUE;
+}
+
+static void
+keyfile_take_string (GKeyFile *key_file, const gchar *key, const gchar **target)
+{
+  if (*target != NULL)
+    return;
+  g_autoptr (GError) error = NULL;
+  gchar *value = g_key_file_get_string (key_file, "daemon", key, &error);
+  if (value == NULL || value[0] == '\0') {
+    g_free (value);
+    return;
+  }
+  *target = value;
+}
+
+static void
+keyfile_take_owned_string (GKeyFile *key_file, const gchar *key, gchar **target)
+{
+  if (*target != NULL)
+    return;
+  g_autoptr (GError) error = NULL;
+  gchar *value = g_key_file_get_string (key_file, "daemon", key, &error);
+  if (value == NULL || value[0] == '\0') {
+    g_free (value);
+    return;
+  }
+  *target = value;
+}
+
+static void
+load_config_defaults (WylDaemonOptions *opts, GKeyFile *key_file)
+{
+  keyfile_take_owned_string (key_file, "profile", &opts->profile_arg);
+  keyfile_take_string (key_file, "template_dir", &opts->template_dir);
+  keyfile_take_string (key_file, "policy_db", &opts->policy_store_path);
+  keyfile_take_string (key_file, "policy_keyprovider",
+      &opts->policy_keyprovider_path);
+  keyfile_take_string (key_file, "audit_db", &opts->audit_store_path);
+  keyfile_take_string (key_file, "event_spool_dir", &opts->event_spool_dir);
+  keyfile_take_string (key_file, "system_url", &opts->system_url);
+  keyfile_take_owned_string (key_file, "listen_port", &opts->listen_port_arg);
+  keyfile_take_owned_string (key_file, "event_queue_limit",
+      &opts->event_queue_limit_arg);
+
+  if (!opts->production_mode && g_key_file_has_key (key_file, "daemon",
+          "production", NULL)) {
+    g_autoptr (GError) error = NULL;
+    opts->production_mode =
+        g_key_file_get_boolean (key_file, "daemon", "production", &error);
+  }
+}
+
+static const gchar *
+default_policy_path (WylDaemonProfile profile)
+{
+  return profile == WYL_DAEMON_PROFILE_SERVICE ?
+      "/var/lib/wyrelog/service/policy.sqlite" :
+      "/var/lib/wyrelog/system/policy.sqlite";
+}
+
+static const gchar *
+default_keyprovider_path (WylDaemonProfile profile)
+{
+  return profile == WYL_DAEMON_PROFILE_SERVICE ?
+      "/etc/wyrelog/service/policy.key" : "/etc/wyrelog/system/policy.key";
+}
+
+static const gchar *
+default_audit_path (WylDaemonProfile profile)
+{
+  return profile == WYL_DAEMON_PROFILE_SERVICE ?
+      "/var/log/wyrelog/service/audit.duckdb" :
+      "/var/log/wyrelog/system/audit.duckdb";
+}
+
+static const gchar *
+default_spool_dir (WylDaemonProfile profile)
+{
+  return profile == WYL_DAEMON_PROFILE_SERVICE ?
+      "/var/lib/wyrelog/service/event-spool" : NULL;
+}
+
 gboolean
 wyl_daemon_parse_options (gint *argc, gchar ***argv, WylDaemonOptions *opts,
     GError **error)
 {
   GOptionEntry entries[] = {
+    {"config", 0, 0, G_OPTION_ARG_STRING, &opts->config_path,
+        "Daemon config file", "PATH"},
+    {"profile", 0, 0, G_OPTION_ARG_STRING, &opts->profile_arg,
+        "Daemon profile: system or service", "PROFILE"},
     {"template-dir", 0, 0, G_OPTION_ARG_STRING, &opts->template_dir,
         "Access policy template directory", "DIR"},
     {"policy-db", 0, 0, G_OPTION_ARG_STRING, &opts->policy_store_path,
@@ -15,8 +153,16 @@ wyl_daemon_parse_options (gint *argc, gchar ***argv, WylDaemonOptions *opts,
         "Path to policy database key provider state", "PATH"},
     {"audit-db", 0, 0, G_OPTION_ARG_STRING, &opts->audit_store_path,
         "Runtime audit sink database path", "PATH"},
+    {"system-url", 0, 0, G_OPTION_ARG_STRING, &opts->system_url,
+          "System-profile daemon URL for service-profile event forwarding",
+        "URL"},
+    {"event-spool-dir", 0, 0, G_OPTION_ARG_STRING, &opts->event_spool_dir,
+        "Service-profile disk spool directory", "DIR"},
+    {"event-queue-limit", 0, 0, G_OPTION_ARG_STRING,
+          &opts->event_queue_limit_arg,
+        "Maximum pending service-profile spool files", "N"},
 #ifdef WYL_HAS_DAEMON_HTTP
-    {"listen-port", 0, 0, G_OPTION_ARG_INT, &opts->listen_port,
+    {"listen-port", 0, 0, G_OPTION_ARG_STRING, &opts->listen_port_arg,
         "HTTP listen port", "PORT"},
 #endif
     {"check", 0, 0, G_OPTION_ARG_NONE, &opts->check_only,
@@ -30,6 +176,8 @@ wyl_daemon_parse_options (gint *argc, gchar ***argv, WylDaemonOptions *opts,
         "Print access template version and exit", NULL},
     {"template-info", 0, 0, G_OPTION_ARG_NONE, &opts->show_template_info,
         "Print access template artifact identity and exit", NULL},
+    {"profile-info", 0, 0, G_OPTION_ARG_NONE, &opts->show_profile_info,
+        "Print resolved daemon profile configuration and exit", NULL},
     {NULL}
   };
 
@@ -38,4 +186,69 @@ wyl_daemon_parse_options (gint *argc, gchar ***argv, WylDaemonOptions *opts,
   g_option_context_add_main_entries (context, entries, NULL);
 
   return g_option_context_parse (context, argc, argv, error);
+}
+
+gboolean
+wyl_daemon_options_resolve (WylDaemonOptions *opts, GError **error)
+{
+  g_return_val_if_fail (opts != NULL, FALSE);
+
+  if (opts->config_path != NULL && opts->config_path[0] != '\0') {
+    g_autoptr (GKeyFile) key_file = g_key_file_new ();
+    if (!g_key_file_load_from_file (key_file, opts->config_path,
+            G_KEY_FILE_NONE, error))
+      return FALSE;
+    load_config_defaults (opts, key_file);
+  }
+
+  if (opts->profile_arg == NULL)
+    opts->profile_arg = g_strdup ("system");
+  if (!parse_profile (opts->profile_arg, &opts->profile)) {
+    g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_BAD_VALUE,
+        "profile must be system or service");
+    return FALSE;
+  }
+
+  if (opts->event_queue_limit_arg == NULL)
+    opts->event_queue_limit = WYL_DAEMON_DEFAULT_EVENT_QUEUE_LIMIT;
+  else if (!parse_uint_arg (opts->event_queue_limit_arg, 1, G_MAXUINT,
+          &opts->event_queue_limit)) {
+    g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_BAD_VALUE,
+        "event queue limit must be a positive integer");
+    return FALSE;
+  }
+
+  if (opts->listen_port_arg != NULL) {
+    guint listen_port = 0;
+    if (!parse_uint_arg (opts->listen_port_arg, 0, 65535, &listen_port)) {
+      g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_BAD_VALUE,
+          "listen port must be between 0 and 65535");
+      return FALSE;
+    }
+    opts->listen_port = (gint) listen_port;
+  } else if (opts->listen_port < 0) {
+    opts->listen_port =
+        opts->profile == WYL_DAEMON_PROFILE_SERVICE ? 8766 : 8765;
+  }
+
+  if (opts->production_mode || opts->show_profile_info) {
+    if (opts->policy_store_path == NULL)
+      opts->policy_store_path = default_policy_path (opts->profile);
+    if (opts->policy_keyprovider_path == NULL)
+      opts->policy_keyprovider_path = default_keyprovider_path (opts->profile);
+    if (opts->audit_store_path == NULL)
+      opts->audit_store_path = default_audit_path (opts->profile);
+  }
+
+  if (opts->profile == WYL_DAEMON_PROFILE_SERVICE) {
+    if ((opts->production_mode || opts->show_profile_info) &&
+        opts->event_spool_dir == NULL)
+      opts->event_spool_dir = default_spool_dir (opts->profile);
+  } else if (opts->system_url != NULL && opts->system_url[0] != '\0') {
+    g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_BAD_VALUE,
+        "system-url is only valid for the service profile");
+    return FALSE;
+  }
+
+  return TRUE;
 }

--- a/wyrelog/daemon/options.h
+++ b/wyrelog/daemon/options.h
@@ -3,19 +3,36 @@
 
 #include <glib.h>
 
+typedef enum
+{
+  WYL_DAEMON_PROFILE_SYSTEM = 0,
+  WYL_DAEMON_PROFILE_SERVICE = 1,
+} WylDaemonProfile;
+
 typedef struct
 {
+  gchar *config_path;
+  gchar *profile_arg;
+  WylDaemonProfile profile;
   const gchar *template_dir;
   const gchar *policy_store_path;
   const gchar *policy_keyprovider_path;
   const gchar *audit_store_path;
+  const gchar *event_spool_dir;
+  const gchar *system_url;
+  gchar *listen_port_arg;
+  gchar *event_queue_limit_arg;
+  guint event_queue_limit;
   gint listen_port;
   gboolean check_only;
   gboolean production_mode;
   gboolean show_version;
   gboolean show_template_version;
   gboolean show_template_info;
+  gboolean show_profile_info;
 } WylDaemonOptions;
 
 gboolean wyl_daemon_parse_options (gint * argc, gchar *** argv,
     WylDaemonOptions * opts, GError ** error);
+gboolean wyl_daemon_options_resolve (WylDaemonOptions * opts, GError ** error);
+const gchar *wyl_daemon_profile_name (WylDaemonProfile profile);

--- a/wyrelog/daemon/runtime.c
+++ b/wyrelog/daemon/runtime.c
@@ -1,8 +1,13 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #include "daemon/runtime.h"
 
+#include <errno.h>
+
 #include <glib.h>
 #include <glib/gstdio.h>
+#ifdef WYL_HAS_DAEMON_HTTP
+#include <libsoup/soup.h>
+#endif
 
 #include "daemon/checks.h"
 #include "daemon/delta.h"
@@ -10,6 +15,221 @@
 #include "daemon/signals.h"
 #include "wyrelog/wyrelog.h"
 #include "wyrelog/wyl-handle-private.h"
+
+static gboolean
+count_service_profile_spool_events (const WylDaemonOptions *opts,
+    guint *out_pending, GError **error)
+{
+  g_return_val_if_fail (out_pending != NULL, FALSE);
+  *out_pending = 0;
+
+  g_autoptr (GError) open_error = NULL;
+  g_autoptr (GDir) dir = g_dir_open (opts->event_spool_dir, 0, &open_error);
+  if (dir == NULL) {
+    g_propagate_prefixed_error (error, g_steal_pointer (&open_error),
+        "failed to open event spool directory: ");
+    return FALSE;
+  }
+
+  const gchar *name = NULL;
+  while ((name = g_dir_read_name (dir)) != NULL) {
+    if (g_str_has_suffix (name, ".event"))
+      (*out_pending)++;
+  }
+  return TRUE;
+}
+
+static gboolean
+prepare_service_profile_spool (const WylDaemonOptions *opts, GError **error)
+{
+  if (opts->profile != WYL_DAEMON_PROFILE_SERVICE)
+    return TRUE;
+  if (opts->event_spool_dir == NULL || opts->event_spool_dir[0] == '\0') {
+    g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_BAD_VALUE,
+        "service profile requires an event spool directory");
+    return FALSE;
+  }
+
+  guint pending = 0;
+  if (g_mkdir_with_parents (opts->event_spool_dir, 0700) != 0) {
+    g_set_error (error, G_FILE_ERROR, g_file_error_from_errno (errno),
+        "failed to create event spool directory: %s", opts->event_spool_dir);
+    return FALSE;
+  }
+  if (!count_service_profile_spool_events (opts, &pending, error))
+    return FALSE;
+  if (pending > opts->event_queue_limit) {
+    g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_BAD_VALUE,
+        "event spool contains %u files, exceeding queue limit %u", pending,
+        opts->event_queue_limit);
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+#ifdef WYL_HAS_DAEMON_HTTP
+static gboolean
+service_profile_forwarding_enabled (const WylDaemonOptions *opts)
+{
+  return opts->profile == WYL_DAEMON_PROFILE_SERVICE &&
+      opts->system_url != NULL && opts->system_url[0] != '\0';
+}
+
+static gchar *
+service_profile_events_url (const WylDaemonOptions *opts)
+{
+  return g_strconcat (opts->system_url,
+      g_str_has_suffix (opts->system_url, "/") ? "profile/events" :
+      "/profile/events", NULL);
+}
+
+static gboolean
+post_service_profile_event (const WylDaemonOptions *opts,
+    const gchar *contents, GError **error)
+{
+  g_autofree gchar *url = service_profile_events_url (opts);
+  g_autoptr (SoupMessage) msg = soup_message_new ("POST", url);
+  if (msg == NULL) {
+    g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT,
+        "invalid system profile URL");
+    return FALSE;
+  }
+
+  g_autoptr (SoupSession) session = soup_session_new ();
+  soup_session_set_timeout (session, 2);
+  g_autoptr (GBytes) request = g_bytes_new_static (contents, strlen (contents));
+  soup_message_set_request_body_from_bytes (msg, "application/json", request);
+
+  g_autoptr (GBytes) response =
+      soup_session_send_and_read (session, msg, NULL, error);
+  if (response == NULL)
+    return FALSE;
+
+  guint status = soup_message_get_status (msg);
+  if (status < 200 || status >= 300) {
+    g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+        "system profile event endpoint returned HTTP %u", status);
+    return FALSE;
+  }
+  return TRUE;
+}
+
+static GPtrArray *
+list_service_profile_spool_events (const WylDaemonOptions *opts, GError **error)
+{
+  g_autoptr (GDir) dir = g_dir_open (opts->event_spool_dir, 0, error);
+  if (dir == NULL)
+    return NULL;
+
+  GPtrArray *paths = g_ptr_array_new_with_free_func (g_free);
+  const gchar *name = NULL;
+  while ((name = g_dir_read_name (dir)) != NULL) {
+    if (g_str_has_suffix (name, ".event"))
+      g_ptr_array_add (paths, g_build_filename (opts->event_spool_dir, name,
+              NULL));
+  }
+  return paths;
+}
+
+static gint
+compare_spool_event_paths (gconstpointer a, gconstpointer b)
+{
+  const gchar *path_a = *(gchar * const *) a;
+  const gchar *path_b = *(gchar * const *) b;
+  return g_strcmp0 (path_a, path_b);
+}
+
+static gboolean
+drain_service_profile_spool (const WylDaemonOptions *opts, GError **error)
+{
+  if (!service_profile_forwarding_enabled (opts))
+    return TRUE;
+
+  g_autoptr (GPtrArray) paths = list_service_profile_spool_events (opts, error);
+  if (paths == NULL)
+    return FALSE;
+  g_ptr_array_sort (paths, compare_spool_event_paths);
+
+  for (guint i = 0; i < paths->len; i++) {
+    const gchar *path = g_ptr_array_index (paths, i);
+    g_autofree gchar *contents = NULL;
+    gsize len = 0;
+    if (!g_file_get_contents (path, &contents, &len, error))
+      return FALSE;
+    (void) len;
+    if (!post_service_profile_event (opts, contents, error))
+      return FALSE;
+    if (g_remove (path) != 0) {
+      g_set_error (error, G_FILE_ERROR, g_file_error_from_errno (errno),
+          "failed to remove drained event spool file: %s", path);
+      return FALSE;
+    }
+  }
+  return TRUE;
+}
+
+static gboolean
+spool_service_profile_event (const WylDaemonOptions *opts,
+    const gchar *contents, GError **error)
+{
+  guint pending = 0;
+  if (!count_service_profile_spool_events (opts, &pending, error))
+    return FALSE;
+  if (pending >= opts->event_queue_limit) {
+    g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_BAD_VALUE,
+        "event spool queue limit reached: %u", opts->event_queue_limit);
+    return FALSE;
+  }
+
+  g_autofree gchar *uuid = g_uuid_string_random ();
+  g_autofree gchar *name = g_strdup_printf ("%020" G_GINT64_FORMAT "-%s.event",
+      g_get_real_time (), uuid);
+  g_autofree gchar *path = g_build_filename (opts->event_spool_dir, name, NULL);
+  g_autofree gchar *tmp_path = g_strdup_printf ("%s.tmp", path);
+  if (!g_file_set_contents (tmp_path, contents, -1, error))
+    return FALSE;
+  if (g_rename (tmp_path, path) != 0) {
+    g_set_error (error, G_FILE_ERROR, g_file_error_from_errno (errno),
+        "failed to commit event spool file: %s", path);
+    return FALSE;
+  }
+  return TRUE;
+}
+
+static gboolean
+emit_service_profile_forwarding_event (const WylDaemonOptions *opts,
+    const gchar *event, GError **error)
+{
+  if (!service_profile_forwarding_enabled (opts))
+    return TRUE;
+
+  g_autoptr (GError) drain_error = NULL;
+  if (!drain_service_profile_spool (opts, &drain_error))
+    g_clear_error (&drain_error);
+
+  g_autofree gchar *contents =
+      g_strdup_printf
+      ("{\"profile\":\"service\",\"event\":\"%s\",\"timestamp_us\":%"
+      G_GINT64_FORMAT "}",
+      event, g_get_real_time ());
+  g_autoptr (GError) post_error = NULL;
+  if (post_service_profile_event (opts, contents, &post_error))
+    return TRUE;
+
+  return spool_service_profile_event (opts, contents, error);
+}
+
+static gboolean
+drain_service_profile_spool_tick (gpointer user_data)
+{
+  const WylDaemonOptions *opts = user_data;
+  g_autoptr (GError) error = NULL;
+  if (!drain_service_profile_spool (opts, &error) && error != NULL)
+    g_debug ("service profile event spool drain skipped: %s", error->message);
+  return G_SOURCE_CONTINUE;
+}
+#endif
 
 static void
 cleanup_readiness_policy_db (gpointer data)
@@ -93,6 +313,11 @@ wyl_daemon_run_runtime (const WylDaemonOptions *opts)
 {
   g_autoptr (GError) error = NULL;
 
+  if (!prepare_service_profile_spool (opts, &error)) {
+    g_printerr ("wyrelogd: profile setup failed: %s\n", error->message);
+    return 1;
+  }
+
   if (!opts->check_only) {
     /* Install early signal handlers so SIGINT/SIGTERM arriving during
      * the readiness phase (before the GMainLoop and its glib-based
@@ -146,6 +371,12 @@ wyl_daemon_run_runtime (const WylDaemonOptions *opts)
         wyrelog_error_string (rc));
     return 1;
   }
+#ifdef WYL_HAS_DAEMON_HTTP
+  if (!emit_service_profile_forwarding_event (opts, "startup", &error)) {
+    g_printerr ("wyrelogd: profile event spool failed: %s\n", error->message);
+    return 1;
+  }
+#endif
 
   g_autoptr (GMainLoop) loop = g_main_loop_new (NULL, FALSE);
 #ifdef WYL_HAS_DAEMON_HTTP
@@ -161,6 +392,12 @@ wyl_daemon_run_runtime (const WylDaemonOptions *opts)
   guint sigint_id = 0;
   guint sigterm_id = 0;
   wyl_daemon_install_signal_handlers (loop, &sigint_id, &sigterm_id);
+  guint service_drain_id = 0;
+#ifdef WYL_HAS_DAEMON_HTTP
+  if (service_profile_forwarding_enabled (opts))
+    service_drain_id = g_timeout_add_seconds (5,
+        drain_service_profile_spool_tick, (gpointer) opts);
+#endif
   guint early_signal_poll_id =
       g_timeout_add (100, quit_loop_on_early_signal, loop);
   /* If SIGTERM/SIGINT arrived during readiness or post-readiness setup,
@@ -173,6 +410,7 @@ wyl_daemon_run_runtime (const WylDaemonOptions *opts)
 #ifdef WYL_HAS_DAEMON_HTTP
   soup_server_disconnect (server);
 #endif
+  wyl_daemon_remove_signal_handler (&service_drain_id);
   wyl_daemon_remove_signal_handler (&early_signal_poll_id);
   wyl_daemon_remove_signal_handler (&sigterm_id);
   wyl_daemon_remove_signal_handler (&sigint_id);

--- a/wyrelog/daemon/wyrelogd.c
+++ b/wyrelog/daemon/wyrelogd.c
@@ -16,11 +16,15 @@ main (int argc, char **argv)
 {
   WylDaemonOptions opts = {
     .template_dir = WYL_DEFAULT_TEMPLATE_DIR,
-    .listen_port = 8765,
+    .listen_port = -1,
   };
   g_autoptr (GError) error = NULL;
 
   if (!wyl_daemon_parse_options (&argc, &argv, &opts, &error)) {
+    g_printerr ("wyrelogd: %s\n", error->message);
+    return 2;
+  }
+  if (!wyl_daemon_options_resolve (&opts, &error)) {
     g_printerr ("wyrelogd: %s\n", error->message);
     return 2;
   }
@@ -76,6 +80,24 @@ main (int argc, char **argv)
         ("version=%u\nsha256=%s\nmigrations=%u\nlatest_migration_version=%u\n",
         info.version, info.sha256_hex, info.migration_count,
         info.latest_migration_version);
+    return 0;
+  }
+
+  if (opts.show_profile_info) {
+    g_print ("profile=%s\n", wyl_daemon_profile_name (opts.profile));
+    g_print ("template_dir=%s\n", opts.template_dir);
+    g_print ("policy_db=%s\n",
+        opts.policy_store_path != NULL ? opts.policy_store_path : "");
+    g_print ("policy_keyprovider=%s\n",
+        opts.policy_keyprovider_path != NULL ? opts.policy_keyprovider_path :
+        "");
+    g_print ("audit_db=%s\n",
+        opts.audit_store_path != NULL ? opts.audit_store_path : "");
+    g_print ("listen_port=%d\n", opts.listen_port);
+    g_print ("system_url=%s\n", opts.system_url != NULL ? opts.system_url : "");
+    g_print ("event_spool_dir=%s\n",
+        opts.event_spool_dir != NULL ? opts.event_spool_dir : "");
+    g_print ("event_queue_limit=%u\n", opts.event_queue_limit);
     return 0;
   }
 


### PR DESCRIPTION
## Summary
- Add system/service daemon profiles with config-file loading, profile-specific defaults, and explicit `--profile-info` output.
- Add service-profile event forwarding to the system-profile endpoint with bounded disk spool fallback and periodic drain.
- Add separate systemd units, tmpfiles paths, environment files, operator runbook updates, and profile/readiness tests.
- Keep the Wirelog wrap on `main`; Windows consumers compile with the existing Wirelog visibility define so static linking does not emit `dllimport` references.

## Validation
- `meson setup builddir --reconfigure`
- `meson compile -C builddir`
- `meson test -C builddir wyrelogd-profiles packaged-install-readiness --print-errorlogs`
- `meson test -C builddir --suite wyrelog --print-errorlogs` (54 passed, 1 skipped)
