### PR TITLE
tests: raise wyctl-basic meson timeout to 60s

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -162,6 +162,7 @@ if build_client
 
   test('wyctl-basic', test_wyctl_basic,
     depends : wyctl_exe,
+    timeout : 60,
   )
 
   # End-to-end: drives wyctl as a subprocess against an in-process daemon


### PR DESCRIPTION
## Summary

Bump the meson timeout for the `wyctl-basic` test from the default 30s to 60s so it has headroom on the macOS CI runner under ASAN + MALLOC_PERTURB_ + new sibling-test parallel pressure.

## Diagnosis

| Run | macOS wyctl-basic | Linux wyctl-basic |
|-----|-------------------|-------------------|
| `engine: align with wirelog easy API rename` (PASS) | 26.04s | 3.77s |
| `package operator readiness path` (PASS) | 24.26s | 3.76s |
| `Split daemon profiles` (FAIL) | **TIMEOUT 30.02s** | (pass) |

The test invokes the `wyctl` binary as a subprocess many times to drive help/error/argument-parsing surfaces and the in-test loopback HTTP harness for policy mutation. On macOS under ASAN+MALLOC_PERTURB_ the cumulative fork+exec cost has been at 24-26s for the last two passing runs - already brushing the 30s default.

`Split daemon profiles` (fa209fc) added a new `wyrelogd-profiles` test that also spawns `wyrelogd` subprocesses. Under CI parallel scheduling on macOS the additional fork+exec contention was enough to push `wyctl-basic` past 30s.

## Why this is the right scope

The test still finishes within ~30s on macOS (the timeout fires at 30.02s, indicating it was just over the line, not hung). Ubuntu and Windows pass cleanly at ~3.8s. There is no regression in correctness - just a wall-clock budget that is too tight for macOS under heavy parallel pressure.

The handle-engine-pair test already uses the same kwarg at 120s; daemon-http-decide-audit was bumped to 60s in #281 for the same reason.

## Test plan

- [ ] CI Main on macOS-latest passes `wyrelog:wyctl-basic`
- [ ] Ubuntu and Windows builds remain green