### PR TITLE
[codex] stabilize packaged readiness CI smoke

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -215,6 +215,13 @@ if host_machine.system() != 'windows' and build_client
       python3.full_path(),
     ],
     depends : [wyctl_exe, wyrelogd_exe],
+    # This smoke test exercises the packaged template tree, production
+    # --check, credential KeyProvider setup, encrypted-store key rotation,
+    # and a live daemon readiness probe.  Keep it isolated from the heavier
+    # daemon/audit integration tests so CI runner contention does not trip
+    # Meson's default 30s timeout while still keeping a bounded deadline.
+    is_parallel : false,
+    timeout : 60,
   )
 
   test('client-audit-daemon', sh,


### PR DESCRIPTION
## Summary

- isolate the packaged install readiness smoke test from other Meson tests
- give the smoke test an explicit 60s deadline instead of relying on Meson's default 30s timeout
- document why this test needs isolation: it exercises package layout, production `--check`, credential KeyProvider setup, encrypted-store rotation, and live daemon readiness

## Root cause

The Ubuntu main CI failure was a timeout in `wyrelog:packaged-install-readiness`. The test had grown into a broader packaged smoke path and was running concurrently with heavier daemon/audit integration tests, so runner contention could push it past Meson's default 30s timeout. The timeout then killed the test and produced cleanup-related stderr from the temporary directory removal.

## Validation

- `meson test -C builddir wyrelog:packaged-install-readiness --print-errorlogs`
- `meson test -C builddir --suite wyrelog --print-errorlogs`
- `git diff --check`
