### PR TITLE
tests: stabilise wyrelogd-profiles and session-username after audit hardening

### DIFF
--- a/tests/check-wyrelogd-profiles.sh
+++ b/tests/check-wyrelogd-profiles.sh
@@ -60,7 +60,9 @@ fi
   >"$TMPDIR/service-run.out" 2>"$TMPDIR/service-run.err" &
 SERVICE_PID=$!
 SPOOLED=0
-for _ in 1 2 3 4 5 6 7 8 9 10; do
+i=0
+while [ "$i" -lt 30 ]; do
+  i=$((i + 1))
   if find "$TMPDIR/service/run-spool" -name '*.event' -print -quit \
       2>/dev/null | grep -q .; then
     SPOOLED=1

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -41,6 +41,7 @@ if host_machine.system() != 'windows'
       python3.full_path(),
     ],
     depends : wyrelogd_exe,
+    timeout : 60,
   )
 
   wyrelogd_sigterm_cmd = '"' + wyrelogd_exe.full_path()
@@ -456,7 +457,9 @@ test_session_username = executable('test-session-username',
   dependencies : [wyrelog_dep, wirelog_dep],
 )
 
-test('session-username', test_session_username)
+test('session-username', test_session_username,
+  timeout : 60,
+)
 
 test_session_username_lifecycle = executable('test-session-username-lifecycle',
   'test-session-username.c',


### PR DESCRIPTION
## Summary

CI Main on ubuntu-latest started failing on commit 5d0e628 (`Harden audit stream invariants`). Two tests cross their 30s wall-clock budget because the new audit invariant checks roughly double the login/logout audit-emit latency:

| Test | fa209fc (pass) | 5d0e628 (fail) | Slowdown |
|------|---------------|----------------|----------|
| wyrelogd-profiles (ubuntu) | ~22s OK | 29.33s exit 1 | 1.3x |
| session-username (ubuntu) | 16.12s OK | TIMEOUT 30.02s | 2x |
| session-username (macos) | 2.39s OK | 4.95s OK | 2x |
| session-username (windows) | 15.28s OK | 13.49s OK | noise |

Ubuntu glibc + the new invariant checks land hardest; macOS shows the same 2x ratio but absolute times stay under the ceiling.

## Changes

Single atomic commit:

- `tests/meson.build` — add `timeout : 60` to both `wyrelogd-profiles` and `session-username` (other CI-flake patterns use the same kwarg).
- `tests/check-wyrelogd-profiles.sh` — extend the spool-detection polling loop from 10 to 30 iterations so the service profile has 30 wall-seconds to emit its first outage event after the audit-emit slowdown.

## Why this is the right scope

These two tests assert correctness (does the service profile spool? does session-username drive its FSM correctly?), not performance. The wall-clock budgets were set when audit emit was fast; after the invariant hardening they need to be more generous.

The audit hardening latency itself is a separate concern worth profiling - the ~2x emit slowdown is consistent across linux/mac. Tracking that as a follow-up.

## Test plan

- [x] `meson test -C builddir --suite wyrelog` passes locally
- [x] `check-wyrelogd-profiles.sh` direct-invoke exits 0
- [ ] CI Main on ubuntu, macos, windows