### PR TITLE
Persist fact batches in typed DuckDB projections

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -276,6 +276,16 @@ test_fact_schema = executable('test-fact-schema',
 
 test('fact-schema', test_fact_schema)
 
+if get_option('enable_fact_store').allowed()
+  test_fact_store = executable('test-fact-store',
+    'test-fact-store.c',
+    include_directories : include_directories('../wyrelog'),
+    dependencies : [wyrelog_dep, duckdb_dep, sqlite_dep],
+  )
+
+  test('fact-store', test_fact_store)
+endif
+
 test_policy_store_toctou = executable('test-policy-store-toctou',
   'test-policy-store-toctou.c',
   dependencies : [wyrelog_dep, sqlite_dep, sodium_dep],

--- a/tests/test-fact-store.c
+++ b/tests/test-fact-store.c
@@ -1,0 +1,438 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <duckdb.h>
+#include <glib.h>
+#include <glib/gstdio.h>
+
+#include "wyrelog/fact/store-private.h"
+#include "wyrelog/policy/store-private.h"
+
+static gboolean
+count_i64 (duckdb_connection conn, const gchar *sql, gint64 *out_value)
+{
+  duckdb_result result = { 0 };
+  if (duckdb_query (conn, sql, &result) != DuckDBSuccess) {
+    duckdb_destroy_result (&result);
+    return FALSE;
+  }
+  *out_value = duckdb_value_int64 (&result, 0, 0);
+  duckdb_destroy_result (&result);
+  return TRUE;
+}
+
+static gboolean
+query_text (duckdb_connection conn, const gchar *sql, gchar **out_value)
+{
+  duckdb_result result = { 0 };
+  *out_value = NULL;
+  if (duckdb_query (conn, sql, &result) != DuckDBSuccess) {
+    duckdb_destroy_result (&result);
+    return FALSE;
+  }
+  if (duckdb_row_count (&result) == 0) {
+    duckdb_destroy_result (&result);
+    return FALSE;
+  }
+  gchar *value = duckdb_value_varchar (&result, 0, 0);
+  *out_value = g_strdup (value);
+  duckdb_free (value);
+  duckdb_destroy_result (&result);
+  return *out_value != NULL;
+}
+
+static gboolean
+create_duckdb_with_sql (const gchar *path, const gchar *sql)
+{
+  duckdb_database db;
+  duckdb_connection conn;
+  duckdb_result result = { 0 };
+
+  if (duckdb_open (path, &db) != DuckDBSuccess)
+    return FALSE;
+  if (duckdb_connect (db, &conn) != DuckDBSuccess) {
+    duckdb_close (&db);
+    return FALSE;
+  }
+  gboolean ok = duckdb_query (conn, sql, &result) == DuckDBSuccess;
+  duckdb_destroy_result (&result);
+  duckdb_disconnect (&conn);
+  duckdb_close (&db);
+  return ok;
+}
+
+static wyl_policy_fact_relation_schema_options_t
+make_schema (const wyl_policy_fact_relation_schema_column_t *columns,
+    gsize n_columns)
+{
+  wyl_policy_fact_relation_schema_options_t schema = {
+    .tenant_id = "tenant-a",
+    .graph_id = "orders",
+    .namespace_id = "shop",
+    .relation_name = "order",
+    .schema_version = 1,
+    .relation_visible = TRUE,
+    .columns = columns,
+    .n_columns = n_columns,
+  };
+  return schema;
+}
+
+static gint
+check_fact_store_appends_idempotently (void)
+{
+  g_autoptr (wyl_fact_store_t) store = NULL;
+  if (wyl_fact_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 10;
+  if (wyl_fact_store_create_schema (store) != WYRELOG_E_OK)
+    return 11;
+
+  const wyl_policy_fact_relation_schema_column_t columns[] = {
+    {"order_id", "symbol", FALSE, TRUE},
+    {"customer_id", "symbol", FALSE, TRUE},
+    {"amount", "int64", FALSE, TRUE},
+    {"status", "symbol", FALSE, TRUE},
+  };
+  wyl_policy_fact_relation_schema_options_t schema = make_schema (columns,
+      G_N_ELEMENTS (columns));
+  g_autofree gchar *table = NULL;
+  if (wyl_fact_store_ensure_projection (store, &schema, &table)
+      != WYRELOG_E_OK)
+    return 12;
+  if (table == NULL || !g_str_has_prefix (table, "rel_"))
+    return 13;
+  wyl_policy_fact_relation_schema_options_t tenant_b_schema = schema;
+  tenant_b_schema.tenant_id = "tenant-b";
+  g_autofree gchar *tenant_b_table =
+      wyl_fact_store_projection_table_name (&tenant_b_schema);
+  if (tenant_b_table == NULL || g_strcmp0 (tenant_b_table, table) == 0)
+    return 131;
+  if (wyl_fact_store_ensure_projection (store, &tenant_b_schema, NULL)
+      != WYRELOG_E_POLICY)
+    return 132;
+
+  const gsize n_rows = 10000;
+  wyl_fact_value_t *values = g_new0 (wyl_fact_value_t,
+      n_rows * G_N_ELEMENTS (columns));
+  wyl_fact_row_t *rows = g_new0 (wyl_fact_row_t, n_rows);
+  gchar **order_ids = g_new0 (gchar *, n_rows);
+  gchar **customer_ids = g_new0 (gchar *, n_rows);
+  for (gsize i = 0; i < n_rows; i++) {
+    order_ids[i] = g_strdup_printf ("o-%05" G_GSIZE_FORMAT, i);
+    customer_ids[i] = g_strdup_printf ("c-%03" G_GSIZE_FORMAT, i % 128);
+    wyl_fact_value_t *row = &values[i * G_N_ELEMENTS (columns)];
+    row[0].type = WYL_FACT_VALUE_SYMBOL;
+    row[0].as.text = order_ids[i];
+    row[1].type = WYL_FACT_VALUE_SYMBOL;
+    row[1].as.text = customer_ids[i];
+    row[2].type = WYL_FACT_VALUE_INT64;
+    row[2].as.int64_value = (gint64) i;
+    row[3].type = WYL_FACT_VALUE_SYMBOL;
+    row[3].as.text = (i % 2) == 0 ? "open" : "closed";
+    rows[i].values = row;
+    rows[i].n_values = G_N_ELEMENTS (columns);
+  }
+
+  const wyl_fact_store_batch_t batch = {
+    .batch_id = "batch-1",
+    .tenant_id = "tenant-a",
+    .graph_id = "orders",
+    .namespace_id = "shop",
+    .relation_name = "order",
+    .schema_version = 1,
+    .source = "unit-test",
+    .request_id = "request-1",
+    .idempotency_key = "source:1",
+    .op = WYL_FACT_STORE_OP_ASSERT,
+    .rows = rows,
+    .n_rows = n_rows,
+  };
+  gboolean inserted = FALSE;
+  if (wyl_fact_store_append_batch (store, &schema, &batch, &inserted)
+      != WYRELOG_E_OK || !inserted)
+    return 14;
+  if (wyl_fact_store_append_batch (store, &schema, &batch, &inserted)
+      != WYRELOG_E_OK || inserted)
+    return 15;
+  wyl_fact_store_batch_t conflicting_key = batch;
+  conflicting_key.idempotency_key = "source:other";
+  if (wyl_fact_store_append_batch (store, &schema, &conflicting_key, NULL)
+      != WYRELOG_E_POLICY)
+    return 151;
+  wyl_fact_store_batch_t conflicting_batch = batch;
+  conflicting_batch.batch_id = "batch-other";
+  if (wyl_fact_store_append_batch (store, &schema, &conflicting_batch, NULL)
+      != WYRELOG_E_POLICY)
+    return 152;
+
+  duckdb_connection conn = wyl_fact_store_get_connection (store);
+  gint64 count = 0;
+  g_autofree gchar *count_sql = g_strdup_printf ("SELECT COUNT(*) FROM %s;",
+      table);
+  if (!count_i64 (conn, count_sql, &count) || count != (gint64) n_rows)
+    return 16;
+  if (!count_i64 (conn, "SELECT COUNT(*) FROM fact_batches;", &count)
+      || count != 1)
+    return 17;
+  if (!count_i64 (conn, "SELECT COUNT(*) FROM fact_event_log;", &count)
+      || count != (gint64) n_rows)
+    return 18;
+
+  g_autofree gchar *type_sql = g_strdup_printf
+      ("SELECT type FROM pragma_table_info('%s') WHERE name = 'amount';",
+      table);
+  g_autofree gchar *amount_type = NULL;
+  if (!query_text (conn, type_sql, &amount_type)
+      || g_strcmp0 (amount_type, "BIGINT") != 0)
+    return 19;
+  if (!count_i64 (conn,
+          "SELECT COUNT(*) FROM pragma_table_info('fact_event_log') "
+          "WHERE lower(type) LIKE '%json%';", &count) || count != 0)
+    return 20;
+  g_autofree gchar *scope_sql = g_strdup_printf
+      ("SELECT COUNT(*) FROM %s WHERE __wyl_tenant_id = 'tenant-a' "
+      "AND __wyl_graph_id = 'orders';", table);
+  if (!count_i64 (conn, scope_sql, &count) || count != (gint64) n_rows)
+    return 201;
+
+  wyl_fact_value_t bad_values[] = {
+    {.type = WYL_FACT_VALUE_SYMBOL,.as.text = "o-00000"},
+    {.type = WYL_FACT_VALUE_SYMBOL,.as.text = "c-000"},
+    {.type = WYL_FACT_VALUE_INT64,.as.int64_value = 999999},
+    {.type = WYL_FACT_VALUE_SYMBOL,.as.text = "open"},
+  };
+  const wyl_fact_row_t bad_rows[] = {
+    {bad_values, G_N_ELEMENTS (bad_values)},
+  };
+  wyl_fact_store_batch_t conflict = batch;
+  conflict.rows = bad_rows;
+  conflict.n_rows = G_N_ELEMENTS (bad_rows);
+  if (wyl_fact_store_append_batch (store, &schema, &conflict, NULL)
+      != WYRELOG_E_POLICY)
+    return 21;
+
+  for (gsize i = 0; i < n_rows; i++) {
+    g_free (order_ids[i]);
+    g_free (customer_ids[i]);
+  }
+  g_free (order_ids);
+  g_free (customer_ids);
+  g_free (rows);
+  g_free (values);
+  return 0;
+}
+
+static gint
+check_fact_corruption_does_not_block_policy_open (void)
+{
+  g_autoptr (GError) error = NULL;
+  g_autofree gchar *dir = g_dir_make_tmp ("wyl-fact-corrupt-XXXXXX", &error);
+  if (dir == NULL)
+    return 50;
+  g_autofree gchar *path = g_build_filename (dir, "facts.duckdb", NULL);
+  if (!g_file_set_contents (path, "not a duckdb database", -1, &error))
+    return 51;
+
+  wyl_fact_store_t *fact_store = NULL;
+  if (wyl_fact_store_open (path, &fact_store) == WYRELOG_E_OK) {
+    wyl_fact_store_close (fact_store);
+    return 52;
+  }
+
+  g_autoptr (wyl_policy_store_t) policy_store = NULL;
+  if (wyl_policy_store_open (NULL, &policy_store) != WYRELOG_E_OK)
+    return 53;
+  if (wyl_policy_store_create_schema (policy_store) != WYRELOG_E_OK)
+    return 54;
+
+  (void) g_remove (path);
+  (void) g_rmdir (dir);
+  return 0;
+}
+
+static gint
+expect_projection_drift_rejected (const wyl_policy_fact_relation_schema_column_t
+    *columns, gsize n_columns, const gchar *projection_columns_sql,
+    gint base_code)
+{
+  g_autoptr (wyl_fact_store_t) store = NULL;
+  if (wyl_fact_store_open (NULL, &store) != WYRELOG_E_OK)
+    return base_code;
+  if (wyl_fact_store_create_schema (store) != WYRELOG_E_OK)
+    return base_code + 1;
+  wyl_policy_fact_relation_schema_options_t schema =
+      make_schema (columns, n_columns);
+  g_autofree gchar *table = wyl_fact_store_projection_table_name (&schema);
+  g_autofree gchar *sql = g_strdup_printf
+      ("CREATE TABLE %s (%s);", table, projection_columns_sql);
+  duckdb_result drift_result = { 0 };
+  if (duckdb_query (wyl_fact_store_get_connection (store), sql, &drift_result)
+      != DuckDBSuccess) {
+    duckdb_destroy_result (&drift_result);
+    return base_code + 2;
+  }
+  duckdb_destroy_result (&drift_result);
+  if (wyl_fact_store_ensure_projection (store, &schema, NULL)
+      != WYRELOG_E_POLICY)
+    return base_code + 3;
+  return 0;
+}
+
+static gint
+check_fact_store_rejects_schema_drift (void)
+{
+  const wyl_policy_fact_relation_schema_column_t required_columns[] = {
+    {"order_id", "symbol", FALSE, TRUE},
+    {"amount", "int64", FALSE, TRUE},
+  };
+  gint rc = expect_projection_drift_rejected (required_columns,
+      G_N_ELEMENTS (required_columns),
+      "order_id VARCHAR NOT NULL, amount BIGINT NOT NULL, "
+      "__wyl_tenant_id VARCHAR NOT NULL, __wyl_graph_id VARCHAR NOT NULL, "
+      "__wyl_seq BIGINT NOT NULL, __wyl_batch_id VARCHAR NOT NULL, "
+      "__wyl_row_index BIGINT NOT NULL, __wyl_valid BOOLEAN NOT NULL", 30);
+  if (rc != 0)
+    return rc;
+
+  rc = expect_projection_drift_rejected (required_columns,
+      G_N_ELEMENTS (required_columns),
+      "order_id VARCHAR NOT NULL, amount VARCHAR NOT NULL, "
+      "__wyl_tenant_id VARCHAR NOT NULL, __wyl_graph_id VARCHAR NOT NULL, "
+      "__wyl_seq BIGINT NOT NULL, __wyl_batch_id VARCHAR NOT NULL, "
+      "__wyl_row_index BIGINT NOT NULL, __wyl_valid BOOLEAN NOT NULL, "
+      "UNIQUE (__wyl_batch_id, __wyl_row_index)", 40);
+  if (rc != 0)
+    return rc;
+
+  rc = expect_projection_drift_rejected (required_columns,
+      G_N_ELEMENTS (required_columns),
+      "order_id VARCHAR NOT NULL, amount BIGINT NOT NULL, "
+      "__wyl_tenant_id VARCHAR NOT NULL, __wyl_graph_id VARCHAR NOT NULL, "
+      "__wyl_seq BIGINT NOT NULL, __wyl_batch_id VARCHAR NOT NULL, "
+      "__wyl_row_index BIGINT NOT NULL, __wyl_valid BOOLEAN NOT NULL, "
+      "UNIQUE (__wyl_batch_id, __wyl_row_index, amount)", 50);
+  if (rc != 0)
+    return rc;
+
+  const wyl_policy_fact_relation_schema_column_t nullable_columns[] = {
+    {"note", "string", TRUE, TRUE},
+  };
+  rc = expect_projection_drift_rejected (nullable_columns,
+      G_N_ELEMENTS (nullable_columns),
+      "note VARCHAR NOT NULL, __wyl_tenant_id VARCHAR NOT NULL, "
+      "__wyl_graph_id VARCHAR NOT NULL, __wyl_seq BIGINT NOT NULL, "
+      "__wyl_batch_id VARCHAR NOT NULL, __wyl_row_index BIGINT NOT NULL, "
+      "__wyl_valid BOOLEAN NOT NULL, "
+      "UNIQUE (__wyl_batch_id, __wyl_row_index)", 60);
+  if (rc != 0)
+    return rc;
+
+  return 0;
+}
+
+static gint
+check_fact_store_rejects_audit_shape (void)
+{
+  g_autoptr (GError) error = NULL;
+  g_autofree gchar *dir = g_dir_make_tmp ("wyl-fact-store-XXXXXX", &error);
+  if (dir == NULL)
+    return 80;
+  g_autofree gchar *path = g_build_filename (dir, "audit.duckdb", NULL);
+  if (!create_duckdb_with_sql (path,
+          "CREATE TABLE audit_events (id VARCHAR PRIMARY KEY);"))
+    return 81;
+
+  wyl_fact_store_t *store = NULL;
+  if (wyl_fact_store_open (path, &store) != WYRELOG_E_POLICY) {
+    wyl_fact_store_close (store);
+    return 82;
+  }
+  (void) g_remove (path);
+  g_autofree gchar *mixed_path = g_build_filename (dir, "mixed.duckdb", NULL);
+  if (!create_duckdb_with_sql (mixed_path,
+          "CREATE TABLE fact_store_metadata (key VARCHAR PRIMARY KEY, "
+          "value VARCHAR NOT NULL);"
+          "INSERT INTO fact_store_metadata VALUES "
+          "('store_kind', 'wyrelog.fact');"
+          "CREATE TABLE audit_events (id VARCHAR PRIMARY KEY);"))
+    return 83;
+  if (wyl_fact_store_open (mixed_path, &store) != WYRELOG_E_POLICY) {
+    wyl_fact_store_close (store);
+    return 84;
+  }
+  (void) g_remove (mixed_path);
+  g_autofree gchar *wrong_path = g_build_filename (dir, "wrong.duckdb", NULL);
+  if (!create_duckdb_with_sql (wrong_path,
+          "CREATE TABLE fact_store_metadata (key VARCHAR PRIMARY KEY, "
+          "value VARCHAR NOT NULL);"
+          "INSERT INTO fact_store_metadata VALUES "
+          "('store_kind', 'wyrelog.audit');"))
+    return 85;
+  if (wyl_fact_store_open (wrong_path, &store) != WYRELOG_E_POLICY) {
+    wyl_fact_store_close (store);
+    return 86;
+  }
+  (void) g_remove (wrong_path);
+
+  g_autoptr (wyl_fact_store_t) live_store = NULL;
+  if (wyl_fact_store_open (NULL, &live_store) != WYRELOG_E_OK)
+    return 87;
+  if (wyl_fact_store_create_schema (live_store) != WYRELOG_E_OK)
+    return 88;
+  const wyl_policy_fact_relation_schema_column_t columns[] = {
+    {"order_id", "symbol", FALSE, TRUE},
+  };
+  wyl_policy_fact_relation_schema_options_t schema = make_schema (columns,
+      G_N_ELEMENTS (columns));
+  if (wyl_fact_store_ensure_projection (live_store, &schema, NULL)
+      != WYRELOG_E_OK)
+    return 89;
+  duckdb_result audit_result = { 0 };
+  if (duckdb_query (wyl_fact_store_get_connection (live_store),
+          "CREATE TABLE audit_events (id VARCHAR PRIMARY KEY);",
+          &audit_result) != DuckDBSuccess) {
+    duckdb_destroy_result (&audit_result);
+    return 90;
+  }
+  duckdb_destroy_result (&audit_result);
+  wyl_fact_value_t values[] = {
+    {.type = WYL_FACT_VALUE_SYMBOL,.as.text = "o-1"},
+  };
+  const wyl_fact_row_t rows[] = {
+    {values, G_N_ELEMENTS (values)},
+  };
+  const wyl_fact_store_batch_t batch = {
+    .batch_id = "batch-contaminated",
+    .tenant_id = "tenant-a",
+    .graph_id = "orders",
+    .namespace_id = "shop",
+    .relation_name = "order",
+    .schema_version = 1,
+    .idempotency_key = "contaminated:1",
+    .op = WYL_FACT_STORE_OP_ASSERT,
+    .rows = rows,
+    .n_rows = G_N_ELEMENTS (rows),
+  };
+  if (wyl_fact_store_append_batch (live_store, &schema, &batch, NULL)
+      != WYRELOG_E_POLICY)
+    return 91;
+
+  (void) g_rmdir (dir);
+  return 0;
+}
+
+int
+main (void)
+{
+  gint rc = check_fact_store_appends_idempotently ();
+  if (rc != 0)
+    return rc;
+  rc = check_fact_store_rejects_schema_drift ();
+  if (rc != 0)
+    return rc;
+  rc = check_fact_store_rejects_audit_shape ();
+  if (rc != 0)
+    return rc;
+  rc = check_fact_corruption_does_not_block_policy_open ();
+  if (rc != 0)
+    return rc;
+  return 0;
+}

--- a/wyrelog/fact/store-private.h
+++ b/wyrelog/fact/store-private.h
@@ -1,0 +1,54 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+
+#include <glib.h>
+#include <duckdb.h>
+
+#include "wyrelog/error.h"
+#include "wyrelog/fact/schema-private.h"
+
+G_BEGIN_DECLS;
+
+typedef struct wyl_fact_store_t wyl_fact_store_t;
+
+typedef enum
+{
+  WYL_FACT_STORE_OP_ASSERT = 0,
+  WYL_FACT_STORE_OP_RETRACT,
+} wyl_fact_store_op_t;
+
+typedef struct
+{
+  const gchar *batch_id;
+  const gchar *tenant_id;
+  const gchar *graph_id;
+  const gchar *namespace_id;
+  const gchar *relation_name;
+  guint32 schema_version;
+  const gchar *source;
+  const gchar *request_id;
+  const gchar *idempotency_key;
+  wyl_fact_store_op_t op;
+  const wyl_fact_row_t *rows;
+  gsize n_rows;
+} wyl_fact_store_batch_t;
+
+wyrelog_error_t wyl_fact_store_open (const gchar * path,
+    wyl_fact_store_t ** out_store);
+void wyl_fact_store_close (wyl_fact_store_t * store);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (wyl_fact_store_t, wyl_fact_store_close);
+
+duckdb_connection wyl_fact_store_get_connection (wyl_fact_store_t * store);
+wyrelog_error_t wyl_fact_store_create_schema (wyl_fact_store_t * store);
+wyrelog_error_t wyl_fact_store_table_exists (wyl_fact_store_t * store,
+    const gchar * table_name, gboolean * out_exists);
+gchar *wyl_fact_store_projection_table_name (const
+    wyl_policy_fact_relation_schema_options_t * schema);
+wyrelog_error_t wyl_fact_store_ensure_projection (wyl_fact_store_t * store,
+    const wyl_policy_fact_relation_schema_options_t * schema,
+    gchar ** out_table_name);
+wyrelog_error_t wyl_fact_store_append_batch (wyl_fact_store_t * store,
+    const wyl_policy_fact_relation_schema_options_t * schema,
+    const wyl_fact_store_batch_t * batch, gboolean * out_inserted);
+
+G_END_DECLS;

--- a/wyrelog/fact/store.c
+++ b/wyrelog/fact/store.c
@@ -1,0 +1,887 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "store-private.h"
+
+#include <string.h>
+
+struct wyl_fact_store_t
+{
+  duckdb_database db;
+  duckdb_connection conn;
+  GMutex lock;
+};
+
+static wyrelog_error_t
+exec_sql (duckdb_connection conn, const gchar *sql)
+{
+  duckdb_result result = { 0 };
+  if (duckdb_query (conn, sql, &result) != DuckDBSuccess) {
+    duckdb_destroy_result (&result);
+    return WYRELOG_E_IO;
+  }
+  duckdb_destroy_result (&result);
+  return WYRELOG_E_OK;
+}
+
+static void
+append_duckdb_identifier (GString *out, const gchar *identifier)
+{
+  g_string_append_c (out, '"');
+  for (const gchar * p = identifier; p != NULL && *p != '\0'; p++) {
+    if (*p == '"')
+      g_string_append_c (out, '"');
+    g_string_append_c (out, *p);
+  }
+  g_string_append_c (out, '"');
+}
+
+static gchar *
+hex_identifier (const gchar *prefix, const gchar *value)
+{
+  g_autoptr (GString) out = g_string_new (prefix);
+  if (value == NULL)
+    return g_string_free (g_steal_pointer (&out), FALSE);
+  for (const gchar * p = value; *p != '\0'; p++)
+    g_string_append_printf (out, "_%02x", (guchar) * p);
+  return g_string_free (g_steal_pointer (&out), FALSE);
+}
+
+static const gchar *
+duckdb_type_for_column (const gchar *column_type)
+{
+  if (g_strcmp0 (column_type, "symbol") == 0
+      || g_strcmp0 (column_type, "string") == 0)
+    return "VARCHAR";
+  if (g_strcmp0 (column_type, "int64") == 0)
+    return "BIGINT";
+  if (g_strcmp0 (column_type, "bool") == 0)
+    return "BOOLEAN";
+  if (g_strcmp0 (column_type, "compound_ref") == 0)
+    return "BIGINT";
+  return NULL;
+}
+
+static gboolean
+value_matches_column (const wyl_fact_value_t *value,
+    const wyl_policy_fact_relation_schema_column_t *column)
+{
+  if (value->type == WYL_FACT_VALUE_NULL)
+    return column->nullable;
+  if (g_strcmp0 (column->column_type, "symbol") == 0)
+    return value->type == WYL_FACT_VALUE_SYMBOL && value->as.text != NULL;
+  if (g_strcmp0 (column->column_type, "string") == 0)
+    return value->type == WYL_FACT_VALUE_STRING && value->as.text != NULL;
+  if (g_strcmp0 (column->column_type, "int64") == 0)
+    return value->type == WYL_FACT_VALUE_INT64;
+  if (g_strcmp0 (column->column_type, "bool") == 0)
+    return value->type == WYL_FACT_VALUE_BOOL;
+  if (g_strcmp0 (column->column_type, "compound_ref") == 0)
+    return value->type == WYL_FACT_VALUE_COMPOUND_REF;
+  return FALSE;
+}
+
+static wyrelog_error_t
+validate_schema_shape (const wyl_policy_fact_relation_schema_options_t *schema)
+{
+  if (schema == NULL || schema->tenant_id == NULL || schema->graph_id == NULL
+      || schema->namespace_id == NULL || schema->relation_name == NULL
+      || schema->schema_version == 0 || schema->columns == NULL
+      || schema->n_columns == 0)
+    return WYRELOG_E_INVALID;
+  for (gsize i = 0; i < schema->n_columns; i++) {
+    if (schema->columns[i].column_name == NULL
+        || duckdb_type_for_column (schema->columns[i].column_type) == NULL)
+      return WYRELOG_E_INVALID;
+  }
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+validate_batch_shape (const wyl_policy_fact_relation_schema_options_t *schema,
+    const wyl_fact_store_batch_t *batch)
+{
+  wyrelog_error_t rc = validate_schema_shape (schema);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if (batch == NULL || batch->batch_id == NULL || batch->batch_id[0] == '\0'
+      || batch->tenant_id == NULL || batch->graph_id == NULL
+      || batch->namespace_id == NULL || batch->relation_name == NULL
+      || batch->schema_version == 0 || batch->idempotency_key == NULL
+      || batch->idempotency_key[0] == '\0' || batch->rows == NULL
+      || batch->n_rows == 0)
+    return WYRELOG_E_INVALID;
+  if (batch->op != WYL_FACT_STORE_OP_ASSERT
+      && batch->op != WYL_FACT_STORE_OP_RETRACT)
+    return WYRELOG_E_INVALID;
+  if (g_strcmp0 (schema->tenant_id, batch->tenant_id) != 0
+      || g_strcmp0 (schema->graph_id, batch->graph_id) != 0
+      || g_strcmp0 (schema->namespace_id, batch->namespace_id) != 0
+      || g_strcmp0 (schema->relation_name, batch->relation_name) != 0
+      || schema->schema_version != batch->schema_version)
+    return WYRELOG_E_POLICY;
+  for (gsize i = 0; i < batch->n_rows; i++) {
+    const wyl_fact_row_t *row = &batch->rows[i];
+    if (row->values == NULL || row->n_values != schema->n_columns)
+      return WYRELOG_E_POLICY;
+    for (gsize j = 0; j < schema->n_columns; j++) {
+      if (!value_matches_column (&row->values[j], &schema->columns[j]))
+        return WYRELOG_E_POLICY;
+    }
+  }
+  return WYRELOG_E_OK;
+}
+
+static gchar *
+batch_content_hash (const wyl_policy_fact_relation_schema_options_t *schema,
+    const wyl_fact_store_batch_t *batch)
+{
+  g_autoptr (GChecksum) checksum = g_checksum_new (G_CHECKSUM_SHA256);
+  if (checksum == NULL)
+    return NULL;
+  g_checksum_update (checksum, (const guchar *) batch->tenant_id, -1);
+  g_checksum_update (checksum, (const guchar *) "\0", 1);
+  g_checksum_update (checksum, (const guchar *) batch->graph_id, -1);
+  g_checksum_update (checksum, (const guchar *) "\0", 1);
+  g_checksum_update (checksum, (const guchar *) batch->namespace_id, -1);
+  g_checksum_update (checksum, (const guchar *) "\0", 1);
+  g_checksum_update (checksum, (const guchar *) batch->relation_name, -1);
+  g_checksum_update (checksum, (const guchar *) "\0", 1);
+  g_checksum_update (checksum, (const guchar *) &batch->schema_version,
+      sizeof (batch->schema_version));
+  g_checksum_update (checksum, (const guchar *) &batch->op, sizeof (batch->op));
+  for (gsize i = 0; i < batch->n_rows; i++) {
+    for (gsize j = 0; j < schema->n_columns; j++) {
+      const wyl_fact_value_t *value = &batch->rows[i].values[j];
+      g_checksum_update (checksum, (const guchar *) &value->type,
+          sizeof (value->type));
+      switch (value->type) {
+        case WYL_FACT_VALUE_NULL:
+          break;
+        case WYL_FACT_VALUE_SYMBOL:
+        case WYL_FACT_VALUE_STRING:
+          g_checksum_update (checksum, (const guchar *) value->as.text, -1);
+          break;
+        case WYL_FACT_VALUE_INT64:
+          g_checksum_update (checksum, (const guchar *) &value->as.int64_value,
+              sizeof (value->as.int64_value));
+          break;
+        case WYL_FACT_VALUE_BOOL:
+          g_checksum_update (checksum, (const guchar *) &value->as.bool_value,
+              sizeof (value->as.bool_value));
+          break;
+        case WYL_FACT_VALUE_COMPOUND_REF:
+          g_checksum_update (checksum, (const guchar *) &value->as.compound_ref,
+              sizeof (value->as.compound_ref));
+          break;
+      }
+      g_checksum_update (checksum, (const guchar *) "\0", 1);
+    }
+  }
+  return g_strdup (g_checksum_get_string (checksum));
+}
+
+static wyrelog_error_t
+table_exists_unlocked (wyl_fact_store_t *store, const gchar *table_name,
+    gboolean *out_exists)
+{
+  duckdb_prepared_statement stmt = NULL;
+  duckdb_result result = { 0 };
+
+  if (store == NULL || table_name == NULL || out_exists == NULL)
+    return WYRELOG_E_INVALID;
+  *out_exists = FALSE;
+  static const gchar *sql =
+      "SELECT COUNT(*) FROM information_schema.tables WHERE table_name = ?;";
+  if (duckdb_prepare (store->conn, sql, &stmt) != DuckDBSuccess)
+    return WYRELOG_E_IO;
+  if (duckdb_bind_varchar (stmt, 1, table_name) != DuckDBSuccess) {
+    duckdb_destroy_prepare (&stmt);
+    return WYRELOG_E_IO;
+  }
+  if (duckdb_execute_prepared (stmt, &result) != DuckDBSuccess) {
+    duckdb_destroy_prepare (&stmt);
+    duckdb_destroy_result (&result);
+    return WYRELOG_E_IO;
+  }
+  duckdb_destroy_prepare (&stmt);
+  *out_exists = duckdb_value_int64 (&result, 0, 0) > 0;
+  duckdb_destroy_result (&result);
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+reject_audit_database_unlocked (wyl_fact_store_t *store)
+{
+  gboolean has_audit_events = FALSE;
+  gboolean has_fact_metadata = FALSE;
+  wyrelog_error_t rc = table_exists_unlocked (store, "audit_events",
+      &has_audit_events);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = table_exists_unlocked (store, "fact_store_metadata", &has_fact_metadata);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if (has_audit_events)
+    return WYRELOG_E_POLICY;
+  if (!has_fact_metadata)
+    return WYRELOG_E_OK;
+
+  duckdb_result result = { 0 };
+  if (duckdb_query (store->conn,
+          "SELECT value FROM fact_store_metadata WHERE key = 'store_kind';",
+          &result) != DuckDBSuccess) {
+    duckdb_destroy_result (&result);
+    return WYRELOG_E_IO;
+  }
+  if (duckdb_row_count (&result) != 1) {
+    duckdb_destroy_result (&result);
+    return WYRELOG_E_POLICY;
+  }
+  gchar *store_kind = duckdb_value_varchar (&result, 0, 0);
+  gboolean valid = g_strcmp0 (store_kind, "wyrelog.fact") == 0;
+  duckdb_free (store_kind);
+  duckdb_destroy_result (&result);
+  return valid ? WYRELOG_E_OK : WYRELOG_E_POLICY;
+}
+
+static wyrelog_error_t
+metadata_value_unlocked (wyl_fact_store_t *store, const gchar *key,
+    gchar **out_value)
+{
+  duckdb_prepared_statement stmt = NULL;
+  duckdb_result result = { 0 };
+
+  *out_value = NULL;
+  if (duckdb_prepare (store->conn,
+          "SELECT value FROM fact_store_metadata WHERE key = ?;", &stmt)
+      != DuckDBSuccess)
+    return WYRELOG_E_IO;
+  if (duckdb_bind_varchar (stmt, 1, key) != DuckDBSuccess) {
+    duckdb_destroy_prepare (&stmt);
+    return WYRELOG_E_IO;
+  }
+  if (duckdb_execute_prepared (stmt, &result) != DuckDBSuccess) {
+    duckdb_destroy_prepare (&stmt);
+    duckdb_destroy_result (&result);
+    return WYRELOG_E_IO;
+  }
+  duckdb_destroy_prepare (&stmt);
+  if (duckdb_row_count (&result) > 1) {
+    duckdb_destroy_result (&result);
+    return WYRELOG_E_POLICY;
+  }
+  if (duckdb_row_count (&result) == 1) {
+    gchar *value = duckdb_value_varchar (&result, 0, 0);
+    *out_value = g_strdup (value);
+    duckdb_free (value);
+    if (*out_value == NULL) {
+      duckdb_destroy_result (&result);
+      return WYRELOG_E_NOMEM;
+    }
+  }
+  duckdb_destroy_result (&result);
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+insert_metadata_value_unlocked (wyl_fact_store_t *store, const gchar *key,
+    const gchar *value)
+{
+  duckdb_prepared_statement stmt = NULL;
+  if (duckdb_prepare (store->conn,
+          "INSERT INTO fact_store_metadata (key, value) VALUES (?, ?);",
+          &stmt) != DuckDBSuccess)
+    return WYRELOG_E_IO;
+  duckdb_state ok = duckdb_bind_varchar (stmt, 1, key)
+      | duckdb_bind_varchar (stmt, 2, value);
+  if (ok != DuckDBSuccess) {
+    duckdb_destroy_prepare (&stmt);
+    return WYRELOG_E_IO;
+  }
+  duckdb_state rc = duckdb_execute_prepared (stmt, NULL);
+  duckdb_destroy_prepare (&stmt);
+  return rc == DuckDBSuccess ? WYRELOG_E_OK : WYRELOG_E_IO;
+}
+
+static wyrelog_error_t
+validate_store_scope_unlocked (wyl_fact_store_t *store, const gchar *tenant_id,
+    const gchar *graph_id, gboolean bind_if_empty)
+{
+  gboolean has_fact_metadata = FALSE;
+  wyrelog_error_t rc = table_exists_unlocked (store, "fact_store_metadata",
+      &has_fact_metadata);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if (!has_fact_metadata)
+    return WYRELOG_E_POLICY;
+
+  g_autofree gchar *stored_tenant = NULL;
+  g_autofree gchar *stored_graph = NULL;
+  rc = metadata_value_unlocked (store, "tenant_id", &stored_tenant);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = metadata_value_unlocked (store, "graph_id", &stored_graph);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  if ((stored_tenant == NULL) != (stored_graph == NULL))
+    return WYRELOG_E_POLICY;
+  if (stored_tenant == NULL) {
+    if (!bind_if_empty)
+      return WYRELOG_E_POLICY;
+    rc = insert_metadata_value_unlocked (store, "tenant_id", tenant_id);
+    if (rc == WYRELOG_E_OK)
+      rc = insert_metadata_value_unlocked (store, "graph_id", graph_id);
+    return rc;
+  }
+
+  return g_strcmp0 (stored_tenant, tenant_id) == 0
+      && g_strcmp0 (stored_graph, graph_id) == 0 ? WYRELOG_E_OK :
+      WYRELOG_E_POLICY;
+}
+
+wyrelog_error_t
+wyl_fact_store_open (const gchar *path, wyl_fact_store_t **out_store)
+{
+  if (out_store == NULL)
+    return WYRELOG_E_INVALID;
+  const gchar *effective_path = path;
+  if (path != NULL && g_strcmp0 (path, ":memory:") == 0)
+    effective_path = NULL;
+
+  wyl_fact_store_t *self = g_new0 (wyl_fact_store_t, 1);
+  if (duckdb_open (effective_path, &self->db) != DuckDBSuccess) {
+    g_free (self);
+    return WYRELOG_E_IO;
+  }
+  if (duckdb_connect (self->db, &self->conn) != DuckDBSuccess) {
+    duckdb_close (&self->db);
+    g_free (self);
+    return WYRELOG_E_INTERNAL;
+  }
+  g_mutex_init (&self->lock);
+  wyrelog_error_t rc = reject_audit_database_unlocked (self);
+  if (rc != WYRELOG_E_OK) {
+    wyl_fact_store_close (self);
+    return rc;
+  }
+  *out_store = self;
+  return WYRELOG_E_OK;
+}
+
+void
+wyl_fact_store_close (wyl_fact_store_t *store)
+{
+  if (store == NULL)
+    return;
+  duckdb_disconnect (&store->conn);
+  duckdb_close (&store->db);
+  g_mutex_clear (&store->lock);
+  g_free (store);
+}
+
+duckdb_connection
+wyl_fact_store_get_connection (wyl_fact_store_t *store)
+{
+  if (store == NULL) {
+    duckdb_connection zero;
+    memset (&zero, 0, sizeof (zero));
+    return zero;
+  }
+  return store->conn;
+}
+
+wyrelog_error_t
+wyl_fact_store_create_schema (wyl_fact_store_t *store)
+{
+  if (store == NULL)
+    return WYRELOG_E_INVALID;
+  g_mutex_lock (&store->lock);
+  wyrelog_error_t rc = reject_audit_database_unlocked (store);
+  if (rc == WYRELOG_E_OK)
+    rc = exec_sql (store->conn,
+        "CREATE TABLE IF NOT EXISTS fact_store_metadata ("
+        "  key VARCHAR PRIMARY KEY,"
+        "  value VARCHAR NOT NULL"
+        ");"
+        "INSERT OR IGNORE INTO fact_store_metadata (key, value) "
+        "VALUES ('store_kind', 'wyrelog.fact');"
+        "CREATE TABLE IF NOT EXISTS fact_batches ("
+        "  batch_id VARCHAR PRIMARY KEY,"
+        "  tenant_id VARCHAR NOT NULL,"
+        "  graph_id VARCHAR NOT NULL,"
+        "  namespace_id VARCHAR NOT NULL,"
+        "  relation_name VARCHAR NOT NULL,"
+        "  schema_version BIGINT NOT NULL,"
+        "  source VARCHAR,"
+        "  request_id VARCHAR,"
+        "  idempotency_key VARCHAR NOT NULL UNIQUE,"
+        "  op VARCHAR NOT NULL CHECK (op IN ('assert', 'retract')),"
+        "  row_count BIGINT NOT NULL,"
+        "  content_hash VARCHAR NOT NULL,"
+        "  created_at_us BIGINT NOT NULL"
+        ");"
+        "CREATE TABLE IF NOT EXISTS fact_event_log ("
+        "  seq BIGINT PRIMARY KEY,"
+        "  batch_id VARCHAR NOT NULL,"
+        "  tenant_id VARCHAR NOT NULL,"
+        "  graph_id VARCHAR NOT NULL,"
+        "  namespace_id VARCHAR NOT NULL,"
+        "  relation_name VARCHAR NOT NULL,"
+        "  schema_version BIGINT NOT NULL,"
+        "  op VARCHAR NOT NULL CHECK (op IN ('assert', 'retract')),"
+        "  created_at_us BIGINT NOT NULL,"
+        "  valid BOOLEAN NOT NULL,"
+        "  FOREIGN KEY (batch_id) REFERENCES fact_batches (batch_id)" ");");
+  if (rc == WYRELOG_E_OK)
+    rc = reject_audit_database_unlocked (store);
+  g_mutex_unlock (&store->lock);
+  return rc;
+}
+
+wyrelog_error_t
+wyl_fact_store_table_exists (wyl_fact_store_t *store, const gchar *table_name,
+    gboolean *out_exists)
+{
+  if (store == NULL)
+    return WYRELOG_E_INVALID;
+  g_mutex_lock (&store->lock);
+  wyrelog_error_t rc = table_exists_unlocked (store, table_name, out_exists);
+  g_mutex_unlock (&store->lock);
+  return rc;
+}
+
+gchar *
+wyl_fact_store_projection_table_name (const
+    wyl_policy_fact_relation_schema_options_t *schema)
+{
+  if (validate_schema_shape (schema) != WYRELOG_E_OK)
+    return NULL;
+  g_autofree gchar *ns = hex_identifier ("n", schema->namespace_id);
+  g_autofree gchar *rel = hex_identifier ("r", schema->relation_name);
+  g_autofree gchar *tenant = hex_identifier ("t", schema->tenant_id);
+  g_autofree gchar *graph = hex_identifier ("g", schema->graph_id);
+  return g_strdup_printf ("rel_%s_%s_%s_%s_v%u", tenant, graph, ns, rel,
+      schema->schema_version);
+}
+
+static wyrelog_error_t
+validate_projection_shape_unlocked (wyl_fact_store_t *store,
+    const wyl_policy_fact_relation_schema_options_t *schema,
+    const gchar *table_name)
+{
+  duckdb_result result = { 0 };
+  g_autofree gchar *sql =
+      g_strdup_printf
+      ("SELECT name, type, \"notnull\" FROM pragma_table_info('%s') ORDER BY cid;",
+      table_name);
+  if (duckdb_query (store->conn, sql, &result) != DuckDBSuccess) {
+    duckdb_destroy_result (&result);
+    return WYRELOG_E_IO;
+  }
+
+  idx_t rows = duckdb_row_count (&result);
+  if (rows != schema->n_columns + 6) {
+    duckdb_destroy_result (&result);
+    return WYRELOG_E_POLICY;
+  }
+  for (gsize i = 0; i < schema->n_columns; i++) {
+    gchar *name = duckdb_value_varchar (&result, 0, i);
+    gchar *type = duckdb_value_varchar (&result, 1, i);
+    gboolean notnull = duckdb_value_int64 (&result, 2, i) != 0;
+    gboolean ok = g_strcmp0 (name, schema->columns[i].column_name) == 0
+        && g_strcmp0 (type,
+        duckdb_type_for_column (schema->columns[i].column_type)) == 0
+        && notnull == !schema->columns[i].nullable;
+    duckdb_free (name);
+    duckdb_free (type);
+    if (!ok) {
+      duckdb_destroy_result (&result);
+      return WYRELOG_E_POLICY;
+    }
+  }
+
+  const gchar *metadata_names[] = {
+    "__wyl_tenant_id",
+    "__wyl_graph_id",
+    "__wyl_seq",
+    "__wyl_batch_id",
+    "__wyl_row_index",
+    "__wyl_valid",
+  };
+  const gchar *metadata_types[] = {
+    "VARCHAR",
+    "VARCHAR",
+    "BIGINT",
+    "VARCHAR",
+    "BIGINT",
+    "BOOLEAN",
+  };
+  for (gsize i = 0; i < G_N_ELEMENTS (metadata_names); i++) {
+    idx_t row = schema->n_columns + i;
+    gchar *name = duckdb_value_varchar (&result, 0, row);
+    gchar *type = duckdb_value_varchar (&result, 1, row);
+    gboolean ok = g_strcmp0 (name, metadata_names[i]) == 0
+        && g_strcmp0 (type, metadata_types[i]) == 0
+        && duckdb_value_int64 (&result, 2, row) != 0;
+    duckdb_free (name);
+    duckdb_free (type);
+    if (!ok) {
+      duckdb_destroy_result (&result);
+      return WYRELOG_E_POLICY;
+    }
+  }
+
+  duckdb_destroy_result (&result);
+
+  g_autofree gchar *unique_sql =
+      g_strdup_printf
+      ("SELECT COUNT(*) FROM duckdb_constraints() WHERE table_name = '%s' "
+      "AND constraint_type = 'UNIQUE' "
+      "AND list_count(constraint_column_names) = 2 "
+      "AND list_contains(constraint_column_names, '__wyl_batch_id') "
+      "AND list_contains(constraint_column_names, '__wyl_row_index');",
+      table_name);
+  if (duckdb_query (store->conn, unique_sql, &result) != DuckDBSuccess) {
+    duckdb_destroy_result (&result);
+    return WYRELOG_E_IO;
+  }
+  gboolean has_unique = duckdb_value_int64 (&result, 0, 0) == 1;
+  duckdb_destroy_result (&result);
+  return has_unique ? WYRELOG_E_OK : WYRELOG_E_POLICY;
+}
+
+wyrelog_error_t
+wyl_fact_store_ensure_projection (wyl_fact_store_t *store,
+    const wyl_policy_fact_relation_schema_options_t *schema,
+    gchar **out_table_name)
+{
+  if (out_table_name != NULL)
+    *out_table_name = NULL;
+  if (store == NULL)
+    return WYRELOG_E_INVALID;
+  wyrelog_error_t rc = validate_schema_shape (schema);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  g_autofree gchar *table = wyl_fact_store_projection_table_name (schema);
+  if (table == NULL)
+    return WYRELOG_E_INVALID;
+
+  g_autoptr (GString) ddl = g_string_new ("CREATE TABLE IF NOT EXISTS ");
+  append_duckdb_identifier (ddl, table);
+  g_string_append (ddl, " (");
+  for (gsize i = 0; i < schema->n_columns; i++) {
+    if (i > 0)
+      g_string_append (ddl, ", ");
+    append_duckdb_identifier (ddl, schema->columns[i].column_name);
+    g_string_append_printf (ddl, " %s%s",
+        duckdb_type_for_column (schema->columns[i].column_type),
+        schema->columns[i].nullable ? "" : " NOT NULL");
+  }
+  g_string_append (ddl,
+      ", __wyl_tenant_id VARCHAR NOT NULL, __wyl_graph_id VARCHAR NOT NULL, "
+      "__wyl_seq BIGINT NOT NULL, __wyl_batch_id VARCHAR NOT NULL, "
+      "__wyl_row_index BIGINT NOT NULL, __wyl_valid BOOLEAN NOT NULL, "
+      "UNIQUE (__wyl_batch_id, __wyl_row_index));");
+
+  g_mutex_lock (&store->lock);
+  rc = reject_audit_database_unlocked (store);
+  if (rc == WYRELOG_E_OK)
+    rc = validate_store_scope_unlocked (store, schema->tenant_id,
+        schema->graph_id, TRUE);
+  if (rc == WYRELOG_E_OK)
+    rc = exec_sql (store->conn, ddl->str);
+  if (rc == WYRELOG_E_OK)
+    rc = validate_projection_shape_unlocked (store, schema, table);
+  g_mutex_unlock (&store->lock);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if (out_table_name != NULL)
+    *out_table_name = g_steal_pointer (&table);
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+existing_batch_matches_unlocked (wyl_fact_store_t *store,
+    const wyl_fact_store_batch_t *batch, const gchar *content_hash,
+    gboolean *out_exists)
+{
+  duckdb_prepared_statement stmt = NULL;
+  duckdb_result result = { 0 };
+  *out_exists = FALSE;
+  static const gchar *sql =
+      "SELECT batch_id, tenant_id, graph_id, namespace_id, relation_name, "
+      "schema_version, source, request_id, idempotency_key, op, row_count, "
+      "content_hash FROM fact_batches "
+      "WHERE batch_id = ? OR idempotency_key = ?;";
+  if (duckdb_prepare (store->conn, sql, &stmt) != DuckDBSuccess)
+    return WYRELOG_E_IO;
+  if (duckdb_bind_varchar (stmt, 1, batch->batch_id) != DuckDBSuccess
+      || duckdb_bind_varchar (stmt, 2, batch->idempotency_key)
+      != DuckDBSuccess) {
+    duckdb_destroy_prepare (&stmt);
+    return WYRELOG_E_IO;
+  }
+  if (duckdb_execute_prepared (stmt, &result) != DuckDBSuccess) {
+    duckdb_destroy_prepare (&stmt);
+    duckdb_destroy_result (&result);
+    return WYRELOG_E_IO;
+  }
+  duckdb_destroy_prepare (&stmt);
+  if (duckdb_row_count (&result) == 0) {
+    duckdb_destroy_result (&result);
+    return WYRELOG_E_OK;
+  }
+  if (duckdb_row_count (&result) != 1) {
+    duckdb_destroy_result (&result);
+    return WYRELOG_E_POLICY;
+  }
+  *out_exists = TRUE;
+  gchar *batch_id = duckdb_value_varchar (&result, 0, 0);
+  gchar *tenant = duckdb_value_varchar (&result, 1, 0);
+  gchar *graph = duckdb_value_varchar (&result, 2, 0);
+  gchar *namespace_id = duckdb_value_varchar (&result, 3, 0);
+  gchar *relation_name = duckdb_value_varchar (&result, 4, 0);
+  gchar *source = duckdb_value_varchar (&result, 6, 0);
+  gchar *request = duckdb_value_varchar (&result, 7, 0);
+  gchar *key = duckdb_value_varchar (&result, 8, 0);
+  gchar *op = duckdb_value_varchar (&result, 9, 0);
+  gchar *stored_hash = duckdb_value_varchar (&result, 11, 0);
+  const gchar *expected_op =
+      batch->op == WYL_FACT_STORE_OP_RETRACT ? "retract" : "assert";
+  gboolean matches = g_strcmp0 (batch_id, batch->batch_id) == 0
+      && g_strcmp0 (tenant, batch->tenant_id) == 0
+      && g_strcmp0 (graph, batch->graph_id) == 0
+      && g_strcmp0 (namespace_id, batch->namespace_id) == 0
+      && g_strcmp0 (relation_name, batch->relation_name) == 0
+      && duckdb_value_int64 (&result, 5, 0) == batch->schema_version
+      && g_strcmp0 (source, batch->source) == 0
+      && g_strcmp0 (request, batch->request_id) == 0
+      && g_strcmp0 (key, batch->idempotency_key) == 0
+      && g_strcmp0 (op, expected_op) == 0
+      && duckdb_value_int64 (&result, 10, 0) == (gint64) batch->n_rows
+      && g_strcmp0 (stored_hash, content_hash) == 0;
+  duckdb_free (batch_id);
+  duckdb_free (tenant);
+  duckdb_free (graph);
+  duckdb_free (namespace_id);
+  duckdb_free (relation_name);
+  duckdb_free (source);
+  duckdb_free (request);
+  duckdb_free (key);
+  duckdb_free (op);
+  duckdb_free (stored_hash);
+  duckdb_destroy_result (&result);
+  return matches ? WYRELOG_E_OK : WYRELOG_E_POLICY;
+}
+
+static wyrelog_error_t
+next_sequence_unlocked (wyl_fact_store_t *store, gint64 *out_seq)
+{
+  duckdb_result result = { 0 };
+  if (duckdb_query (store->conn,
+          "SELECT COALESCE(MAX(seq), 0) + 1 FROM fact_event_log;", &result)
+      != DuckDBSuccess) {
+    duckdb_destroy_result (&result);
+    return WYRELOG_E_IO;
+  }
+  *out_seq = duckdb_value_int64 (&result, 0, 0);
+  duckdb_destroy_result (&result);
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+insert_batch_unlocked (wyl_fact_store_t *store,
+    const wyl_fact_store_batch_t *batch, const gchar *content_hash,
+    gint64 created_at_us)
+{
+  duckdb_prepared_statement stmt = NULL;
+  static const gchar *sql =
+      "INSERT INTO fact_batches "
+      "(batch_id, tenant_id, graph_id, namespace_id, relation_name, "
+      " schema_version, source, request_id, idempotency_key, op, row_count, "
+      " content_hash, created_at_us) "
+      "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);";
+  if (duckdb_prepare (store->conn, sql, &stmt) != DuckDBSuccess)
+    return WYRELOG_E_IO;
+  duckdb_state ok = duckdb_bind_varchar (stmt, 1, batch->batch_id)
+      | duckdb_bind_varchar (stmt, 2, batch->tenant_id)
+      | duckdb_bind_varchar (stmt, 3, batch->graph_id)
+      | duckdb_bind_varchar (stmt, 4, batch->namespace_id)
+      | duckdb_bind_varchar (stmt, 5, batch->relation_name)
+      | duckdb_bind_int64 (stmt, 6, batch->schema_version)
+      | (batch->source != NULL ? duckdb_bind_varchar (stmt, 7, batch->source)
+      : duckdb_bind_null (stmt, 7))
+      | (batch->request_id != NULL ? duckdb_bind_varchar (stmt, 8,
+          batch->request_id) : duckdb_bind_null (stmt, 8))
+      | duckdb_bind_varchar (stmt, 9, batch->idempotency_key)
+      | duckdb_bind_varchar (stmt, 10,
+      batch->op == WYL_FACT_STORE_OP_RETRACT ? "retract" : "assert")
+      | duckdb_bind_int64 (stmt, 11, (gint64) batch->n_rows)
+      | duckdb_bind_varchar (stmt, 12, content_hash)
+      | duckdb_bind_int64 (stmt, 13, created_at_us);
+  if (ok != DuckDBSuccess) {
+    duckdb_destroy_prepare (&stmt);
+    return WYRELOG_E_IO;
+  }
+  duckdb_state rc = duckdb_execute_prepared (stmt, NULL);
+  duckdb_destroy_prepare (&stmt);
+  return rc == DuckDBSuccess ? WYRELOG_E_OK : WYRELOG_E_IO;
+}
+
+static wyrelog_error_t
+insert_event_unlocked (wyl_fact_store_t *store,
+    const wyl_fact_store_batch_t *batch, gint64 seq, gint64 created_at_us)
+{
+  duckdb_prepared_statement stmt = NULL;
+  static const gchar *sql =
+      "INSERT INTO fact_event_log "
+      "(seq, batch_id, tenant_id, graph_id, namespace_id, relation_name, "
+      " schema_version, op, created_at_us, valid) "
+      "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);";
+  if (duckdb_prepare (store->conn, sql, &stmt) != DuckDBSuccess)
+    return WYRELOG_E_IO;
+  const gchar *op = batch->op == WYL_FACT_STORE_OP_RETRACT ? "retract" :
+      "assert";
+  gboolean valid = batch->op != WYL_FACT_STORE_OP_RETRACT;
+  duckdb_state ok = duckdb_bind_int64 (stmt, 1, seq)
+      | duckdb_bind_varchar (stmt, 2, batch->batch_id)
+      | duckdb_bind_varchar (stmt, 3, batch->tenant_id)
+      | duckdb_bind_varchar (stmt, 4, batch->graph_id)
+      | duckdb_bind_varchar (stmt, 5, batch->namespace_id)
+      | duckdb_bind_varchar (stmt, 6, batch->relation_name)
+      | duckdb_bind_int64 (stmt, 7, batch->schema_version)
+      | duckdb_bind_varchar (stmt, 8, op)
+      | duckdb_bind_int64 (stmt, 9, created_at_us)
+      | duckdb_bind_boolean (stmt, 10, valid);
+  if (ok != DuckDBSuccess) {
+    duckdb_destroy_prepare (&stmt);
+    return WYRELOG_E_IO;
+  }
+  duckdb_state rc = duckdb_execute_prepared (stmt, NULL);
+  duckdb_destroy_prepare (&stmt);
+  return rc == DuckDBSuccess ? WYRELOG_E_OK : WYRELOG_E_IO;
+}
+
+static wyrelog_error_t
+append_value (duckdb_appender appender, const wyl_fact_value_t *value)
+{
+  if (value->type == WYL_FACT_VALUE_NULL)
+    return duckdb_append_null (appender) == DuckDBSuccess ? WYRELOG_E_OK :
+        WYRELOG_E_IO;
+  switch (value->type) {
+    case WYL_FACT_VALUE_SYMBOL:
+    case WYL_FACT_VALUE_STRING:
+      return duckdb_append_varchar (appender, value->as.text) == DuckDBSuccess
+          ? WYRELOG_E_OK : WYRELOG_E_IO;
+    case WYL_FACT_VALUE_INT64:
+      return duckdb_append_int64 (appender, value->as.int64_value)
+          == DuckDBSuccess ? WYRELOG_E_OK : WYRELOG_E_IO;
+    case WYL_FACT_VALUE_BOOL:
+      return duckdb_append_bool (appender, value->as.bool_value)
+          == DuckDBSuccess ? WYRELOG_E_OK : WYRELOG_E_IO;
+    case WYL_FACT_VALUE_COMPOUND_REF:
+      return duckdb_append_int64 (appender, value->as.compound_ref)
+          == DuckDBSuccess ? WYRELOG_E_OK : WYRELOG_E_IO;
+    case WYL_FACT_VALUE_NULL:
+    default:
+      return WYRELOG_E_INVALID;
+  }
+}
+
+wyrelog_error_t
+wyl_fact_store_append_batch (wyl_fact_store_t *store,
+    const wyl_policy_fact_relation_schema_options_t *schema,
+    const wyl_fact_store_batch_t *batch, gboolean *out_inserted)
+{
+  if (out_inserted != NULL)
+    *out_inserted = FALSE;
+  if (store == NULL)
+    return WYRELOG_E_INVALID;
+  wyrelog_error_t rc = validate_batch_shape (schema, batch);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  g_autofree gchar *table = NULL;
+  rc = wyl_fact_store_ensure_projection (store, schema, &table);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  g_autofree gchar *content_hash = batch_content_hash (schema, batch);
+  if (content_hash == NULL)
+    return WYRELOG_E_NOMEM;
+
+  g_mutex_lock (&store->lock);
+  gboolean exists = FALSE;
+  rc = reject_audit_database_unlocked (store);
+  if (rc == WYRELOG_E_OK)
+    rc = validate_store_scope_unlocked (store, batch->tenant_id,
+        batch->graph_id, FALSE);
+  if (rc == WYRELOG_E_OK)
+    rc = existing_batch_matches_unlocked (store, batch, content_hash, &exists);
+  if (rc == WYRELOG_E_OK && exists) {
+    if (out_inserted != NULL)
+      *out_inserted = FALSE;
+    g_mutex_unlock (&store->lock);
+    return WYRELOG_E_OK;
+  }
+  if (rc != WYRELOG_E_OK) {
+    g_mutex_unlock (&store->lock);
+    return rc;
+  }
+
+  rc = exec_sql (store->conn, "BEGIN TRANSACTION;");
+  gint64 first_seq = 0;
+  gint64 created_at_us = g_get_real_time ();
+  if (rc == WYRELOG_E_OK)
+    rc = next_sequence_unlocked (store, &first_seq);
+  if (rc == WYRELOG_E_OK)
+    rc = insert_batch_unlocked (store, batch, content_hash, created_at_us);
+
+  duckdb_appender appender = NULL;
+  if (rc == WYRELOG_E_OK
+      && duckdb_appender_create (store->conn, NULL, table, &appender)
+      != DuckDBSuccess)
+    rc = WYRELOG_E_IO;
+  for (gsize i = 0; rc == WYRELOG_E_OK && i < batch->n_rows; i++) {
+    gint64 seq = first_seq + (gint64) i;
+    if (duckdb_appender_begin_row (appender) != DuckDBSuccess) {
+      rc = WYRELOG_E_IO;
+      break;
+    }
+    for (gsize j = 0; rc == WYRELOG_E_OK && j < schema->n_columns; j++)
+      rc = append_value (appender, &batch->rows[i].values[j]);
+    if (rc == WYRELOG_E_OK)
+      rc = duckdb_append_varchar (appender, batch->tenant_id)
+          == DuckDBSuccess ? WYRELOG_E_OK : WYRELOG_E_IO;
+    if (rc == WYRELOG_E_OK)
+      rc = duckdb_append_varchar (appender, batch->graph_id)
+          == DuckDBSuccess ? WYRELOG_E_OK : WYRELOG_E_IO;
+    if (rc == WYRELOG_E_OK)
+      rc = duckdb_append_int64 (appender, seq) == DuckDBSuccess ?
+          WYRELOG_E_OK : WYRELOG_E_IO;
+    if (rc == WYRELOG_E_OK)
+      rc = duckdb_append_varchar (appender, batch->batch_id) == DuckDBSuccess ?
+          WYRELOG_E_OK : WYRELOG_E_IO;
+    if (rc == WYRELOG_E_OK)
+      rc = duckdb_append_int64 (appender, (gint64) i) == DuckDBSuccess ?
+          WYRELOG_E_OK : WYRELOG_E_IO;
+    if (rc == WYRELOG_E_OK)
+      rc = duckdb_append_bool (appender, batch->op != WYL_FACT_STORE_OP_RETRACT)
+          == DuckDBSuccess ? WYRELOG_E_OK : WYRELOG_E_IO;
+    if (rc == WYRELOG_E_OK
+        && duckdb_appender_end_row (appender) != DuckDBSuccess)
+      rc = WYRELOG_E_IO;
+    if (rc == WYRELOG_E_OK)
+      rc = insert_event_unlocked (store, batch, seq, created_at_us);
+  }
+  if (appender != NULL
+      && duckdb_appender_destroy (&appender) != DuckDBSuccess
+      && rc == WYRELOG_E_OK)
+    rc = WYRELOG_E_IO;
+  if (rc == WYRELOG_E_OK)
+    rc = exec_sql (store->conn, "COMMIT;");
+  else
+    (void) exec_sql (store->conn, "ROLLBACK;");
+  g_mutex_unlock (&store->lock);
+  if (rc == WYRELOG_E_OK && out_inserted != NULL)
+    *out_inserted = TRUE;
+  return rc;
+}

--- a/wyrelog/meson.build
+++ b/wyrelog/meson.build
@@ -70,8 +70,12 @@ if get_option('enable_audit').allowed()
   wyrelog_sources += files('audit/conn.c')
   wyrelog_deps += duckdb_dep
   wyrelog_c_args += '-DWYL_HAS_AUDIT'
-elif get_option('enable_fact_store').allowed()
-  wyrelog_deps += duckdb_dep
+endif
+if get_option('enable_fact_store').allowed()
+  wyrelog_sources += files('fact/store.c')
+  if not get_option('enable_audit').allowed()
+    wyrelog_deps += duckdb_dep
+  endif
 endif
 if get_option('enable_fact_store').allowed()
   wyrelog_c_args += '-DWYL_HAS_FACT_STORE'


### PR DESCRIPTION
## Summary
- add a private DuckDB-backed fact store with independent open/create/close lifecycle
- append schema-validated fact batches through typed relation projection tables and an event log
- enforce idempotent batch replay, tenant/graph store binding, projection drift checks, and audit-store fail-closed guards

## Validation
- `meson test -C builddir-issue50-fact --print-errorlogs` — 68 passed, 1 skipped
- `meson test -C builddir-issue50-default --print-errorlogs` — 67 passed, 1 skipped
- `git diff --check`
