### PR TITLE
[codex] Add systemd credential KeyProvider support

### DIFF
--- a/docs/auth-session-restart-model.md
+++ b/docs/auth-session-restart-model.md
@@ -23,8 +23,11 @@ previous token state is reloaded.
 ## JWT Signing Key Custody
 
 Production JWT signing key material is rooted in the configured production
-KeyProvider path. On each daemon boot, the daemon derives a JWT root secret
-from the KeyProvider and mixes in a random boot epoch before issuing tokens.
+KeyProvider spec. Packaged Linux services use `systemd-creds:NAME`, where
+systemd exposes the credential under `$CREDENTIALS_DIRECTORY`; manual
+operator checks may use `file:PATH`. On each daemon boot, the daemon derives a
+JWT root secret from the KeyProvider and mixes in a random boot epoch before
+issuing tokens.
 The boot epoch is reflected in the JWT `kid`, so tokens from a previous
 process epoch fail the key-id gate before they can bind to live token state.
 

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -10,10 +10,12 @@ support files from `packaging/`.
 - Binaries: `/usr/bin/wyrelogd`, `/usr/bin/wyctl`
 - Templates: `/usr/share/wyrelog/access`
 - Daemon environment: `/etc/wyrelog/wyrelogd.env`
-- System KeyProvider state: `/etc/wyrelog/system/policy.key`
+- System KeyProvider root: `/etc/wyrelog/system/policy.key` loaded by
+  systemd as credential `wyrelog-system-policy-key`
 - System policy store: `/var/lib/wyrelog/system/policy.sqlite`
 - System audit store: `/var/log/wyrelog/system/audit.duckdb`
-- Service KeyProvider state: `/etc/wyrelog/service/policy.key`
+- Service KeyProvider root: `/etc/wyrelog/service/policy.key` loaded by
+  systemd as credential `wyrelog-service-policy-key`
 - Service policy store: `/var/lib/wyrelog/service/policy.sqlite`
 - Service audit store: `/var/log/wyrelog/service/audit.duckdb`
 - Runtime directory: `/run/wyrelog`
@@ -35,10 +37,10 @@ Wyrelog ships two daemon profiles:
 Packaged profile paths:
 
 - System policy store: `/var/lib/wyrelog/system/policy.sqlite`
-- System KeyProvider state: `/etc/wyrelog/system/policy.key`
+- System KeyProvider root: `/etc/wyrelog/system/policy.key`
 - System audit store: `/var/log/wyrelog/system/audit.duckdb`
 - Service policy store: `/var/lib/wyrelog/service/policy.sqlite`
-- Service KeyProvider state: `/etc/wyrelog/service/policy.key`
+- Service KeyProvider root: `/etc/wyrelog/service/policy.key`
 - Service audit store: `/var/log/wyrelog/service/audit.duckdb`
 - Service event spool: `/var/lib/wyrelog/service/event-spool`
 
@@ -58,7 +60,10 @@ wyrelogd --profile=service --profile-info --production
    systemd-tmpfiles --create /usr/lib/tmpfiles.d/wyrelog.conf
    ```
 
-2. Create the production KeyProvider state once:
+2. Create the production KeyProvider root once. Packaged systemd units pass
+   this file through `LoadCredential=`, so `wyrelogd` reads it as
+   `systemd-creds:wyrelog-system-policy-key` rather than opening the
+   `/etc` file directly:
 
    ```sh
    install -m 0640 -o root -g wyrelog /dev/null /etc/wyrelog/system/policy.key
@@ -78,7 +83,7 @@ PY
      --profile system \
      --template-dir /usr/share/wyrelog/access \
      --policy-db /var/lib/wyrelog/system/policy.sqlite \
-     --policy-keyprovider /etc/wyrelog/system/policy.key \
+     --policy-keyprovider file:/etc/wyrelog/system/policy.key \
      --audit-db /var/log/wyrelog/system/audit.duckdb \
      --check
    wyrelogd --template-info --template-dir /usr/share/wyrelog/access
@@ -98,14 +103,16 @@ PY
 
 ## Day-2 Operations
 
-- Template validation:
+- Template validation from an operator shell. Use `file:` for manual checks;
+  the packaged service uses `systemd-creds:` after systemd loads the
+  credential:
 
   ```sh
   wyrelogd --template-info --template-dir /usr/share/wyrelog/access
   wyrelogd --production --template-dir /usr/share/wyrelog/access \
     --profile system \
     --policy-db /var/lib/wyrelog/system/policy.sqlite \
-    --policy-keyprovider /etc/wyrelog/system/policy.key \
+    --policy-keyprovider file:/etc/wyrelog/system/policy.key \
     --audit-db /var/log/wyrelog/system/audit.duckdb --check
   ```
 
@@ -162,7 +169,7 @@ PY
    systemctl stop wyrelog-system.service
    ```
 
-2. Back up the active profile's KeyProvider state, policy store, audit
+2. Back up the active profile's KeyProvider root, policy store, audit
    store, event spool when present, and the output of
    `wyrelogd --template-info`.
 
@@ -185,7 +192,7 @@ PY
 2. Back up the current key and policy store together.
 3. Replace the active profile's `policy.key` with a new 32-byte file
    using mode `0640`, owner `root`, and group `wyrelog`.
-4. Run `wyctl key status --keyprovider PATH`.
+4. Run `wyctl key status --keyprovider file:PATH`.
 5. Run production `--check`, then start the daemon.
 
 Changing the KeyProvider root invalidates sealed policy-store material

--- a/packaging/systemd/wyrelog-service.service
+++ b/packaging/systemd/wyrelog-service.service
@@ -10,7 +10,8 @@ User=wyrelog
 Group=wyrelog
 Environment=WYL_LOG=warn
 EnvironmentFile=-/etc/wyrelog/service.env
-ExecStart=/usr/bin/wyrelogd --production --profile=service --template-dir /usr/share/wyrelog/access --policy-db /var/lib/wyrelog/service/policy.sqlite --policy-keyprovider /etc/wyrelog/service/policy.key --audit-db /var/log/wyrelog/service/audit.duckdb --system-url http://127.0.0.1:8765 --event-spool-dir /var/lib/wyrelog/service/event-spool --event-queue-limit 1024 --listen-port 8766
+LoadCredential=wyrelog-service-policy-key:/etc/wyrelog/service/policy.key
+ExecStart=/usr/bin/wyrelogd --production --profile=service --template-dir /usr/share/wyrelog/access --policy-db /var/lib/wyrelog/service/policy.sqlite --policy-keyprovider systemd-creds:wyrelog-service-policy-key --audit-db /var/log/wyrelog/service/audit.duckdb --system-url http://127.0.0.1:8765 --event-spool-dir /var/lib/wyrelog/service/event-spool --event-queue-limit 1024 --listen-port 8766
 Restart=on-failure
 RestartSec=5s
 NoNewPrivileges=true

--- a/packaging/systemd/wyrelog-system.service
+++ b/packaging/systemd/wyrelog-system.service
@@ -10,7 +10,8 @@ User=wyrelog
 Group=wyrelog
 Environment=WYL_LOG=warn
 EnvironmentFile=-/etc/wyrelog/system.env
-ExecStart=/usr/bin/wyrelogd --production --profile=system --template-dir /usr/share/wyrelog/access --policy-db /var/lib/wyrelog/system/policy.sqlite --policy-keyprovider /etc/wyrelog/system/policy.key --audit-db /var/log/wyrelog/system/audit.duckdb --listen-port 8765
+LoadCredential=wyrelog-system-policy-key:/etc/wyrelog/system/policy.key
+ExecStart=/usr/bin/wyrelogd --production --profile=system --template-dir /usr/share/wyrelog/access --policy-db /var/lib/wyrelog/system/policy.sqlite --policy-keyprovider systemd-creds:wyrelog-system-policy-key --audit-db /var/log/wyrelog/system/audit.duckdb --listen-port 8765
 Restart=on-failure
 RestartSec=5s
 NoNewPrivileges=true

--- a/packaging/systemd/wyrelog.service
+++ b/packaging/systemd/wyrelog.service
@@ -10,7 +10,8 @@ User=wyrelog
 Group=wyrelog
 Environment=WYL_LOG=warn
 EnvironmentFile=-/etc/wyrelog/wyrelogd.env
-ExecStart=/usr/bin/wyrelogd --production --profile=system --template-dir /usr/share/wyrelog/access --policy-db /var/lib/wyrelog/system/policy.sqlite --policy-keyprovider /etc/wyrelog/system/policy.key --audit-db /var/log/wyrelog/system/audit.duckdb --listen-port 8765
+LoadCredential=wyrelog-system-policy-key:/etc/wyrelog/system/policy.key
+ExecStart=/usr/bin/wyrelogd --production --profile=system --template-dir /usr/share/wyrelog/access --policy-db /var/lib/wyrelog/system/policy.sqlite --policy-keyprovider systemd-creds:wyrelog-system-policy-key --audit-db /var/log/wyrelog/system/audit.duckdb --listen-port 8765
 Restart=on-failure
 RestartSec=5s
 NoNewPrivileges=true

--- a/tests/check-packaged-install-readiness.sh
+++ b/tests/check-packaged-install-readiness.sh
@@ -47,6 +47,16 @@ if ! grep -q -- "--production" \
   echo "service unit does not enable production gates" >&2
   exit 1
 fi
+if ! grep -q -- "LoadCredential=wyrelog-system-policy-key:" \
+    "$SOURCE_ROOT/packaging/systemd/wyrelog-system.service"; then
+  echo "system unit does not load policy key as a systemd credential" >&2
+  exit 1
+fi
+if ! grep -q -- "--policy-keyprovider systemd-creds:wyrelog-system-policy-key" \
+    "$SOURCE_ROOT/packaging/systemd/wyrelog-system.service"; then
+  echo "system unit does not use the systemd credential KeyProvider" >&2
+  exit 1
+fi
 if ! grep -q -- "--profile=system" \
     "$SOURCE_ROOT/packaging/systemd/wyrelog-system.service"; then
   echo "system unit does not select the system profile" >&2
@@ -98,6 +108,14 @@ if [ "$(cat "$TMPDIR/key.out")" != "status=ready type=file bytes=32" ]; then
   cat "$TMPDIR/key.out" >&2
   exit 1
 fi
+CREDENTIALS_DIRECTORY="$INSTALL_ROOT/etc/wyrelog/system" \
+  "$WYCTL" key status --keyprovider systemd-creds:policy.key \
+  >"$TMPDIR/key-creds.out"
+if [ "$(cat "$TMPDIR/key-creds.out")" != "status=ready type=systemd-creds bytes=32" ]; then
+  echo "unexpected credential key status output" >&2
+  cat "$TMPDIR/key-creds.out" >&2
+  exit 1
+fi
 
 "$WYRELOGD" --template-info --template-dir "$TEMPLATE_INSTALL" \
   >"$TMPDIR/template-info.out"
@@ -109,15 +127,24 @@ grep -q '^migrations=' "$TMPDIR/template-info.out"
   --profile system \
   --template-dir "$TEMPLATE_INSTALL" \
   --policy-db "$POLICY_DB" \
-  --policy-keyprovider "$KEY" \
+  --policy-keyprovider "file:$KEY" \
   --audit-db "$AUDIT_DB" \
+  --check
+
+CREDENTIALS_DIRECTORY="$INSTALL_ROOT/etc/wyrelog/system" \
+  "$WYRELOGD" --production \
+  --profile system \
+  --template-dir "$TEMPLATE_INSTALL" \
+  --policy-db "$POLICY_DB.credential" \
+  --policy-keyprovider systemd-creds:policy.key \
+  --audit-db "$AUDIT_DB.credential" \
   --check
 
 "$WYRELOGD" --production \
   --profile system \
   --template-dir "$TEMPLATE_INSTALL" \
   --policy-db "$POLICY_DB" \
-  --policy-keyprovider "$KEY" \
+  --policy-keyprovider "file:$KEY" \
   --audit-db "$AUDIT_DB" \
   --listen-port "$PORT" &
 PID=$!

--- a/tests/check-wyrelogd-production-gates.sh
+++ b/tests/check-wyrelogd-production-gates.sh
@@ -47,3 +47,15 @@ PY
 "$WYRELOGD" --production --template-dir "$TEMPLATE_DIR" \
   --policy-db "$TMPDIR/prod.sqlite" \
   --policy-keyprovider "$TMPDIR/prod.key" --check
+
+if CREDENTIALS_DIRECTORY= "$WYRELOGD" --production --template-dir "$TEMPLATE_DIR" \
+    --policy-db "$TMPDIR/prod-missing-creds.sqlite" \
+    --policy-keyprovider systemd-creds:prod.key --check; then
+  echo "production mode accepted unavailable systemd credentials" >&2
+  exit 1
+fi
+
+CREDENTIALS_DIRECTORY="$TMPDIR" "$WYRELOGD" --production \
+  --template-dir "$TEMPLATE_DIR" \
+  --policy-db "$TMPDIR/prod-systemd-creds.sqlite" \
+  --policy-keyprovider systemd-creds:prod.key --check

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -408,6 +408,13 @@ test_keyprovider_dev = executable('test-keyprovider-dev',
 
 test('keyprovider-dev', test_keyprovider_dev)
 
+test_keyprovider_file = executable('test-keyprovider-file',
+  'test-keyprovider-file.c',
+  dependencies : [wyrelog_dep],
+)
+
+test('keyprovider-file', test_keyprovider_file)
+
 test_id = executable('test-id',
   'test-id.c',
   dependencies : [wyrelog_dep, libchronoid_dep],

--- a/tests/test-keyprovider-file.c
+++ b/tests/test-keyprovider-file.c
@@ -1,0 +1,211 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <glib.h>
+#include <glib/gstdio.h>
+#include <string.h>
+
+#include "wyrelog/wyl-keyprovider-file-private.h"
+
+static gboolean
+write_key (const gchar *path, guint8 seed)
+{
+  guint8 key[32];
+  for (gsize i = 0; i < sizeof key; i++)
+    key[i] = (guint8) (seed + i);
+  return g_file_set_contents (path, (const gchar *) key, sizeof key, NULL);
+}
+
+static gint
+check_file_spec_roundtrip (void)
+{
+  g_autoptr (GError) err = NULL;
+  g_autofree gchar *tmpdir = g_dir_make_tmp ("wyl-kp-file-XXXXXX", &err);
+  if (tmpdir == NULL)
+    return 1;
+  g_autofree gchar *path = g_build_filename (tmpdir, "policy.key", NULL);
+  if (!write_key (path, 1))
+    return 2;
+
+  g_autofree gchar *spec = g_strdup_printf ("file:%s", path);
+  g_autoptr (wyl_keyprovider_file_t) self =
+      wyl_keyprovider_file_new_from_spec (spec);
+  if (self == NULL)
+    return 3;
+  if (g_strcmp0 (wyl_keyprovider_file_get_source_name (self), "file") != 0)
+    return 4;
+
+  const wyl_keyprovider_vtable_t *vt = wyl_keyprovider_file_get_vtable ();
+  if (vt->probe (self) != WYRELOG_E_OK)
+    return 5;
+
+  const guint8 plaintext[] = { 'w', 'y', 'r', 'e', 'l', 'o', 'g' };
+  wyl_sealed_blob_t blob = { 0 };
+  if (vt->seal (self, plaintext, sizeof plaintext, &blob) != WYRELOG_E_OK)
+    return 6;
+  if (blob.len <= sizeof plaintext || blob.bytes == NULL)
+    return 7;
+  if (memcmp (blob.bytes, plaintext, sizeof plaintext) == 0)
+    return 8;
+
+  guint8 recovered[sizeof plaintext];
+  gsize written = 0;
+  if (vt->unseal (self, &blob, recovered, sizeof recovered, &written)
+      != WYRELOG_E_OK)
+    return 9;
+  if (written != sizeof plaintext || memcmp (recovered, plaintext,
+          sizeof plaintext) != 0)
+    return 10;
+  g_free (blob.bytes);
+
+  g_unlink (path);
+  g_rmdir (tmpdir);
+  return 0;
+}
+
+static gint
+check_wrong_provider_state_fails_unseal (void)
+{
+  g_autoptr (GError) err = NULL;
+  g_autofree gchar *tmpdir = g_dir_make_tmp ("wyl-kp-wrong-XXXXXX", &err);
+  if (tmpdir == NULL)
+    return 20;
+  g_autofree gchar *path_a = g_build_filename (tmpdir, "a.key", NULL);
+  g_autofree gchar *path_b = g_build_filename (tmpdir, "b.key", NULL);
+  if (!write_key (path_a, 11) || !write_key (path_b, 99))
+    return 21;
+
+  g_autoptr (wyl_keyprovider_file_t) a = wyl_keyprovider_file_new (path_a);
+  g_autoptr (wyl_keyprovider_file_t) b = wyl_keyprovider_file_new (path_b);
+  if (a == NULL || b == NULL)
+    return 22;
+
+  const wyl_keyprovider_vtable_t *vt = wyl_keyprovider_file_get_vtable ();
+  const guint8 plaintext[] = { 1, 2, 3, 4 };
+  wyl_sealed_blob_t blob = { 0 };
+  if (vt->seal (a, plaintext, sizeof plaintext, &blob) != WYRELOG_E_OK)
+    return 23;
+
+  guint8 recovered[sizeof plaintext] = { 0 };
+  gsize written = 0;
+  if (vt->unseal (b, &blob, recovered, sizeof recovered, &written)
+      != WYRELOG_E_CRYPTO)
+    return 24;
+  if (written != 0)
+    return 25;
+  g_free (blob.bytes);
+
+  g_unlink (path_a);
+  g_unlink (path_b);
+  g_rmdir (tmpdir);
+  return 0;
+}
+
+static gint
+check_systemd_credentials_spec (void)
+{
+  g_autoptr (GError) err = NULL;
+  g_autofree gchar *tmpdir = g_dir_make_tmp ("wyl-kp-creds-XXXXXX", &err);
+  if (tmpdir == NULL)
+    return 30;
+  g_autofree gchar *path = g_build_filename (tmpdir, "policy.key", NULL);
+  if (!write_key (path, 33))
+    return 31;
+
+  const gchar *old_dir = g_getenv ("CREDENTIALS_DIRECTORY");
+  g_autofree gchar *old_dir_copy = g_strdup (old_dir);
+  g_setenv ("CREDENTIALS_DIRECTORY", tmpdir, TRUE);
+
+  g_autoptr (wyl_keyprovider_file_t) self =
+      wyl_keyprovider_file_new_from_spec ("systemd-creds:policy.key");
+  if (old_dir_copy != NULL)
+    g_setenv ("CREDENTIALS_DIRECTORY", old_dir_copy, TRUE);
+  else
+    g_unsetenv ("CREDENTIALS_DIRECTORY");
+  if (self == NULL)
+    return 32;
+  if (g_strcmp0 (wyl_keyprovider_file_get_source_name (self),
+          "systemd-creds") != 0)
+    return 33;
+
+  const wyl_keyprovider_vtable_t *vt = wyl_keyprovider_file_get_vtable ();
+  guint8 key_a[16];
+  guint8 key_b[16];
+  if (vt->derive (self, "label-a", key_a, sizeof key_a) != WYRELOG_E_OK)
+    return 34;
+  if (vt->derive (self, "label-b", key_b, sizeof key_b) != WYRELOG_E_OK)
+    return 35;
+  if (memcmp (key_a, key_b, sizeof key_a) == 0)
+    return 36;
+
+  g_unlink (path);
+  g_rmdir (tmpdir);
+  return 0;
+}
+
+static gint
+check_unavailable_and_invalid_specs_fail_closed (void)
+{
+  const gchar *old_dir = g_getenv ("CREDENTIALS_DIRECTORY");
+  g_autofree gchar *old_dir_copy = g_strdup (old_dir);
+  g_unsetenv ("CREDENTIALS_DIRECTORY");
+
+  g_autoptr (wyl_keyprovider_file_t) missing =
+      wyl_keyprovider_file_new_from_spec ("systemd-creds:policy.key");
+  if (old_dir_copy != NULL)
+    g_setenv ("CREDENTIALS_DIRECTORY", old_dir_copy, TRUE);
+  if (missing != NULL)
+    return 40;
+  if (wyl_keyprovider_file_new_from_spec ("systemd-creds:../policy.key")
+      != NULL)
+    return 41;
+  if (wyl_keyprovider_file_new_from_spec ("systemd-creds:dir/policy.key")
+      != NULL)
+    return 42;
+  if (wyl_keyprovider_file_new_from_spec ("file:") != NULL)
+    return 43;
+  return 0;
+}
+
+static gint
+check_wipe_fails_closed (void)
+{
+  g_autoptr (GError) err = NULL;
+  g_autofree gchar *tmpdir = g_dir_make_tmp ("wyl-kp-wipe-XXXXXX", &err);
+  if (tmpdir == NULL)
+    return 50;
+  g_autofree gchar *path = g_build_filename (tmpdir, "policy.key", NULL);
+  if (!write_key (path, 51))
+    return 51;
+
+  g_autoptr (wyl_keyprovider_file_t) self = wyl_keyprovider_file_new (path);
+  if (self == NULL)
+    return 52;
+
+  const wyl_keyprovider_vtable_t *vt = wyl_keyprovider_file_get_vtable ();
+  vt->wipe (self);
+  if (vt->probe (self) != WYRELOG_E_INTERNAL)
+    return 53;
+  guint8 out[16] = { 0 };
+  if (vt->derive (self, "label", out, sizeof out) != WYRELOG_E_INTERNAL)
+    return 54;
+
+  g_unlink (path);
+  g_rmdir (tmpdir);
+  return 0;
+}
+
+int
+main (void)
+{
+  gint rc;
+  if ((rc = check_file_spec_roundtrip ()) != 0)
+    return rc;
+  if ((rc = check_wrong_provider_state_fails_unseal ()) != 0)
+    return rc;
+  if ((rc = check_systemd_credentials_spec ()) != 0)
+    return rc;
+  if ((rc = check_unavailable_and_invalid_specs_fail_closed ()) != 0)
+    return rc;
+  if ((rc = check_wipe_fails_closed ()) != 0)
+    return rc;
+  return 0;
+}

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -263,7 +263,7 @@ derive_access_token_secret (const WylDaemonOptions *opts,
   }
 
   g_autoptr (wyl_keyprovider_file_t) keyprovider =
-      wyl_keyprovider_file_new (opts->policy_keyprovider_path);
+      wyl_keyprovider_file_new_from_spec (opts->policy_keyprovider_path);
   if (keyprovider == NULL) {
     sodium_memzero (epoch, sizeof epoch);
     return WYRELOG_E_CRYPTO;

--- a/wyrelog/daemon/options.c
+++ b/wyrelog/daemon/options.c
@@ -117,7 +117,8 @@ static const gchar *
 default_keyprovider_path (WylDaemonProfile profile)
 {
   return profile == WYL_DAEMON_PROFILE_SERVICE ?
-      "/etc/wyrelog/service/policy.key" : "/etc/wyrelog/system/policy.key";
+      "systemd-creds:wyrelog-service-policy-key" :
+      "systemd-creds:wyrelog-system-policy-key";
 }
 
 static const gchar *
@@ -150,7 +151,7 @@ wyl_daemon_parse_options (gint *argc, gchar ***argv, WylDaemonOptions *opts,
         "Policy authority database path", "PATH"},
     {"policy-keyprovider", 0, 0, G_OPTION_ARG_STRING,
           &opts->policy_keyprovider_path,
-        "Path to policy database key provider state", "PATH"},
+        "Policy KeyProvider spec: systemd-creds:NAME or file:PATH", "SPEC"},
     {"audit-db", 0, 0, G_OPTION_ARG_STRING, &opts->audit_store_path,
         "Runtime audit sink database path", "PATH"},
     {"system-url", 0, 0, G_OPTION_ARG_STRING, &opts->system_url,

--- a/wyrelog/wyctl/wyctl.c
+++ b/wyrelog/wyctl/wyctl.c
@@ -10,6 +10,7 @@
 #include "wyrelog/version.h"
 #include "wyrelog/wyl-client-private.h"
 #include "wyrelog/wyl-common-private.h"
+#include "wyrelog/wyl-keyprovider-file-private.h"
 #include "wyrelog/wyl-permission-scope-private.h"
 
 typedef struct
@@ -1142,7 +1143,7 @@ run_key_status (gint argc, gchar **argv)
   WyctlKeyOptions opts = { 0 };
   GOptionEntry entries[] = {
     {"keyprovider", 0, 0, G_OPTION_ARG_STRING, &opts.keyprovider_path,
-        "Policy KeyProvider state file", "PATH"},
+        "Policy KeyProvider spec: systemd-creds:NAME or file:PATH", "SPEC"},
     {NULL}
   };
   g_autoptr (GError) error = NULL;
@@ -1163,18 +1164,20 @@ run_key_status (gint argc, gchar **argv)
     return 2;
   }
 
-  g_autofree gchar *contents = NULL;
-  gsize len = 0;
-  if (!g_file_get_contents (opts.keyprovider_path, &contents, &len, NULL)) {
+  g_autoptr (wyl_keyprovider_file_t) keyprovider =
+      wyl_keyprovider_file_new_from_spec (opts.keyprovider_path);
+  if (keyprovider == NULL) {
     g_printerr ("wyctl: keyprovider unreadable\n");
     return 1;
   }
-  if (len != WYCTL_KEYPROVIDER_FILE_BYTES) {
+  const wyl_keyprovider_vtable_t *vt = wyl_keyprovider_file_get_vtable ();
+  if (vt->probe (keyprovider) != WYRELOG_E_OK) {
     g_printerr ("wyctl: keyprovider invalid\n");
     return 1;
   }
 
-  g_print ("status=ready type=file bytes=%u\n",
+  g_print ("status=ready type=%s bytes=%u\n",
+      wyl_keyprovider_file_get_source_name (keyprovider),
       (guint) WYCTL_KEYPROVIDER_FILE_BYTES);
   return 0;
 }

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -596,7 +596,7 @@ wyl_handle_open_with_options (const WylHandleOpenOptions *opts,
       return WYRELOG_E_POLICY;
     }
     keyprovider_state =
-        wyl_keyprovider_file_new (opts->policy_keyprovider_path);
+        wyl_keyprovider_file_new_from_spec (opts->policy_keyprovider_path);
     if (keyprovider_state == NULL) {
       WYL_LOG_ERROR (WYL_LOG_SECTION_BOOT,
           "production mode keyprovider initialization failed");

--- a/wyrelog/wyl-keyprovider-file-private.h
+++ b/wyrelog/wyl-keyprovider-file-private.h
@@ -11,15 +11,20 @@ G_BEGIN_DECLS;
 /*
  * Filesystem-backed keyprovider state.
  *
- * The file must contain a raw 32-byte root key. This is intentionally
- * a narrow implementation used for bootstrap and CI-style deployments:
- * production hosts are expected to replace this with a hardware-backed
- * provider at build/runtime time, while retaining the same trait
- * seam for future key custody backends.
+ * The provider spec accepts:
+ *
+ *   systemd-creds:NAME  read NAME from $CREDENTIALS_DIRECTORY
+ *   file:PATH          read PATH directly
+ *   PATH               compatibility alias for file:PATH
+ *
+ * The selected file must contain a raw 32-byte root key. systemd-creds is
+ * the supported packaged production custody path; direct file mode remains a
+ * bootstrap/test path for hosts that are not launched by systemd.
  */
 typedef struct wyl_keyprovider_file_t wyl_keyprovider_file_t;
 
 wyl_keyprovider_file_t *wyl_keyprovider_file_new (const gchar * path);
+wyl_keyprovider_file_t *wyl_keyprovider_file_new_from_spec (const gchar * spec);
 
 void wyl_keyprovider_file_free (wyl_keyprovider_file_t * self);
 
@@ -27,5 +32,7 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC (wyl_keyprovider_file_t,
     wyl_keyprovider_file_free);
 
 const wyl_keyprovider_vtable_t *wyl_keyprovider_file_get_vtable (void);
+const gchar *wyl_keyprovider_file_get_source_name
+    (const wyl_keyprovider_file_t * self);
 
 G_END_DECLS;

--- a/wyrelog/wyl-keyprovider-file.c
+++ b/wyrelog/wyl-keyprovider-file.c
@@ -6,12 +6,31 @@
 #include <sodium.h>
 
 #define WYL_KEYPROVIDER_FILE_KEY_LEN crypto_secretbox_KEYBYTES
+#define WYL_KEYPROVIDER_SEAL_MAGIC "WYLKPF1"
+#define WYL_KEYPROVIDER_SEAL_MAGIC_LEN 7
+#define WYL_KEYPROVIDER_SEAL_HEADER_LEN \
+  (WYL_KEYPROVIDER_SEAL_MAGIC_LEN + crypto_secretbox_NONCEBYTES)
+
+typedef enum
+{
+  WYL_KEYPROVIDER_FILE_SOURCE_FILE = 0,
+  WYL_KEYPROVIDER_FILE_SOURCE_SYSTEMD_CREDS = 1,
+} WylKeyProviderFileSource;
 
 struct wyl_keyprovider_file_t
 {
+  WylKeyProviderFileSource source;
   gchar *path;
+  gchar *credential_name;
   guint8 key[WYL_KEYPROVIDER_FILE_KEY_LEN];
+  gboolean wiped;
 };
+
+static wyrelog_error_t
+ensure_sodium (void)
+{
+  return sodium_init () < 0 ? WYRELOG_E_CRYPTO : WYRELOG_E_OK;
+}
 
 static wyrelog_error_t
 read_file_key (const gchar *path, guint8 out_key[WYL_KEYPROVIDER_FILE_KEY_LEN])
@@ -27,20 +46,69 @@ read_file_key (const gchar *path, guint8 out_key[WYL_KEYPROVIDER_FILE_KEY_LEN])
   return WYRELOG_E_OK;
 }
 
-wyl_keyprovider_file_t *
-wyl_keyprovider_file_new (const gchar *path)
+static gboolean
+credential_name_is_valid (const gchar *name)
+{
+  if (name == NULL || name[0] == '\0')
+    return FALSE;
+  if (g_path_is_absolute (name) || strstr (name, "..") != NULL ||
+      strchr (name, '/') != NULL || strchr (name, '\\') != NULL)
+    return FALSE;
+  return TRUE;
+}
+
+static wyl_keyprovider_file_t *
+new_resolved (WylKeyProviderFileSource source, const gchar *path,
+    const gchar *credential_name)
 {
   if (path == NULL || path[0] == '\0')
     return NULL;
+  if (ensure_sodium () != WYRELOG_E_OK)
+    return NULL;
 
   wyl_keyprovider_file_t *self = g_new0 (wyl_keyprovider_file_t, 1);
+  self->source = source;
   self->path = g_strdup (path);
+  self->credential_name = g_strdup (credential_name);
   if (read_file_key (self->path, (guint8 *) self->key) != WYRELOG_E_OK) {
     g_clear_pointer (&self, wyl_keyprovider_file_free);
     return NULL;
   }
+  self->wiped = FALSE;
 
   return self;
+}
+
+wyl_keyprovider_file_t *
+wyl_keyprovider_file_new (const gchar *path)
+{
+  return new_resolved (WYL_KEYPROVIDER_FILE_SOURCE_FILE, path, NULL);
+}
+
+wyl_keyprovider_file_t *
+wyl_keyprovider_file_new_from_spec (const gchar *spec)
+{
+  if (spec == NULL || spec[0] == '\0')
+    return NULL;
+
+  static const gchar *file_prefix = "file:";
+  static const gchar *creds_prefix = "systemd-creds:";
+  if (g_str_has_prefix (spec, file_prefix))
+    return new_resolved (WYL_KEYPROVIDER_FILE_SOURCE_FILE,
+        spec + strlen (file_prefix), NULL);
+
+  if (g_str_has_prefix (spec, creds_prefix)) {
+    const gchar *name = spec + strlen (creds_prefix);
+    if (!credential_name_is_valid (name))
+      return NULL;
+    const gchar *dir = g_getenv ("CREDENTIALS_DIRECTORY");
+    if (dir == NULL || dir[0] == '\0')
+      return NULL;
+    g_autofree gchar *path = g_build_filename (dir, name, NULL);
+    return new_resolved (WYL_KEYPROVIDER_FILE_SOURCE_SYSTEMD_CREDS, path, name);
+  }
+
+  return wyl_keyprovider_file_new (spec);
 }
 
 void
@@ -51,6 +119,8 @@ wyl_keyprovider_file_free (wyl_keyprovider_file_t *self)
 
   if (self->path != NULL)
     g_free (self->path);
+  if (self->credential_name != NULL)
+    g_free (self->credential_name);
   sodium_memzero (self->key, sizeof self->key);
   g_free (self);
 }
@@ -61,6 +131,8 @@ file_probe (gpointer self_p)
   wyl_keyprovider_file_t *self = self_p;
   if (self == NULL || self->path == NULL)
     return WYRELOG_E_INVALID;
+  if (self->wiped)
+    return WYRELOG_E_INTERNAL;
   if (!g_file_test (self->path, G_FILE_TEST_EXISTS))
     return WYRELOG_E_INTERNAL;
   return WYRELOG_E_OK;
@@ -75,13 +147,28 @@ file_seal (gpointer self_p, const guint8 *plaintext, gsize plaintext_len,
     return WYRELOG_E_INVALID;
   if (self->path == NULL)
     return WYRELOG_E_INTERNAL;
+  if (self->wiped)
+    return WYRELOG_E_INTERNAL;
   if (plaintext_len > 0 && plaintext == NULL)
     return WYRELOG_E_INVALID;
 
-  guint8 *bytes = g_malloc (plaintext_len);
-  memcpy (bytes, plaintext, plaintext_len);
+  gsize ciphertext_len = plaintext_len + crypto_secretbox_MACBYTES;
+  gsize total_len = WYL_KEYPROVIDER_SEAL_HEADER_LEN + ciphertext_len;
+  guint8 *bytes = g_malloc0 (total_len);
+  memcpy (bytes, WYL_KEYPROVIDER_SEAL_MAGIC, WYL_KEYPROVIDER_SEAL_MAGIC_LEN);
+  guint8 *nonce = bytes + WYL_KEYPROVIDER_SEAL_MAGIC_LEN;
+  randombytes_buf (nonce, crypto_secretbox_NONCEBYTES);
+  guint8 *ciphertext = bytes + WYL_KEYPROVIDER_SEAL_HEADER_LEN;
+  const guint8 empty_plaintext = 0;
+  const guint8 *message = plaintext_len > 0 ? plaintext : &empty_plaintext;
+  if (crypto_secretbox_easy (ciphertext, message, plaintext_len, nonce,
+          self->key) != 0) {
+    sodium_memzero (bytes, total_len);
+    g_free (bytes);
+    return WYRELOG_E_CRYPTO;
+  }
   out_blob->bytes = bytes;
-  out_blob->len = plaintext_len;
+  out_blob->len = total_len;
   return WYRELOG_E_OK;
 }
 
@@ -94,15 +181,32 @@ file_unseal (gpointer self_p, const wyl_sealed_blob_t *blob,
     return WYRELOG_E_INVALID;
   if (self->path == NULL)
     return WYRELOG_E_INTERNAL;
+  if (self->wiped)
+    return WYRELOG_E_INTERNAL;
   if (blob->len > 0 && blob->bytes == NULL)
     return WYRELOG_E_INVALID;
-  if (out_capacity < blob->len)
+  if (blob->len < WYL_KEYPROVIDER_SEAL_HEADER_LEN + crypto_secretbox_MACBYTES)
     return WYRELOG_E_INVALID;
-  if (out_plaintext == NULL && blob->len > 0)
+  if (memcmp (blob->bytes, WYL_KEYPROVIDER_SEAL_MAGIC,
+          WYL_KEYPROVIDER_SEAL_MAGIC_LEN) != 0)
     return WYRELOG_E_INVALID;
 
-  memcpy (out_plaintext, blob->bytes, blob->len);
-  *out_written = blob->len;
+  gsize ciphertext_len = blob->len - WYL_KEYPROVIDER_SEAL_HEADER_LEN;
+  gsize plaintext_len = ciphertext_len - crypto_secretbox_MACBYTES;
+  if (out_capacity < plaintext_len)
+    return WYRELOG_E_INVALID;
+  if (out_plaintext == NULL && plaintext_len > 0)
+    return WYRELOG_E_INVALID;
+
+  const guint8 *nonce = blob->bytes + WYL_KEYPROVIDER_SEAL_MAGIC_LEN;
+  const guint8 *ciphertext = blob->bytes + WYL_KEYPROVIDER_SEAL_HEADER_LEN;
+  guint8 empty_plaintext = 0;
+  guint8 *output = plaintext_len > 0 ? out_plaintext : &empty_plaintext;
+  if (crypto_secretbox_open_easy (output, ciphertext, ciphertext_len,
+          nonce, self->key) != 0)
+    return WYRELOG_E_CRYPTO;
+
+  *out_written = plaintext_len;
   return WYRELOG_E_OK;
 }
 
@@ -114,6 +218,8 @@ file_derive (gpointer self_p, const gchar *label, guint8 *out_key,
   if (self == NULL || out_key == NULL || label == NULL)
     return WYRELOG_E_INVALID;
   if (self->path == NULL)
+    return WYRELOG_E_INTERNAL;
+  if (self->wiped)
     return WYRELOG_E_INTERNAL;
 
   if (crypto_generichash (out_key, out_len, (const guint8 *) label,
@@ -130,6 +236,7 @@ file_wipe (gpointer self_p)
   if (self == NULL)
     return;
   sodium_memzero (self->key, sizeof self->key);
+  self->wiped = TRUE;
 }
 
 static const wyl_keyprovider_vtable_t file_vtable = {
@@ -144,4 +251,13 @@ const wyl_keyprovider_vtable_t *
 wyl_keyprovider_file_get_vtable (void)
 {
   return &file_vtable;
+}
+
+const gchar *
+wyl_keyprovider_file_get_source_name (const wyl_keyprovider_file_t *self)
+{
+  if (self == NULL)
+    return NULL;
+  return self->source == WYL_KEYPROVIDER_FILE_SOURCE_SYSTEMD_CREDS ?
+      "systemd-creds" : "file";
 }


### PR DESCRIPTION
## Summary
- add KeyProvider specs for systemd credentials and explicit file fallback
- move packaged systemd units to LoadCredential-backed policy keys
- authenticate sealed KeyProvider blobs and fail closed after wipe, wrong key, or unavailable credentials
- add provider, production gate, and packaged readiness coverage

## Validation
- meson compile -C builddir
- meson compile -C builddir-audit
- meson test -C builddir --suite wyrelog --print-errorlogs
- meson test -C builddir-audit wyrelog:keyprovider-file wyrelog:wyrelogd-production-gates wyrelog:packaged-install-readiness wyrelog:daemon-http-decide-audit wyrelog:audit-emit --print-errorlogs