### PR TITLE
Separate fact-store configuration from audit

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -18,7 +18,12 @@ sodium_dep = dependency('libsodium', required : true)
 sqlite_dep = dependency('sqlite3', required : true)
 tss2_esys_dep = dependency('tss2-esys', required : get_option('enable_tpm'))
 enable_audit_opt = get_option('enable_audit')
+enable_fact_store_opt = get_option('enable_fact_store')
 enable_break_glass_opt = get_option('enable_break_glass')
+if enable_fact_store_opt.allowed() and host_machine.system() == 'windows'
+  error('enable_fact_store requires Unix path isolation semantics; '
+      + 'disable enable_fact_store for native Windows builds.')
+endif
 if enable_break_glass_opt and not enable_audit_opt.allowed()
   # The break-glass override path emits an audit event with a stable
   # reason code on every arming and every override decision. Without
@@ -30,7 +35,7 @@ if enable_break_glass_opt and not enable_audit_opt.allowed()
       + '(auto or enabled); the override path needs a durable audit '
       + 'sink for reason-code emission.')
 endif
-if enable_audit_opt.allowed()
+if enable_audit_opt.allowed() or enable_fact_store_opt.allowed()
   duckdb_source = get_option('duckdb_source')
   if duckdb_source == 'prebuilt'
     if host_machine.system() == 'linux'

--- a/meson.options
+++ b/meson.options
@@ -40,11 +40,20 @@ option('enable_audit',
               + 'to opt in to the DuckDB-backed audit sink.'
 )
 
+option('enable_fact_store',
+  type : 'feature',
+  value : 'disabled',
+  description : 'Build the DuckDB-backed Datalog fact store foundation. '
+              + 'This is independent from the audit subsystem: builds with '
+              + 'enable_audit=disabled and enable_fact_store=enabled must '
+              + 'still make DuckDB available for fact storage.'
+)
+
 option('duckdb_source',
   type : 'combo',
   choices : ['prebuilt', 'subproject'],
   value : 'prebuilt',
-  description : 'How libduckdb is sourced when enable_audit is on. '
+  description : 'How libduckdb is sourced when audit or fact storage is on. '
               + '"prebuilt" downloads the upstream-published library '
               + 'binary for the host platform (fast: ~30 MB download '
               + 'and zero compile). "subproject" downloads the '

--- a/packaging/tmpfiles.d/wyrelog.conf
+++ b/packaging/tmpfiles.d/wyrelog.conf
@@ -4,6 +4,8 @@ d /etc/wyrelog/service 0750 root wyrelog -
 d /var/lib/wyrelog 0750 wyrelog wyrelog -
 d /var/lib/wyrelog/system 0750 wyrelog wyrelog -
 d /var/lib/wyrelog/service 0750 wyrelog wyrelog -
+d /var/lib/wyrelog/service/facts 0700 wyrelog wyrelog -
+d /var/lib/wyrelog/system/facts 0700 wyrelog wyrelog -
 d /var/lib/wyrelog/service/event-spool 0700 wyrelog wyrelog -
 d /var/log/wyrelog 0750 wyrelog wyrelog -
 d /var/log/wyrelog/system 0750 wyrelog wyrelog -

--- a/tests/check-packaged-install-readiness.sh
+++ b/tests/check-packaged-install-readiness.sh
@@ -68,6 +68,16 @@ if ! grep -q -- "--profile=service" \
   echo "service unit does not select the service profile" >&2
   exit 1
 fi
+if ! grep -q -- "/var/lib/wyrelog/system/facts" \
+    "$SOURCE_ROOT/packaging/tmpfiles.d/wyrelog.conf"; then
+  echo "tmpfiles does not create the system fact root" >&2
+  exit 1
+fi
+if ! grep -q -- "/var/lib/wyrelog/service/facts" \
+    "$SOURCE_ROOT/packaging/tmpfiles.d/wyrelog.conf"; then
+  echo "tmpfiles does not create the service fact root" >&2
+  exit 1
+fi
 if ! grep -q "WYL_LOG=warn" \
     "$SOURCE_ROOT/packaging/systemd/wyrelog.service"; then
   echo "service unit does not set production log ceiling" >&2
@@ -82,11 +92,15 @@ mkdir -p "$INSTALL_ROOT/usr/share/wyrelog" \
   "$INSTALL_ROOT/etc/wyrelog/service" \
   "$INSTALL_ROOT/var/lib/wyrelog" \
   "$INSTALL_ROOT/var/lib/wyrelog/system" \
+  "$INSTALL_ROOT/var/lib/wyrelog/system/facts" \
   "$INSTALL_ROOT/var/lib/wyrelog/service" \
+  "$INSTALL_ROOT/var/lib/wyrelog/service/facts" \
   "$INSTALL_ROOT/var/log/wyrelog" \
   "$INSTALL_ROOT/var/log/wyrelog/system" \
   "$INSTALL_ROOT/var/log/wyrelog/service" \
   "$INSTALL_ROOT/run/wyrelog"
+chmod 0700 "$INSTALL_ROOT/var/lib/wyrelog/system/facts" \
+  "$INSTALL_ROOT/var/lib/wyrelog/service/facts"
 cp -R "$TEMPLATE_DIR" "$INSTALL_ROOT/usr/share/wyrelog/access"
 cp "$SOURCE_ROOT/tools/verify-template-release.sh" \
   "$INSTALL_ROOT/usr/share/wyrelog/tools/verify-template-release.sh"
@@ -104,7 +118,13 @@ PY
 TEMPLATE_INSTALL="$INSTALL_ROOT/usr/share/wyrelog/access"
 POLICY_DB="$INSTALL_ROOT/var/lib/wyrelog/system/policy.sqlite"
 AUDIT_DB="$INSTALL_ROOT/var/log/wyrelog/system/audit.duckdb"
+FACT_ROOT="$INSTALL_ROOT/var/lib/wyrelog/system/facts"
 KEY="$INSTALL_ROOT/etc/wyrelog/system/policy.key"
+FACT_ARGS=
+if "$WYRELOGD" --profile=system --production --profile-info \
+    | grep -q '^fact_root=/var/lib/wyrelog/system/facts$'; then
+  FACT_ARGS="--fact-root $FACT_ROOT"
+fi
 BASE_URL="http://127.0.0.1:$PORT"
 
 "$WYCTL" key status --keyprovider "$KEY" >"$TMPDIR/key.out"
@@ -153,7 +173,12 @@ fi
   --policy-db "$POLICY_DB" \
   --policy-keyprovider "file:$KEY" \
   --audit-db "$AUDIT_DB" \
+  $FACT_ARGS \
   --check
+if [ -n "$FACT_ARGS" ]; then
+  printf 'fact-root-writable\n' >"$FACT_ROOT/.write-check"
+  test -s "$FACT_ROOT/.write-check"
+fi
 
 ROTATE_DB="$INSTALL_ROOT/var/lib/wyrelog/system/rotate.sqlite"
 ROTATE_AUDIT_DB="$INSTALL_ROOT/var/log/wyrelog/system/rotate-audit.duckdb"
@@ -172,6 +197,7 @@ PY
   --policy-db "$ROTATE_DB" \
   --policy-keyprovider "file:$KEY" \
   --audit-db "$ROTATE_AUDIT_DB" \
+  $FACT_ARGS \
   --check
 "$WYCTL" key rotate --store "$ROTATE_DB" \
   --from-keyprovider "file:$KEY" \
@@ -199,6 +225,7 @@ CREDENTIALS_DIRECTORY="$INSTALL_ROOT/etc/wyrelog/system" \
   --policy-db "$POLICY_DB.credential" \
   --policy-keyprovider systemd-creds:policy.key \
   --audit-db "$AUDIT_DB.credential" \
+  $FACT_ARGS \
   --check
 
 "$WYRELOGD" --production \
@@ -207,6 +234,7 @@ CREDENTIALS_DIRECTORY="$INSTALL_ROOT/etc/wyrelog/system" \
   --policy-db "$POLICY_DB" \
   --policy-keyprovider "file:$KEY" \
   --audit-db "$AUDIT_DB" \
+  $FACT_ARGS \
   --listen-port "$PORT" &
 PID=$!
 

--- a/tests/check-wyrelogd-production-gates.sh
+++ b/tests/check-wyrelogd-production-gates.sh
@@ -10,6 +10,12 @@ PYTHON=$3
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT INT TERM
 
+FACT_ARGS=
+if "$WYRELOGD" --profile=system --production --profile-info \
+    | grep -q '^fact_root=/var/lib/wyrelog/system/facts$'; then
+  FACT_ARGS="--fact-root $TMPDIR/facts"
+fi
+
 "$PYTHON" - "$TEMPLATE_DIR" "$TMPDIR/access-no-manifest" <<'PY'
 import pathlib
 import shutil
@@ -25,13 +31,15 @@ PY
   --policy-db "$TMPDIR/nonprod.sqlite" --check
 
 if "$WYRELOGD" --production --template-dir "$TMPDIR/access-no-manifest" \
-    --policy-db "$TMPDIR/prod-missing-manifest.sqlite" --check; then
+    --policy-db "$TMPDIR/prod-missing-manifest.sqlite" \
+    $FACT_ARGS --check; then
   echo "production mode accepted templates without a manifest" >&2
   exit 1
 fi
 
 if "$WYRELOGD" --production --template-dir "$TEMPLATE_DIR" \
-    --policy-db "$TMPDIR/prod-dev-keyprovider.sqlite" --check; then
+    --policy-db "$TMPDIR/prod-dev-keyprovider.sqlite" \
+    $FACT_ARGS --check; then
   echo "production mode accepted the development KeyProvider" >&2
   exit 1
 fi
@@ -46,11 +54,13 @@ PY
 
 "$WYRELOGD" --production --template-dir "$TEMPLATE_DIR" \
   --policy-db "$TMPDIR/prod.sqlite" \
-  --policy-keyprovider "$TMPDIR/prod.key" --check
+  --policy-keyprovider "$TMPDIR/prod.key" \
+  $FACT_ARGS --check
 
 if CREDENTIALS_DIRECTORY= "$WYRELOGD" --production --template-dir "$TEMPLATE_DIR" \
     --policy-db "$TMPDIR/prod-missing-creds.sqlite" \
-    --policy-keyprovider systemd-creds:prod.key --check; then
+    --policy-keyprovider systemd-creds:prod.key \
+    $FACT_ARGS --check; then
   echo "production mode accepted unavailable systemd credentials" >&2
   exit 1
 fi
@@ -58,4 +68,5 @@ fi
 CREDENTIALS_DIRECTORY="$TMPDIR" "$WYRELOGD" --production \
   --template-dir "$TEMPLATE_DIR" \
   --policy-db "$TMPDIR/prod-systemd-creds.sqlite" \
-  --policy-keyprovider systemd-creds:prod.key --check
+  --policy-keyprovider systemd-creds:prod.key \
+  $FACT_ARGS --check

--- a/tests/check-wyrelogd-profiles.sh
+++ b/tests/check-wyrelogd-profiles.sh
@@ -19,6 +19,21 @@ for raw in sys.argv[1:]:
     pathlib.Path(raw).write_bytes(os.urandom(32))
 PY
 
+FACT_ARGS=
+FACT_SYSTEM_ARGS=
+FACT_SERVICE_ARGS=
+if "$WYRELOGD" --profile=system --production --profile-info \
+    | grep -q '^fact_root=/var/lib/wyrelog/system/facts$'; then
+  FACT_ARGS=1
+  FACT_SYSTEM_ARGS="--fact-root $TMPDIR/system/facts"
+  FACT_SERVICE_ARGS="--fact-root $TMPDIR/service/facts"
+else
+  "$WYRELOGD" --profile=system --production --profile-info \
+    >"$TMPDIR/profile-system-no-fact.out"
+  grep -q '^fact_root=$' "$TMPDIR/profile-system-no-fact.out"
+  grep -q '^fact_store_mode=$' "$TMPDIR/profile-system-no-fact.out"
+fi
+
 if "$WYRELOGD" --profile=nope --check >/dev/null 2>"$TMPDIR/bad.err"; then
   echo "invalid profile was accepted" >&2
   exit 1
@@ -34,6 +49,7 @@ fi
   --policy-db "$TMPDIR/system/policy.sqlite" \
   --policy-keyprovider "$TMPDIR/system.key" \
   --audit-db "$TMPDIR/system/audit.duckdb" \
+  $FACT_SYSTEM_ARGS \
   --check
 
 "$WYRELOGD" --production --profile=service \
@@ -41,6 +57,7 @@ fi
   --policy-db "$TMPDIR/service/policy.sqlite" \
   --policy-keyprovider "$TMPDIR/service.key" \
   --audit-db "$TMPDIR/service/audit.duckdb" \
+  $FACT_SERVICE_ARGS \
   --system-url "http://127.0.0.1:1" \
   --event-spool-dir "$TMPDIR/service/event-spool" \
   --event-queue-limit 8 \
@@ -48,6 +65,10 @@ fi
 
 if [ ! -d "$TMPDIR/service/event-spool" ]; then
   echo "service profile did not create the event spool" >&2
+  exit 1
+fi
+if [ -n "$FACT_ARGS" ] && [ ! -d "$TMPDIR/service/facts" ]; then
+  echo "service profile did not create the fact root" >&2
   exit 1
 fi
 
@@ -207,6 +228,8 @@ template_dir=$TEMPLATE_DIR
 policy_db=$TMPDIR/config/policy.sqlite
 policy_keyprovider=$TMPDIR/service.key
 audit_db=$TMPDIR/config/audit.duckdb
+fact_root=$TMPDIR/config/facts
+fact_store_mode=per-tenant-graph
 system_url=http://127.0.0.1:8765
 event_spool_dir=$TMPDIR/config/event-spool
 event_queue_limit=9
@@ -218,6 +241,139 @@ EOF
   >"$TMPDIR/profile.out"
 grep -q '^profile=service$' "$TMPDIR/profile.out"
 grep -q "^policy_db=$TMPDIR/config/policy.sqlite$" "$TMPDIR/profile.out"
+grep -q "^fact_root=$TMPDIR/config/facts$" "$TMPDIR/profile.out"
+grep -q '^fact_store_mode=per-tenant-graph$' "$TMPDIR/profile.out"
 grep -q "^event_spool_dir=$TMPDIR/config/event-spool$" "$TMPDIR/profile.out"
 grep -q '^event_queue_limit=9$' "$TMPDIR/profile.out"
 grep -q '^listen_port=9876$' "$TMPDIR/profile.out"
+
+if [ -n "$FACT_ARGS" ]; then
+  "$WYRELOGD" --production --profile=system --profile-info \
+    >"$TMPDIR/profile-system-default.out"
+  grep -q '^fact_root=/var/lib/wyrelog/system/facts$' \
+    "$TMPDIR/profile-system-default.out"
+  "$WYRELOGD" --production --profile=service --profile-info \
+    >"$TMPDIR/profile-service-default.out"
+  grep -q '^fact_root=/var/lib/wyrelog/service/facts$' \
+    "$TMPDIR/profile-service-default.out"
+
+  if "$WYRELOGD" --production --profile=system \
+      --template-dir "$TEMPLATE_DIR" \
+      --policy-db "$TMPDIR/conflict/policy.sqlite" \
+      --policy-keyprovider "$TMPDIR/system.key" \
+      --audit-db "$TMPDIR/conflict/audit.duckdb" \
+      --fact-root "$TMPDIR/conflict" \
+      --check >/dev/null 2>"$TMPDIR/fact-policy-conflict.err"; then
+    echo "fact root containing policy database was accepted" >&2
+    exit 1
+  fi
+  grep -q "fact root must be distinct from the policy database path" \
+    "$TMPDIR/fact-policy-conflict.err"
+
+  if "$WYRELOGD" --production --profile=system \
+      --template-dir "$TEMPLATE_DIR" \
+      --policy-db "$TMPDIR/policy-file" \
+      --policy-keyprovider "$TMPDIR/system.key" \
+      --audit-db "$TMPDIR/audit.duckdb" \
+      --fact-root "$TMPDIR/policy-file/facts" \
+      --check >/dev/null 2>"$TMPDIR/fact-under-policy-conflict.err"; then
+    echo "fact root under policy database path was accepted" >&2
+    exit 1
+  fi
+  grep -q "fact root must be distinct from the policy database path" \
+    "$TMPDIR/fact-under-policy-conflict.err"
+
+  if "$WYRELOGD" --production --profile=system \
+      --template-dir "$TEMPLATE_DIR" \
+      --policy-db "$TMPDIR/policy.sqlite" \
+      --policy-keyprovider "$TMPDIR/system.key" \
+      --audit-db "$TMPDIR/audit-file" \
+      --fact-root "$TMPDIR/audit-file/facts" \
+      --check >/dev/null 2>"$TMPDIR/fact-under-audit-conflict.err"; then
+    echo "fact root under audit database path was accepted" >&2
+    exit 1
+  fi
+  grep -q "fact root must be distinct from the audit database path" \
+    "$TMPDIR/fact-under-audit-conflict.err"
+
+  mkdir -p "$TMPDIR/policy-real" "$TMPDIR/audit-real" "$TMPDIR/spool-real"
+  ln -s "$TMPDIR/policy-real" "$TMPDIR/policy-link"
+  ln -s "$TMPDIR/audit-real" "$TMPDIR/audit-link"
+  ln -s "$TMPDIR/spool-real" "$TMPDIR/spool-link"
+
+  if "$WYRELOGD" --production --profile=system \
+      --template-dir "$TEMPLATE_DIR" \
+      --policy-db "$TMPDIR/policy-real/policy.sqlite" \
+      --policy-keyprovider "$TMPDIR/system.key" \
+      --audit-db "$TMPDIR/audit.duckdb" \
+      --fact-root "$TMPDIR/policy-link" \
+      --check >/dev/null 2>"$TMPDIR/fact-policy-symlink-conflict.err"; then
+    echo "fact root aliasing the policy database tree was accepted" >&2
+    exit 1
+  fi
+  grep -q "fact root must be distinct from the policy database path" \
+    "$TMPDIR/fact-policy-symlink-conflict.err"
+
+  if "$WYRELOGD" --production --profile=system \
+      --template-dir "$TEMPLATE_DIR" \
+      --policy-db "$TMPDIR/policy.sqlite" \
+      --policy-keyprovider "$TMPDIR/system.key" \
+      --audit-db "$TMPDIR/audit-real/audit.duckdb" \
+      --fact-root "$TMPDIR/audit-link" \
+      --check >/dev/null 2>"$TMPDIR/fact-audit-symlink-conflict.err"; then
+    echo "fact root aliasing the audit database tree was accepted" >&2
+    exit 1
+  fi
+  grep -q "fact root must be distinct from the audit database path" \
+    "$TMPDIR/fact-audit-symlink-conflict.err"
+
+  if "$WYRELOGD" --profile=service \
+      --event-spool-dir "$TMPDIR/same-tree" \
+      --fact-root "$TMPDIR/same-tree" \
+      --check >/dev/null 2>"$TMPDIR/fact-spool-conflict.err"; then
+    echo "fact root matching event spool was accepted" >&2
+    exit 1
+  fi
+  grep -q "fact root must be distinct from the service event spool" \
+    "$TMPDIR/fact-spool-conflict.err"
+
+  if "$WYRELOGD" --profile=service \
+      --event-spool-dir "$TMPDIR/spool-real" \
+      --fact-root "$TMPDIR/spool-link" \
+      --check >/dev/null 2>"$TMPDIR/fact-spool-symlink-conflict.err"; then
+    echo "fact root aliasing the service event spool was accepted" >&2
+    exit 1
+  fi
+  grep -q "fact root must be distinct from the service event spool" \
+    "$TMPDIR/fact-spool-symlink-conflict.err"
+
+  mkdir -p "$TMPDIR/open-facts"
+  chmod 0755 "$TMPDIR/open-facts"
+  if "$WYRELOGD" --production --profile=system \
+      --template-dir "$TEMPLATE_DIR" \
+      --policy-db "$TMPDIR/open-policy.sqlite" \
+      --policy-keyprovider "$TMPDIR/system.key" \
+      --audit-db "$TMPDIR/open-audit.duckdb" \
+      --fact-root "$TMPDIR/open-facts" \
+      --check >/dev/null 2>"$TMPDIR/fact-open-permissions.err"; then
+    echo "group-or-other-accessible fact root was accepted" >&2
+    exit 1
+  fi
+  grep -q "fact root must not be accessible by group or other users" \
+    "$TMPDIR/fact-open-permissions.err"
+
+  mkdir -p "$TMPDIR/no-write-facts"
+  chmod 0500 "$TMPDIR/no-write-facts"
+  if "$WYRELOGD" --production --profile=system \
+      --template-dir "$TEMPLATE_DIR" \
+      --policy-db "$TMPDIR/no-write-policy.sqlite" \
+      --policy-keyprovider "$TMPDIR/system.key" \
+      --audit-db "$TMPDIR/no-write-audit.duckdb" \
+      --fact-root "$TMPDIR/no-write-facts" \
+      --check >/dev/null 2>"$TMPDIR/fact-owner-permissions.err"; then
+    echo "owner-unwritable fact root was accepted" >&2
+    exit 1
+  fi
+  grep -q "fact root must be readable, writable, and searchable by owner" \
+    "$TMPDIR/fact-owner-permissions.err"
+fi

--- a/wyrelog/daemon/options.c
+++ b/wyrelog/daemon/options.c
@@ -1,7 +1,13 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+#if defined(__unix__) || defined(__APPLE__)
+#define _XOPEN_SOURCE 700
+#endif
 #include "daemon/options.h"
 
 #include <errno.h>
+#ifdef G_OS_UNIX
+#include <stdlib.h>
+#endif
 #include <string.h>
 
 #define WYL_DAEMON_DEFAULT_EVENT_QUEUE_LIMIT 1024
@@ -54,6 +60,59 @@ parse_uint_arg (const gchar *value, guint min_value, guint max_value,
   return TRUE;
 }
 
+static gchar *
+path_resolve_existing_prefix (const gchar *path)
+{
+  g_autofree gchar *canon_path = g_canonicalize_filename (path, NULL);
+#ifdef G_OS_UNIX
+  g_autofree gchar *probe = g_strdup (canon_path);
+  g_autoptr (GString) suffix = g_string_new (NULL);
+
+  while (TRUE) {
+    gchar *resolved = realpath (probe, NULL);
+    if (resolved != NULL) {
+      if (suffix->len == 0)
+        return resolved;
+
+      g_autofree gchar *resolved_owner = resolved;
+      return g_build_filename (resolved_owner, suffix->str, NULL);
+    }
+
+    if (g_strcmp0 (probe, G_DIR_SEPARATOR_S) == 0)
+      return g_strdup (canon_path);
+
+    g_autofree gchar *basename = g_path_get_basename (probe);
+    g_autofree gchar *dirname = g_path_get_dirname (probe);
+    if (suffix->len == 0) {
+      g_string_assign (suffix, basename);
+    } else {
+      g_string_prepend_c (suffix, G_DIR_SEPARATOR);
+      g_string_prepend (suffix, basename);
+    }
+    g_free (probe);
+    probe = g_steal_pointer (&dirname);
+  }
+#else
+  return g_steal_pointer (&canon_path);
+#endif
+}
+
+static gboolean
+path_equal_or_contains (const gchar *root, const gchar *path)
+{
+  if (root == NULL || root[0] == '\0' || path == NULL || path[0] == '\0')
+    return FALSE;
+
+  g_autofree gchar *canon_root = path_resolve_existing_prefix (root);
+  g_autofree gchar *canon_path = path_resolve_existing_prefix (path);
+  if (g_strcmp0 (canon_root, canon_path) == 0)
+    return TRUE;
+
+  g_autofree gchar *root_prefix =
+      g_strconcat (canon_root, G_DIR_SEPARATOR_S, NULL);
+  return g_str_has_prefix (canon_path, root_prefix);
+}
+
 static void
 keyfile_take_string (GKeyFile *key_file, const gchar *key, const gchar **target)
 {
@@ -91,6 +150,8 @@ load_config_defaults (WylDaemonOptions *opts, GKeyFile *key_file)
   keyfile_take_string (key_file, "policy_keyprovider",
       &opts->policy_keyprovider_path);
   keyfile_take_string (key_file, "audit_db", &opts->audit_store_path);
+  keyfile_take_string (key_file, "fact_root", &opts->fact_root);
+  keyfile_take_string (key_file, "fact_store_mode", &opts->fact_store_mode);
   keyfile_take_string (key_file, "event_spool_dir", &opts->event_spool_dir);
   keyfile_take_string (key_file, "system_url", &opts->system_url);
   keyfile_take_owned_string (key_file, "listen_port", &opts->listen_port_arg);
@@ -140,6 +201,15 @@ default_audit_path (WylDaemonProfile profile)
       "/var/log/wyrelog/system/audit.duckdb";
 }
 
+#ifdef WYL_HAS_FACT_STORE
+static const gchar *
+default_fact_root (WylDaemonProfile profile)
+{
+  return profile == WYL_DAEMON_PROFILE_SERVICE ?
+      "/var/lib/wyrelog/service/facts" : "/var/lib/wyrelog/system/facts";
+}
+#endif
+
 static const gchar *
 default_spool_dir (WylDaemonProfile profile)
 {
@@ -165,6 +235,11 @@ wyl_daemon_parse_options (gint *argc, gchar ***argv, WylDaemonOptions *opts,
         "Policy KeyProvider spec: systemd-creds:NAME or file:PATH", "SPEC"},
     {"audit-db", 0, 0, G_OPTION_ARG_STRING, &opts->audit_store_path,
         "Runtime audit sink database path", "PATH"},
+    {"fact-root", 0, 0, G_OPTION_ARG_STRING, &opts->fact_root,
+        "Datalog fact store root directory", "DIR"},
+    {"fact-store-mode", 0, 0, G_OPTION_ARG_STRING,
+          &opts->fact_store_mode,
+        "Datalog fact store layout mode: per-tenant-graph", "MODE"},
     {"system-url", 0, 0, G_OPTION_ARG_STRING, &opts->system_url,
           "System-profile daemon URL for service-profile event forwarding",
         "URL"},
@@ -259,12 +334,47 @@ wyl_daemon_options_resolve (WylDaemonOptions *opts, GError **error)
       opts->policy_keyprovider_path = default_keyprovider_path (opts->profile);
     if (opts->audit_store_path == NULL)
       opts->audit_store_path = default_audit_path (opts->profile);
+#ifdef WYL_HAS_FACT_STORE
+    if (opts->fact_root == NULL)
+      opts->fact_root = default_fact_root (opts->profile);
+#endif
+  }
+
+  if (opts->fact_store_mode == NULL &&
+      (opts->fact_root != NULL && opts->fact_root[0] != '\0'))
+    opts->fact_store_mode = "per-tenant-graph";
+  if (opts->fact_store_mode != NULL &&
+      g_strcmp0 (opts->fact_store_mode, "per-tenant-graph") != 0) {
+    g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_BAD_VALUE,
+        "fact store mode must be per-tenant-graph");
+    return FALSE;
+  }
+
+  if (opts->fact_root != NULL && opts->fact_root[0] != '\0') {
+    if (path_equal_or_contains (opts->fact_root, opts->policy_store_path) ||
+        path_equal_or_contains (opts->policy_store_path, opts->fact_root)) {
+      g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_BAD_VALUE,
+          "fact root must be distinct from the policy database path");
+      return FALSE;
+    }
+    if (path_equal_or_contains (opts->fact_root, opts->audit_store_path) ||
+        path_equal_or_contains (opts->audit_store_path, opts->fact_root)) {
+      g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_BAD_VALUE,
+          "fact root must be distinct from the audit database path");
+      return FALSE;
+    }
   }
 
   if (opts->profile == WYL_DAEMON_PROFILE_SERVICE) {
     if ((opts->production_mode || opts->show_profile_info) &&
         opts->event_spool_dir == NULL)
       opts->event_spool_dir = default_spool_dir (opts->profile);
+    if (path_equal_or_contains (opts->fact_root, opts->event_spool_dir) ||
+        path_equal_or_contains (opts->event_spool_dir, opts->fact_root)) {
+      g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_BAD_VALUE,
+          "fact root must be distinct from the service event spool");
+      return FALSE;
+    }
   } else if (opts->system_url != NULL && opts->system_url[0] != '\0') {
     g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_BAD_VALUE,
         "system-url is only valid for the service profile");

--- a/wyrelog/daemon/options.h
+++ b/wyrelog/daemon/options.h
@@ -18,6 +18,8 @@ typedef struct
   const gchar *policy_store_path;
   const gchar *policy_keyprovider_path;
   const gchar *audit_store_path;
+  const gchar *fact_root;
+  const gchar *fact_store_mode;
   const gchar *event_spool_dir;
   const gchar *system_url;
   gchar *listen_port_arg;

--- a/wyrelog/daemon/runtime.c
+++ b/wyrelog/daemon/runtime.c
@@ -2,6 +2,7 @@
 #include "daemon/runtime.h"
 
 #include <errno.h>
+#include <sys/stat.h>
 
 #include <glib.h>
 #include <glib/gstdio.h>
@@ -38,6 +39,49 @@ count_service_profile_spool_events (const WylDaemonOptions *opts,
       (*out_pending)++;
   }
   return TRUE;
+}
+
+static gboolean
+prepare_fact_root (const WylDaemonOptions *opts, GError **error)
+{
+  if (opts->fact_root == NULL || opts->fact_root[0] == '\0')
+    return TRUE;
+
+#ifdef WYL_HAS_FACT_STORE
+  struct stat fact_root_stat;
+  if (g_mkdir_with_parents (opts->fact_root, 0700) != 0) {
+    g_set_error (error, G_FILE_ERROR, g_file_error_from_errno (errno),
+        "failed to create fact root directory: %s", opts->fact_root);
+    return FALSE;
+  }
+  if (!g_file_test (opts->fact_root, G_FILE_TEST_IS_DIR)) {
+    g_set_error (error, G_FILE_ERROR, G_FILE_ERROR_NOTDIR,
+        "fact root is not a directory: %s", opts->fact_root);
+    return FALSE;
+  }
+  if (g_stat (opts->fact_root, &fact_root_stat) != 0) {
+    g_set_error (error, G_FILE_ERROR, g_file_error_from_errno (errno),
+        "failed to stat fact root directory: %s", opts->fact_root);
+    return FALSE;
+  }
+  if ((fact_root_stat.st_mode & 077) != 0) {
+    g_set_error (error, G_FILE_ERROR, G_FILE_ERROR_ACCES,
+        "fact root must not be accessible by group or other users: %s",
+        opts->fact_root);
+    return FALSE;
+  }
+  if ((fact_root_stat.st_mode & 0700) != 0700) {
+    g_set_error (error, G_FILE_ERROR, G_FILE_ERROR_ACCES,
+        "fact root must be readable, writable, and searchable by owner: %s",
+        opts->fact_root);
+    return FALSE;
+  }
+  return TRUE;
+#else
+  g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_BAD_VALUE,
+      "fact store support is not built in");
+  return FALSE;
+#endif
 }
 
 static gboolean
@@ -335,6 +379,11 @@ wyl_daemon_run_runtime (const WylDaemonOptions *opts)
   if (bootstrap_admin_requested (opts) && !audit_subsystem_enabled (opts)) {
     g_printerr ("wyrelogd: --bootstrap-admin-subject requires the audit "
         "subsystem.\n");
+    return 1;
+  }
+
+  if (!prepare_fact_root (opts, &error)) {
+    g_printerr ("wyrelogd: fact store setup failed: %s\n", error->message);
     return 1;
   }
 

--- a/wyrelog/daemon/wyrelogd.c
+++ b/wyrelog/daemon/wyrelogd.c
@@ -93,6 +93,10 @@ main (int argc, char **argv)
         "");
     g_print ("audit_db=%s\n",
         opts.audit_store_path != NULL ? opts.audit_store_path : "");
+    g_print ("fact_root=%s\n", opts.fact_root != NULL ? opts.fact_root : "");
+    g_print ("fact_store_mode=%s\n",
+        (opts.fact_root != NULL && opts.fact_root[0] != '\0' &&
+            opts.fact_store_mode != NULL) ? opts.fact_store_mode : "");
     g_print ("listen_port=%d\n", opts.listen_port);
     g_print ("system_url=%s\n", opts.system_url != NULL ? opts.system_url : "");
     g_print ("event_spool_dir=%s\n",

--- a/wyrelog/meson.build
+++ b/wyrelog/meson.build
@@ -69,6 +69,11 @@ if get_option('enable_audit').allowed()
   wyrelog_sources += files('audit/conn.c')
   wyrelog_deps += duckdb_dep
   wyrelog_c_args += '-DWYL_HAS_AUDIT'
+elif get_option('enable_fact_store').allowed()
+  wyrelog_deps += duckdb_dep
+endif
+if get_option('enable_fact_store').allowed()
+  wyrelog_c_args += '-DWYL_HAS_FACT_STORE'
 endif
 if get_option('require_template_manifest')
   wyrelog_c_args += '-DWYL_REQUIRE_TEMPLATE_MANIFEST'
@@ -145,6 +150,11 @@ endif
 if get_option('enable_audit').allowed()
   wyrelogd_deps += duckdb_dep
   wyrelogd_c_args += '-DWYL_HAS_AUDIT'
+elif get_option('enable_fact_store').allowed()
+  wyrelogd_deps += duckdb_dep
+endif
+if get_option('enable_fact_store').allowed()
+  wyrelogd_c_args += '-DWYL_HAS_FACT_STORE'
 endif
 if get_option('enable_break_glass')
   wyrelogd_c_args += '-DWYL_HAS_BREAK_GLASS'


### PR DESCRIPTION
## Summary
- Add an independent fact-store build option with DuckDB wiring separate from audit.
- Add profile/runtime fact-root configuration with path isolation and private permissions.
- Extend production, profile, and packaged-readiness checks for fact-root privacy and writability.

## Validation
- `meson test -C builddir-issue50-default --print-errorlogs --suite wyrelog wyrelogd-profiles packaged-install-readiness wyrelogd-production-gates`
- `meson test -C builddir-issue50-fact --print-errorlogs --suite wyrelog wyrelogd-profiles packaged-install-readiness wyrelogd-production-gates`
- Reviewer, architect, and critic verification completed with no blockers.
