### PR TITLE
[codex] Add GA hardening gates

### DIFF
--- a/docs/ga-hardening-gates.md
+++ b/docs/ga-hardening-gates.md
@@ -1,0 +1,77 @@
+# GA Hardening Gates
+
+This document defines the bounded release-confidence gates for the
+decision hot path, fuzz harnesses, leak checking, sanitizer runs,
+cold-start readiness, and dependency pinning.
+
+## Decision Latency
+
+`wyrelog:decision-latency` seeds a deterministic policy-store fixture and
+measures repeated `wyl_decide` calls after warmup. The default CI smoke
+uses a small sample count and intentionally conservative budgets so
+hosted runners and audit-enabled builds do not create noise:
+
+- `WYL_LATENCY_ITERATIONS=32`
+- `WYL_LATENCY_P50_USEC=250000`
+- `WYL_LATENCY_P95_USEC=750000`
+- `WYL_LATENCY_P99_USEC=1000000`
+
+Release candidates can tighten the same executable without changing the
+code, for example:
+
+```
+WYL_LATENCY_ITERATIONS=5000 WYL_LATENCY_P99_USEC=5000 \
+  meson test -C builddir wyrelog:decision-latency --print-errorlogs
+```
+
+## Bounded Fuzz
+
+`wyrelog:hardening-fuzz` runs deterministic corpus generation for:
+
+- decide request carriers and guard-context values;
+- invalid and partial decision inputs;
+- template loading with malformed fixed-order template trees.
+
+Set `WYL_FUZZ_SEED` to reproduce a run. Set `WYL_FUZZ_ARTIFACT_DIR` to
+preserve the last seed before each fuzz case, which gives CI/nightly jobs
+a stable crash-reproduction hook.
+
+## Valgrind
+
+`tools/run-valgrind-gate.sh` wraps a test executable with:
+
+- `--leak-check=full`
+- `--show-leak-kinds=definite`
+- `--errors-for-leak-kinds=definite`
+
+The gate fails when definitely-lost bytes are nonzero. It exits with 77
+when Valgrind is not installed so Meson reports a skip on unsupported
+platforms.
+
+## Sanitizers
+
+`tools/run-sanitizer-suite.sh` configures a separate build directory with
+AddressSanitizer and UndefinedBehaviorSanitizer flags, then runs the
+requested Meson test set. ThreadSanitizer should be run in a separate
+toolchain job because it is mutually noisy with ASan on common CI images.
+
+## Cold-Start Readiness
+
+`wyrelogd-startup-readiness` keeps the daemon fail-closed during policy
+engine load failures. It distinguishes startup not-ready behavior from
+ordinary HTTP authorization failures by proving the daemon does not serve
+`/healthz` after a deliberately broken template tree fails `--check`.
+
+## Supply Chain
+
+`wyrelog:supply-chain-pins` verifies wrap metadata before release:
+
+- file wraps must carry `source_url`, `source_filename`, `source_hash`,
+  and `directory`;
+- git wraps must carry `url` and `revision`;
+- moving git revisions are rejected unless explicitly allowlisted for an
+  in-family development dependency;
+- vendored subprojects must carry LICENSE or NOTICE metadata;
+- when `subprojects/packagecache` exists, missing platform archives are
+  reported; set `WYL_SUPPLY_CHAIN_REQUIRE_PACKAGECACHE=1` to make partial
+  cache coverage fail the gate.

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -353,6 +353,36 @@ test_template_tree = executable('test-template-tree',
 
 test('template-tree', test_template_tree)
 
+test_decision_latency = executable('test-decision-latency',
+  'test-decision-latency.c',
+  c_args : [
+    '-DWYL_TEST_TEMPLATE_DIR="' + meson.project_source_root() / 'templates' / 'access' + '"',
+  ],
+  dependencies : [wyrelog_dep, wirelog_dep],
+)
+
+test('decision-latency', test_decision_latency,
+  timeout : 60,
+)
+
+test_hardening_fuzz = executable('test-hardening-fuzz',
+  'test-hardening-fuzz.c',
+  c_args : [
+    '-DWYL_TEST_TEMPLATE_DIR="' + meson.project_source_root() / 'templates' / 'access' + '"',
+  ],
+  dependencies : [wyrelog_dep, wirelog_dep],
+)
+
+hardening_fuzz_env = environment()
+hardening_fuzz_env.set('WYL_FUZZ_ARTIFACT_DIR',
+  meson.current_build_dir() / 'hardening-fuzz-artifacts',
+)
+
+test('hardening-fuzz', test_hardening_fuzz,
+  env : hardening_fuzz_env,
+  timeout : 60,
+)
+
 test_fsm_bisim = executable('test-fsm-bisim',
   'test-fsm-bisim.c',
   c_args : [
@@ -641,6 +671,26 @@ check_no_derived_fsm_replay = find_program(
 test('check-no-derived-fsm-replay', check_no_derived_fsm_replay,
   args : [meson.project_source_root()],
 )
+
+check_supply_chain_pins = find_program(
+  '../tools/check-supply-chain-pins.sh',
+)
+
+test('supply-chain-pins', check_supply_chain_pins,
+  args : [meson.project_source_root()],
+)
+
+if host_machine.system() != 'windows'
+  valgrind_gate = find_program(
+    '../tools/run-valgrind-gate.sh',
+  )
+
+  test('valgrind-smoke', valgrind_gate,
+    args : [test_smoke.full_path()],
+    depends : test_smoke,
+    timeout : 120,
+  )
+endif
 
 if get_option('enable_audit').allowed()
   audit_conn_test_env = environment()

--- a/tests/test-decision-latency.c
+++ b/tests/test-decision-latency.c
@@ -1,0 +1,127 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <glib.h>
+#include <stdlib.h>
+
+#include "wyrelog/wyrelog.h"
+#include "wyrelog/policy/store-private.h"
+#include "wyrelog/wyl-handle-private.h"
+
+#ifndef WYL_TEST_TEMPLATE_DIR
+#error "WYL_TEST_TEMPLATE_DIR must be defined by the build."
+#endif
+
+typedef struct
+{
+  gint64 usec;
+} Sample;
+
+static gint
+sample_cmp (gconstpointer a, gconstpointer b)
+{
+  const Sample *sa = a;
+  const Sample *sb = b;
+  return (sa->usec > sb->usec) - (sa->usec < sb->usec);
+}
+
+static gint64
+env_i64 (const gchar *name, gint64 fallback)
+{
+  const gchar *value = g_getenv (name);
+  if (value == NULL || value[0] == '\0')
+    return fallback;
+  gchar *end = NULL;
+  gint64 parsed = g_ascii_strtoll (value, &end, 10);
+  return end != value && end != NULL && *end == '\0' ? parsed : fallback;
+}
+
+static wyrelog_error_t
+seed_fixture (WylHandle *handle)
+{
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  wyrelog_error_t rc = wyl_policy_store_upsert_permission (store,
+      "bench.decision.read", "bench decision read", "basic");
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_policy_store_grant_direct_permission (store, "bench-user",
+      "bench.decision.read", "bench-scope");
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_policy_store_set_principal_state (store, "bench-user",
+      "authenticated");
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_policy_store_set_session_state (store, "bench-scope", "active");
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_policy_store_set_permission_state (store, "bench-user",
+      "bench.decision.read", "bench-scope", "armed");
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_reload_engine_pair (handle);
+}
+
+static wyrelog_error_t
+run_one_decide (WylHandle *handle, wyl_decide_req_t *req,
+    wyl_decide_resp_t *resp)
+{
+  wyl_decide_resp_set_decision (resp, WYL_DECISION_DENY);
+  wyrelog_error_t rc = wyl_decide (handle, req, resp);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_decide_resp_get_decision (resp) == WYL_DECISION_ALLOW ?
+      WYRELOG_E_OK : WYRELOG_E_POLICY;
+}
+
+int
+main (void)
+{
+  const guint warmup = (guint) env_i64 ("WYL_LATENCY_WARMUP", 4);
+  const guint iterations = (guint) env_i64 ("WYL_LATENCY_ITERATIONS", 32);
+  const gint64 p50_budget = env_i64 ("WYL_LATENCY_P50_USEC", 250000);
+  const gint64 p95_budget = env_i64 ("WYL_LATENCY_P95_USEC", 750000);
+  const gint64 p99_budget = env_i64 ("WYL_LATENCY_P99_USEC", 1000000);
+
+  if (iterations < 32)
+    return 1;
+
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 2;
+  if (seed_fixture (handle) != WYRELOG_E_OK)
+    return 3;
+
+  g_autoptr (wyl_decide_req_t) req = wyl_decide_req_new ();
+  g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
+  wyl_decide_req_set_subject_id (req, "bench-user");
+  wyl_decide_req_set_action (req, "bench.decision.read");
+  wyl_decide_req_set_resource_id (req, "bench-scope");
+
+  for (guint i = 0; i < warmup; i++) {
+    if (run_one_decide (handle, req, resp) != WYRELOG_E_OK)
+      return 4;
+  }
+
+  g_autofree Sample *samples = g_new0 (Sample, iterations);
+  for (guint i = 0; i < iterations; i++) {
+    gint64 start = g_get_monotonic_time ();
+    if (run_one_decide (handle, req, resp) != WYRELOG_E_OK)
+      return 5;
+    samples[i].usec = g_get_monotonic_time () - start;
+  }
+
+  qsort (samples, iterations, sizeof (Sample), sample_cmp);
+  gint64 p50 = samples[(iterations * 50) / 100].usec;
+  gint64 p95 = samples[(iterations * 95) / 100].usec;
+  gint64 p99 = samples[(iterations * 99) / 100].usec;
+  g_print ("decision-latency iterations=%u p50=%" G_GINT64_FORMAT
+      "us p95=%" G_GINT64_FORMAT "us p99=%" G_GINT64_FORMAT "us\n",
+      iterations, p50, p95, p99);
+
+  if (p50 > p50_budget || p95 > p95_budget || p99 > p99_budget) {
+    g_printerr ("decision latency budget exceeded: p50<=%" G_GINT64_FORMAT
+        "us p95<=%" G_GINT64_FORMAT "us p99<=%" G_GINT64_FORMAT "us\n",
+        p50_budget, p95_budget, p99_budget);
+    return 6;
+  }
+  return 0;
+}

--- a/tests/test-hardening-fuzz.c
+++ b/tests/test-hardening-fuzz.c
@@ -1,0 +1,161 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <glib.h>
+#include <glib/gstdio.h>
+
+#include "wyrelog/wyrelog.h"
+#include "wyrelog/wyl-engine-private.h"
+
+#ifndef WYL_TEST_TEMPLATE_DIR
+#error "WYL_TEST_TEMPLATE_DIR must be defined by the build."
+#endif
+
+static guint32
+next_u32 (guint32 *state)
+{
+  *state = *state * 1664525u + 1013904223u;
+  return *state;
+}
+
+static void
+record_seed (guint32 seed)
+{
+  const gchar *dir = g_getenv ("WYL_FUZZ_ARTIFACT_DIR");
+  if (dir == NULL || dir[0] == '\0')
+    return;
+  g_mkdir_with_parents (dir, 0755);
+  g_autofree gchar *path = g_build_filename (dir, "last-seed.txt", NULL);
+  g_autofree gchar *body = g_strdup_printf ("%u\n", seed);
+  (void) g_file_set_contents (path, body, -1, NULL);
+}
+
+static gchar *
+make_payload (guint32 *state, guint max_len)
+{
+  guint len = next_u32 (state) % (max_len + 1);
+  gchar *payload = g_malloc0 (len + 1);
+  for (guint i = 0; i < len; i++) {
+    guint32 v = next_u32 (state);
+    payload[i] = (gchar) (32 + (v % 95));
+  }
+  return payload;
+}
+
+static gint
+fuzz_decide_inputs (guint32 seed)
+{
+  guint32 state = seed;
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 10;
+
+  for (guint i = 0; i < 256; i++) {
+    record_seed (seed + i);
+    g_autoptr (wyl_decide_req_t) req = wyl_decide_req_new ();
+    g_autoptr (wyl_decide_resp_t) resp = wyl_decide_resp_new ();
+    g_autofree gchar *subject = make_payload (&state, 64);
+    g_autofree gchar *action = make_payload (&state, 64);
+    g_autofree gchar *resource = make_payload (&state, 64);
+    g_autofree gchar *loc = make_payload (&state, 32);
+
+    if ((next_u32 (&state) & 1) != 0)
+      wyl_decide_req_set_subject_id (req, subject);
+    if ((next_u32 (&state) & 1) != 0)
+      wyl_decide_req_set_action (req, action);
+    if ((next_u32 (&state) & 1) != 0)
+      wyl_decide_req_set_resource_id (req, resource);
+    if ((next_u32 (&state) & 1) != 0)
+      wyl_decide_req_set_guard_context (req, (gint64) next_u32 (&state) - 100,
+          loc, (gint64) (next_u32 (&state) % 140) - 20);
+
+    wyrelog_error_t rc = wyl_decide (handle, req, resp);
+    if (rc != WYRELOG_E_OK && rc != WYRELOG_E_INVALID)
+      return 11;
+  }
+  return 0;
+}
+
+static gboolean
+write_template_file (const gchar *dir, const gchar *rel, const gchar *body)
+{
+  g_autofree gchar *path = g_build_filename (dir, rel, NULL);
+  g_autofree gchar *parent = g_path_get_dirname (path);
+  if (g_mkdir_with_parents (parent, 0755) != 0)
+    return FALSE;
+  return g_file_set_contents (path, body, -1, NULL);
+}
+
+static gint
+fuzz_template_loading (guint32 seed)
+{
+  guint32 state = seed ^ 0x9e3779b9u;
+  for (guint i = 0; i < 64; i++) {
+    record_seed (seed + 1000 + i);
+    g_autoptr (GError) err = NULL;
+    gchar *tmp = g_dir_make_tmp ("wyl-fuzz-template-XXXXXX", &err);
+    if (tmp == NULL)
+      return 20;
+    g_autofree gchar *bootstrap = make_payload (&state, 192);
+    g_autofree gchar *principal = make_payload (&state, 192);
+    g_autofree gchar *session = make_payload (&state, 192);
+    g_autofree gchar *perm = make_payload (&state, 192);
+    g_autofree gchar *decision = make_payload (&state, 192);
+
+    gboolean ok = write_template_file (tmp, "bootstrap.dl", bootstrap)
+        && write_template_file (tmp, "fsm/principal.dl", principal)
+        && write_template_file (tmp, "fsm/session.dl", session)
+        && write_template_file (tmp, "fsm/permission_scope.dl", perm)
+        && write_template_file (tmp, "lobac/decision.dl", decision);
+
+    gchar *dl_src = NULL;
+    gsize dl_src_len = 0;
+    if (ok) {
+      wyrelog_error_t rc = wyl_engine_load_templates (tmp, &dl_src,
+          &dl_src_len);
+      if (rc == WYRELOG_E_OK && dl_src_len == 0) {
+        g_free (dl_src);
+        g_remove (tmp);
+        return 21;
+      }
+    }
+    if (dl_src != NULL) {
+      memset (dl_src, 0, dl_src_len);
+      g_free (dl_src);
+    }
+
+    g_autofree gchar *bootstrap_path = g_build_filename (tmp, "bootstrap.dl",
+        NULL);
+    g_autofree gchar *principal_path = g_build_filename (tmp, "fsm",
+        "principal.dl", NULL);
+    g_autofree gchar *session_path = g_build_filename (tmp, "fsm",
+        "session.dl", NULL);
+    g_autofree gchar *perm_path = g_build_filename (tmp, "fsm",
+        "permission_scope.dl", NULL);
+    g_autofree gchar *decision_path = g_build_filename (tmp, "lobac",
+        "decision.dl", NULL);
+    g_unlink (bootstrap_path);
+    g_unlink (principal_path);
+    g_unlink (session_path);
+    g_unlink (perm_path);
+    g_unlink (decision_path);
+    g_autofree gchar *fsm_dir = g_build_filename (tmp, "fsm", NULL);
+    g_autofree gchar *lobac_dir = g_build_filename (tmp, "lobac", NULL);
+    g_rmdir (fsm_dir);
+    g_rmdir (lobac_dir);
+    g_rmdir (tmp);
+  }
+  return 0;
+}
+
+int
+main (void)
+{
+  guint32 seed = 0x57594c46u;
+  const gchar *seed_env = g_getenv ("WYL_FUZZ_SEED");
+  if (seed_env != NULL && seed_env[0] != '\0')
+    seed = (guint32) g_ascii_strtoull (seed_env, NULL, 10);
+
+  gint rc = fuzz_decide_inputs (seed);
+  if (rc != 0)
+    return rc;
+  return fuzz_template_loading (seed);
+}

--- a/tools/check-supply-chain-pins.sh
+++ b/tools/check-supply-chain-pins.sh
@@ -1,0 +1,82 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+set -eu
+
+ROOT=${1:-.}
+status=0
+
+check_wrap_file() {
+  wrap=$1
+  case "$(basename "$wrap")" in
+    nanoarrow.wrap|xxhash.wrap)
+      if ! grep -q '^filename = wirelog/subprojects/' "$wrap"; then
+        echo "$wrap: redirect must point at vendored wirelog subproject wrap" >&2
+        status=1
+      fi
+      return
+      ;;
+  esac
+
+  if grep -q '^\[wrap-file\]' "$wrap"; then
+    for key in source_url source_filename source_hash directory; do
+      if ! grep -q "^${key} =" "$wrap"; then
+        echo "$wrap: missing $key" >&2
+        status=1
+      fi
+    done
+    return
+  fi
+
+  if grep -q '^\[wrap-git\]' "$wrap"; then
+    for key in url revision; do
+      if ! grep -q "^${key} =" "$wrap"; then
+        echo "$wrap: missing $key" >&2
+        status=1
+      fi
+    done
+    if grep -Eq '^revision = (main|master|HEAD)$' "$wrap"; then
+      if [ "$(basename "$wrap")" != "wirelog.wrap" ]; then
+        echo "$wrap: moving git revision requires an explicit allowlist" >&2
+        status=1
+      else
+        echo "$wrap: moving revision allowed for in-family development dependency" >&2
+      fi
+    fi
+    return
+  fi
+
+  echo "$wrap: unknown wrap type" >&2
+  status=1
+}
+
+for wrap in "$ROOT"/subprojects/*.wrap; do
+  [ -e "$wrap" ] || continue
+  check_wrap_file "$wrap"
+done
+
+for name in wirelog libchronoid nanoarrow "xxHash-0.8.3"; do
+  if [ -d "$ROOT/subprojects/$name" ]; then
+    if ! find "$ROOT/subprojects/$name" -maxdepth 2 \
+        \( -iname 'LICENSE*' -o -iname 'NOTICE*' \) | grep -q .; then
+      echo "subprojects/$name: missing LICENSE/NOTICE metadata" >&2
+      status=1
+    fi
+  fi
+done
+
+if [ -d "$ROOT/subprojects/packagecache" ]; then
+  missing=0
+  for wrap in "$ROOT"/subprojects/*.wrap; do
+    filename=$(sed -n 's/^source_filename = //p' "$wrap" | head -n 1)
+    if [ -n "$filename" ] && [ ! -f "$ROOT/subprojects/packagecache/$filename" ]; then
+      echo "$wrap: packagecache missing $filename" >&2
+      missing=1
+    fi
+  done
+  if [ "$missing" -ne 0 ] && [ "${WYL_SUPPLY_CHAIN_REQUIRE_PACKAGECACHE:-0}" = "1" ]; then
+    status=1
+  fi
+fi
+
+exit "$status"

--- a/tools/run-sanitizer-suite.sh
+++ b/tools/run-sanitizer-suite.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+set -eu
+
+BUILD_DIR=${1:-builddir-sanitize}
+shift || true
+TEST_ARGS=${*:-"--suite wyrelog"}
+
+CC=${CC:-cc}
+CFLAGS="${CFLAGS:-} -fsanitize=address,undefined -fno-omit-frame-pointer"
+LDFLAGS="${LDFLAGS:-} -fsanitize=address,undefined"
+export CC CFLAGS LDFLAGS
+export ASAN_OPTIONS="${ASAN_OPTIONS:-halt_on_error=1:abort_on_error=1:print_summary=1}"
+export UBSAN_OPTIONS="${UBSAN_OPTIONS:-halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1}"
+
+if [ ! -d "$BUILD_DIR" ]; then
+  meson setup "$BUILD_DIR" -Denable_audit=enabled -Dduckdb_source=prebuilt
+fi
+
+meson test -C "$BUILD_DIR" --print-errorlogs $TEST_ARGS

--- a/tools/run-valgrind-gate.sh
+++ b/tools/run-valgrind-gate.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+set -eu
+
+if [ "$#" -lt 1 ]; then
+  echo "usage: $0 <executable> [args...]" >&2
+  exit 2
+fi
+
+if ! command -v valgrind >/dev/null 2>&1; then
+  echo "valgrind not installed; skipping leak-budget gate" >&2
+  exit 77
+fi
+
+LOG=${WYL_VALGRIND_LOG:-valgrind.log}
+rm -f "$LOG"
+
+set +e
+valgrind \
+  --leak-check=full \
+  --show-leak-kinds=definite \
+  --errors-for-leak-kinds=definite \
+  --error-exitcode=99 \
+  --log-file="$LOG" \
+  "$@"
+rc=$?
+set -e
+
+if [ "$rc" -ne 0 ]; then
+  cat "$LOG" >&2 || true
+  exit "$rc"
+fi
+
+if ! grep -Eq 'definitely lost: 0 bytes in 0 blocks' "$LOG"; then
+  cat "$LOG" >&2 || true
+  echo "valgrind definitely-lost budget exceeded" >&2
+  exit 99
+fi
+
+echo "valgrind definitely-lost budget: 0 bytes"


### PR DESCRIPTION
## Summary
- add a bounded decision-latency Meson test with tunable percentile budgets
- add deterministic hardening fuzz coverage for decision inputs, guard context, and template loading
- add release hardening helpers for supply-chain pin checks, Valgrind leak budget checks, and sanitizer suite runs
- document the GA hardening gate expectations and release-time tightening knobs

## Validation
- meson compile -C builddir
- meson test -C builddir wyrelog:decision-latency wyrelog:hardening-fuzz wyrelog:supply-chain-pins wyrelog:valgrind-smoke --print-errorlogs
- meson test -C builddir wyrelog:decision-latency wyrelog:hardening-fuzz wyrelog:supply-chain-pins wyrelog:valgrind-smoke wyrelog:wyrelogd-startup-readiness wyrelog:daemon-http-decide wyrelog:engine --print-errorlogs
- meson compile -C builddir-audit
- meson test -C builddir-audit wyrelog:decision-latency wyrelog:hardening-fuzz wyrelog:supply-chain-pins wyrelog:daemon-http-decide-audit wyrelog:audit-emit wyrelog:audit-conn --print-errorlogs
- meson test -C builddir --suite wyrelog --print-errorlogs
- git diff --check
