### PR TITLE
[codex] Harden encrypted policy store rotation

### DIFF
--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -190,14 +190,25 @@ PY
 
 1. Stop the daemon.
 2. Back up the current key and policy store together.
-3. Replace the active profile's `policy.key` with a new 32-byte file
-   using mode `0640`, owner `root`, and group `wyrelog`.
-4. Run `wyctl key status --keyprovider file:PATH`.
-5. Run production `--check`, then start the daemon.
+3. Create the new 32-byte key file using mode `0640`, owner `root`, and group
+   `wyrelog`.
+4. Verify both key specs with `wyctl key status --keyprovider file:PATH`.
+5. Rotate the encrypted policy store while the daemon is offline:
 
-Changing the KeyProvider root invalidates sealed policy-store material
-that was written under the previous root. Perform root rotation only with
-a coordinated restore or migration plan.
+   ```sh
+   wyctl key rotate \
+     --store /var/lib/wyrelog/system/policy.sqlite \
+     --from-keyprovider file:/etc/wyrelog/system/policy.key \
+     --to-keyprovider file:/etc/wyrelog/system/policy.next.key
+   ```
+
+6. Move the new key into the profile's `policy.key` location, run production
+   `--check`, then start the daemon.
+
+The rotation command verifies the existing store with the current provider,
+rewrites the store with the new provider through the encrypted store atomic
+write protocol, and leaves the previous store usable if rotation fails before
+the final rename.
 
 ## Emergency Break-Glass
 

--- a/tests/check-packaged-install-readiness.sh
+++ b/tests/check-packaged-install-readiness.sh
@@ -131,6 +131,43 @@ grep -q '^migrations=' "$TMPDIR/template-info.out"
   --audit-db "$AUDIT_DB" \
   --check
 
+ROTATE_DB="$INSTALL_ROOT/var/lib/wyrelog/system/rotate.sqlite"
+ROTATE_AUDIT_DB="$INSTALL_ROOT/var/log/wyrelog/system/rotate-audit.duckdb"
+ROTATE_NEW_KEY="$INSTALL_ROOT/etc/wyrelog/system/policy-rotated.key"
+"$PYTHON" - "$ROTATE_NEW_KEY" <<'PY'
+import os
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+path.write_bytes(os.urandom(32))
+PY
+"$WYRELOGD" --production \
+  --profile system \
+  --template-dir "$TEMPLATE_INSTALL" \
+  --policy-db "$ROTATE_DB" \
+  --policy-keyprovider "file:$KEY" \
+  --audit-db "$ROTATE_AUDIT_DB" \
+  --check
+"$WYCTL" key rotate --store "$ROTATE_DB" \
+  --from-keyprovider "file:$KEY" \
+  --to-keyprovider "file:$ROTATE_NEW_KEY" >"$TMPDIR/rotate.out"
+if [ "$(cat "$TMPDIR/rotate.out")" != "status=rotated store=$ROTATE_DB" ]; then
+  echo "unexpected key rotation output" >&2
+  cat "$TMPDIR/rotate.out" >&2
+  exit 1
+fi
+if "$WYCTL" key rotate --store "$ROTATE_DB" \
+    --from-keyprovider "file:$KEY" \
+    --to-keyprovider "file:$ROTATE_NEW_KEY" \
+    >"$TMPDIR/rotate-old.out" 2>"$TMPDIR/rotate-old.err"; then
+  echo "old keyprovider still opens rotated policy store" >&2
+  exit 1
+fi
+"$WYCTL" key rotate --store "$ROTATE_DB" \
+  --from-keyprovider "file:$ROTATE_NEW_KEY" \
+  --to-keyprovider "file:$ROTATE_NEW_KEY" >"$TMPDIR/rotate-verify.out"
+
 CREDENTIALS_DIRECTORY="$INSTALL_ROOT/etc/wyrelog/system" \
   "$WYRELOGD" --production \
   --profile system \

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -244,7 +244,9 @@ test_policy_store = executable('test-policy-store',
   dependencies : [wyrelog_dep, sqlite_dep],
 )
 
-test('policy-store', test_policy_store)
+test('policy-store', test_policy_store,
+  timeout : 90,
+)
 
 test_dl_static = executable('test-dl-static',
   'test-dl-static.c',

--- a/tests/test-policy-store.c
+++ b/tests/test-policy-store.c
@@ -1,9 +1,11 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #include <glib.h>
+#include <glib/gstdio.h>
 
 #include "wyrelog/wyrelog.h"
 #include "wyrelog/policy/store-private.h"
 #include "wyrelog/wyl-handle-private.h"
+#include "wyrelog/wyl-keyprovider-file-private.h"
 
 #ifndef WYL_TEST_SQLITE_SCHEMA_PATH
 #error "WYL_TEST_SQLITE_SCHEMA_PATH must be defined by the build."
@@ -267,6 +269,258 @@ check_handle_owns_policy_store (void)
     return 33;
   if (!exists)
     return 34;
+  return 0;
+}
+
+static gboolean
+write_policy_key (const gchar *path, guint8 seed)
+{
+  guint8 key[32];
+  for (gsize i = 0; i < sizeof key; i++)
+    key[i] = (guint8) (seed + i);
+  return g_file_set_contents (path, (const gchar *) key, sizeof key, NULL);
+}
+
+static wyrelog_error_t
+open_encrypted_policy_store (const gchar *store_path, const gchar *key_path,
+    wyl_policy_store_t **out_store)
+{
+  wyl_keyprovider_file_t *keyprovider = wyl_keyprovider_file_new (key_path);
+  if (keyprovider == NULL)
+    return WYRELOG_E_IO;
+  wyl_policy_store_open_options_t opts = {
+    .path = store_path,
+    .keyprovider_vtable = wyl_keyprovider_file_get_vtable (),
+    .keyprovider_state = keyprovider,
+    .keyprovider_state_free = (void (*)(gpointer)) wyl_keyprovider_file_free,
+    .require_encrypted = TRUE,
+  };
+  return wyl_policy_store_open_with_options (&opts, out_store);
+}
+
+static wyrelog_error_t
+rotate_encrypted_policy_store (const gchar *store_path,
+    const gchar *old_key_path, const gchar *new_key_path)
+{
+  wyl_keyprovider_file_t *old_keyprovider =
+      wyl_keyprovider_file_new (old_key_path);
+  if (old_keyprovider == NULL)
+    return WYRELOG_E_IO;
+  wyl_keyprovider_file_t *new_keyprovider =
+      wyl_keyprovider_file_new (new_key_path);
+  if (new_keyprovider == NULL) {
+    wyl_keyprovider_file_free (old_keyprovider);
+    return WYRELOG_E_IO;
+  }
+  const wyl_keyprovider_vtable_t *vt = wyl_keyprovider_file_get_vtable ();
+  wyl_policy_store_open_options_t old_opts = {
+    .keyprovider_vtable = vt,
+    .keyprovider_state = old_keyprovider,
+    .keyprovider_state_free = (void (*)(gpointer)) wyl_keyprovider_file_free,
+    .require_encrypted = TRUE,
+  };
+  wyl_policy_store_open_options_t new_opts = {
+    .keyprovider_vtable = vt,
+    .keyprovider_state = new_keyprovider,
+    .keyprovider_state_free = (void (*)(gpointer)) wyl_keyprovider_file_free,
+    .require_encrypted = TRUE,
+  };
+  return wyl_policy_store_rotate_keyprovider (store_path, &old_opts, &new_opts);
+}
+
+static wyrelog_error_t
+failing_keyprovider_probe (gpointer self)
+{
+  (void) self;
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+failing_keyprovider_derive (gpointer self, const gchar *label, guint8 *out_key,
+    gsize out_len)
+{
+  (void) self;
+  (void) label;
+  (void) out_key;
+  (void) out_len;
+  return WYRELOG_E_INTERNAL;
+}
+
+static const wyl_keyprovider_vtable_t failing_keyprovider_vtable = {
+  .probe = failing_keyprovider_probe,
+  .derive = failing_keyprovider_derive,
+};
+
+static wyrelog_error_t
+rotate_encrypted_policy_store_to_failing_provider (const gchar *store_path,
+    const gchar *old_key_path)
+{
+  wyl_keyprovider_file_t *old_keyprovider =
+      wyl_keyprovider_file_new (old_key_path);
+  if (old_keyprovider == NULL)
+    return WYRELOG_E_IO;
+  const guint8 failing_state = 0;
+  wyl_policy_store_open_options_t old_opts = {
+    .keyprovider_vtable = wyl_keyprovider_file_get_vtable (),
+    .keyprovider_state = old_keyprovider,
+    .keyprovider_state_free = (void (*)(gpointer)) wyl_keyprovider_file_free,
+    .require_encrypted = TRUE,
+  };
+  wyl_policy_store_open_options_t new_opts = {
+    .keyprovider_vtable = &failing_keyprovider_vtable,
+    .keyprovider_state = (gpointer) & failing_state,
+    .require_encrypted = TRUE,
+  };
+  return wyl_policy_store_rotate_keyprovider (store_path, &old_opts, &new_opts);
+}
+
+static gint
+check_encrypted_policy_store_hardening_and_rotation (void)
+{
+  g_autoptr (GError) error = NULL;
+  g_autofree gchar *tmpdir = g_dir_make_tmp ("wyl-policy-enc-XXXXXX", &error);
+  if (tmpdir == NULL)
+    return 300;
+  g_autofree gchar *store_path =
+      g_build_filename (tmpdir, "policy.store", NULL);
+  g_autofree gchar *old_key_path = g_build_filename (tmpdir, "old.key", NULL);
+  g_autofree gchar *new_key_path = g_build_filename (tmpdir, "new.key", NULL);
+  g_autofree gchar *wrong_key_path =
+      g_build_filename (tmpdir, "wrong.key", NULL);
+  if (!write_policy_key (old_key_path, 1)
+      || !write_policy_key (new_key_path, 44)
+      || !write_policy_key (wrong_key_path, 99))
+    return 301;
+
+  {
+    g_autoptr (wyl_policy_store_t) store = NULL;
+    if (open_encrypted_policy_store (store_path, old_key_path, &store)
+        != WYRELOG_E_OK)
+      return 302;
+    if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+      return 303;
+    if (wyl_policy_store_set_deployment_mode (store, "development")
+        != WYRELOG_E_OK)
+      return 304;
+  }
+
+  g_autofree gchar *valid_bytes = NULL;
+  gsize valid_len = 0;
+  if (!g_file_get_contents (store_path, &valid_bytes, &valid_len, &error))
+    return 305;
+  if (valid_len < 96)
+    return 306;
+  if (memcmp (valid_bytes, "WYLPS", 5) != 0)
+    return 307;
+  if (((const guint8 *) valid_bytes)[5] != 1)
+    return 308;
+#ifndef G_OS_WIN32
+  struct stat st;
+  if (g_stat (store_path, &st) != 0)
+    return 309;
+  if ((st.st_mode & 0777) != 0600)
+    return 310;
+#endif
+
+  g_autoptr (wyl_policy_store_t) wrong_store = NULL;
+  if (open_encrypted_policy_store (store_path, wrong_key_path, &wrong_store)
+      == WYRELOG_E_OK)
+    return 311;
+
+  g_autofree gchar *variant_path = g_build_filename (tmpdir, "variant.store",
+      NULL);
+  g_autofree gchar *variant_bytes = g_memdup2 (valid_bytes, valid_len);
+  variant_bytes[0] ^= 0x01;
+  if (!g_file_set_contents (variant_path, variant_bytes, valid_len, NULL))
+    return 312;
+  g_autoptr (wyl_policy_store_t) variant_store = NULL;
+  if (open_encrypted_policy_store (variant_path, old_key_path, &variant_store)
+      == WYRELOG_E_OK)
+    return 313;
+
+  memcpy (variant_bytes, valid_bytes, valid_len);
+  ((guint8 *) variant_bytes)[5] = 0xff;
+  if (!g_file_set_contents (variant_path, variant_bytes, valid_len, NULL))
+    return 314;
+  g_clear_pointer (&variant_store, wyl_policy_store_close);
+  if (open_encrypted_policy_store (variant_path, old_key_path, &variant_store)
+      == WYRELOG_E_OK)
+    return 315;
+
+  memcpy (variant_bytes, valid_bytes, valid_len);
+  variant_bytes[8] ^= 0x01;
+  if (!g_file_set_contents (variant_path, variant_bytes, valid_len, NULL))
+    return 316;
+  g_clear_pointer (&variant_store, wyl_policy_store_close);
+  if (open_encrypted_policy_store (variant_path, old_key_path, &variant_store)
+      == WYRELOG_E_OK)
+    return 317;
+
+  if (!g_file_set_contents (variant_path, valid_bytes, valid_len - 3, NULL))
+    return 318;
+  g_clear_pointer (&variant_store, wyl_policy_store_close);
+  if (open_encrypted_policy_store (variant_path, old_key_path, &variant_store)
+      == WYRELOG_E_OK)
+    return 319;
+
+  g_autofree gchar *tmp_write_path = g_strdup_printf ("%s.wyrelog-tmp",
+      store_path);
+  if (!g_file_set_contents (tmp_write_path, "interrupted", -1, NULL))
+    return 320;
+  {
+    g_autoptr (wyl_policy_store_t) store = NULL;
+    g_autofree gchar *mode = NULL;
+    if (open_encrypted_policy_store (store_path, old_key_path, &store)
+        != WYRELOG_E_OK)
+      return 321;
+    if (wyl_policy_store_get_deployment_mode (store, &mode) != WYRELOG_E_OK)
+      return 322;
+    if (g_strcmp0 (mode, "development") != 0)
+      return 323;
+  }
+
+  if (rotate_encrypted_policy_store (store_path, old_key_path, new_key_path)
+      != WYRELOG_E_OK)
+    return 324;
+  g_clear_pointer (&wrong_store, wyl_policy_store_close);
+  if (open_encrypted_policy_store (store_path, old_key_path, &wrong_store)
+      == WYRELOG_E_OK)
+    return 325;
+  {
+    g_autoptr (wyl_policy_store_t) store = NULL;
+    g_autofree gchar *mode = NULL;
+    if (open_encrypted_policy_store (store_path, new_key_path, &store)
+        != WYRELOG_E_OK)
+      return 326;
+    if (wyl_policy_store_get_deployment_mode (store, &mode) != WYRELOG_E_OK)
+      return 327;
+    if (g_strcmp0 (mode, "development") != 0)
+      return 328;
+  }
+
+  if (rotate_encrypted_policy_store_to_failing_provider (store_path,
+          new_key_path)
+      == WYRELOG_E_OK)
+    return 329;
+  {
+    g_autoptr (wyl_policy_store_t) store = NULL;
+    g_autofree gchar *mode = NULL;
+    if (open_encrypted_policy_store (store_path, new_key_path, &store)
+        != WYRELOG_E_OK)
+      return 330;
+    if (wyl_policy_store_get_deployment_mode (store, &mode) != WYRELOG_E_OK)
+      return 331;
+    if (g_strcmp0 (mode, "development") != 0)
+      return 332;
+  }
+
+  (void) g_remove (tmp_write_path);
+  (void) g_remove (variant_path);
+  (void) g_remove (store_path);
+  (void) g_remove (old_key_path);
+  (void) g_remove (new_key_path);
+  (void) g_remove (wrong_key_path);
+  (void) g_rmdir (tmpdir);
   return 0;
 }
 
@@ -2636,6 +2890,8 @@ main (void)
   if ((rc = check_store_sets_deployment_mode ()) != 0)
     return rc;
   if ((rc = check_handle_owns_policy_store ()) != 0)
+    return rc;
+  if ((rc = check_encrypted_policy_store_hardening_and_rotation ()) != 0)
     return rc;
   if ((rc = check_store_seeds_builtin_catalog ()) != 0)
     return rc;

--- a/wyrelog/policy/store-private.h
+++ b/wyrelog/policy/store-private.h
@@ -77,6 +77,9 @@ wyrelog_error_t wyl_policy_store_open (const gchar * path,
     wyl_policy_store_t ** out_store);
 wyrelog_error_t wyl_policy_store_open_with_options (const
     wyl_policy_store_open_options_t * opts, wyl_policy_store_t ** out_store);
+wyrelog_error_t wyl_policy_store_rotate_keyprovider (const gchar * path,
+    const wyl_policy_store_open_options_t * old_opts,
+    const wyl_policy_store_open_options_t * new_opts);
 void wyl_policy_store_close (wyl_policy_store_t * store);
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (wyl_policy_store_t, wyl_policy_store_close);

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -1,8 +1,20 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <errno.h>
+#include <fcntl.h>
 #include <string.h>
 
 #include <sodium.h>
 #include <glib/gstdio.h>
+
+#ifdef G_OS_WIN32
+#include <io.h>
+#else
+#include <unistd.h>
+#endif
+
+#ifndef O_BINARY
+#define O_BINARY 0
+#endif
 
 #include "store-private.h"
 
@@ -16,18 +28,22 @@
 #define WYL_POLICY_STORE_KEY_LEN crypto_secretbox_KEYBYTES
 #define WYL_POLICY_STORE_KEY_ID_LEN crypto_generichash_BYTES
 #define WYL_POLICY_STORE_ENCRYPTION_LABEL "policy_store_v1"
-#define WYL_POLICY_STORE_MAGIC "WYLPS1"
-#define WYL_POLICY_STORE_MAGIC_LEN sizeof (WYL_POLICY_STORE_MAGIC)
+#define WYL_POLICY_STORE_MAGIC "WYLPS"
+#define WYL_POLICY_STORE_MAGIC_LEN 5
+#define WYL_POLICY_STORE_FORMAT_VERSION 1
 
 typedef struct
 {
-  gchar magic[WYL_POLICY_STORE_MAGIC_LEN];
-  gchar key_id[WYL_POLICY_STORE_KEY_ID_LEN];
-  guint8 nonce[crypto_secretbox_NONCEBYTES];
+  guint8 magic[WYL_POLICY_STORE_MAGIC_LEN];
+  guint8 version;
+  guint8 flags;
+  guint8 reserved;
+  guint8 provider_id[WYL_POLICY_STORE_KEY_ID_LEN];
+  guint8 nonce[crypto_aead_xchacha20poly1305_ietf_NPUBBYTES];
   guint64 ciphertext_len_le;
 } __attribute__((packed)) WylPolicyStoreFileHeader;
 
-G_STATIC_ASSERT (sizeof (WYL_POLICY_STORE_MAGIC) == 7);
+G_STATIC_ASSERT (WYL_POLICY_STORE_MAGIC_LEN == 5);
 
 struct wyl_policy_store_t
 {
@@ -316,6 +332,119 @@ read_whole_file (const gchar *path, guint8 **out_bytes, gsize *out_len)
 }
 
 static wyrelog_error_t
+fsync_fd_best_effort (int fd)
+{
+#ifdef G_OS_WIN32
+  (void) fd;
+  return WYRELOG_E_OK;
+#else
+  return fsync (fd) == 0 ? WYRELOG_E_OK : WYRELOG_E_IO;
+#endif
+}
+
+static void
+fsync_parent_directory_best_effort (const gchar *path)
+{
+#ifdef G_OS_WIN32
+  (void) path;
+#else
+  if (path == NULL)
+    return;
+  g_autofree gchar *dir = g_path_get_dirname (path);
+  if (dir == NULL || dir[0] == '\0')
+    return;
+#ifdef O_DIRECTORY
+  int fd = g_open (dir, O_RDONLY | O_DIRECTORY, 0);
+#else
+  int fd = g_open (dir, O_RDONLY, 0);
+#endif
+  if (fd >= 0) {
+    (void) fsync (fd);
+    (void) close (fd);
+  }
+#endif
+}
+
+static wyrelog_error_t
+write_whole_file_atomic_private (const gchar *path, const guint8 *bytes,
+    gsize len)
+{
+  if (path == NULL || path[0] == '\0' || (bytes == NULL && len > 0))
+    return WYRELOG_E_INVALID;
+
+  g_autofree gchar *tmp_path = g_strdup_printf ("%s%s", path,
+      WYL_POLICY_STORE_TMP_SUFFIX);
+  int fd = g_open (tmp_path, O_WRONLY | O_CREAT | O_TRUNC | O_BINARY, 0600);
+  if (fd < 0)
+    return WYRELOG_E_IO;
+
+  gsize written = 0;
+  while (written < len) {
+    gsize remaining = len - written;
+#ifdef G_OS_WIN32
+    if (remaining > G_MAXUINT)
+      remaining = G_MAXUINT;
+#else
+    if (remaining > G_MAXSSIZE)
+      remaining = G_MAXSSIZE;
+#endif
+#ifdef G_OS_WIN32
+    int n = _write (fd, bytes + written, (unsigned int) remaining);
+#else
+    ssize_t n = write (fd, bytes + written, remaining);
+#endif
+    if (n < 0) {
+      int saved_errno = errno;
+#ifdef G_OS_WIN32
+      (void) _close (fd);
+#else
+      (void) close (fd);
+#endif
+      errno = saved_errno;
+      (void) g_remove (tmp_path);
+      return WYRELOG_E_IO;
+    }
+    if (n == 0) {
+#ifdef G_OS_WIN32
+      (void) _close (fd);
+#else
+      (void) close (fd);
+#endif
+      (void) g_remove (tmp_path);
+      return WYRELOG_E_IO;
+    }
+    written += (gsize) n;
+  }
+
+  wyrelog_error_t rc = fsync_fd_best_effort (fd);
+#ifdef G_OS_WIN32
+  if (_close (fd) != 0)
+    rc = WYRELOG_E_IO;
+#else
+  if (close (fd) != 0)
+    rc = WYRELOG_E_IO;
+#endif
+  if (rc != WYRELOG_E_OK) {
+    (void) g_remove (tmp_path);
+    return rc;
+  }
+
+  (void) g_chmod (tmp_path, 0600);
+  if (g_rename (tmp_path, path) != 0) {
+    (void) g_remove (tmp_path);
+    return WYRELOG_E_IO;
+  }
+  fsync_parent_directory_best_effort (path);
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+write_plaintext_work_file (const gchar *path, const guint8 *bytes, gsize len)
+{
+  return write_whole_file_atomic_private (path, bytes, len);
+}
+
+static wyrelog_error_t
 decrypt_policy_store_from_canonical (wyl_policy_store_t *store,
     const gchar *canonical_path, const gchar *work_path)
 {
@@ -333,13 +462,16 @@ decrypt_policy_store_from_canonical (wyl_policy_store_t *store,
   if (memcmp (header->magic, WYL_POLICY_STORE_MAGIC, WYL_POLICY_STORE_MAGIC_LEN)
       != 0)
     return WYRELOG_E_POLICY;
-  if (memcmp (header->key_id, store->encryption_key_id,
+  if (header->version != WYL_POLICY_STORE_FORMAT_VERSION || header->flags != 0
+      || header->reserved != 0)
+    return WYRELOG_E_POLICY;
+  if (memcmp (header->provider_id, store->encryption_key_id,
           WYL_POLICY_STORE_KEY_ID_LEN)
       != 0)
     return WYRELOG_E_POLICY;
 
   const gsize max_header_and_mac = sizeof (WylPolicyStoreFileHeader)
-      + crypto_secretbox_MACBYTES;
+      + crypto_aead_xchacha20poly1305_ietf_ABYTES;
   if (ciphertext_len < max_header_and_mac)
     return WYRELOG_E_POLICY;
   guint64 cipher_len_le = GUINT64_FROM_LE (header->ciphertext_len_le);
@@ -351,22 +483,25 @@ decrypt_policy_store_from_canonical (wyl_policy_store_t *store,
     return WYRELOG_E_POLICY;
 
   if (cipher_len_le + sizeof (WylPolicyStoreFileHeader) != ciphertext_len
-      || cipher_len_le <= crypto_secretbox_MACBYTES)
+      || cipher_len_le <= crypto_aead_xchacha20poly1305_ietf_ABYTES)
     return WYRELOG_E_POLICY;
 
-  gsize plaintext_len = (gsize) cipher_len_le;
+  gsize plaintext_len = (gsize) cipher_len_le
+      - crypto_aead_xchacha20poly1305_ietf_ABYTES;
   g_autofree guint8 *plaintext = g_malloc (plaintext_len);
   const guint8 *ciphertext_body =
       ciphertext + sizeof (WylPolicyStoreFileHeader);
+  unsigned long long decrypted_len = 0;
 
-  if (crypto_secretbox_open_easy (plaintext, ciphertext_body, cipher_len_le,
+  if (crypto_aead_xchacha20poly1305_ietf_decrypt (plaintext, &decrypted_len,
+          NULL, ciphertext_body, cipher_len_le,
+          (const guint8 *) header, sizeof (WylPolicyStoreFileHeader),
           header->nonce, store->encryption_key) != 0)
     return WYRELOG_E_CRYPTO;
+  if (decrypted_len != plaintext_len)
+    return WYRELOG_E_CRYPTO;
 
-  if (!g_file_set_contents (work_path, (const gchar *) plaintext, plaintext_len,
-          NULL))
-    return WYRELOG_E_IO;
-  return WYRELOG_E_OK;
+  return write_plaintext_work_file (work_path, plaintext, plaintext_len);
 }
 
 static wyrelog_error_t
@@ -621,9 +756,8 @@ persist_policy_store_encrypted (wyl_policy_store_t *store)
       || store->canonical_path[0] == '\0')
     return WYRELOG_E_INVALID;
 
-  wyrelog_error_t rc = exec_sql (store->db, "PRAGMA wal_checkpoint(TRUNCATE);");
-  if (rc != WYRELOG_E_OK)
-    return rc;
+  if (store->db != NULL && sqlite3_db_cacheflush (store->db) != SQLITE_OK)
+    return WYRELOG_E_IO;
 
   g_autofree guint8 *plaintext = NULL;
   gsize plaintext_len = 0;
@@ -631,28 +765,33 @@ persist_policy_store_encrypted (wyl_policy_store_t *store)
           &plaintext_len) != WYRELOG_E_OK)
     return WYRELOG_E_IO;
 
-  const gsize encrypted_len =
-      sizeof (WylPolicyStoreFileHeader) + crypto_secretbox_MACBYTES
-      + plaintext_len;
+  const gsize encrypted_len = sizeof (WylPolicyStoreFileHeader)
+      + crypto_aead_xchacha20poly1305_ietf_ABYTES + plaintext_len;
   g_autofree guint8 *encrypted = g_malloc0 (encrypted_len);
   WylPolicyStoreFileHeader *header = (WylPolicyStoreFileHeader *) encrypted;
   memcpy (header->magic, WYL_POLICY_STORE_MAGIC, WYL_POLICY_STORE_MAGIC_LEN);
-  memcpy (header->key_id, store->encryption_key_id,
+  header->version = WYL_POLICY_STORE_FORMAT_VERSION;
+  header->flags = 0;
+  header->reserved = 0;
+  memcpy (header->provider_id, store->encryption_key_id,
       WYL_POLICY_STORE_KEY_ID_LEN);
   randombytes_buf (header->nonce, sizeof (header->nonce));
   header->ciphertext_len_le = GUINT64_TO_LE ((guint64) (plaintext_len
-          + crypto_secretbox_MACBYTES));
+          + crypto_aead_xchacha20poly1305_ietf_ABYTES));
 
   guint8 *ciphertext = encrypted + sizeof (WylPolicyStoreFileHeader);
-  if (crypto_secretbox_easy (ciphertext, plaintext, plaintext_len,
+  unsigned long long ciphertext_len = 0;
+  if (crypto_aead_xchacha20poly1305_ietf_encrypt (ciphertext, &ciphertext_len,
+          plaintext, plaintext_len,
+          (const guint8 *) header, sizeof (WylPolicyStoreFileHeader), NULL,
           header->nonce, store->encryption_key) != 0)
     return WYRELOG_E_CRYPTO;
+  if (ciphertext_len != (unsigned long long) (encrypted_len
+          - sizeof (WylPolicyStoreFileHeader)))
+    return WYRELOG_E_CRYPTO;
 
-  if (!g_file_set_contents (store->canonical_path, (const gchar *) encrypted,
-          encrypted_len, NULL))
-    return WYRELOG_E_IO;
-  (void) g_remove (store->work_path);
-  return WYRELOG_E_OK;
+  return write_whole_file_atomic_private (store->canonical_path, encrypted,
+      encrypted_len);
 }
 
 wyrelog_error_t
@@ -678,6 +817,54 @@ wyl_policy_store_rollback_mutation (wyl_policy_store_t *store)
     return;
   (void) exec_sql (store->db, "ROLLBACK TO SAVEPOINT wyrelog_policy_mutation;");
   (void) exec_sql (store->db, "RELEASE SAVEPOINT wyrelog_policy_mutation;");
+}
+
+wyrelog_error_t
+wyl_policy_store_rotate_keyprovider (const gchar *path,
+    const wyl_policy_store_open_options_t *old_opts,
+    const wyl_policy_store_open_options_t *new_opts)
+{
+  if (path == NULL || path[0] == '\0' || old_opts == NULL || new_opts == NULL)
+    return WYRELOG_E_INVALID;
+
+  wyl_policy_store_open_options_t open_opts = *old_opts;
+  open_opts.path = path;
+  open_opts.require_encrypted = TRUE;
+
+  wyl_policy_store_t *store = NULL;
+  wyrelog_error_t rc = wyl_policy_store_open_with_options (&open_opts, &store);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  guint8 old_key[WYL_POLICY_STORE_KEY_LEN];
+  guint8 old_key_id[WYL_POLICY_STORE_KEY_ID_LEN];
+  memcpy (old_key, store->encryption_key, sizeof old_key);
+  memcpy (old_key_id, store->encryption_key_id, sizeof old_key_id);
+
+  wyl_policy_store_open_options_t rotate_opts = *new_opts;
+  rotate_opts.path = path;
+  rotate_opts.require_encrypted = TRUE;
+
+  rc = wyl_policy_store_create_schema (store);
+  if (rc == WYRELOG_E_OK)
+    rc = wyl_policy_store_validate_snapshot (store);
+  if (rc == WYRELOG_E_OK)
+    rc = materialize_store_key (store, &rotate_opts);
+  (void) cleanup_keyprovider_state (&rotate_opts);
+
+  if (rc == WYRELOG_E_OK)
+    rc = persist_policy_store_encrypted (store);
+
+  if (rc != WYRELOG_E_OK) {
+    memcpy (store->encryption_key, old_key, sizeof old_key);
+    memcpy (store->encryption_key_id, old_key_id, sizeof old_key_id);
+    store->key_materialized = TRUE;
+  }
+
+  sodium_memzero (old_key, sizeof old_key);
+  sodium_memzero (old_key_id, sizeof old_key_id);
+  wyl_policy_store_close (store);
+  return rc;
 }
 
 wyrelog_error_t
@@ -746,9 +933,10 @@ wyl_policy_store_open_with_options (const wyl_policy_store_open_options_t *opts,
     return WYRELOG_E_IO;
   }
 
-  if (exec_sql (self->db,
-          "PRAGMA foreign_keys = ON;" "PRAGMA journal_mode = WAL;") !=
-      WYRELOG_E_OK) {
+  const gchar *open_pragmas = self->encrypted ?
+      "PRAGMA foreign_keys = ON;" "PRAGMA journal_mode = MEMORY;" :
+      "PRAGMA foreign_keys = ON;" "PRAGMA journal_mode = WAL;";
+  if (exec_sql (self->db, open_pragmas) != WYRELOG_E_OK) {
     cleanup_keyprovider_state (opts);
     wyl_policy_store_close (self);
     return WYRELOG_E_IO;
@@ -774,9 +962,10 @@ wyl_policy_store_close (wyl_policy_store_t *store)
   if (store->db != NULL) {
     if (store->encrypted)
       (void) persist_policy_store_encrypted (store);
-    else
-      sqlite3_close (store->db);
+    sqlite3_close (store->db);
     store->db = NULL;
+    if (store->encrypted && store->work_path != NULL)
+      (void) g_remove (store->work_path);
   }
   g_clear_pointer (&store->canonical_path, g_free);
   g_clear_pointer (&store->work_path, g_free);

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -372,6 +372,18 @@ write_whole_file_atomic_private (const gchar *path, const guint8 *bytes,
   if (path == NULL || path[0] == '\0' || (bytes == NULL && len > 0))
     return WYRELOG_E_INVALID;
 
+#ifdef G_OS_WIN32
+  /* GLib's g_file_set_contents already performs a temp-file + rename on
+     Windows. The hand-rolled _write loop below was observed to wedge
+     inside a single 288 KB write call for the full meson test budget on
+     hosted GitHub Actions runners, while g_file_set_contents completes in
+     under a second with the same payload. The Windows path therefore
+     defers to GLib and tightens the resulting file's mode to 0600. */
+  if (!g_file_set_contents (path, (const gchar *) bytes, (gssize) len, NULL))
+    return WYRELOG_E_IO;
+  (void) g_chmod (path, 0600);
+  return WYRELOG_E_OK;
+#else
   g_autofree gchar *tmp_path = g_strdup_printf ("%s%s", path,
       WYL_POLICY_STORE_TMP_SUFFIX);
   int fd = g_open (tmp_path, O_WRONLY | O_CREAT | O_TRUNC | O_BINARY, 0600);
@@ -381,35 +393,18 @@ write_whole_file_atomic_private (const gchar *path, const guint8 *bytes,
   gsize written = 0;
   while (written < len) {
     gsize remaining = len - written;
-#ifdef G_OS_WIN32
-    if (remaining > G_MAXUINT)
-      remaining = G_MAXUINT;
-#else
     if (remaining > G_MAXSSIZE)
       remaining = G_MAXSSIZE;
-#endif
-#ifdef G_OS_WIN32
-    int n = _write (fd, bytes + written, (unsigned int) remaining);
-#else
     ssize_t n = write (fd, bytes + written, remaining);
-#endif
     if (n < 0) {
       int saved_errno = errno;
-#ifdef G_OS_WIN32
-      (void) _close (fd);
-#else
       (void) close (fd);
-#endif
       errno = saved_errno;
       (void) g_remove (tmp_path);
       return WYRELOG_E_IO;
     }
     if (n == 0) {
-#ifdef G_OS_WIN32
-      (void) _close (fd);
-#else
       (void) close (fd);
-#endif
       (void) g_remove (tmp_path);
       return WYRELOG_E_IO;
     }
@@ -417,13 +412,8 @@ write_whole_file_atomic_private (const gchar *path, const guint8 *bytes,
   }
 
   wyrelog_error_t rc = fsync_fd_best_effort (fd);
-#ifdef G_OS_WIN32
-  if (_close (fd) != 0)
-    rc = WYRELOG_E_IO;
-#else
   if (close (fd) != 0)
     rc = WYRELOG_E_IO;
-#endif
   if (rc != WYRELOG_E_OK) {
     (void) g_remove (tmp_path);
     return rc;
@@ -436,6 +426,7 @@ write_whole_file_atomic_private (const gchar *path, const guint8 *bytes,
   }
   fsync_parent_directory_best_effort (path);
   return WYRELOG_E_OK;
+#endif
 }
 
 static wyrelog_error_t

--- a/wyrelog/wyctl/wyctl.c
+++ b/wyrelog/wyctl/wyctl.c
@@ -7,6 +7,7 @@
 
 #include "wyrelog/client.h"
 #include "wyrelog/decide.h"
+#include "wyrelog/policy/store-private.h"
 #include "wyrelog/version.h"
 #include "wyrelog/wyl-client-private.h"
 #include "wyrelog/wyl-common-private.h"
@@ -64,6 +65,9 @@ typedef struct
 typedef struct
 {
   gchar *keyprovider_path;
+  gchar *store_path;
+  gchar *from_keyprovider_path;
+  gchar *to_keyprovider_path;
 } WyctlKeyOptions;
 
 #define WYCTL_DEFAULT_TIMEOUT_MS 2000
@@ -1183,6 +1187,84 @@ run_key_status (gint argc, gchar **argv)
 }
 
 static int
+run_key_rotate (gint argc, gchar **argv)
+{
+  WyctlKeyOptions opts = { 0 };
+  GOptionEntry entries[] = {
+    {"store", 0, 0, G_OPTION_ARG_STRING, &opts.store_path,
+        "Encrypted policy store path", "PATH"},
+    {"from-keyprovider", 0, 0, G_OPTION_ARG_STRING,
+        &opts.from_keyprovider_path, "Current Policy KeyProvider spec", "SPEC"},
+    {"to-keyprovider", 0, 0, G_OPTION_ARG_STRING,
+        &opts.to_keyprovider_path, "New Policy KeyProvider spec", "SPEC"},
+    {NULL}
+  };
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GOptionContext) context =
+      g_option_context_new ("- rotate encrypted policy store key material");
+  g_option_context_add_main_entries (context, entries, NULL);
+
+  if (!g_option_context_parse (context, &argc, &argv, &error)) {
+    g_printerr ("wyctl: %s\n", error->message);
+    return 2;
+  }
+  if (argc > 1) {
+    g_printerr ("wyctl: unexpected key rotate argument: %s\n", argv[1]);
+    return 2;
+  }
+  if (opts.store_path == NULL || opts.store_path[0] == '\0') {
+    g_printerr ("wyctl: missing --store\n");
+    return 2;
+  }
+  if (opts.from_keyprovider_path == NULL
+      || opts.from_keyprovider_path[0] == '\0') {
+    g_printerr ("wyctl: missing --from-keyprovider\n");
+    return 2;
+  }
+  if (opts.to_keyprovider_path == NULL || opts.to_keyprovider_path[0] == '\0') {
+    g_printerr ("wyctl: missing --to-keyprovider\n");
+    return 2;
+  }
+
+  wyl_keyprovider_file_t *from_keyprovider =
+      wyl_keyprovider_file_new_from_spec (opts.from_keyprovider_path);
+  if (from_keyprovider == NULL) {
+    g_printerr ("wyctl: current keyprovider unreadable\n");
+    return 1;
+  }
+  wyl_keyprovider_file_t *to_keyprovider =
+      wyl_keyprovider_file_new_from_spec (opts.to_keyprovider_path);
+  if (to_keyprovider == NULL) {
+    wyl_keyprovider_file_free (from_keyprovider);
+    g_printerr ("wyctl: new keyprovider unreadable\n");
+    return 1;
+  }
+
+  const wyl_keyprovider_vtable_t *vt = wyl_keyprovider_file_get_vtable ();
+  wyl_policy_store_open_options_t old_opts = {
+    .keyprovider_vtable = vt,
+    .keyprovider_state = from_keyprovider,
+    .keyprovider_state_free = (void (*)(gpointer)) wyl_keyprovider_file_free,
+    .require_encrypted = TRUE,
+  };
+  wyl_policy_store_open_options_t new_opts = {
+    .keyprovider_vtable = vt,
+    .keyprovider_state = to_keyprovider,
+    .keyprovider_state_free = (void (*)(gpointer)) wyl_keyprovider_file_free,
+    .require_encrypted = TRUE,
+  };
+  wyrelog_error_t rc = wyl_policy_store_rotate_keyprovider (opts.store_path,
+      &old_opts, &new_opts);
+  if (rc != WYRELOG_E_OK) {
+    g_printerr ("wyctl: key rotation failed: %s\n", wyrelog_error_string (rc));
+    return 1;
+  }
+
+  g_print ("status=rotated store=%s\n", opts.store_path);
+  return 0;
+}
+
+static int
 run_key (gint argc, gchar **argv)
 {
   if (argc < 2) {
@@ -1192,6 +1274,8 @@ run_key (gint argc, gchar **argv)
 
   if (g_strcmp0 (argv[1], "status") == 0)
     return run_key_status (argc - 1, argv + 1);
+  if (g_strcmp0 (argv[1], "rotate") == 0)
+    return run_key_rotate (argc - 1, argv + 1);
 
   g_printerr ("wyctl: unknown key command: %s\n", argv[1]);
   return 2;


### PR DESCRIPTION
## Summary
- add a versioned encrypted policy-store header with provider identity and authenticated metadata
- write encrypted stores through a temp-file, fsync, chmod, atomic-rename persistence path
- add offline key rotation through wyctl and private policy-store rotation support
- cover wrong provider, corrupt metadata, truncated ciphertext, interrupted writes, and rotation rollback in tests

## Validation
- meson compile -C builddir
- meson test -C builddir --suite wyrelog --print-errorlogs
- meson compile -C builddir-audit
- meson test -C builddir-audit wyrelog:policy-store wyrelog:packaged-install-readiness wyrelog:wyrelogd-production-gates wyrelog:daemon-http-decide-audit wyrelog:audit-emit --print-errorlogs