### PR TITLE
Document template artifact release custody

### DIFF
--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -9,6 +9,7 @@ support files from `packaging/`.
 
 - Binaries: `/usr/bin/wyrelogd`, `/usr/bin/wyctl`
 - Templates: `/usr/share/wyrelog/access`
+- Template release verifier: `/usr/share/wyrelog/tools/verify-template-release.sh`
 - Daemon environment: `/etc/wyrelog/wyrelogd.env`
 - System KeyProvider root: `/etc/wyrelog/system/policy.key` loaded by
   systemd as credential `wyrelog-system-policy-key`
@@ -179,12 +180,70 @@ PY
 ## Template Upgrade
 
 1. Install the new package without starting the daemon.
-2. Run `wyrelogd --template-info` and record version, hash, migration
-   count, and latest migration version.
+2. Verify the installed template tree against the release note values:
+
+   ```sh
+   /usr/share/wyrelog/tools/verify-template-release.sh \
+     /usr/bin/wyrelogd /usr/share/wyrelog/access \
+     EXPECTED_VERSION EXPECTED_SHA256 \
+     EXPECTED_MIGRATIONS EXPECTED_LATEST_MIGRATION_VERSION
+   ```
+
 3. Run production `--check` against the existing policy and audit stores.
 4. Restart the service.
-5. If readiness fails, roll back the package and restore the previous
-   template tree and policy store backup.
+5. If readiness fails, roll back by restoring the previous package, template
+   tree, policy store, audit store, and KeyProvider backup together.
+
+## Template Artifact Release And Replay Policy
+
+Template artifacts are release artifacts, not runtime secrets. The private
+Ed25519 signing keys are owned by the release custodian role and kept outside
+the deployed Wyrelog hosts. Production hosts receive only signed template
+artifacts and embedded public verification keys in `manifest.ini` and
+`migrations/*.ini`.
+
+The signing process is:
+
+1. Build the package from a tagged release commit.
+2. Generate the canonical template digest for the fixed engine load order
+   documented in `templates/access/manifest.ini`.
+3. Sign the digest with context `wyrelog-template-v0-sha256`.
+4. Sign each migration digest with context
+   `wyrelog-template-migration-v0-sha256`.
+5. Publish the package with release notes that record template version,
+   template SHA-256, migration count, latest migration version, and the
+   signing public key fingerprints.
+
+Signing-key rotation is a release event. Add the new public key to the next
+artifact manifest or migration artifact, sign the artifact with the new
+offline private key, and record the rotation in the release notes. The old
+private key must be retired from signing use after the last release that
+depends on it is published. If a signing key is suspected to be compromised,
+stop rollout, publish a superseding release signed by a new key, and reject
+the affected artifact identity in deployment automation.
+
+Downgrade and replay policy is fail-closed by default:
+
+- A package downgrade is unsupported as an in-place operation.
+- Replaying a previously signed template with an older release identity is
+  rejected by comparing `verify-template-release.sh` output against the
+  release note values approved for the deployment.
+- Rollback is restore-from-backup only: restore the previous package,
+  template tree, policy store, audit store, and KeyProvider state as one
+  consistent snapshot, then run production `--check`.
+- Supersession is the supported correction path for a bad artifact: publish a
+  new release with a new template identity and verify that exact identity on
+  every host before restart.
+
+Operator provenance verification:
+
+```sh
+wyrelogd --template-info --template-dir /usr/share/wyrelog/access
+/usr/share/wyrelog/tools/verify-template-release.sh \
+  /usr/bin/wyrelogd /usr/share/wyrelog/access \
+  EXPECTED_VERSION EXPECTED_SHA256 \
+  EXPECTED_MIGRATIONS EXPECTED_LATEST_MIGRATION_VERSION
+```
 
 ## Key Rotation
 

--- a/meson.build
+++ b/meson.build
@@ -96,6 +96,11 @@ install_subdir(
   'templates/access',
   install_dir : join_paths(get_option('datadir'), 'wyrelog'),
 )
+install_data(
+  'tools/verify-template-release.sh',
+  install_dir : join_paths(get_option('datadir'), 'wyrelog', 'tools'),
+  install_mode : 'rwxr-xr-x',
+)
 
 install_data(
   'packaging/systemd/wyrelog.service',

--- a/tests/check-packaged-install-readiness.sh
+++ b/tests/check-packaged-install-readiness.sh
@@ -38,6 +38,7 @@ for path in \
   "$SOURCE_ROOT/packaging/wyrelogd.env" \
   "$SOURCE_ROOT/packaging/system.env" \
   "$SOURCE_ROOT/packaging/service.env" \
+  "$SOURCE_ROOT/tools/verify-template-release.sh" \
   "$SOURCE_ROOT/docs/operator-runbook.md"; do
   test -s "$path"
 done
@@ -75,6 +76,7 @@ fi
 
 INSTALL_ROOT="$TMPDIR/install"
 mkdir -p "$INSTALL_ROOT/usr/share/wyrelog" \
+  "$INSTALL_ROOT/usr/share/wyrelog/tools" \
   "$INSTALL_ROOT/etc/wyrelog" \
   "$INSTALL_ROOT/etc/wyrelog/system" \
   "$INSTALL_ROOT/etc/wyrelog/service" \
@@ -86,6 +88,9 @@ mkdir -p "$INSTALL_ROOT/usr/share/wyrelog" \
   "$INSTALL_ROOT/var/log/wyrelog/service" \
   "$INSTALL_ROOT/run/wyrelog"
 cp -R "$TEMPLATE_DIR" "$INSTALL_ROOT/usr/share/wyrelog/access"
+cp "$SOURCE_ROOT/tools/verify-template-release.sh" \
+  "$INSTALL_ROOT/usr/share/wyrelog/tools/verify-template-release.sh"
+chmod 0755 "$INSTALL_ROOT/usr/share/wyrelog/tools/verify-template-release.sh"
 
 "$PYTHON" - "$INSTALL_ROOT/etc/wyrelog/system/policy.key" <<'PY'
 import os
@@ -122,6 +127,25 @@ fi
 grep -q '^version=' "$TMPDIR/template-info.out"
 grep -q '^sha256=' "$TMPDIR/template-info.out"
 grep -q '^migrations=' "$TMPDIR/template-info.out"
+grep -q '^latest_migration_version=' "$TMPDIR/template-info.out"
+
+"$INSTALL_ROOT/usr/share/wyrelog/tools/verify-template-release.sh" \
+  "$WYRELOGD" "$TEMPLATE_INSTALL" \
+  0 0ffe885e14222878f18fc1376adf2df32efeda66fab2e8437e320d7d6928b028 \
+  1 0 >"$TMPDIR/template-release.out"
+if [ "$(cat "$TMPDIR/template-release.out")" != \
+    "status=verified version=0 sha256=0ffe885e14222878f18fc1376adf2df32efeda66fab2e8437e320d7d6928b028 migrations=1 latest_migration_version=0" ]; then
+  echo "unexpected template release verification output" >&2
+  cat "$TMPDIR/template-release.out" >&2
+  exit 1
+fi
+if "$INSTALL_ROOT/usr/share/wyrelog/tools/verify-template-release.sh" \
+    "$WYRELOGD" "$TEMPLATE_INSTALL" \
+    0 0000000000000000000000000000000000000000000000000000000000000000 \
+    1 0 >"$TMPDIR/template-replay.out" 2>"$TMPDIR/template-replay.err"; then
+  echo "template release verification accepted a stale artifact identity" >&2
+  exit 1
+fi
 
 "$WYRELOGD" --production \
   --profile system \

--- a/tools/verify-template-release.sh
+++ b/tools/verify-template-release.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+set -eu
+
+if [ "$#" -ne 6 ]; then
+  echo "usage: $0 WYRELOGD TEMPLATE_DIR VERSION SHA256 MIGRATIONS LATEST_MIGRATION_VERSION" >&2
+  exit 64
+fi
+
+WYRELOGD=$1
+TEMPLATE_DIR=$2
+EXPECTED_VERSION=$3
+EXPECTED_SHA256=$4
+EXPECTED_MIGRATIONS=$5
+EXPECTED_LATEST_MIGRATION_VERSION=$6
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT INT TERM
+
+"$WYRELOGD" --template-info --template-dir "$TEMPLATE_DIR" \
+  >"$TMPDIR/template-info.out"
+
+read_field() {
+  sed -n "s/^$1=//p" "$TMPDIR/template-info.out" | tail -n 1
+}
+
+VERSION=$(read_field version)
+SHA256=$(read_field sha256)
+MIGRATIONS=$(read_field migrations)
+LATEST_MIGRATION_VERSION=$(read_field latest_migration_version)
+
+if [ "$VERSION" != "$EXPECTED_VERSION" ]; then
+  echo "template version mismatch: expected $EXPECTED_VERSION, got $VERSION" >&2
+  exit 1
+fi
+if [ "$SHA256" != "$EXPECTED_SHA256" ]; then
+  echo "template sha256 mismatch: expected $EXPECTED_SHA256, got $SHA256" >&2
+  exit 1
+fi
+if [ "$MIGRATIONS" != "$EXPECTED_MIGRATIONS" ]; then
+  echo "template migration count mismatch: expected $EXPECTED_MIGRATIONS, got $MIGRATIONS" >&2
+  exit 1
+fi
+if [ "$LATEST_MIGRATION_VERSION" != "$EXPECTED_LATEST_MIGRATION_VERSION" ]; then
+  echo "template latest migration version mismatch: expected $EXPECTED_LATEST_MIGRATION_VERSION, got $LATEST_MIGRATION_VERSION" >&2
+  exit 1
+fi
+
+printf 'status=verified version=%s sha256=%s migrations=%s latest_migration_version=%s\n' \
+  "$VERSION" "$SHA256" "$MIGRATIONS" "$LATEST_MIGRATION_VERSION"


### PR DESCRIPTION
## Summary
- document template artifact signing custody, key rotation, replay/downgrade, and rollback policy
- install a template release verifier that checks signed template identity against release-note values
- extend packaged readiness coverage to exercise valid verification and stale identity rejection

## Tests
- tools/verify-template-release.sh builddir/wyrelog/wyrelogd templates/access 0 0ffe885e14222878f18fc1376adf2df32efeda66fab2e8437e320d7d6928b028 1 0
- stale SHA verification rejects with a template sha256 mismatch
- meson test -C builddir wyrelog:packaged-install-readiness wyrelog:template-tree wyrelog:wyrelogd-production-gates --print-errorlogs
- meson test -C builddir --suite wyrelog --print-errorlogs