### PR TITLE
Fix bootstrap admin first-token flow

### DIFF
--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -116,8 +116,9 @@ The flags are:
 - `--bootstrap-admin-subject=SUBJECT` records `SUBJECT` as the initial
   `wr.system_admin` role member on the default tenant.
 - `--bootstrap-admin-allow-skip-mfa` (optional) grants the same subject
-  the `wr.login.skip_mfa` direct permission so it can mint a first
-  bearer token through `/auth/login` before an IdP is wired in.
+  the `wr.login.skip_mfa` direct permission on the synthetic `login`
+  scope so it can mint a first bearer token through `/auth/login` before an
+  IdP is wired in.
 
 Both flags are honored only on the live runtime store and are rejected
 if combined with `--check` because readiness uses a scratch store that
@@ -196,7 +197,7 @@ wyctl.exe --daemon-url http://127.0.0.1:8765 audit query ^
   through `wyctl policy role-grant`.
 - `--bootstrap-admin-allow-skip-mfa` installs a **persisted**
   `wr.login.skip_mfa` direct-permission grant against the bootstrap
-  subject. The grant survives daemon restarts and the flag's
+  subject on the `login` scope. The grant survives daemon restarts and the flag's
   presence/absence on subsequent boots; the flag on later boots is a
   no-op once the seal exists. The grant must be revoked explicitly
   once the operator has rotated to an IdP-issued bearer (see
@@ -210,7 +211,7 @@ wyctl.exe --daemon-url http://127.0.0.1:8765 audit query ^
 
 The `--bootstrap-admin-allow-skip-mfa` flag installs a **persisted**
 `wr.login.skip_mfa` direct-permission grant against the bootstrap
-subject. The grant survives daemon restarts and the flag's
+subject on the `login` scope. The grant survives daemon restarts and the flag's
 presence/absence on subsequent boots, so it must be revoked
 explicitly once the operator has rotated to an IdP-issued bearer:
 
@@ -218,7 +219,7 @@ explicitly once the operator has rotated to an IdP-issued bearer:
 wyctl --daemon-url http://127.0.0.1:8765 policy permission-revoke \
     --subject <bootstrap-subject> \
     --perm wr.login.skip_mfa \
-    --scope __wr_default \
+    --scope login \
     --access-token-file /run/wyrelog/operator.token \
     --guard-timestamp $(date +%s) \
     --guard-loc-class internal_network \

--- a/tests/check-wyrelogd-bootstrap-admin.sh
+++ b/tests/check-wyrelogd-bootstrap-admin.sh
@@ -9,6 +9,8 @@
 #   1. fresh bootstrap on an empty store seals the marker and applies
 #      the wr.system_admin role membership and the
 #      wr.login.skip_mfa direct permission;
+#   1b. the bootstrapped admin can mint a first bearer token and use it
+#      through wyctl policy mutation;
 #   2. restart with the same subject is idempotent and the marker
 #      remains stable;
 #   3. restart with a different subject fails closed with a clear
@@ -152,6 +154,45 @@ if ! wait_until_serving "$PORT"; then
   cat "$LOG.err" >&2
   exit 1
 fi
+
+TOKEN_FILE="$TMPDIR/admin1.token"
+"$PYTHON" - "http://127.0.0.1:$PORT" "$TOKEN_FILE" <<'PY'
+import json
+import sys
+import urllib.error
+import urllib.request
+
+base_url = sys.argv[1]
+token_path = sys.argv[2]
+url = f"{base_url}/auth/login?username=admin1&skip_mfa=true"
+req = urllib.request.Request(url, method="POST")
+try:
+    with urllib.request.urlopen(req, timeout=3) as response:
+        body = json.load(response)
+except urllib.error.HTTPError as exc:
+    sys.stderr.write(f"bootstrap admin login failed: HTTP {exc.code}\n")
+    sys.stderr.write(exc.read().decode("utf-8", "replace"))
+    sys.stderr.write("\n")
+    raise SystemExit(1)
+
+token = body.get("access_token")
+if not token:
+    sys.stderr.write("bootstrap admin login response did not include access_token\n")
+    raise SystemExit(1)
+with open(token_path, "w", encoding="utf-8") as f:
+    f.write(token)
+    f.write("\n")
+PY
+
+"$WYCTL" --daemon-url "http://127.0.0.1:$PORT" policy permission-grant \
+  --subject "bootstrap-target" \
+  --perm "wr.stream.read" \
+  --scope "__wr_default" \
+  --access-token-file "$TOKEN_FILE" \
+  --guard-timestamp 123 \
+  --guard-loc-class public \
+  --guard-risk 29 >/dev/null
+
 stop_daemon
 
 if [ ! -e "$POLICY_DB" ]; then

--- a/tests/test-policy-store.c
+++ b/tests/test-policy-store.c
@@ -2925,6 +2925,26 @@ check_bootstrap_admin_applies_on_fresh_store (void)
   if (membership_count != 1)
     return 813;
 
+  gint default_scope_state_count = 0;
+  if (count_rows (store,
+          "SELECT COUNT(*) FROM session_states "
+          "WHERE session_id = '__wr_default' "
+          "  AND state = 'active';", &default_scope_state_count) != 0)
+    return 816;
+  if (default_scope_state_count != 1)
+    return 817;
+
+  gint default_scope_event_count = 0;
+  if (count_rows (store,
+          "SELECT COUNT(*) FROM session_events "
+          "WHERE session_id = '__wr_default' "
+          "  AND event = 'request' "
+          "  AND from_state = 'idle' "
+          "  AND to_state = 'active';", &default_scope_event_count) != 0)
+    return 818;
+  if (default_scope_event_count != 1)
+    return 819;
+
   gint skip_mfa_count = 0;
   if (count_rows (store,
           "SELECT COUNT(*) FROM direct_permissions "
@@ -3293,28 +3313,60 @@ check_bootstrap_admin_allow_skip_mfa_flag (void)
           "SELECT COUNT(*) FROM direct_permissions "
           "WHERE subject_id = 'alice.root' "
           "  AND perm_id = 'wr.login.skip_mfa' "
-          "  AND scope = '__wr_default';", &skip_mfa_count) != 0)
+          "  AND scope = 'login';", &skip_mfa_count) != 0)
     return 944;
   if (skip_mfa_count != 1)
     return 945;
 
+  gint skip_mfa_state_count = 0;
+  if (count_rows (store,
+          "SELECT COUNT(*) FROM permission_states "
+          "WHERE subject_id = 'alice.root' "
+          "  AND perm_id = 'wr.login.skip_mfa' "
+          "  AND scope = 'login' "
+          "  AND state = 'armed';", &skip_mfa_state_count) != 0)
+    return 946;
+  if (skip_mfa_state_count != 1)
+    return 947;
+
+  gint skip_mfa_state_event_count = 0;
+  if (count_rows (store,
+          "SELECT COUNT(*) FROM permission_state_events "
+          "WHERE subject_id = 'alice.root' "
+          "  AND perm_id = 'wr.login.skip_mfa' "
+          "  AND scope = 'login' "
+          "  AND event = 'grant' "
+          "  AND from_state = 'dormant' "
+          "  AND to_state = 'armed';", &skip_mfa_state_event_count) != 0)
+    return 948;
+  if (skip_mfa_state_event_count != 1)
+    return 949;
+
   /* Reapply with allow_login_skip_mfa = FALSE: idempotent no-op, the
-   * existing skip-mfa grant remains untouched. */
+   * existing skip-mfa grant and state remain untouched. */
   applied = TRUE;
   g_autofree gchar *existing2 = NULL;
   if (wyl_policy_store_apply_bootstrap_admin (store, "alice.root", FALSE,
           &applied, &existing2) != WYRELOG_E_OK)
-    return 946;
+    return 950;
   if (applied)
-    return 947;
+    return 951;
 
   if (count_rows (store,
           "SELECT COUNT(*) FROM direct_permissions "
           "WHERE subject_id = 'alice.root' "
           "  AND perm_id = 'wr.login.skip_mfa';", &skip_mfa_count) != 0)
-    return 948;
+    return 952;
   if (skip_mfa_count != 1)
-    return 949;
+    return 953;
+
+  if (count_rows (store,
+          "SELECT COUNT(*) FROM permission_states "
+          "WHERE subject_id = 'alice.root' "
+          "  AND perm_id = 'wr.login.skip_mfa';", &skip_mfa_state_count) != 0)
+    return 954;
+  if (skip_mfa_state_count != 1)
+    return 955;
 
   return 0;
 }

--- a/wyrelog/daemon/runtime.c
+++ b/wyrelog/daemon/runtime.c
@@ -413,6 +413,13 @@ wyl_daemon_run_runtime (const WylDaemonOptions *opts)
       return 1;
     }
 
+    wyrelog_error_t reload_rc = wyl_handle_reload_engine_pair (handle);
+    if (reload_rc != WYRELOG_E_OK) {
+      g_printerr ("wyrelogd: bootstrap_admin: reload failed: %s\n",
+          wyrelog_error_string (reload_rc));
+      return 1;
+    }
+
     wyrelog_error_t audit_rc = wyl_daemon_emit_bootstrap_admin_audit (handle,
         opts->bootstrap_admin_subject, applied);
     if (audit_rc != WYRELOG_E_OK) {
@@ -424,7 +431,8 @@ wyl_daemon_run_runtime (const WylDaemonOptions *opts)
     /* No process-wide skip-MFA override is needed: when
      * --bootstrap-admin-allow-skip-mfa is set, apply_bootstrap_admin
      * already grants the wr.login.skip_mfa direct permission to the
-     * bootstrap subject inside the same transaction. The engine's
+     * bootstrap subject inside the same transaction, and the engine
+     * pair is reloaded before HTTP handlers are exposed. The engine's
      * login_skip_mfa_authz relation will admit that subject (and only
      * that subject) without an in-process override that would otherwise
      * admit every caller for the lifetime of the boot. The audit row

--- a/wyrelog/policy/store-private.h
+++ b/wyrelog/policy/store-private.h
@@ -303,8 +303,10 @@ wyrelog_error_t wyl_policy_store_bootstrap_admin_eligible (wyl_policy_store_t *
 /* Performs the bootstrap. Inside a BEGIN IMMEDIATE transaction:
  *  - re-checks eligibility (race-safe second read)
  *  - grants role membership: subject -> 'wr.system_admin' on WYL_TENANT_DEFAULT
- *  - if allow_login_skip_mfa: grants direct permission
- *    subject + 'wr.login.skip_mfa' + WYL_TENANT_DEFAULT
+ *  - marks WYL_TENANT_DEFAULT active for policy decisions on the bootstrap
+ *    scope
+ *  - if allow_login_skip_mfa: grants and arms direct permission
+ *    subject + 'wr.login.skip_mfa' + 'login'
  *  - writes wyrelog_config rows:
  *      bootstrap_admin_subject       = <subject>
  *      bootstrap_admin_sealed_at_us  = <wallclock us>

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -137,6 +137,12 @@ static const BuiltinPermission builtin_permissions[] = {
   {"wr.audit.write", "audit write", "critical"},
 };
 
+/* Login skip-MFA authorization is intentionally scoped to the synthetic
+ * "login" resource rather than a tenant. Keep the bootstrap grant aligned
+ * with wyl-handle.c's WYL_LOGIN_SKIP_MFA_SCOPE so a freshly bootstrapped
+ * admin can mint its first bearer token through the normal login path. */
+#define WYL_BOOTSTRAP_LOGIN_SKIP_MFA_SCOPE "login"
+
 static const gchar *const required_tables[] = {
   "wyrelog_config",
   "tenants",
@@ -4469,16 +4475,40 @@ wyl_policy_store_apply_bootstrap_admin (wyl_policy_store_t *store,
     (void) exec_sql (store->db, "ROLLBACK;");
     return rc;
   }
+  rc = wyl_policy_store_set_session_state (store, WYL_TENANT_DEFAULT, "active");
+  if (rc != WYRELOG_E_OK) {
+    (void) exec_sql (store->db, "ROLLBACK;");
+    return rc;
+  }
+  rc = wyl_policy_store_append_session_event (store, WYL_TENANT_DEFAULT,
+      "request", "idle", "active", NULL);
+  if (rc != WYRELOG_E_OK) {
+    (void) exec_sql (store->db, "ROLLBACK;");
+    return rc;
+  }
 
   if (allow_login_skip_mfa) {
     rc = wyl_policy_store_grant_direct_permission (store, subject_id,
-        "wr.login.skip_mfa", WYL_TENANT_DEFAULT);
+        "wr.login.skip_mfa", WYL_BOOTSTRAP_LOGIN_SKIP_MFA_SCOPE);
     if (rc != WYRELOG_E_OK) {
       (void) exec_sql (store->db, "ROLLBACK;");
       return rc;
     }
     rc = wyl_policy_store_append_direct_permission_event (store, subject_id,
-        "wr.login.skip_mfa", WYL_TENANT_DEFAULT, "grant");
+        "wr.login.skip_mfa", WYL_BOOTSTRAP_LOGIN_SKIP_MFA_SCOPE, "grant");
+    if (rc != WYRELOG_E_OK) {
+      (void) exec_sql (store->db, "ROLLBACK;");
+      return rc;
+    }
+    rc = wyl_policy_store_set_permission_state (store, subject_id,
+        "wr.login.skip_mfa", WYL_BOOTSTRAP_LOGIN_SKIP_MFA_SCOPE, "armed");
+    if (rc != WYRELOG_E_OK) {
+      (void) exec_sql (store->db, "ROLLBACK;");
+      return rc;
+    }
+    rc = wyl_policy_store_append_permission_state_event (store, subject_id,
+        "wr.login.skip_mfa", WYL_BOOTSTRAP_LOGIN_SKIP_MFA_SCOPE, "grant",
+        "dormant", "armed", NULL);
     if (rc != WYRELOG_E_OK) {
       (void) exec_sql (store->db, "ROLLBACK;");
       return rc;


### PR DESCRIPTION
## Summary
- Fix the bootstrap admin skip-MFA grant to use the login authorization scope and arm the permission state.
- Mark the default bootstrap scope active and reload the engine pair before exposing HTTP handlers so the first token can authorize policy mutations.
- Extend the bootstrap-admin integration test to mint a bearer token and perform a `wyctl policy permission-grant`; update policy-store coverage and runbook revoke guidance.

## Root cause
The bootstrap helper persisted `wr.login.skip_mfa` on the default tenant scope, while the login path authorizes skip-MFA only on the synthetic `login` scope and requires the permission state to be `armed`. The daemon also needed to reload the policy engine after applying the bootstrap transaction so the HTTP login/mutation handlers see the new facts.

Fixes #305

## Tests
- `git diff --check`
- `meson compile -C builddir-305-check wyrelogd wyctl test-policy-store`
- `meson test -C builddir-305-check --print-errorlogs policy-store wyrelogd-bootstrap-admin`
- `meson test -C builddir-305-check --print-errorlogs session-username daemon-http-decide`
- `meson test -C builddir-305-check --print-errorlogs daemon-checks`
