### PR TITLE
Validate relation schemas before fact append

### DIFF
--- a/templates/access/sqlite-schema.sql
+++ b/templates/access/sqlite-schema.sql
@@ -438,6 +438,98 @@ CREATE TABLE IF NOT EXISTS fact_graph_query_allowlist (
 );
 
 -- ---------------------------------------------------------------------------
+-- Table: fact_namespaces
+-- Tenant/graph-scoped customer namespace registry. Reserved namespaces are
+-- rejected by store-side validators. No fact rows live here.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS fact_namespaces (
+    tenant_id    TEXT    NOT NULL,
+    graph_id     TEXT    NOT NULL,
+    namespace_id TEXT    NOT NULL,
+    visibility   INTEGER NOT NULL DEFAULT 1 CHECK (visibility IN (0, 1)),
+    created_at   INTEGER NOT NULL,
+    updated_at   INTEGER NOT NULL,
+    PRIMARY KEY (tenant_id, graph_id, namespace_id),
+    FOREIGN KEY (tenant_id, graph_id)
+        REFERENCES fact_graphs (tenant_id, graph_id)
+        ON DELETE CASCADE
+);
+
+-- ---------------------------------------------------------------------------
+-- Table: fact_relation_schemas
+-- Immutable relation schema metadata keyed by tenant, graph, namespace,
+-- relation, and relation schema version.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS fact_relation_schemas (
+    tenant_id        TEXT    NOT NULL,
+    graph_id         TEXT    NOT NULL,
+    namespace_id     TEXT    NOT NULL,
+    relation_name    TEXT    NOT NULL,
+    schema_version   INTEGER NOT NULL CHECK (schema_version > 0),
+    arity            INTEGER NOT NULL CHECK (arity > 0),
+    relation_visible INTEGER NOT NULL DEFAULT 1 CHECK
+        (relation_visible IN (0, 1)),
+    created_at       INTEGER NOT NULL,
+    updated_at       INTEGER NOT NULL,
+    PRIMARY KEY (tenant_id, graph_id, namespace_id, relation_name,
+        schema_version),
+    FOREIGN KEY (tenant_id, graph_id, namespace_id)
+        REFERENCES fact_namespaces (tenant_id, graph_id, namespace_id)
+        ON DELETE CASCADE
+);
+
+-- ---------------------------------------------------------------------------
+-- Table: fact_relation_schema_columns
+-- Ordered typed column metadata for validating fact batches before append.
+-- compound_ref names a durable logical marker; raw evaluator handles are not
+-- stored in policy SQLite.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS fact_relation_schema_columns (
+    tenant_id      TEXT    NOT NULL,
+    graph_id       TEXT    NOT NULL,
+    namespace_id   TEXT    NOT NULL,
+    relation_name  TEXT    NOT NULL,
+    schema_version INTEGER NOT NULL CHECK (schema_version > 0),
+    column_index   INTEGER NOT NULL CHECK (column_index >= 0),
+    column_name    TEXT    NOT NULL,
+    column_type    TEXT    NOT NULL CHECK
+        (column_type IN ('symbol', 'string', 'int64', 'bool',
+            'compound_ref')),
+    nullable       INTEGER NOT NULL DEFAULT 0 CHECK (nullable IN (0, 1)),
+    visible        INTEGER NOT NULL DEFAULT 1 CHECK (visible IN (0, 1)),
+    PRIMARY KEY (tenant_id, graph_id, namespace_id, relation_name,
+        schema_version, column_index),
+    UNIQUE (tenant_id, graph_id, namespace_id, relation_name, schema_version,
+        column_name),
+    FOREIGN KEY (tenant_id, graph_id, namespace_id, relation_name,
+        schema_version)
+        REFERENCES fact_relation_schemas (tenant_id, graph_id, namespace_id,
+            relation_name, schema_version)
+        ON DELETE CASCADE
+);
+
+-- ---------------------------------------------------------------------------
+-- Table: fact_relation_query_allowlist
+-- Query metadata tied to an exact relation schema version.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS fact_relation_query_allowlist (
+    tenant_id              TEXT    NOT NULL,
+    graph_id               TEXT    NOT NULL,
+    namespace_id           TEXT    NOT NULL,
+    relation_name          TEXT    NOT NULL,
+    schema_version         INTEGER NOT NULL CHECK (schema_version > 0),
+    query_name             TEXT    NOT NULL,
+    required_permission_id TEXT    NOT NULL,
+    max_rows               INTEGER NOT NULL CHECK (max_rows > 0),
+    PRIMARY KEY (tenant_id, graph_id, query_name),
+    FOREIGN KEY (tenant_id, graph_id, namespace_id, relation_name,
+        schema_version)
+        REFERENCES fact_relation_schemas (tenant_id, graph_id, namespace_id,
+            relation_name, schema_version),
+    FOREIGN KEY (required_permission_id) REFERENCES permissions (perm_id)
+);
+
+-- ---------------------------------------------------------------------------
 -- Table: policy_signatures
 -- Ed25519 signatures over policy snapshots, authored by security_officer.
 -- Each policy version is immutably signed; versions are monotonically

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -268,6 +268,14 @@ test('policy-store', test_policy_store,
   timeout : 90,
 )
 
+test_fact_schema = executable('test-fact-schema',
+  'test-fact-schema.c',
+  include_directories : include_directories('../wyrelog'),
+  dependencies : [wyrelog_dep, sqlite_dep],
+)
+
+test('fact-schema', test_fact_schema)
+
 test_policy_store_toctou = executable('test-policy-store-toctou',
   'test-policy-store-toctou.c',
   dependencies : [wyrelog_dep, sqlite_dep, sodium_dep],

--- a/tests/test-fact-schema.c
+++ b/tests/test-fact-schema.c
@@ -1,0 +1,281 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#if !defined(_WIN32) && !defined(_XOPEN_SOURCE)
+#define _XOPEN_SOURCE 700
+#endif
+
+#include <glib.h>
+#include <glib/gstdio.h>
+
+#include "wyrelog/fact/schema-private.h"
+#include "wyrelog/policy/store-private.h"
+
+static void
+cleanup_fact_root (const gchar *root)
+{
+  if (root == NULL)
+    return;
+  g_autofree gchar *graph =
+      g_build_filename (root, "tenant-a", "graph-main", NULL);
+  g_autofree gchar *tenant = g_build_filename (root, "tenant-a", NULL);
+  (void) g_rmdir (graph);
+  (void) g_rmdir (tenant);
+  (void) g_rmdir (root);
+}
+
+static wyrelog_error_t
+open_store_with_graph (wyl_policy_store_t **out_store, gchar **out_root)
+{
+#ifdef G_OS_WIN32
+  (void) out_store;
+  (void) out_root;
+  return WYRELOG_E_POLICY;
+#else
+  g_autoptr (GError) error = NULL;
+  g_autofree gchar *root = g_dir_make_tmp ("wyl-fact-schema-XXXXXX", &error);
+  if (root == NULL)
+    return WYRELOG_E_IO;
+
+  g_autoptr (wyl_policy_store_t) store = NULL;
+  gboolean created = FALSE;
+  wyrelog_error_t rc = wyl_policy_store_open (NULL, &store);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_policy_store_create_schema (store);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_policy_store_create_tenant (store, "tenant-a", &created);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  const wyl_policy_fact_graph_column_t graph_columns[] = {
+    {"subject", "symbol"},
+    {"object", "symbol"},
+  };
+  const wyl_policy_fact_graph_relation_t graph_relations[] = {
+    {"site.edge", graph_columns, G_N_ELEMENTS (graph_columns)},
+  };
+  const wyl_policy_fact_graph_create_options_t graph_opts = {
+    .tenant_id = "tenant-a",
+    .graph_id = "graph-main",
+    .fact_root = root,
+    .schema_version = 1,
+    .owner_scope = "tenant-a",
+    .relations = graph_relations,
+    .n_relations = G_N_ELEMENTS (graph_relations),
+  };
+  rc = wyl_policy_store_create_fact_graph (store, &graph_opts, NULL);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  *out_store = g_steal_pointer (&store);
+  *out_root = g_steal_pointer (&root);
+  return WYRELOG_E_OK;
+#endif
+}
+
+static wyl_policy_fact_relation_schema_options_t
+make_order_schema (const wyl_policy_fact_relation_schema_column_t *columns,
+    gsize n_columns,
+    const wyl_policy_fact_relation_schema_query_t *queries, gsize n_queries)
+{
+  wyl_policy_fact_relation_schema_options_t opts = {
+    .tenant_id = "tenant-a",
+    .graph_id = "graph-main",
+    .namespace_id = "shop",
+    .relation_name = "orders",
+    .schema_version = 1,
+    .relation_visible = TRUE,
+    .columns = columns,
+    .n_columns = n_columns,
+    .queries = queries,
+    .n_queries = n_queries,
+  };
+  return opts;
+}
+
+static gint
+check_relation_schema_registration_and_validation (void)
+{
+#ifdef G_OS_WIN32
+  return 0;
+#else
+  g_autoptr (wyl_policy_store_t) store = NULL;
+  g_autofree gchar *root = NULL;
+  wyrelog_error_t rc = open_store_with_graph (&store, &root);
+  if (rc != WYRELOG_E_OK)
+    return 10;
+
+  const wyl_policy_fact_relation_schema_column_t columns[] = {
+    {"order_id", "symbol", FALSE, TRUE},
+    {"customer_id", "symbol", FALSE, TRUE},
+    {"amount", "int64", FALSE, TRUE},
+    {"status", "symbol", FALSE, TRUE},
+  };
+  const wyl_policy_fact_relation_schema_query_t queries[] = {
+    {"orders_by_status", "wr.fact.read", 1000},
+  };
+  wyl_policy_fact_relation_schema_options_t opts = make_order_schema (columns,
+      G_N_ELEMENTS (columns), queries, G_N_ELEMENTS (queries));
+  if (wyl_policy_store_register_fact_relation_schema (store, &opts)
+      != WYRELOG_E_OK)
+    return 11;
+
+  gboolean relation_visible = FALSE;
+  wyl_policy_fact_relation_schema_column_info_t *loaded = NULL;
+  gsize n_loaded = 0;
+  if (wyl_policy_store_load_fact_relation_schema_columns (store, "tenant-a",
+          "graph-main", "shop", "orders", 1, &relation_visible, &loaded,
+          &n_loaded) != WYRELOG_E_OK)
+    return 12;
+  if (!relation_visible || n_loaded != G_N_ELEMENTS (columns)
+      || g_strcmp0 (loaded[2].column_name, "amount") != 0
+      || g_strcmp0 (loaded[2].column_type, "int64") != 0
+      || loaded[2].nullable || !loaded[2].visible) {
+    wyl_policy_fact_relation_schema_columns_free (loaded, n_loaded);
+    return 13;
+  }
+  wyl_policy_fact_relation_schema_columns_free (loaded, n_loaded);
+
+  const wyl_fact_value_t good_values[] = {
+    {.type = WYL_FACT_VALUE_SYMBOL,.as.text = "o-1"},
+    {.type = WYL_FACT_VALUE_SYMBOL,.as.text = "c-1"},
+    {.type = WYL_FACT_VALUE_INT64,.as.int64_value = 42},
+    {.type = WYL_FACT_VALUE_SYMBOL,.as.text = "open"},
+  };
+  const wyl_fact_row_t good_rows[] = {
+    {good_values, G_N_ELEMENTS (good_values)},
+  };
+  const wyl_fact_batch_t good_batch = {
+    .tenant_id = "tenant-a",
+    .graph_id = "graph-main",
+    .namespace_id = "shop",
+    .relation_name = "orders",
+    .schema_version = 1,
+    .rows = good_rows,
+    .n_rows = G_N_ELEMENTS (good_rows),
+  };
+  g_autofree gchar *reason = NULL;
+  if (wyl_fact_schema_validate_batch (store, &good_batch, &reason)
+      != WYRELOG_E_OK || reason != NULL)
+    return 14;
+
+  const wyl_fact_value_t short_values[] = {
+    {.type = WYL_FACT_VALUE_SYMBOL,.as.text = "o-1"},
+  };
+  const wyl_fact_row_t short_rows[] = {
+    {short_values, G_N_ELEMENTS (short_values)},
+  };
+  wyl_fact_batch_t bad_batch = good_batch;
+  bad_batch.rows = short_rows;
+  if (wyl_fact_schema_validate_batch (store, &bad_batch, NULL)
+      != WYRELOG_E_POLICY)
+    return 15;
+
+  const wyl_fact_value_t typed_bad_values[] = {
+    {.type = WYL_FACT_VALUE_SYMBOL,.as.text = "o-1"},
+    {.type = WYL_FACT_VALUE_SYMBOL,.as.text = "c-1"},
+    {.type = WYL_FACT_VALUE_SYMBOL,.as.text = "not-an-int"},
+    {.type = WYL_FACT_VALUE_SYMBOL,.as.text = "open"},
+  };
+  const wyl_fact_row_t typed_bad_rows[] = {
+    {typed_bad_values, G_N_ELEMENTS (typed_bad_values)},
+  };
+  bad_batch = good_batch;
+  bad_batch.rows = typed_bad_rows;
+  if (wyl_fact_schema_validate_batch (store, &bad_batch, NULL)
+      != WYRELOG_E_POLICY)
+    return 16;
+
+  const wyl_fact_value_t null_text_values[] = {
+    {.type = WYL_FACT_VALUE_SYMBOL,.as.text = NULL},
+    {.type = WYL_FACT_VALUE_SYMBOL,.as.text = "c-1"},
+    {.type = WYL_FACT_VALUE_INT64,.as.int64_value = 42},
+    {.type = WYL_FACT_VALUE_SYMBOL,.as.text = "open"},
+  };
+  const wyl_fact_row_t null_text_rows[] = {
+    {null_text_values, G_N_ELEMENTS (null_text_values)},
+  };
+  bad_batch = good_batch;
+  bad_batch.rows = null_text_rows;
+  if (wyl_fact_schema_validate_batch (store, &bad_batch, NULL)
+      != WYRELOG_E_POLICY)
+    return 161;
+
+  bad_batch = good_batch;
+  bad_batch.schema_version = 2;
+  if (wyl_fact_schema_validate_batch (store, &bad_batch, NULL)
+      != WYRELOG_E_NOT_FOUND)
+    return 17;
+  if (wyl_fact_schema_validate_batch (store, &good_batch, NULL)
+      != WYRELOG_E_OK)
+    return 171;
+
+  bad_batch = good_batch;
+  bad_batch.relation_name = "missing";
+  if (wyl_fact_schema_validate_batch (store, &bad_batch, NULL)
+      != WYRELOG_E_NOT_FOUND)
+    return 18;
+
+  g_autofree gchar *ddl = wyl_fact_schema_build_duckdb_projection_ddl (&opts);
+  if (ddl == NULL || !g_str_has_prefix (ddl,
+          "CREATE TABLE IF NOT EXISTS \"tenant-a__graph-main__shop__orders_v1\"")
+      || strstr (ddl, "\"amount\" BIGINT NOT NULL") == NULL)
+    return 19;
+
+  g_autofree gchar *decl = wyl_fact_schema_build_wirelog_declaration (&opts);
+  if (decl == NULL
+      || g_strcmp0 (decl,
+          ".decl w_73_68_6f_70_w_6f_72_64_65_72_73(w_6f_72_64_65_72_5f_69_64: symbol, w_63_75_73_74_6f_6d_65_72_5f_69_64: symbol, w_61_6d_6f_75_6e_74: int64, w_73_74_61_74_75_73: symbol)")
+      != 0)
+    return 20;
+
+  const wyl_policy_fact_relation_schema_column_t wirelog_columns[] = {
+    {"order-id", "symbol", FALSE, TRUE},
+  };
+  wyl_policy_fact_relation_schema_options_t wirelog_opts = opts;
+  wirelog_opts.namespace_id = "shop-us";
+  wirelog_opts.relation_name = "order-line";
+  wirelog_opts.columns = wirelog_columns;
+  wirelog_opts.n_columns = G_N_ELEMENTS (wirelog_columns);
+  g_autofree gchar *mangled_decl =
+      wyl_fact_schema_build_wirelog_declaration (&wirelog_opts);
+  if (mangled_decl == NULL
+      || g_strcmp0 (mangled_decl,
+          ".decl w_73_68_6f_70_2d_75_73_w_6f_72_64_65_72_2d_6c_69_6e_65(w_6f_72_64_65_72_2d_69_64: symbol)")
+      != 0)
+    return 201;
+  wirelog_opts.namespace_id = "shop_x2d_us";
+  g_autofree gchar *collision_decl =
+      wyl_fact_schema_build_wirelog_declaration (&wirelog_opts);
+  if (collision_decl == NULL || g_strcmp0 (collision_decl, mangled_decl) == 0)
+    return 202;
+
+  if (wyl_policy_store_register_fact_relation_schema (store, &opts)
+      != WYRELOG_E_POLICY)
+    return 21;
+
+  opts.namespace_id = "wr.internal";
+  if (wyl_policy_store_register_fact_relation_schema (store, &opts)
+      != WYRELOG_E_INVALID)
+    return 22;
+
+  if (wyl_policy_store_seal_fact_graph (store, "tenant-a", "graph-main")
+      != WYRELOG_E_OK)
+    return 23;
+  if (wyl_fact_schema_validate_batch (store, &good_batch, NULL)
+      != WYRELOG_E_NOT_FOUND)
+    return 24;
+
+  cleanup_fact_root (root);
+  return 0;
+#endif
+}
+
+int
+main (void)
+{
+  gint rc = check_relation_schema_registration_and_validation ();
+  if (rc != 0)
+    return rc;
+  return 0;
+}

--- a/wyrelog/fact/schema-private.h
+++ b/wyrelog/fact/schema-private.h
@@ -1,0 +1,57 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+
+#include <glib.h>
+
+#include "wyrelog/error.h"
+#include "wyrelog/policy/store-private.h"
+
+G_BEGIN_DECLS;
+
+typedef enum
+{
+  WYL_FACT_VALUE_NULL = 0,
+  WYL_FACT_VALUE_SYMBOL,
+  WYL_FACT_VALUE_STRING,
+  WYL_FACT_VALUE_INT64,
+  WYL_FACT_VALUE_BOOL,
+  WYL_FACT_VALUE_COMPOUND_REF,
+} wyl_fact_value_type_t;
+
+typedef struct
+{
+  wyl_fact_value_type_t type;
+  union
+  {
+    const gchar *text;
+    gint64 int64_value;
+    gboolean bool_value;
+    gint64 compound_ref;
+  } as;
+} wyl_fact_value_t;
+
+typedef struct
+{
+  const wyl_fact_value_t *values;
+  gsize n_values;
+} wyl_fact_row_t;
+
+typedef struct
+{
+  const gchar *tenant_id;
+  const gchar *graph_id;
+  const gchar *namespace_id;
+  const gchar *relation_name;
+  guint32 schema_version;
+  const wyl_fact_row_t *rows;
+  gsize n_rows;
+} wyl_fact_batch_t;
+
+wyrelog_error_t wyl_fact_schema_validate_batch (wyl_policy_store_t * store,
+    const wyl_fact_batch_t * batch, gchar ** out_reason);
+gchar *wyl_fact_schema_build_duckdb_projection_ddl (const
+    wyl_policy_fact_relation_schema_options_t * opts);
+gchar *wyl_fact_schema_build_wirelog_declaration (const
+    wyl_policy_fact_relation_schema_options_t * opts);
+
+G_END_DECLS;

--- a/wyrelog/fact/schema.c
+++ b/wyrelog/fact/schema.c
@@ -1,0 +1,204 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "schema-private.h"
+
+#include <string.h>
+
+static void
+set_reason (gchar **out_reason, const gchar *reason)
+{
+  if (out_reason != NULL)
+    *out_reason = g_strdup (reason);
+}
+
+static gboolean
+value_matches_column (const wyl_fact_value_t *value,
+    const wyl_policy_fact_relation_schema_column_info_t *column)
+{
+  if (value->type == WYL_FACT_VALUE_NULL)
+    return column->nullable;
+  if (g_strcmp0 (column->column_type, "symbol") == 0)
+    return value->type == WYL_FACT_VALUE_SYMBOL && value->as.text != NULL;
+  if (g_strcmp0 (column->column_type, "string") == 0)
+    return value->type == WYL_FACT_VALUE_STRING && value->as.text != NULL;
+  if (g_strcmp0 (column->column_type, "int64") == 0)
+    return value->type == WYL_FACT_VALUE_INT64;
+  if (g_strcmp0 (column->column_type, "bool") == 0)
+    return value->type == WYL_FACT_VALUE_BOOL;
+  if (g_strcmp0 (column->column_type, "compound_ref") == 0)
+    return value->type == WYL_FACT_VALUE_COMPOUND_REF;
+  return FALSE;
+}
+
+wyrelog_error_t
+wyl_fact_schema_validate_batch (wyl_policy_store_t *store,
+    const wyl_fact_batch_t *batch, gchar **out_reason)
+{
+  gboolean relation_visible = FALSE;
+  wyl_policy_fact_relation_schema_column_info_t *columns = NULL;
+  gsize n_columns = 0;
+
+  if (out_reason != NULL)
+    *out_reason = NULL;
+  if (store == NULL || batch == NULL || batch->tenant_id == NULL
+      || batch->graph_id == NULL || batch->namespace_id == NULL
+      || batch->relation_name == NULL || batch->schema_version == 0
+      || (batch->rows == NULL && batch->n_rows > 0)) {
+    set_reason (out_reason, "invalid batch");
+    return WYRELOG_E_INVALID;
+  }
+
+  gboolean graph_active = FALSE;
+  wyrelog_error_t rc = wyl_policy_store_fact_graph_is_active (store,
+      batch->tenant_id, batch->graph_id, &graph_active);
+  if (rc != WYRELOG_E_OK) {
+    set_reason (out_reason, "invalid graph scope");
+    return rc;
+  }
+  if (!graph_active) {
+    set_reason (out_reason, "fact graph not active");
+    return WYRELOG_E_NOT_FOUND;
+  }
+
+  rc = wyl_policy_store_load_fact_relation_schema_columns
+      (store, batch->tenant_id, batch->graph_id, batch->namespace_id,
+      batch->relation_name, batch->schema_version, &relation_visible,
+      &columns, &n_columns);
+  if (rc != WYRELOG_E_OK) {
+    set_reason (out_reason, "relation schema not found");
+    return rc;
+  }
+  (void) relation_visible;
+
+  for (gsize i = 0; i < batch->n_rows; i++) {
+    const wyl_fact_row_t *row = &batch->rows[i];
+    if (row->values == NULL || row->n_values != n_columns) {
+      wyl_policy_fact_relation_schema_columns_free (columns, n_columns);
+      set_reason (out_reason, "fact row arity mismatch");
+      return WYRELOG_E_POLICY;
+    }
+    for (gsize j = 0; j < n_columns; j++) {
+      if (!value_matches_column (&row->values[j], &columns[j])) {
+        wyl_policy_fact_relation_schema_columns_free (columns, n_columns);
+        set_reason (out_reason, "fact row type mismatch");
+        return WYRELOG_E_POLICY;
+      }
+    }
+  }
+
+  wyl_policy_fact_relation_schema_columns_free (columns, n_columns);
+  return WYRELOG_E_OK;
+}
+
+static void
+append_duckdb_identifier (GString *out, const gchar *identifier)
+{
+  g_string_append_c (out, '"');
+  for (const gchar * p = identifier; p != NULL && *p != '\0'; p++) {
+    if (*p == '"')
+      g_string_append_c (out, '"');
+    g_string_append_c (out, *p);
+  }
+  g_string_append_c (out, '"');
+}
+
+static const gchar *
+duckdb_type_for_column (const gchar *column_type)
+{
+  if (g_strcmp0 (column_type, "symbol") == 0
+      || g_strcmp0 (column_type, "string") == 0)
+    return "VARCHAR";
+  if (g_strcmp0 (column_type, "int64") == 0)
+    return "BIGINT";
+  if (g_strcmp0 (column_type, "bool") == 0)
+    return "BOOLEAN";
+  if (g_strcmp0 (column_type, "compound_ref") == 0)
+    return "BIGINT";
+  return NULL;
+}
+
+static const gchar *
+wirelog_type_for_column (const gchar *column_type)
+{
+  if (g_strcmp0 (column_type, "symbol") == 0
+      || g_strcmp0 (column_type, "string") == 0)
+    return "symbol";
+  if (g_strcmp0 (column_type, "int64") == 0
+      || g_strcmp0 (column_type, "compound_ref") == 0)
+    return "int64";
+  if (g_strcmp0 (column_type, "bool") == 0)
+    return "bool";
+  return NULL;
+}
+
+static void
+append_wirelog_identifier (GString *out, const gchar *identifier)
+{
+  if (identifier == NULL || identifier[0] == '\0') {
+    g_string_append_c (out, 'w');
+    return;
+  }
+
+  g_string_append_c (out, 'w');
+  for (const gchar * p = identifier; *p != '\0'; p++) {
+    guchar c = (guchar) * p;
+    g_string_append_printf (out, "_%02x", c);
+  }
+}
+
+gchar *
+wyl_fact_schema_build_duckdb_projection_ddl (const
+    wyl_policy_fact_relation_schema_options_t *opts)
+{
+  if (opts == NULL || opts->tenant_id == NULL || opts->graph_id == NULL
+      || opts->namespace_id == NULL || opts->relation_name == NULL
+      || opts->schema_version == 0 || opts->columns == NULL
+      || opts->n_columns == 0)
+    return NULL;
+
+  g_autoptr (GString) out = g_string_new ("CREATE TABLE IF NOT EXISTS ");
+  g_autofree gchar *table = g_strdup_printf ("%s__%s__%s__%s_v%u",
+      opts->tenant_id, opts->graph_id, opts->namespace_id,
+      opts->relation_name, opts->schema_version);
+  append_duckdb_identifier (out, table);
+  g_string_append (out, " (");
+  for (gsize i = 0; i < opts->n_columns; i++) {
+    const gchar *duck_type =
+        duckdb_type_for_column (opts->columns[i].column_type);
+    if (duck_type == NULL)
+      return NULL;
+    if (i > 0)
+      g_string_append (out, ", ");
+    append_duckdb_identifier (out, opts->columns[i].column_name);
+    g_string_append_printf (out, " %s%s", duck_type,
+        opts->columns[i].nullable ? "" : " NOT NULL");
+  }
+  g_string_append (out, ");");
+  return g_string_free (g_steal_pointer (&out), FALSE);
+}
+
+gchar *
+wyl_fact_schema_build_wirelog_declaration (const
+    wyl_policy_fact_relation_schema_options_t *opts)
+{
+  if (opts == NULL || opts->namespace_id == NULL || opts->relation_name == NULL
+      || opts->columns == NULL || opts->n_columns == 0)
+    return NULL;
+
+  g_autoptr (GString) out = g_string_new (".decl ");
+  append_wirelog_identifier (out, opts->namespace_id);
+  g_string_append_c (out, '_');
+  append_wirelog_identifier (out, opts->relation_name);
+  g_string_append_c (out, '(');
+  for (gsize i = 0; i < opts->n_columns; i++) {
+    const gchar *wirelog_type = wirelog_type_for_column
+        (opts->columns[i].column_type);
+    if (wirelog_type == NULL)
+      return NULL;
+    if (i > 0)
+      g_string_append (out, ", ");
+    append_wirelog_identifier (out, opts->columns[i].column_name);
+    g_string_append_printf (out, ": %s", wirelog_type);
+  }
+  g_string_append_c (out, ')');
+  return g_string_free (g_steal_pointer (&out), FALSE);
+}

--- a/wyrelog/meson.build
+++ b/wyrelog/meson.build
@@ -19,6 +19,7 @@ wyrelog_sources = files(
   'access/decision.c',
   'auth/jwt.c',
   'audit/event.c',
+  'fact/schema.c',
   'policy/store.c',
   'wyl-boot.c',
   'wyl-decide.c',

--- a/wyrelog/policy/store-private.h
+++ b/wyrelog/policy/store-private.h
@@ -114,6 +114,46 @@ typedef struct
 typedef wyrelog_error_t (*wyl_policy_fact_graph_cb) (const
     wyl_policy_fact_graph_info_t * info, gpointer user_data);
 
+typedef struct
+{
+  const gchar *column_name;
+  const gchar *column_type;
+  gboolean nullable;
+  gboolean visible;
+} wyl_policy_fact_relation_schema_column_t;
+
+typedef struct
+{
+  const gchar *query_name;
+  const gchar *required_permission_id;
+  guint max_rows;
+} wyl_policy_fact_relation_schema_query_t;
+
+typedef struct
+{
+  const gchar *tenant_id;
+  const gchar *graph_id;
+  const gchar *namespace_id;
+  const gchar *relation_name;
+  guint32 schema_version;
+  gboolean relation_visible;
+  const wyl_policy_fact_relation_schema_column_t *columns;
+  gsize n_columns;
+  const wyl_policy_fact_relation_schema_query_t *queries;
+  gsize n_queries;
+} wyl_policy_fact_relation_schema_options_t;
+
+typedef struct
+{
+  gchar *column_name;
+  gchar *column_type;
+  gboolean nullable;
+  gboolean visible;
+} wyl_policy_fact_relation_schema_column_info_t;
+
+void wyl_policy_fact_relation_schema_columns_free
+    (wyl_policy_fact_relation_schema_column_info_t * columns, gsize n_columns);
+
 /*
  * Policy authority store lifecycle wrapper.
  *
@@ -176,6 +216,16 @@ wyrelog_error_t wyl_policy_store_seal_fact_graph (wyl_policy_store_t * store,
 wyrelog_error_t wyl_policy_store_fact_graph_is_active (wyl_policy_store_t *
     store, const gchar * tenant_id, const gchar * graph_id,
     gboolean * out_active);
+wyrelog_error_t wyl_policy_store_register_fact_relation_schema
+    (wyl_policy_store_t * store,
+    const wyl_policy_fact_relation_schema_options_t * opts);
+wyrelog_error_t wyl_policy_store_load_fact_relation_schema_columns
+    (wyl_policy_store_t * store, const gchar * tenant_id,
+    const gchar * graph_id, const gchar * namespace_id,
+    const gchar * relation_name, guint32 schema_version,
+    gboolean * out_relation_visible,
+    wyl_policy_fact_relation_schema_column_info_t ** out_columns,
+    gsize * out_n_columns);
 wyrelog_error_t wyl_policy_store_upsert_role (wyl_policy_store_t * store,
     const gchar * role_id, const gchar * role_name);
 wyrelog_error_t wyl_policy_store_upsert_permission (wyl_policy_store_t * store,

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -175,6 +175,10 @@ static const gchar *const required_tables[] = {
   "fact_graph_relations",
   "fact_graph_relation_columns",
   "fact_graph_query_allowlist",
+  "fact_namespaces",
+  "fact_relation_schemas",
+  "fact_relation_schema_columns",
+  "fact_relation_query_allowlist",
   "policy_signatures",
 };
 
@@ -1895,6 +1899,74 @@ wyl_policy_store_create_schema (wyl_policy_store_t *store)
       "      (tenant_id, graph_id, relation_name),"
       "  FOREIGN KEY (required_permission_id) REFERENCES permissions (perm_id)"
       ");"
+      "CREATE TABLE IF NOT EXISTS fact_namespaces ("
+      "  tenant_id TEXT NOT NULL,"
+      "  graph_id TEXT NOT NULL,"
+      "  namespace_id TEXT NOT NULL,"
+      "  visibility INTEGER NOT NULL DEFAULT 1 CHECK (visibility IN (0, 1)),"
+      "  created_at INTEGER NOT NULL,"
+      "  updated_at INTEGER NOT NULL,"
+      "  PRIMARY KEY (tenant_id, graph_id, namespace_id),"
+      "  FOREIGN KEY (tenant_id, graph_id) "
+      "    REFERENCES fact_graphs (tenant_id, graph_id) "
+      "    ON DELETE CASCADE"
+      ");"
+      "CREATE TABLE IF NOT EXISTS fact_relation_schemas ("
+      "  tenant_id TEXT NOT NULL,"
+      "  graph_id TEXT NOT NULL,"
+      "  namespace_id TEXT NOT NULL,"
+      "  relation_name TEXT NOT NULL,"
+      "  schema_version INTEGER NOT NULL CHECK (schema_version > 0),"
+      "  arity INTEGER NOT NULL CHECK (arity > 0),"
+      "  relation_visible INTEGER NOT NULL DEFAULT 1 CHECK "
+      "    (relation_visible IN (0, 1)),"
+      "  created_at INTEGER NOT NULL,"
+      "  updated_at INTEGER NOT NULL,"
+      "  PRIMARY KEY (tenant_id, graph_id, namespace_id, relation_name, "
+      "    schema_version),"
+      "  FOREIGN KEY (tenant_id, graph_id, namespace_id) "
+      "    REFERENCES fact_namespaces (tenant_id, graph_id, namespace_id) "
+      "    ON DELETE CASCADE"
+      ");"
+      "CREATE TABLE IF NOT EXISTS fact_relation_schema_columns ("
+      "  tenant_id TEXT NOT NULL,"
+      "  graph_id TEXT NOT NULL,"
+      "  namespace_id TEXT NOT NULL,"
+      "  relation_name TEXT NOT NULL,"
+      "  schema_version INTEGER NOT NULL CHECK (schema_version > 0),"
+      "  column_index INTEGER NOT NULL CHECK (column_index >= 0),"
+      "  column_name TEXT NOT NULL,"
+      "  column_type TEXT NOT NULL CHECK "
+      "    (column_type IN ('symbol', 'string', 'int64', 'bool', "
+      "      'compound_ref')),"
+      "  nullable INTEGER NOT NULL DEFAULT 0 CHECK (nullable IN (0, 1)),"
+      "  visible INTEGER NOT NULL DEFAULT 1 CHECK (visible IN (0, 1)),"
+      "  PRIMARY KEY (tenant_id, graph_id, namespace_id, relation_name, "
+      "    schema_version, column_index),"
+      "  UNIQUE (tenant_id, graph_id, namespace_id, relation_name, "
+      "    schema_version, column_name),"
+      "  FOREIGN KEY (tenant_id, graph_id, namespace_id, relation_name, "
+      "    schema_version) REFERENCES fact_relation_schemas "
+      "      (tenant_id, graph_id, namespace_id, relation_name, "
+      "        schema_version) "
+      "    ON DELETE CASCADE"
+      ");"
+      "CREATE TABLE IF NOT EXISTS fact_relation_query_allowlist ("
+      "  tenant_id TEXT NOT NULL,"
+      "  graph_id TEXT NOT NULL,"
+      "  namespace_id TEXT NOT NULL,"
+      "  relation_name TEXT NOT NULL,"
+      "  schema_version INTEGER NOT NULL CHECK (schema_version > 0),"
+      "  query_name TEXT NOT NULL,"
+      "  required_permission_id TEXT NOT NULL,"
+      "  max_rows INTEGER NOT NULL CHECK (max_rows > 0),"
+      "  PRIMARY KEY (tenant_id, graph_id, query_name),"
+      "  FOREIGN KEY (tenant_id, graph_id, namespace_id, relation_name, "
+      "    schema_version) REFERENCES fact_relation_schemas "
+      "      (tenant_id, graph_id, namespace_id, relation_name, "
+      "        schema_version),"
+      "  FOREIGN KEY (required_permission_id) REFERENCES permissions (perm_id)"
+      ");"
       "CREATE TABLE IF NOT EXISTS policy_signatures ("
       "  policy_version INTEGER PRIMARY KEY,"
       "  policy_hash BLOB NOT NULL,"
@@ -2263,7 +2335,7 @@ fact_graph_customer_name_is_valid (const gchar *name)
 {
   if (!fact_graph_component_is_valid (name))
     return FALSE;
-  if (g_str_has_prefix (name, "wr.")
+  if (g_strcmp0 (name, "wr") == 0 || g_str_has_prefix (name, "wr.")
       || g_str_has_prefix (name, "__wyrelog."))
     return FALSE;
   return TRUE;
@@ -2273,6 +2345,16 @@ static gboolean
 fact_graph_column_type_is_valid (const gchar *column_type)
 {
   return g_strcmp0 (column_type, "symbol") == 0
+      || g_strcmp0 (column_type, "int64") == 0
+      || g_strcmp0 (column_type, "bool") == 0
+      || g_strcmp0 (column_type, "compound_ref") == 0;
+}
+
+static gboolean
+fact_relation_schema_column_type_is_valid (const gchar *column_type)
+{
+  return g_strcmp0 (column_type, "symbol") == 0
+      || g_strcmp0 (column_type, "string") == 0
       || g_strcmp0 (column_type, "int64") == 0
       || g_strcmp0 (column_type, "bool") == 0
       || g_strcmp0 (column_type, "compound_ref") == 0;
@@ -2769,6 +2851,312 @@ wyl_policy_store_fact_graph_is_active (wyl_policy_store_t *store,
   if (rc != WYRELOG_E_OK)
     return rc;
   *out_active = tenant_active && !graph_sealed;
+  return WYRELOG_E_OK;
+}
+
+void wyl_policy_fact_relation_schema_columns_free
+    (wyl_policy_fact_relation_schema_column_info_t * columns, gsize n_columns)
+{
+  if (columns == NULL)
+    return;
+  for (gsize i = 0; i < n_columns; i++) {
+    g_free (columns[i].column_name);
+    g_free (columns[i].column_type);
+  }
+  g_free (columns);
+}
+
+static wyrelog_error_t
+validate_fact_relation_schema_options (wyl_policy_store_t *store,
+    const wyl_policy_fact_relation_schema_options_t *opts)
+{
+  if (store == NULL || store->db == NULL || opts == NULL)
+    return WYRELOG_E_INVALID;
+  if (!wyl_policy_store_tenant_id_is_valid (opts->tenant_id)
+      || !fact_graph_component_is_valid (opts->tenant_id)
+      || !fact_graph_customer_name_is_valid (opts->graph_id)
+      || !fact_graph_customer_name_is_valid (opts->namespace_id)
+      || !fact_graph_customer_name_is_valid (opts->relation_name)
+      || opts->schema_version == 0 || opts->columns == NULL
+      || opts->n_columns == 0 || opts->n_columns > G_MAXINT)
+    return WYRELOG_E_INVALID;
+  if (opts->queries == NULL && opts->n_queries > 0)
+    return WYRELOG_E_INVALID;
+
+  for (gsize i = 0; i < opts->n_columns; i++) {
+    const wyl_policy_fact_relation_schema_column_t *column = &opts->columns[i];
+    if (!fact_graph_customer_name_is_valid (column->column_name)
+        || !fact_relation_schema_column_type_is_valid (column->column_type))
+      return WYRELOG_E_POLICY;
+    for (gsize j = 0; j < i; j++) {
+      if (g_strcmp0 (opts->columns[j].column_name, column->column_name) == 0)
+        return WYRELOG_E_POLICY;
+    }
+  }
+
+  for (gsize i = 0; i < opts->n_queries; i++) {
+    const wyl_policy_fact_relation_schema_query_t *query = &opts->queries[i];
+    if (!fact_graph_customer_name_is_valid (query->query_name)
+        || query->required_permission_id == NULL
+        || query->required_permission_id[0] == '\0' || query->max_rows == 0)
+      return WYRELOG_E_POLICY;
+    gboolean permission_exists = FALSE;
+    wyrelog_error_t rc = wyl_policy_store_permission_exists (store,
+        query->required_permission_id, &permission_exists);
+    if (rc != WYRELOG_E_OK)
+      return rc;
+    if (!permission_exists)
+      return WYRELOG_E_POLICY;
+  }
+
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+insert_fact_namespace_metadata (wyl_policy_store_t *store,
+    const wyl_policy_fact_relation_schema_options_t *opts)
+{
+  sqlite3_stmt *stmt = NULL;
+  static const gchar *sql =
+      "INSERT INTO fact_namespaces "
+      "(tenant_id, graph_id, namespace_id, visibility, created_at, updated_at) "
+      "VALUES (?, ?, ?, 1, unixepoch(), unixepoch()) "
+      "ON CONFLICT (tenant_id, graph_id, namespace_id) DO UPDATE SET "
+      "updated_at = excluded.updated_at;";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if ((rc = bind_text (stmt, 1, opts->tenant_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 2, opts->graph_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 3, opts->namespace_id)) != WYRELOG_E_OK) {
+    sqlite3_finalize (stmt);
+    return rc;
+  }
+  int step_rc = sqlite3_step (stmt);
+  sqlite3_finalize (stmt);
+  return (step_rc == SQLITE_DONE) ? WYRELOG_E_OK : WYRELOG_E_IO;
+}
+
+static wyrelog_error_t
+insert_fact_relation_schema_metadata (wyl_policy_store_t *store,
+    const wyl_policy_fact_relation_schema_options_t *opts)
+{
+  sqlite3_stmt *stmt = NULL;
+  static const gchar *sql =
+      "INSERT INTO fact_relation_schemas "
+      "(tenant_id, graph_id, namespace_id, relation_name, schema_version, "
+      " arity, relation_visible, created_at, updated_at) "
+      "VALUES (?, ?, ?, ?, ?, ?, ?, unixepoch(), unixepoch());";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if ((rc = bind_text (stmt, 1, opts->tenant_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 2, opts->graph_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 3, opts->namespace_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 4, opts->relation_name)) != WYRELOG_E_OK
+      || sqlite3_bind_int64 (stmt, 5, opts->schema_version) != SQLITE_OK
+      || sqlite3_bind_int64 (stmt, 6, opts->n_columns) != SQLITE_OK
+      || sqlite3_bind_int (stmt, 7, opts->relation_visible ? 1 : 0)
+      != SQLITE_OK) {
+    sqlite3_finalize (stmt);
+    return WYRELOG_E_IO;
+  }
+  int step_rc = sqlite3_step (stmt);
+  sqlite3_finalize (stmt);
+  return (step_rc == SQLITE_DONE) ? WYRELOG_E_OK : WYRELOG_E_POLICY;
+}
+
+static wyrelog_error_t
+insert_fact_relation_schema_column_metadata (wyl_policy_store_t *store,
+    const wyl_policy_fact_relation_schema_options_t *opts, gsize column_index)
+{
+  sqlite3_stmt *stmt = NULL;
+  const wyl_policy_fact_relation_schema_column_t *column =
+      &opts->columns[column_index];
+  static const gchar *sql =
+      "INSERT INTO fact_relation_schema_columns "
+      "(tenant_id, graph_id, namespace_id, relation_name, schema_version, "
+      " column_index, column_name, column_type, nullable, visible) "
+      "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if ((rc = bind_text (stmt, 1, opts->tenant_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 2, opts->graph_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 3, opts->namespace_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 4, opts->relation_name)) != WYRELOG_E_OK
+      || sqlite3_bind_int64 (stmt, 5, opts->schema_version) != SQLITE_OK
+      || sqlite3_bind_int64 (stmt, 6, (sqlite3_int64) column_index)
+      != SQLITE_OK || (rc = bind_text (stmt, 7, column->column_name))
+      != WYRELOG_E_OK || (rc = bind_text (stmt, 8, column->column_type))
+      != WYRELOG_E_OK || sqlite3_bind_int (stmt, 9,
+          column->nullable ? 1 : 0) != SQLITE_OK
+      || sqlite3_bind_int (stmt, 10, column->visible ? 1 : 0) != SQLITE_OK) {
+    sqlite3_finalize (stmt);
+    return WYRELOG_E_IO;
+  }
+  int step_rc = sqlite3_step (stmt);
+  sqlite3_finalize (stmt);
+  return (step_rc == SQLITE_DONE) ? WYRELOG_E_OK : WYRELOG_E_IO;
+}
+
+static wyrelog_error_t
+insert_fact_relation_query_metadata (wyl_policy_store_t *store,
+    const wyl_policy_fact_relation_schema_options_t *opts,
+    const wyl_policy_fact_relation_schema_query_t *query)
+{
+  sqlite3_stmt *stmt = NULL;
+  static const gchar *sql =
+      "INSERT INTO fact_relation_query_allowlist "
+      "(tenant_id, graph_id, namespace_id, relation_name, schema_version, "
+      " query_name, required_permission_id, max_rows) "
+      "VALUES (?, ?, ?, ?, ?, ?, ?, ?);";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if ((rc = bind_text (stmt, 1, opts->tenant_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 2, opts->graph_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 3, opts->namespace_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 4, opts->relation_name)) != WYRELOG_E_OK
+      || sqlite3_bind_int64 (stmt, 5, opts->schema_version) != SQLITE_OK
+      || (rc = bind_text (stmt, 6, query->query_name)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 7, query->required_permission_id))
+      != WYRELOG_E_OK || sqlite3_bind_int64 (stmt, 8, query->max_rows)
+      != SQLITE_OK) {
+    sqlite3_finalize (stmt);
+    return WYRELOG_E_IO;
+  }
+  int step_rc = sqlite3_step (stmt);
+  sqlite3_finalize (stmt);
+  return (step_rc == SQLITE_DONE) ? WYRELOG_E_OK : WYRELOG_E_IO;
+}
+
+wyrelog_error_t
+wyl_policy_store_register_fact_relation_schema (wyl_policy_store_t *store,
+    const wyl_policy_fact_relation_schema_options_t *opts)
+{
+  wyrelog_error_t rc = validate_fact_relation_schema_options (store, opts);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  gboolean active = FALSE;
+  rc = wyl_policy_store_fact_graph_is_active (store, opts->tenant_id,
+      opts->graph_id, &active);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if (!active)
+    return WYRELOG_E_NOT_FOUND;
+
+  rc = wyl_policy_store_begin_mutation (store);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = insert_fact_namespace_metadata (store, opts);
+  if (rc == WYRELOG_E_OK)
+    rc = insert_fact_relation_schema_metadata (store, opts);
+  for (gsize i = 0; rc == WYRELOG_E_OK && i < opts->n_columns; i++)
+    rc = insert_fact_relation_schema_column_metadata (store, opts, i);
+  for (gsize i = 0; rc == WYRELOG_E_OK && i < opts->n_queries; i++)
+    rc = insert_fact_relation_query_metadata (store, opts, &opts->queries[i]);
+  if (rc != WYRELOG_E_OK) {
+    wyl_policy_store_rollback_mutation (store);
+    return rc;
+  }
+  return wyl_policy_store_commit_mutation (store);
+}
+
+wyrelog_error_t
+wyl_policy_store_load_fact_relation_schema_columns (wyl_policy_store_t *store,
+    const gchar *tenant_id, const gchar *graph_id, const gchar *namespace_id,
+    const gchar *relation_name, guint32 schema_version,
+    gboolean *out_relation_visible,
+    wyl_policy_fact_relation_schema_column_info_t **out_columns,
+    gsize *out_n_columns)
+{
+  sqlite3_stmt *stmt = NULL;
+  wyl_policy_fact_relation_schema_column_info_t *columns = NULL;
+  gsize len = 0;
+  gsize cap = 0;
+
+  if (out_relation_visible != NULL)
+    *out_relation_visible = FALSE;
+  if (out_columns != NULL)
+    *out_columns = NULL;
+  if (out_n_columns != NULL)
+    *out_n_columns = 0;
+  if (store == NULL || store->db == NULL || out_columns == NULL
+      || out_n_columns == NULL || !wyl_policy_store_tenant_id_is_valid
+      (tenant_id) || !fact_graph_component_is_valid (tenant_id)
+      || !fact_graph_customer_name_is_valid (graph_id)
+      || !fact_graph_customer_name_is_valid (namespace_id)
+      || !fact_graph_customer_name_is_valid (relation_name)
+      || schema_version == 0)
+    return WYRELOG_E_INVALID;
+
+  static const gchar *sql =
+      "SELECT c.column_name, c.column_type, c.nullable, c.visible, "
+      "s.relation_visible "
+      "FROM fact_relation_schema_columns c "
+      "JOIN fact_relation_schemas s "
+      "  ON s.tenant_id = c.tenant_id AND s.graph_id = c.graph_id "
+      " AND s.namespace_id = c.namespace_id "
+      " AND s.relation_name = c.relation_name "
+      " AND s.schema_version = c.schema_version "
+      "WHERE c.tenant_id = ? AND c.graph_id = ? AND c.namespace_id = ? "
+      "  AND c.relation_name = ? AND c.schema_version = ? "
+      "ORDER BY c.column_index;";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if ((rc = bind_text (stmt, 1, tenant_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 2, graph_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 3, namespace_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 4, relation_name)) != WYRELOG_E_OK
+      || sqlite3_bind_int64 (stmt, 5, schema_version) != SQLITE_OK) {
+    sqlite3_finalize (stmt);
+    return WYRELOG_E_IO;
+  }
+
+  int step_rc;
+  while ((step_rc = sqlite3_step (stmt)) == SQLITE_ROW) {
+    if (len == cap) {
+      gsize next_cap = cap == 0 ? 4 : cap * 2;
+      wyl_policy_fact_relation_schema_column_info_t *next =
+          g_renew (wyl_policy_fact_relation_schema_column_info_t, columns,
+          next_cap);
+      if (next == NULL) {
+        wyl_policy_fact_relation_schema_columns_free (columns, len);
+        sqlite3_finalize (stmt);
+        return WYRELOG_E_NOMEM;
+      }
+      memset (next + cap, 0, sizeof (*next) * (next_cap - cap));
+      columns = next;
+      cap = next_cap;
+    }
+    columns[len].column_name =
+        g_strdup ((const gchar *) sqlite3_column_text (stmt, 0));
+    columns[len].column_type =
+        g_strdup ((const gchar *) sqlite3_column_text (stmt, 1));
+    if (columns[len].column_name == NULL || columns[len].column_type == NULL) {
+      wyl_policy_fact_relation_schema_columns_free (columns, len + 1);
+      sqlite3_finalize (stmt);
+      return WYRELOG_E_NOMEM;
+    }
+    columns[len].nullable = sqlite3_column_int (stmt, 2) != 0;
+    columns[len].visible = sqlite3_column_int (stmt, 3) != 0;
+    if (out_relation_visible != NULL)
+      *out_relation_visible = sqlite3_column_int (stmt, 4) != 0;
+    len++;
+  }
+  sqlite3_finalize (stmt);
+  if (step_rc != SQLITE_DONE) {
+    wyl_policy_fact_relation_schema_columns_free (columns, len);
+    return WYRELOG_E_IO;
+  }
+  if (len == 0)
+    return WYRELOG_E_NOT_FOUND;
+
+  *out_columns = columns;
+  *out_n_columns = len;
   return WYRELOG_E_OK;
 }
 


### PR DESCRIPTION
## Summary
- add metadata-only relation schema tables keyed by tenant, graph, namespace, relation, and schema version
- add private registration and schema-column lookup helpers for fact relation metadata
- add fact batch validation for active graph, exact schema version, arity, nullability, and explicit value types
- add DuckDB projection DDL and Wirelog declaration generation from registered schema shape

## Validation
- meson test -C builddir-issue50-default --print-errorlogs
- meson test -C builddir-issue50-fact --print-errorlogs

## Review
- reviewer approved after requested fixes
- architect and critic final verification approved
