### PR TITLE
Enable Windows libsoup client CI coverage

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -99,10 +99,10 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
-          key: vcpkg-windows-v3-2026.04.27-x64-windows-glib-sqlite3-libsodium
+          key: vcpkg-windows-v4-2026.04.27-x64-windows-glib-sqlite3-libsodium-libsoup
           restore-keys: |
             vcpkg-windows-v3-2026.04.27-x64-windows-
-            vcpkg-windows-2026.04.27-glib-sqlite3-libsodium
+            vcpkg-windows-2026.04.27-glib-sqlite3-libsodium-libsoup
 
       - name: Restore vcpkg installed tree
         id: vcpkg-installed-cache
@@ -110,7 +110,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: ${{ env.VCPKG_ROOT }}\installed
-          key: vcpkg-windows-installed-v1-2026.04.27-x64-windows-glib-sqlite3-libsodium
+          key: vcpkg-windows-installed-v2-2026.04.27-x64-windows-glib-sqlite3-libsodium-libsoup
           restore-keys: |
             vcpkg-windows-installed-v1-2026.04.27-x64-windows-
 
@@ -135,7 +135,7 @@ jobs:
         shell: cmd
         run: |
           @echo off
-          "%VCPKG_ROOT%\vcpkg.exe" install glib:x64-windows sqlite3:x64-windows libsodium:x64-windows --x-abi-tools-use-exact-versions
+          "%VCPKG_ROOT%\vcpkg.exe" install glib:x64-windows sqlite3:x64-windows libsodium:x64-windows libsoup:x64-windows --x-abi-tools-use-exact-versions
 
       - name: Save vcpkg installed tree
         if: steps.vcpkg-installed-cache.outcome == 'success' && steps.vcpkg-installed-cache.outputs.cache-hit != 'true'
@@ -159,14 +159,20 @@ jobs:
           @echo off
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           set PKG_CONFIG_PATH=%VCPKG_INSTALLED_DIR%\lib\pkgconfig
+          set PATH=%VCPKG_INSTALLED_DIR%\bin;%PATH%
           set CC=clang-cl
-          meson setup builddir -Denable_tpm=disabled -Denable_client=disabled -Ddefault_library=static -Denable_audit=enabled -Dduckdb_source=prebuilt
+          meson setup builddir -Denable_tpm=disabled -Denable_client=enabled -Ddefault_library=static -Denable_audit=enabled -Dduckdb_source=prebuilt
 
       - name: Build and test (clang-cl)
         shell: cmd
         run: |
           @echo off
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          set PATH=%VCPKG_INSTALLED_DIR%\bin;%PATH%
+          meson compile -C builddir wyctl wyrelogd
+          if not exist builddir\wyrelog\wyctl.exe exit /b 1
+          builddir\wyrelog\wyctl.exe --help >NUL
+          builddir\wyrelog\wyrelogd.exe --help | findstr /C:"--listen-port"
           meson test -C builddir --print-errorlogs --suite wyrelog
 
       - name: Upload meson logs on failure

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -100,10 +100,10 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
-          key: vcpkg-windows-v3-2026.04.27-x64-windows-glib-sqlite3-libsodium
+          key: vcpkg-windows-v4-2026.04.27-x64-windows-glib-sqlite3-libsodium-libsoup
           restore-keys: |
             vcpkg-windows-v3-2026.04.27-x64-windows-
-            vcpkg-windows-2026.04.27-glib-sqlite3-libsodium
+            vcpkg-windows-2026.04.27-glib-sqlite3-libsodium-libsoup
 
       - name: Restore vcpkg installed tree
         id: vcpkg-installed-cache
@@ -111,7 +111,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: ${{ env.VCPKG_ROOT }}\installed
-          key: vcpkg-windows-installed-v1-2026.04.27-x64-windows-glib-sqlite3-libsodium
+          key: vcpkg-windows-installed-v2-2026.04.27-x64-windows-glib-sqlite3-libsodium-libsoup
           restore-keys: |
             vcpkg-windows-installed-v1-2026.04.27-x64-windows-
 
@@ -136,7 +136,7 @@ jobs:
         shell: cmd
         run: |
           @echo off
-          "%VCPKG_ROOT%\vcpkg.exe" install glib:x64-windows sqlite3:x64-windows libsodium:x64-windows --x-abi-tools-use-exact-versions
+          "%VCPKG_ROOT%\vcpkg.exe" install glib:x64-windows sqlite3:x64-windows libsodium:x64-windows libsoup:x64-windows --x-abi-tools-use-exact-versions
 
       - name: Save vcpkg binary packages
         if: steps.vcpkg-cache.outputs.cache-hit != 'true'
@@ -169,8 +169,9 @@ jobs:
           @echo off
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           set PKG_CONFIG_PATH=%VCPKG_INSTALLED_DIR%\lib\pkgconfig
+          set PATH=%VCPKG_INSTALLED_DIR%\bin;%PATH%
           set CC=clang-cl
-          meson setup builddir -Denable_tpm=disabled -Denable_client=disabled -Ddefault_library=static -Denable_audit=enabled -Dduckdb_source=prebuilt
+          meson setup builddir -Denable_tpm=disabled -Denable_client=enabled -Ddefault_library=static -Denable_audit=enabled -Dduckdb_source=prebuilt
 
       - name: Save meson packagecache
         if: steps.meson-packagecache.outputs.cache-hit != 'true'
@@ -185,6 +186,11 @@ jobs:
         run: |
           @echo off
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          set PATH=%VCPKG_INSTALLED_DIR%\bin;%PATH%
+          meson compile -C builddir wyctl wyrelogd
+          if not exist builddir\wyrelog\wyctl.exe exit /b 1
+          builddir\wyrelog\wyctl.exe --help >NUL
+          builddir\wyrelog\wyrelogd.exe --help | findstr /C:"--listen-port"
           meson test -C builddir --print-errorlogs --suite wyrelog
 
       - name: Upload meson logs on failure

--- a/meson.options
+++ b/meson.options
@@ -16,8 +16,8 @@ option('enable_client',
   description : 'Build the libwyrelog-client HTTP client library. Pulls '
               + 'in libsoup-3.0 as a hard dependency. Set to disabled to '
               + 'skip the client library entirely on platforms where '
-              + 'libsoup-3.0 is unavailable (notably native Windows MSVC '
-              + 'builds without vcpkg-staged libsoup); the server library '
+              + 'libsoup-3.0 is unavailable (for example native Windows MSVC '
+              + 'builds that have not staged vcpkg libsoup); the server library '
               + '(libwyrelog) and its tests still build under disabled.'
 )
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -152,7 +152,7 @@ test_client_audit_daemon = executable('test-client-audit-daemon',
   dependencies : [wyrelog_client_dep],
 )
 
-if build_client
+if build_client and host_machine.system() != 'windows'
   test_wyctl_basic = executable('test-wyctl-basic',
     'test-wyctl-basic.c',
     c_args : [


### PR DESCRIPTION
## Summary
- stage libsoup:x64-windows in Windows CI
- enable the Windows client/HTTP build path
- assert wyctl.exe exists and wyrelogd exposes --listen-port before tests

## Local validation
- meson setup builddir-libsoup-verify -Denable_tpm=disabled -Denable_client=enabled -Denable_audit=enabled -Dduckdb_source=prebuilt
- meson compile -C builddir-libsoup-verify wyctl wyrelogd
- builddir-libsoup-verify/wyrelog/wyrelogd --help | grep -- --listen-port
- meson test -C builddir-libsoup-verify --suite wyrelog client-smoke daemon-http-decide wyctl-basic wyctl-policy-daemon --print-errorlogs