### PR TITLE
tests: extend wyrelogd-profiles drain and http-port polling budgets

### DIFF
--- a/tests/check-wyrelogd-profiles.sh
+++ b/tests/check-wyrelogd-profiles.sh
@@ -131,7 +131,9 @@ while seen < 2:
     server.handle_request()
 PY
 HTTP_PID=$!
-for _ in 1 2 3 4 5; do
+i=0
+while [ "$i" -lt 15 ]; do
+  i=$((i + 1))
   [ -s "$TMPDIR/http.port" ] && break
   sleep 1
 done
@@ -154,7 +156,9 @@ printf '{"profile":"service","event":"existing"}' \
   >"$TMPDIR/service-drain.out" 2>"$TMPDIR/service-drain.err" &
 SERVICE_PID=$!
 HTTP_DONE=0
-for _ in 1 2 3 4 5 6 7 8 9 10; do
+i=0
+while [ "$i" -lt 30 ]; do
+  i=$((i + 1))
   if ! kill -0 "$HTTP_PID" 2>/dev/null; then
     HTTP_DONE=1
     break


### PR DESCRIPTION
## Summary

Two short polling loops in `tests/check-wyrelogd-profiles.sh` are still under-budget on ubuntu-latest after the audit chain-tail cache landed in `1cfeb7b`. Extend both to the same 30-iter / 1s budget the original spool-detection loop already uses.

| Loop | Old budget | New budget | Purpose |
|------|-----------|-----------|---------|
| Python HTTP port-file wait (line 134) | 5 iter | 15 iter | http.server startup + port write |
| Service-profile drain forward wait (line 157) | 10 iter | 30 iter | daemon emits + forwards events through python HTTP harness |

## Why

Current main CI run on `1cfeb7b` fails with:

```
26/65 wyrelog / wyrelogd-profiles  FAIL  46.85s  exit status 1
stderr:
service profile did not drain and forward events
```

The drain-loop at line 157 polls 10 iter × 1s waiting for the python HTTP server (which exits after `seen < 2` events) to die. The daemon needs that long to emit `daemon_start`, drain the seeded `existing.event`, and forward both via HTTP. Even with chain-tail caching reducing per-emit cost, the audit emit + glib HTTP send + python `handle_request` loop on ubuntu-latest exceeds the 10s ceiling.

## Why this is *not* the issue-#295 fix

#295 calls out that bumping CI timeouts is symptom management for an audit perf regression. The chain-tail cache (`1cfeb7b`) addressed the *per-emit* regression. This PR is a different concern: the script's drain-loop was already too tight even pre-hardening for slow runners (10s for a 2-event forward over python http.server has minimal margin). Bumping the script's *internal* polling budget while keeping the meson 60s ceiling is appropriate.

The healthy-path wall remains well under 30s; only the polling ceilings change.

## Test plan

- [x] Local `tests/check-wyrelogd-profiles.sh` exits 0 in <30s
- [ ] CI Main on ubuntu/macos/windows