### PR TITLE
Load durable fact projections into graph engines

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -280,7 +280,7 @@ if get_option('enable_fact_store').allowed()
   test_fact_store = executable('test-fact-store',
     'test-fact-store.c',
     include_directories : include_directories('../wyrelog'),
-    dependencies : [wyrelog_dep, duckdb_dep, sqlite_dep],
+    dependencies : [wyrelog_dep, wirelog_dep, duckdb_dep, sqlite_dep],
   )
 
   test('fact-store', test_fact_store)
@@ -295,6 +295,15 @@ if get_option('enable_fact_store').allowed()
   )
 
   test('fact-compound', test_fact_compound)
+
+  test_fact_replay = executable('test-fact-replay',
+    'test-fact-replay.c',
+    c_args : ['-DWYL_HAS_FACT_STORE'],
+    include_directories : include_directories('../wyrelog'),
+    dependencies : [wyrelog_dep, duckdb_dep, sqlite_dep],
+  )
+
+  test('fact-replay', test_fact_replay)
 endif
 
 test_policy_store_toctou = executable('test-policy-store-toctou',

--- a/tests/test-fact-replay.c
+++ b/tests/test-fact-replay.c
@@ -1,0 +1,620 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#if !defined(_WIN32) && !defined(_XOPEN_SOURCE)
+#define _XOPEN_SOURCE 700
+#endif
+
+#include <glib.h>
+#include <glib/gstdio.h>
+
+#include "wyrelog/fact/compound-private.h"
+#include "wyrelog/fact/replay-private.h"
+#include "wyrelog/fact/store-private.h"
+#include "wyrelog/policy/store-private.h"
+#include "wyrelog/wyl-handle-private.h"
+
+#define TEST(name) g_test_message ("%s", name)
+
+wyrelog_error_t wyl_engine_open_source (const gchar * dl_src,
+    guint32 num_workers, WylEngine ** out);
+
+typedef struct
+{
+  const gchar *tenant_id;
+  const gchar *graph_id;
+  gchar *storage_path;
+} GraphPathProbe;
+
+static wyrelog_error_t
+capture_graph_path_cb (const wyl_policy_fact_graph_info_t *info,
+    gpointer user_data)
+{
+  GraphPathProbe *probe = user_data;
+  if (g_strcmp0 (probe->tenant_id, info->tenant_id) == 0
+      && g_strcmp0 (probe->graph_id, info->graph_id) == 0)
+    probe->storage_path = g_strdup (info->storage_path);
+  return WYRELOG_E_OK;
+}
+
+static gchar *
+lookup_graph_storage_path (wyl_policy_store_t *store, const gchar *tenant_id,
+    const gchar *graph_id)
+{
+  GraphPathProbe probe = { tenant_id, graph_id, NULL };
+  if (wyl_policy_store_foreach_fact_graph (store, tenant_id,
+          capture_graph_path_cb, &probe) != WYRELOG_E_OK)
+    return NULL;
+  return probe.storage_path;
+}
+
+static void
+remove_tree (const gchar *path)
+{
+  if (path == NULL)
+    return;
+  g_autoptr (GDir) dir = g_dir_open (path, 0, NULL);
+  if (dir != NULL) {
+    const gchar *name = NULL;
+    while ((name = g_dir_read_name (dir)) != NULL) {
+      g_autofree gchar *child = g_build_filename (path, name, NULL);
+      if (g_file_test (child, G_FILE_TEST_IS_DIR))
+        remove_tree (child);
+      else
+        (void) g_remove (child);
+    }
+  }
+  (void) g_rmdir (path);
+}
+
+static wyl_policy_fact_relation_schema_options_t
+make_schema (const gchar *tenant_id, const gchar *graph_id,
+    const wyl_policy_fact_relation_schema_column_t *columns, gsize n_columns)
+{
+  wyl_policy_fact_relation_schema_options_t schema = {
+    .tenant_id = tenant_id,
+    .graph_id = graph_id,
+    .namespace_id = "shop.ns",
+    .relation_name = "orders-rel",
+    .schema_version = 1,
+    .relation_visible = TRUE,
+    .columns = columns,
+    .n_columns = n_columns,
+  };
+  return schema;
+}
+
+static void
+create_graph_with_schema (wyl_policy_store_t *store, const gchar *root,
+    const gchar *tenant_id, const gchar *graph_id)
+{
+  gboolean created = FALSE;
+  g_assert_cmpint (wyl_policy_store_create_tenant (store, tenant_id, &created),
+      ==, WYRELOG_E_OK);
+
+  const wyl_policy_fact_graph_column_t graph_columns[] = {
+    {"order_id", "symbol"},
+    {"amount", "int64"},
+    {"expedited", "bool"},
+  };
+  const wyl_policy_fact_graph_relation_t graph_relations[] = {
+    {"orders-rel", graph_columns, G_N_ELEMENTS (graph_columns)},
+  };
+  const wyl_policy_fact_graph_create_options_t graph_opts = {
+    .tenant_id = tenant_id,
+    .graph_id = graph_id,
+    .fact_root = root,
+    .schema_version = 1,
+    .owner_scope = tenant_id,
+    .relations = graph_relations,
+    .n_relations = G_N_ELEMENTS (graph_relations),
+  };
+  g_assert_cmpint (wyl_policy_store_create_fact_graph (store, &graph_opts,
+          NULL), ==, WYRELOG_E_OK);
+
+  const wyl_policy_fact_relation_schema_column_t columns[] = {
+    {"order_id", "symbol", FALSE, TRUE},
+    {"amount", "int64", FALSE, TRUE},
+    {"expedited", "bool", FALSE, TRUE},
+  };
+  wyl_policy_fact_relation_schema_options_t schema = make_schema (tenant_id,
+      graph_id, columns, G_N_ELEMENTS (columns));
+  g_assert_cmpint (wyl_policy_store_register_fact_relation_schema (store,
+          &schema), ==, WYRELOG_E_OK);
+}
+
+static wyl_policy_fact_relation_schema_options_t
+make_route_schema (const gchar *tenant_id, const gchar *graph_id,
+    const gchar *relation_name,
+    const wyl_policy_fact_relation_schema_column_t *columns, gsize n_columns)
+{
+  wyl_policy_fact_relation_schema_options_t schema = {
+    .tenant_id = tenant_id,
+    .graph_id = graph_id,
+    .namespace_id = "logistics",
+    .relation_name = relation_name,
+    .schema_version = 1,
+    .relation_visible = TRUE,
+    .columns = columns,
+    .n_columns = n_columns,
+  };
+  return schema;
+}
+
+static void
+create_compound_graph_with_schemas (wyl_policy_store_t *store,
+    const gchar *root, const gchar *tenant_id, const gchar *graph_id)
+{
+  gboolean created = FALSE;
+  g_assert_cmpint (wyl_policy_store_create_tenant (store, tenant_id, &created),
+      ==, WYRELOG_E_OK);
+
+  const wyl_policy_fact_graph_column_t graph_columns[] = {
+    {"route", "compound_ref"},
+  };
+  const wyl_policy_fact_graph_relation_t graph_relations[] = {
+    {"shipment-route", graph_columns, G_N_ELEMENTS (graph_columns)},
+    {"shipment-audit", graph_columns, G_N_ELEMENTS (graph_columns)},
+  };
+  const wyl_policy_fact_graph_create_options_t graph_opts = {
+    .tenant_id = tenant_id,
+    .graph_id = graph_id,
+    .fact_root = root,
+    .schema_version = 1,
+    .owner_scope = tenant_id,
+    .relations = graph_relations,
+    .n_relations = G_N_ELEMENTS (graph_relations),
+  };
+  g_assert_cmpint (wyl_policy_store_create_fact_graph (store, &graph_opts,
+          NULL), ==, WYRELOG_E_OK);
+
+  const wyl_policy_fact_relation_schema_column_t columns[] = {
+    {"route", "compound_ref", FALSE, TRUE},
+  };
+  for (guint i = 0; i < G_N_ELEMENTS (graph_relations); i++) {
+    wyl_policy_fact_relation_schema_options_t schema = make_route_schema
+        (tenant_id, graph_id, graph_relations[i].relation_name, columns,
+        G_N_ELEMENTS (columns));
+    g_assert_cmpint (wyl_policy_store_register_fact_relation_schema (store,
+            &schema), ==, WYRELOG_E_OK);
+  }
+}
+
+static void
+append_order_batches (wyl_policy_store_t *policy, const gchar *root,
+    const gchar *tenant_id, const gchar *graph_id)
+{
+  (void) root;
+  g_autofree gchar *storage_path = lookup_graph_storage_path (policy,
+      tenant_id, graph_id);
+  g_assert_nonnull (storage_path);
+  g_autofree gchar *fact_path = g_build_filename (storage_path,
+      "facts.duckdb", NULL);
+  g_autoptr (wyl_fact_store_t) store = NULL;
+  g_assert_cmpint (wyl_fact_store_open (fact_path, &store), ==, WYRELOG_E_OK);
+  g_assert_cmpint (wyl_fact_store_create_schema (store), ==, WYRELOG_E_OK);
+
+  const wyl_policy_fact_relation_schema_column_t columns[] = {
+    {"order_id", "symbol", FALSE, TRUE},
+    {"amount", "int64", FALSE, TRUE},
+    {"expedited", "bool", FALSE, TRUE},
+  };
+  wyl_policy_fact_relation_schema_options_t schema = make_schema (tenant_id,
+      graph_id, columns, G_N_ELEMENTS (columns));
+
+  wyl_fact_value_t values1[] = {
+    {.type = WYL_FACT_VALUE_SYMBOL,.as.text = "order-a"},
+    {.type = WYL_FACT_VALUE_INT64,.as.int64_value = 11},
+    {.type = WYL_FACT_VALUE_BOOL,.as.bool_value = TRUE},
+    {.type = WYL_FACT_VALUE_SYMBOL,.as.text = "order-b"},
+    {.type = WYL_FACT_VALUE_INT64,.as.int64_value = 22},
+    {.type = WYL_FACT_VALUE_BOOL,.as.bool_value = FALSE},
+  };
+  wyl_fact_row_t rows1[] = {
+    {values1, 3},
+    {values1 + 3, 3},
+  };
+  const wyl_fact_store_batch_t batch1 = {
+    .batch_id = "batch-1",
+    .tenant_id = tenant_id,
+    .graph_id = graph_id,
+    .namespace_id = "shop.ns",
+    .relation_name = "orders-rel",
+    .schema_version = 1,
+    .source = "test",
+    .idempotency_key = "key-1",
+    .op = WYL_FACT_STORE_OP_ASSERT,
+    .rows = rows1,
+    .n_rows = G_N_ELEMENTS (rows1),
+  };
+  gboolean inserted = FALSE;
+  g_assert_cmpint (wyl_fact_store_append_batch (store, &schema, &batch1,
+          &inserted), ==, WYRELOG_E_OK);
+  g_assert_true (inserted);
+
+  wyl_fact_value_t values2[] = {
+    {.type = WYL_FACT_VALUE_SYMBOL,.as.text = "order-a"},
+    {.type = WYL_FACT_VALUE_INT64,.as.int64_value = 11},
+    {.type = WYL_FACT_VALUE_BOOL,.as.bool_value = TRUE},
+  };
+  wyl_fact_row_t rows2[] = {
+    {values2, 3},
+  };
+  const wyl_fact_store_batch_t batch2 = {
+    .batch_id = "batch-2",
+    .tenant_id = tenant_id,
+    .graph_id = graph_id,
+    .namespace_id = "shop.ns",
+    .relation_name = "orders-rel",
+    .schema_version = 1,
+    .source = "test",
+    .idempotency_key = "key-2",
+    .op = WYL_FACT_STORE_OP_RETRACT,
+    .rows = rows2,
+    .n_rows = G_N_ELEMENTS (rows2),
+  };
+  g_assert_cmpint (wyl_fact_store_append_batch (store, &schema, &batch2,
+          &inserted), ==, WYRELOG_E_OK);
+  g_assert_true (inserted);
+}
+
+static void
+put_route_compounds (wyl_fact_store_t *store, const gchar *tenant_id,
+    const gchar *graph_id, gint64 *out_child_ref, gint64 *out_parent_ref)
+{
+  const wyl_fact_compound_arg_t args[] = {
+    {.type = WYL_FACT_COMPOUND_ARG_SYMBOL,.as.text = "ICN"},
+    {.type = WYL_FACT_COMPOUND_ARG_SYMBOL,.as.text = "LAX"},
+  };
+  const wyl_fact_compound_value_t value = {
+    .tenant_id = tenant_id,
+    .graph_id = graph_id,
+    .namespace_id = "logistics",
+    .functor = "path",
+    .args = args,
+    .n_args = G_N_ELEMENTS (args),
+  };
+  gint64 child_ref = 0;
+  g_assert_cmpint (wyl_fact_compound_put (store, &value, &child_ref), ==,
+      WYRELOG_E_OK);
+  g_assert_cmpint (child_ref, >, 0);
+
+  const wyl_fact_compound_arg_t parent_args[] = {
+    {.type = WYL_FACT_COMPOUND_ARG_COMPOUND_REF,.as.compound_ref = child_ref},
+  };
+  const wyl_fact_compound_value_t parent_value = {
+    .tenant_id = tenant_id,
+    .graph_id = graph_id,
+    .namespace_id = "logistics",
+    .functor = "wrap",
+    .args = parent_args,
+    .n_args = G_N_ELEMENTS (parent_args),
+  };
+  gint64 parent_ref = 0;
+  g_assert_cmpint (wyl_fact_compound_put (store, &parent_value, &parent_ref),
+      ==, WYRELOG_E_OK);
+  g_assert_cmpint (parent_ref, >, 0);
+  *out_child_ref = child_ref;
+  *out_parent_ref = parent_ref;
+}
+
+static void
+append_compound_route_batches (wyl_policy_store_t *policy,
+    const gchar *tenant_id, const gchar *graph_id)
+{
+  g_autofree gchar *storage_path = lookup_graph_storage_path (policy,
+      tenant_id, graph_id);
+  g_assert_nonnull (storage_path);
+  g_autofree gchar *fact_path = g_build_filename (storage_path,
+      "facts.duckdb", NULL);
+  g_autoptr (wyl_fact_store_t) store = NULL;
+  g_assert_cmpint (wyl_fact_store_open (fact_path, &store), ==, WYRELOG_E_OK);
+  g_assert_cmpint (wyl_fact_store_create_schema (store), ==, WYRELOG_E_OK);
+  g_assert_cmpint (wyl_fact_compound_create_schema (store), ==, WYRELOG_E_OK);
+  gint64 child_ref = 0;
+  gint64 parent_ref = 0;
+  put_route_compounds (store, tenant_id, graph_id, &child_ref, &parent_ref);
+
+  const wyl_policy_fact_relation_schema_column_t columns[] = {
+    {"route", "compound_ref", FALSE, TRUE},
+  };
+  const gchar *relations[] = { "shipment-route", "shipment-audit" };
+  const gint64 refs[] = { child_ref, parent_ref };
+  for (guint i = 0; i < G_N_ELEMENTS (relations); i++) {
+    wyl_policy_fact_relation_schema_options_t schema = make_route_schema
+        (tenant_id, graph_id, relations[i], columns, G_N_ELEMENTS (columns));
+    wyl_fact_value_t values[] = {
+      {.type = WYL_FACT_VALUE_COMPOUND_REF,.as.compound_ref = refs[i]},
+    };
+    wyl_fact_row_t rows[] = {
+      {values, G_N_ELEMENTS (values)},
+    };
+    g_autofree gchar *batch_id = g_strdup_printf ("route-batch-%u", i);
+    g_autofree gchar *idempotency_key = g_strdup_printf ("route-key-%u", i);
+    const wyl_fact_store_batch_t batch = {
+      .batch_id = batch_id,
+      .tenant_id = tenant_id,
+      .graph_id = graph_id,
+      .namespace_id = "logistics",
+      .relation_name = relations[i],
+      .schema_version = 1,
+      .source = "test",
+      .idempotency_key = idempotency_key,
+      .op = WYL_FACT_STORE_OP_ASSERT,
+      .rows = rows,
+      .n_rows = G_N_ELEMENTS (rows),
+    };
+    gboolean inserted = FALSE;
+    g_assert_cmpint (wyl_fact_store_append_batch (store, &schema, &batch,
+            &inserted), ==, WYRELOG_E_OK);
+    g_assert_true (inserted);
+  }
+}
+
+typedef struct
+{
+  const gchar *relation;
+  guint count;
+  gboolean saw_order_b;
+} SnapshotProbe;
+
+static void
+snapshot_cb (const gchar *relation, const gint64 *row, guint ncols,
+    gpointer user_data)
+{
+  SnapshotProbe *probe = user_data;
+  if (g_strcmp0 (relation, probe->relation) != 0 || ncols != 3)
+    return;
+  probe->count++;
+  if (row[1] == 22 && row[2] == 0)
+    probe->saw_order_b = TRUE;
+}
+
+static void
+assert_replayed_order_b_only (WylEngine *engine)
+{
+  g_autofree gchar *relation = wyl_fact_replay_wirelog_relation_name
+      ("shop.ns", "orders-rel");
+  g_autofree gchar *observed = g_strdup_printf ("%s_observed", relation);
+  SnapshotProbe probe = { observed, 0, FALSE };
+  g_assert_cmpint (wyl_engine_snapshot (engine, observed, snapshot_cb, &probe),
+      ==, WYRELOG_E_OK);
+  g_assert_cmpuint (probe.count, ==, 1);
+  g_assert_true (probe.saw_order_b);
+}
+
+typedef struct
+{
+  const gchar *relation;
+  guint count;
+  gint64 handle;
+} CompoundSnapshotProbe;
+
+static void
+compound_snapshot_cb (const gchar *relation, const gint64 *row, guint ncols,
+    gpointer user_data)
+{
+  CompoundSnapshotProbe *probe = user_data;
+  if (g_strcmp0 (relation, probe->relation) != 0 || ncols != 1)
+    return;
+  probe->count++;
+  if (probe->handle > 0)
+    g_assert_cmpint (probe->handle, ==, row[0]);
+  probe->handle = row[0];
+}
+
+static gint64
+snapshot_single_compound_handle (WylEngine *engine, const gchar *relation_name)
+{
+  g_autofree gchar *relation = wyl_fact_replay_wirelog_relation_name
+      ("logistics", relation_name);
+  g_autofree gchar *observed = g_strdup_printf ("%s_observed", relation);
+  CompoundSnapshotProbe probe = { observed, 0, 0 };
+  g_assert_cmpint (wyl_engine_snapshot (engine, observed, compound_snapshot_cb,
+          &probe), ==, WYRELOG_E_OK);
+  g_assert_cmpuint (probe.count, >, 0);
+  g_assert_cmpint (probe.handle, >, 0);
+  return probe.handle;
+}
+
+static void
+test_direct_replay_retracts_and_mangles (void)
+{
+#ifndef G_OS_WIN32
+  TEST ("direct replay loads net facts with mangled relation names");
+  g_autoptr (GError) error = NULL;
+  g_autofree gchar *root = g_dir_make_tmp ("wyl-fact-replay-XXXXXX", &error);
+  g_assert_no_error (error);
+  g_assert_nonnull (root);
+  g_autoptr (wyl_policy_store_t) policy = NULL;
+  g_assert_cmpint (wyl_policy_store_open (NULL, &policy), ==, WYRELOG_E_OK);
+  g_assert_cmpint (wyl_policy_store_create_schema (policy), ==, WYRELOG_E_OK);
+  create_graph_with_schema (policy, root, "tenant-a", "orders");
+  append_order_batches (policy, root, "tenant-a", "orders");
+
+  GraphPathProbe info_probe = { "tenant-a", "orders", NULL };
+  g_assert_cmpint (wyl_policy_store_foreach_fact_graph (policy, "tenant-a",
+          capture_graph_path_cb, &info_probe), ==, WYRELOG_E_OK);
+  g_assert_nonnull (info_probe.storage_path);
+  wyl_policy_fact_graph_info_t info = {
+    .tenant_id = "tenant-a",
+    .graph_id = "orders",
+    .storage_path = info_probe.storage_path,
+    .schema_version = 1,
+  };
+  g_autoptr (WylEngine) engine = NULL;
+  g_assert_cmpint (wyl_fact_replay_open_graph_engine (policy, &info, &engine),
+      ==, WYRELOG_E_OK);
+  assert_replayed_order_b_only (engine);
+  g_free (info_probe.storage_path);
+  remove_tree (root);
+#else
+  g_test_skip ("fact graph path isolation is Unix-only in this build");
+#endif
+}
+
+static void
+test_direct_replay_shares_compounds_across_relations (void)
+{
+#ifndef G_OS_WIN32
+  TEST ("direct replay keeps compound handles graph scoped across relations");
+  g_autoptr (GError) error = NULL;
+  g_autofree gchar *root = g_dir_make_tmp ("wyl-fact-replay-compound-XXXXXX",
+      &error);
+  g_assert_no_error (error);
+  g_assert_nonnull (root);
+  g_autoptr (wyl_policy_store_t) policy = NULL;
+  g_assert_cmpint (wyl_policy_store_open (NULL, &policy), ==, WYRELOG_E_OK);
+  g_assert_cmpint (wyl_policy_store_create_schema (policy), ==, WYRELOG_E_OK);
+  create_compound_graph_with_schemas (policy, root, "tenant-a", "shipments");
+  append_compound_route_batches (policy, "tenant-a", "shipments");
+
+  GraphPathProbe info_probe = { "tenant-a", "shipments", NULL };
+  g_assert_cmpint (wyl_policy_store_foreach_fact_graph (policy, "tenant-a",
+          capture_graph_path_cb, &info_probe), ==, WYRELOG_E_OK);
+  g_assert_nonnull (info_probe.storage_path);
+  wyl_policy_fact_graph_info_t info = {
+    .tenant_id = "tenant-a",
+    .graph_id = "shipments",
+    .storage_path = info_probe.storage_path,
+    .schema_version = 1,
+  };
+  g_autoptr (WylEngine) engine = NULL;
+  g_assert_cmpint (wyl_fact_replay_open_graph_engine (policy, &info, &engine),
+      ==, WYRELOG_E_OK);
+
+  gint64 child_handle = snapshot_single_compound_handle (engine,
+      "shipment-route");
+  gint64 parent_handle = snapshot_single_compound_handle (engine,
+      "shipment-audit");
+  g_assert_cmpint (child_handle, >, 0);
+  g_assert_cmpint (parent_handle, >, 0);
+  g_free (info_probe.storage_path);
+  remove_tree (root);
+#else
+  g_test_skip ("fact graph path isolation is Unix-only in this build");
+#endif
+}
+
+static gchar *
+test_compound_cache_key (const gchar *namespace_id, gint64 compound_ref)
+{
+  return g_strdup_printf ("%s:%" G_GINT64_FORMAT, namespace_id, compound_ref);
+}
+
+static void
+test_compound_replay_cache_reuses_nested_child (void)
+{
+#ifndef G_OS_WIN32
+  TEST ("compound replay cache reuses nested child handles");
+  g_autoptr (GError) error = NULL;
+  g_autofree gchar *root = g_dir_make_tmp ("wyl-fact-replay-cache-XXXXXX",
+      &error);
+  g_assert_no_error (error);
+  g_autofree gchar *fact_path = g_build_filename (root, "facts.duckdb", NULL);
+  g_autoptr (wyl_fact_store_t) store = NULL;
+  g_assert_cmpint (wyl_fact_store_open (fact_path, &store), ==, WYRELOG_E_OK);
+  g_assert_cmpint (wyl_fact_store_create_schema (store), ==, WYRELOG_E_OK);
+  g_assert_cmpint (wyl_fact_compound_create_schema (store), ==, WYRELOG_E_OK);
+  gint64 child_ref = 0;
+  gint64 parent_ref = 0;
+  put_route_compounds (store, "tenant-a", "shipments", &child_ref, &parent_ref);
+
+  g_autoptr (WylEngine) engine = NULL;
+  g_assert_cmpint (wyl_engine_open_source
+      (".decl shipment(route: path/2 side)\n", 1, &engine), ==, WYRELOG_E_OK);
+  g_autoptr (GHashTable) handles =
+      g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
+  gint64 parent_handle = 0;
+  g_assert_cmpint (wyl_fact_compound_replay_cached (store, engine, "tenant-a",
+          "shipments", "logistics", parent_ref, handles, &parent_handle), ==,
+      WYRELOG_E_OK);
+  g_assert_cmpint (parent_handle, >, 0);
+  g_autofree gchar *child_key = test_compound_cache_key ("logistics",
+      child_ref);
+  gint64 *nested_child_handle = g_hash_table_lookup (handles, child_key);
+  g_assert_nonnull (nested_child_handle);
+  g_assert_cmpint (*nested_child_handle, >, 0);
+
+  gint64 direct_child_handle = 0;
+  g_assert_cmpint (wyl_fact_compound_replay_cached (store, engine, "tenant-a",
+          "shipments", "logistics", child_ref, handles, &direct_child_handle),
+      ==, WYRELOG_E_OK);
+  g_assert_cmpint (direct_child_handle, ==, *nested_child_handle);
+  remove_tree (root);
+#else
+  g_test_skip ("fact graph path isolation is Unix-only in this build");
+#endif
+}
+
+static void
+test_handle_replay_is_idempotent_and_graph_local (void)
+{
+#ifndef G_OS_WIN32
+  TEST ("handle replay replaces graph engines and isolates corrupt graphs");
+  g_autoptr (GError) error = NULL;
+  g_autofree gchar *root = g_dir_make_tmp ("wyl-fact-replay-handle-XXXXXX",
+      &error);
+  g_assert_no_error (error);
+  g_autofree gchar *policy_path = g_build_filename (root, "policy.sqlite",
+      NULL);
+
+  {
+    g_autoptr (wyl_policy_store_t) policy = NULL;
+    g_assert_cmpint (wyl_policy_store_open (policy_path, &policy), ==,
+        WYRELOG_E_OK);
+    g_assert_cmpint (wyl_policy_store_create_schema (policy), ==, WYRELOG_E_OK);
+    create_graph_with_schema (policy, root, "tenant-a", "orders");
+    create_graph_with_schema (policy, root, "tenant-b", "orders");
+    append_order_batches (policy, root, "tenant-a", "orders");
+
+    g_autofree gchar *bad_path = lookup_graph_storage_path (policy,
+        "tenant-b", "orders");
+    g_assert_nonnull (bad_path);
+    g_autofree gchar *bad_fact_path = g_build_filename (bad_path,
+        "facts.duckdb", NULL);
+    g_assert_true (g_file_set_contents (bad_fact_path, "not a database", -1,
+            NULL));
+  }
+
+  g_autoptr (WylHandle) handle = NULL;
+  const WylHandleOpenOptions opts = {
+    .policy_store_path = policy_path,
+  };
+  g_assert_cmpint (wyl_handle_open_with_options (&opts, &handle), ==,
+      WYRELOG_E_OK);
+  WylEngine *tenant_a = wyl_handle_get_fact_graph_engine (handle, "tenant-a",
+      "orders");
+  WylEngine *tenant_b = wyl_handle_get_fact_graph_engine (handle, "tenant-b",
+      "orders");
+  g_assert_nonnull (tenant_a);
+  g_assert_null (tenant_b);
+  assert_replayed_order_b_only (tenant_a);
+
+  wyl_fact_replay_summary_t summary = { 0 };
+  g_assert_cmpint (wyl_handle_replay_fact_graphs (handle, &summary), ==,
+      WYRELOG_E_OK);
+  g_assert_cmpuint (summary.graphs_seen, ==, 2);
+  g_assert_cmpuint (summary.graphs_loaded, ==, 1);
+  g_assert_cmpuint (summary.graphs_degraded, ==, 1);
+  tenant_a = wyl_handle_get_fact_graph_engine (handle, "tenant-a", "orders");
+  g_assert_nonnull (tenant_a);
+  assert_replayed_order_b_only (tenant_a);
+  remove_tree (root);
+#else
+  g_test_skip ("fact graph path isolation is Unix-only in this build");
+#endif
+}
+
+int
+main (int argc, char **argv)
+{
+  g_test_init (&argc, &argv, NULL);
+  g_test_add_func ("/fact-replay/direct",
+      test_direct_replay_retracts_and_mangles);
+  g_test_add_func ("/fact-replay/compound-shared",
+      test_direct_replay_shares_compounds_across_relations);
+  g_test_add_func ("/fact-replay/compound-cache-nested",
+      test_compound_replay_cache_reuses_nested_child);
+  g_test_add_func ("/fact-replay/handle",
+      test_handle_replay_is_idempotent_and_graph_local);
+  return g_test_run ();
+}

--- a/wyrelog/fact/compound-private.h
+++ b/wyrelog/fact/compound-private.h
@@ -50,5 +50,9 @@ wyrelog_error_t wyl_fact_compound_ref_exists (wyl_fact_store_t * store,
 wyrelog_error_t wyl_fact_compound_replay (wyl_fact_store_t * store,
     WylEngine * engine, const gchar * tenant_id, const gchar * graph_id,
     const gchar * namespace_id, gint64 compound_ref, gint64 * out_handle);
+wyrelog_error_t wyl_fact_compound_replay_cached (wyl_fact_store_t * store,
+    WylEngine * engine, const gchar * tenant_id, const gchar * graph_id,
+    const gchar * namespace_id, gint64 compound_ref, GHashTable * handles,
+    gint64 * out_handle);
 
 G_END_DECLS;

--- a/wyrelog/fact/compound.c
+++ b/wyrelog/fact/compound.c
@@ -540,6 +540,12 @@ loaded_term_clear (loaded_term_t *term)
   g_free (term->content_hash);
 }
 
+static gchar *
+compound_replay_cache_key (const gchar *namespace_id, gint64 compound_ref)
+{
+  return g_strdup_printf ("%s:%" G_GINT64_FORMAT, namespace_id, compound_ref);
+}
+
 static wyrelog_error_t
 load_term_unlocked (duckdb_connection conn, const gchar *tenant_id,
     const gchar *graph_id, const gchar *namespace_id, gint64 compound_ref,
@@ -592,7 +598,7 @@ load_term_unlocked (duckdb_connection conn, const gchar *tenant_id,
 static wyrelog_error_t replay_unlocked (duckdb_connection conn,
     WylEngine * engine, const gchar * tenant_id, const gchar * graph_id,
     const gchar * namespace_id, gint64 compound_ref, guint depth,
-    GHashTable * seen, gint64 * out_handle);
+    GHashTable * seen, GHashTable * handles, gint64 * out_handle);
 
 static wyrelog_error_t
 load_logical_arg_unlocked (idx_t row, duckdb_result *result,
@@ -683,7 +689,7 @@ static wyrelog_error_t
 materialize_arg_unlocked (duckdb_connection conn, WylEngine *engine,
     const gchar *tenant_id, const gchar *graph_id, const gchar *namespace_id,
     guint depth, GHashTable *seen, const wyl_fact_compound_arg_t *logical_arg,
-    wirelog_compound_arg_t *out_arg)
+    GHashTable *handles, wirelog_compound_arg_t *out_arg)
 {
   switch (logical_arg->type) {
     case WYL_FACT_COMPOUND_ARG_SYMBOL:
@@ -711,7 +717,7 @@ materialize_arg_unlocked (duckdb_connection conn, WylEngine *engine,
       gint64 child_handle = 0;
       wyrelog_error_t rc = replay_unlocked (conn, engine, tenant_id, graph_id,
           namespace_id, logical_arg->as.compound_ref, depth + 1, seen,
-          &child_handle);
+          handles, &child_handle);
       if (rc != WYRELOG_E_OK)
         return rc;
       out_arg->type = WIRELOG_TYPE_INT64;
@@ -726,10 +732,20 @@ materialize_arg_unlocked (duckdb_connection conn, WylEngine *engine,
 static wyrelog_error_t
 replay_unlocked (duckdb_connection conn, WylEngine *engine,
     const gchar *tenant_id, const gchar *graph_id, const gchar *namespace_id,
-    gint64 compound_ref, guint depth, GHashTable *seen, gint64 *out_handle)
+    gint64 compound_ref, guint depth, GHashTable *seen, GHashTable *handles,
+    gint64 *out_handle)
 {
   if (depth > WYL_FACT_COMPOUND_MAX_DEPTH)
     return WYRELOG_E_POLICY;
+  if (handles != NULL) {
+    g_autofree gchar *key = compound_replay_cache_key (namespace_id,
+        compound_ref);
+    gint64 *cached = g_hash_table_lookup (handles, key);
+    if (cached != NULL) {
+      *out_handle = *cached;
+      return WYRELOG_E_OK;
+    }
+  }
   if (g_hash_table_contains (seen, &compound_ref))
     return WYRELOG_E_POLICY;
   gint64 *seen_key = g_new (gint64, 1);
@@ -800,10 +816,17 @@ replay_unlocked (duckdb_connection conn, WylEngine *engine,
       (gsize) term.arity);
   for (gsize i = 0; rc == WYRELOG_E_OK && i < (gsize) term.arity; i++)
     rc = materialize_arg_unlocked (conn, engine, tenant_id, graph_id,
-        namespace_id, depth, seen, &logical_args[i], &args[i]);
+        namespace_id, depth, seen, &logical_args[i], handles, &args[i]);
   if (rc == WYRELOG_E_OK)
     rc = wyl_engine_owned_make_compound (engine, term.functor, args,
         (gsize) term.arity, out_handle);
+  if (rc == WYRELOG_E_OK && handles != NULL) {
+    g_autofree gchar *key = compound_replay_cache_key (namespace_id,
+        compound_ref);
+    gint64 *cached = g_new (gint64, 1);
+    *cached = *out_handle;
+    g_hash_table_insert (handles, g_steal_pointer (&key), cached);
+  }
   clear_logical_args (logical_args, (gsize) term.arity);
   loaded_term_clear (&term);
   g_hash_table_remove (seen, &compound_ref);
@@ -828,7 +851,31 @@ wyl_fact_compound_replay (wyl_fact_store_t *store, WylEngine *engine,
       FALSE);
   if (rc == WYRELOG_E_OK)
     rc = replay_unlocked (conn, engine, tenant_id, graph_id, namespace_id,
-        compound_ref, 0, seen, out_handle);
+        compound_ref, 0, seen, NULL, out_handle);
+  wyl_fact_store_unlock (store);
+  return rc;
+}
+
+wyrelog_error_t
+wyl_fact_compound_replay_cached (wyl_fact_store_t *store, WylEngine *engine,
+    const gchar *tenant_id, const gchar *graph_id, const gchar *namespace_id,
+    gint64 compound_ref, GHashTable *handles, gint64 *out_handle)
+{
+  if (out_handle != NULL)
+    *out_handle = 0;
+  if (store == NULL || engine == NULL || tenant_id == NULL || graph_id == NULL
+      || namespace_id == NULL || compound_ref <= 0 || handles == NULL
+      || out_handle == NULL)
+    return WYRELOG_E_INVALID;
+  duckdb_connection conn = wyl_fact_store_get_connection (store);
+  g_autoptr (GHashTable) seen = g_hash_table_new_full (g_int64_hash,
+      g_int64_equal, g_free, NULL);
+  wyl_fact_store_lock (store);
+  wyrelog_error_t rc = validate_scope_unlocked (conn, tenant_id, graph_id,
+      FALSE);
+  if (rc == WYRELOG_E_OK)
+    rc = replay_unlocked (conn, engine, tenant_id, graph_id, namespace_id,
+        compound_ref, 0, seen, handles, out_handle);
   wyl_fact_store_unlock (store);
   return rc;
 }

--- a/wyrelog/fact/replay-private.h
+++ b/wyrelog/fact/replay-private.h
@@ -1,0 +1,29 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+
+#include <glib.h>
+
+#include "wyrelog/error.h"
+#include "wyrelog/engine.h"
+#include "wyrelog/fact/store-private.h"
+#include "wyrelog/policy/store-private.h"
+
+G_BEGIN_DECLS;
+
+typedef struct
+{
+  guint graphs_seen;
+  guint graphs_loaded;
+  guint graphs_degraded;
+} wyl_fact_replay_summary_t;
+
+gchar *wyl_fact_replay_wirelog_relation_name (const gchar * namespace_id,
+    const gchar * relation_name);
+
+wyrelog_error_t wyl_fact_replay_open_graph_engine (wyl_policy_store_t * policy,
+    const wyl_policy_fact_graph_info_t * graph_info, WylEngine ** out_engine);
+
+wyrelog_error_t wyl_fact_replay_policy_graphs (wyl_policy_store_t * policy,
+    GHashTable * graph_engines, wyl_fact_replay_summary_t * out_summary);
+
+G_END_DECLS;

--- a/wyrelog/fact/replay.c
+++ b/wyrelog/fact/replay.c
@@ -1,0 +1,570 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "replay-private.h"
+
+#include <string.h>
+
+#include "compound-private.h"
+#include "wyrelog/wyl-engine-private.h"
+
+#define WYL_FACT_REPLAY_MAX_ROWS G_MAXUINT32
+
+typedef struct
+{
+  gchar *namespace_id;
+  gchar *relation_name;
+  guint32 schema_version;
+  gboolean relation_visible;
+  wyl_policy_fact_relation_schema_column_t *columns;
+  gsize n_columns;
+  gchar *projection_table;
+  gchar *wirelog_relation;
+} ReplayRelation;
+
+typedef struct
+{
+  WylEngine *engine;
+  const gchar *tenant_id;
+  const gchar *graph_id;
+  const gchar *namespace_id;
+  wyl_fact_store_t *store;
+  GHashTable *compound_handles;
+} ReplayMaterializeCtx;
+
+typedef struct
+{
+  wyl_policy_store_t *policy;
+  GHashTable *graph_engines;
+  wyl_fact_replay_summary_t *summary;
+} PolicyReplayCtx;
+
+static void
+append_wirelog_identifier (GString *out, const gchar *identifier)
+{
+  if (identifier == NULL || identifier[0] == '\0') {
+    g_string_append_c (out, 'w');
+    return;
+  }
+
+  g_string_append_c (out, 'w');
+  for (const gchar * p = identifier; *p != '\0'; p++)
+    g_string_append_printf (out, "_%02x", (guchar) * p);
+}
+
+gchar *
+wyl_fact_replay_wirelog_relation_name (const gchar *namespace_id,
+    const gchar *relation_name)
+{
+  if (namespace_id == NULL || relation_name == NULL)
+    return NULL;
+
+  g_autoptr (GString) out = g_string_new (NULL);
+  append_wirelog_identifier (out, namespace_id);
+  g_string_append_c (out, '_');
+  append_wirelog_identifier (out, relation_name);
+  return g_string_free (g_steal_pointer (&out), FALSE);
+}
+
+static void
+append_duckdb_identifier (GString *out, const gchar *identifier)
+{
+  g_string_append_c (out, '"');
+  for (const gchar * p = identifier; p != NULL && *p != '\0'; p++) {
+    if (*p == '"')
+      g_string_append_c (out, '"');
+    g_string_append_c (out, *p);
+  }
+  g_string_append_c (out, '"');
+}
+
+static void
+replay_relation_free (gpointer data)
+{
+  ReplayRelation *rel = data;
+  if (rel == NULL)
+    return;
+  g_free (rel->namespace_id);
+  g_free (rel->relation_name);
+  for (gsize i = 0; i < rel->n_columns; i++) {
+    g_free ((gchar *) rel->columns[i].column_name);
+    g_free ((gchar *) rel->columns[i].column_type);
+  }
+  g_free (rel->columns);
+  g_free (rel->projection_table);
+  g_free (rel->wirelog_relation);
+  g_free (rel);
+}
+
+static wyrelog_error_t
+copy_schema_columns (const wyl_policy_fact_relation_schema_column_info_t *in,
+    gsize n_columns, wyl_policy_fact_relation_schema_column_t **out)
+{
+  *out = NULL;
+  if (in == NULL || n_columns == 0)
+    return WYRELOG_E_INVALID;
+
+  wyl_policy_fact_relation_schema_column_t *copy =
+      g_new0 (wyl_policy_fact_relation_schema_column_t, n_columns);
+  for (gsize i = 0; i < n_columns; i++) {
+    copy[i].column_name = g_strdup (in[i].column_name);
+    copy[i].column_type = g_strdup (in[i].column_type);
+    copy[i].nullable = in[i].nullable;
+    copy[i].visible = in[i].visible;
+    if (copy[i].column_name == NULL || copy[i].column_type == NULL) {
+      for (gsize j = 0; j <= i; j++) {
+        g_free ((gchar *) copy[j].column_name);
+        g_free ((gchar *) copy[j].column_type);
+      }
+      g_free (copy);
+      return WYRELOG_E_NOMEM;
+    }
+  }
+  *out = copy;
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+load_relation_schema (wyl_policy_store_t *policy,
+    const wyl_policy_fact_graph_info_t *graph, const gchar *namespace_id,
+    const gchar *relation_name, guint32 schema_version,
+    ReplayRelation **out_relation)
+{
+  *out_relation = NULL;
+
+  gboolean relation_visible = FALSE;
+  wyl_policy_fact_relation_schema_column_info_t *columns = NULL;
+  gsize n_columns = 0;
+  wyrelog_error_t rc = wyl_policy_store_load_fact_relation_schema_columns
+      (policy, graph->tenant_id, graph->graph_id, namespace_id, relation_name,
+      schema_version, &relation_visible, &columns, &n_columns);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  ReplayRelation *rel = g_new0 (ReplayRelation, 1);
+  rel->namespace_id = g_strdup (namespace_id);
+  rel->relation_name = g_strdup (relation_name);
+  rel->schema_version = schema_version;
+  rel->relation_visible = relation_visible;
+  rc = copy_schema_columns (columns, n_columns, &rel->columns);
+  rel->n_columns = n_columns;
+  wyl_policy_fact_relation_schema_columns_free (columns, n_columns);
+  if (rc != WYRELOG_E_OK) {
+    replay_relation_free (rel);
+    return rc;
+  }
+
+  const wyl_policy_fact_relation_schema_options_t opts = {
+    .tenant_id = graph->tenant_id,
+    .graph_id = graph->graph_id,
+    .namespace_id = rel->namespace_id,
+    .relation_name = rel->relation_name,
+    .schema_version = rel->schema_version,
+    .relation_visible = rel->relation_visible,
+    .columns = rel->columns,
+    .n_columns = rel->n_columns,
+  };
+  rel->projection_table = wyl_fact_store_projection_table_name (&opts);
+  rel->wirelog_relation =
+      wyl_fact_replay_wirelog_relation_name (rel->namespace_id,
+      rel->relation_name);
+  if (rel->namespace_id == NULL || rel->relation_name == NULL
+      || rel->projection_table == NULL || rel->wirelog_relation == NULL) {
+    replay_relation_free (rel);
+    return WYRELOG_E_NOMEM;
+  }
+
+  *out_relation = rel;
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+list_replay_relations (wyl_policy_store_t *policy, wyl_fact_store_t *store,
+    const wyl_policy_fact_graph_info_t *graph, GPtrArray **out_relations)
+{
+  *out_relations = NULL;
+  duckdb_connection conn = wyl_fact_store_get_connection (store);
+  if (conn == NULL || graph == NULL)
+    return WYRELOG_E_INVALID;
+
+  duckdb_prepared_statement stmt = NULL;
+  duckdb_result result = { 0 };
+  static const gchar *sql =
+      "SELECT DISTINCT namespace_id, relation_name, schema_version "
+      "FROM fact_batches WHERE tenant_id = ? AND graph_id = ? "
+      "ORDER BY namespace_id, relation_name, schema_version;";
+  if (duckdb_prepare (conn, sql, &stmt) != DuckDBSuccess)
+    return WYRELOG_E_IO;
+  if (duckdb_bind_varchar (stmt, 1, graph->tenant_id) != DuckDBSuccess
+      || duckdb_bind_varchar (stmt, 2, graph->graph_id) != DuckDBSuccess) {
+    duckdb_destroy_prepare (&stmt);
+    return WYRELOG_E_IO;
+  }
+  if (duckdb_execute_prepared (stmt, &result) != DuckDBSuccess) {
+    duckdb_destroy_prepare (&stmt);
+    duckdb_destroy_result (&result);
+    return WYRELOG_E_IO;
+  }
+  duckdb_destroy_prepare (&stmt);
+
+  g_autoptr (GPtrArray) relations =
+      g_ptr_array_new_with_free_func (replay_relation_free);
+  wyrelog_error_t rc = WYRELOG_E_OK;
+  for (idx_t row = 0; rc == WYRELOG_E_OK && row < duckdb_row_count (&result);
+      row++) {
+    if (duckdb_value_is_null (&result, 0, row)
+        || duckdb_value_is_null (&result, 1, row)
+        || duckdb_value_is_null (&result, 2, row)) {
+      rc = WYRELOG_E_POLICY;
+      break;
+    }
+    gchar *namespace_id = duckdb_value_varchar (&result, 0, row);
+    gchar *relation_name = duckdb_value_varchar (&result, 1, row);
+    gint64 schema_version = duckdb_value_int64 (&result, 2, row);
+    if (namespace_id == NULL || relation_name == NULL || schema_version <= 0
+        || schema_version > G_MAXUINT32) {
+      rc = WYRELOG_E_POLICY;
+    } else {
+      ReplayRelation *rel = NULL;
+      rc = load_relation_schema (policy, graph, namespace_id, relation_name,
+          (guint32) schema_version, &rel);
+      if (rc == WYRELOG_E_OK)
+        g_ptr_array_add (relations, rel);
+    }
+    duckdb_free (namespace_id);
+    duckdb_free (relation_name);
+  }
+  duckdb_destroy_result (&result);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  *out_relations = g_steal_pointer (&relations);
+  return WYRELOG_E_OK;
+}
+
+static gchar *
+build_graph_program (GPtrArray *relations)
+{
+  g_autoptr (GString) program = g_string_new (NULL);
+  for (guint i = 0; relations != NULL && i < relations->len; i++) {
+    ReplayRelation *rel = g_ptr_array_index (relations, i);
+    const gchar *relation_names[2] = { rel->wirelog_relation, NULL };
+    g_autofree gchar *observed_relation = g_strdup_printf ("%s_observed",
+        rel->wirelog_relation);
+    relation_names[1] = observed_relation;
+
+    for (guint decl_idx = 0; decl_idx < G_N_ELEMENTS (relation_names);
+        decl_idx++) {
+      g_string_append (program, ".decl ");
+      g_string_append (program, relation_names[decl_idx]);
+      g_string_append_c (program, '(');
+      for (gsize col = 0; col < rel->n_columns; col++) {
+        const gchar *column_type = rel->columns[col].column_type;
+        const gchar *wire_type = NULL;
+        if (g_strcmp0 (column_type, "symbol") == 0
+            || g_strcmp0 (column_type, "string") == 0)
+          wire_type = "symbol";
+        else if (g_strcmp0 (column_type, "int64") == 0
+            || g_strcmp0 (column_type, "bool") == 0
+            || g_strcmp0 (column_type, "compound_ref") == 0)
+          wire_type = "int64";
+        else
+          return NULL;
+        if (col > 0)
+          g_string_append (program, ", ");
+        append_wirelog_identifier (program, rel->columns[col].column_name);
+        g_string_append_printf (program, ": %s", wire_type);
+      }
+      g_string_append (program, ")\n");
+    }
+
+    g_string_append (program, observed_relation);
+    g_string_append_c (program, '(');
+    for (gsize col = 0; col < rel->n_columns; col++) {
+      if (col > 0)
+        g_string_append (program, ", ");
+      g_string_append_printf (program, "V%" G_GSIZE_FORMAT, col);
+    }
+    g_string_append (program, ") :- ");
+    g_string_append (program, rel->wirelog_relation);
+    g_string_append_c (program, '(');
+    for (gsize col = 0; col < rel->n_columns; col++) {
+      if (col > 0)
+        g_string_append (program, ", ");
+      g_string_append_printf (program, "V%" G_GSIZE_FORMAT, col);
+    }
+    g_string_append (program, ").\n");
+  }
+  return g_string_free (g_steal_pointer (&program), FALSE);
+}
+
+static wyrelog_error_t
+materialize_cell (ReplayMaterializeCtx *ctx,
+    const wyl_policy_fact_relation_schema_column_t *column,
+    duckdb_result *result, idx_t col, idx_t row, gint64 *out)
+{
+  if (duckdb_value_is_null (result, col, row))
+    return WYRELOG_E_POLICY;
+
+  if (g_strcmp0 (column->column_type, "symbol") == 0
+      || g_strcmp0 (column->column_type, "string") == 0) {
+    gchar *value = duckdb_value_varchar (result, col, row);
+    if (value == NULL)
+      return WYRELOG_E_POLICY;
+    wyrelog_error_t rc = wyl_engine_owned_intern_symbol (ctx->engine, value,
+        out);
+    duckdb_free (value);
+    return rc;
+  }
+  if (g_strcmp0 (column->column_type, "int64") == 0) {
+    *out = duckdb_value_int64 (result, col, row);
+    return WYRELOG_E_OK;
+  }
+  if (g_strcmp0 (column->column_type, "bool") == 0) {
+    *out = duckdb_value_boolean (result, col, row) ? 1 : 0;
+    return WYRELOG_E_OK;
+  }
+  if (g_strcmp0 (column->column_type, "compound_ref") == 0) {
+    gint64 compound_ref = duckdb_value_int64 (result, col, row);
+    wyrelog_error_t rc = wyl_fact_compound_replay_cached (ctx->store,
+        ctx->engine, ctx->tenant_id, ctx->graph_id, ctx->namespace_id,
+        compound_ref, ctx->compound_handles, out);
+    if (rc != WYRELOG_E_OK)
+      return rc;
+    if (*out <= 0)
+      return WYRELOG_E_INTERNAL;
+    return WYRELOG_E_OK;
+  }
+  return WYRELOG_E_POLICY;
+}
+
+static gchar *
+row_key (const gint64 *row, gsize ncols)
+{
+  return g_base64_encode ((const guchar *) row, sizeof (gint64) * ncols);
+}
+
+static void
+insert_or_replace_row (GHashTable *rows, const gint64 *row, gsize ncols)
+{
+  g_autofree gchar *key = row_key (row, ncols);
+  gint64 *copy = g_memdup2 (row, sizeof (gint64) * ncols);
+  g_hash_table_replace (rows, g_steal_pointer (&key), copy);
+}
+
+static void
+remove_row (GHashTable *rows, const gint64 *row, gsize ncols)
+{
+  g_autofree gchar *key = row_key (row, ncols);
+  g_hash_table_remove (rows, key);
+}
+
+static wyrelog_error_t
+replay_relation_into_engine (wyl_fact_store_t *store,
+    const wyl_policy_fact_graph_info_t *graph, ReplayRelation *rel,
+    WylEngine *engine, GHashTable *compound_handles)
+{
+  duckdb_connection conn = wyl_fact_store_get_connection (store);
+  if (conn == NULL || graph == NULL || rel == NULL || engine == NULL
+      || compound_handles == NULL)
+    return WYRELOG_E_INVALID;
+
+  g_autoptr (GString) sql = g_string_new ("SELECT ");
+  for (gsize i = 0; i < rel->n_columns; i++) {
+    if (i > 0)
+      g_string_append (sql, ", ");
+    append_duckdb_identifier (sql, rel->columns[i].column_name);
+  }
+  g_string_append (sql, ", __wyl_valid FROM ");
+  append_duckdb_identifier (sql, rel->projection_table);
+  g_string_append (sql,
+      " WHERE __wyl_tenant_id = ? AND __wyl_graph_id = ? "
+      "ORDER BY __wyl_seq, __wyl_row_index;");
+
+  duckdb_prepared_statement stmt = NULL;
+  duckdb_result result = { 0 };
+  if (duckdb_prepare (conn, sql->str, &stmt) != DuckDBSuccess)
+    return WYRELOG_E_IO;
+  if (duckdb_bind_varchar (stmt, 1, graph->tenant_id) != DuckDBSuccess
+      || duckdb_bind_varchar (stmt, 2, graph->graph_id) != DuckDBSuccess) {
+    duckdb_destroy_prepare (&stmt);
+    return WYRELOG_E_IO;
+  }
+  if (duckdb_execute_prepared (stmt, &result) != DuckDBSuccess) {
+    duckdb_destroy_prepare (&stmt);
+    duckdb_destroy_result (&result);
+    return WYRELOG_E_IO;
+  }
+  duckdb_destroy_prepare (&stmt);
+
+  if (duckdb_row_count (&result) > WYL_FACT_REPLAY_MAX_ROWS) {
+    duckdb_destroy_result (&result);
+    return WYRELOG_E_POLICY;
+  }
+
+  g_autoptr (GHashTable) current_rows =
+      g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
+  ReplayMaterializeCtx mat = {
+    .engine = engine,
+    .tenant_id = graph->tenant_id,
+    .graph_id = graph->graph_id,
+    .namespace_id = rel->namespace_id,
+    .store = store,
+    .compound_handles = compound_handles,
+  };
+
+  wyrelog_error_t rc = WYRELOG_E_OK;
+  for (idx_t r = 0; rc == WYRELOG_E_OK && r < duckdb_row_count (&result); r++) {
+    if (duckdb_value_is_null (&result, rel->n_columns, r)) {
+      rc = WYRELOG_E_POLICY;
+      break;
+    }
+    g_autofree gint64 *wire_row = g_new0 (gint64, rel->n_columns);
+    for (gsize c = 0; rc == WYRELOG_E_OK && c < rel->n_columns; c++)
+      rc = materialize_cell (&mat, &rel->columns[c], &result, c, r,
+          &wire_row[c]);
+    if (rc != WYRELOG_E_OK)
+      break;
+    gboolean valid = duckdb_value_boolean (&result, rel->n_columns, r);
+    if (valid)
+      insert_or_replace_row (current_rows, wire_row, rel->n_columns);
+    else
+      remove_row (current_rows, wire_row, rel->n_columns);
+  }
+  duckdb_destroy_result (&result);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  GHashTableIter iter;
+  gpointer key = NULL;
+  gpointer value = NULL;
+  g_hash_table_iter_init (&iter, current_rows);
+  while (g_hash_table_iter_next (&iter, &key, &value)) {
+    (void) key;
+    rc = wyl_engine_owned_insert (engine, rel->wirelog_relation,
+        (const gint64 *) value, rel->n_columns);
+    if (rc != WYRELOG_E_OK)
+      return rc;
+  }
+  return WYRELOG_E_OK;
+}
+
+static wyrelog_error_t
+replay_relations_into_engine (wyl_fact_store_t *store,
+    const wyl_policy_fact_graph_info_t *graph, GPtrArray *relations,
+    WylEngine *engine)
+{
+  g_autoptr (GHashTable) compound_handles =
+      g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
+  for (guint i = 0; relations != NULL && i < relations->len; i++) {
+    wyrelog_error_t rc = replay_relation_into_engine (store, graph,
+        g_ptr_array_index (relations, i), engine, compound_handles);
+    if (rc != WYRELOG_E_OK)
+      return rc;
+  }
+  return WYRELOG_E_OK;
+}
+
+static gchar *
+fact_db_path_for_graph (const gchar *storage_path)
+{
+  if (storage_path == NULL)
+    return NULL;
+  if (g_file_test (storage_path, G_FILE_TEST_IS_DIR))
+    return g_build_filename (storage_path, "facts.duckdb", NULL);
+  return g_strdup (storage_path);
+}
+
+wyrelog_error_t
+wyl_fact_replay_open_graph_engine (wyl_policy_store_t *policy,
+    const wyl_policy_fact_graph_info_t *graph_info, WylEngine **out_engine)
+{
+  if (out_engine != NULL)
+    *out_engine = NULL;
+  if (policy == NULL || graph_info == NULL || graph_info->storage_path == NULL
+      || out_engine == NULL)
+    return WYRELOG_E_INVALID;
+  if (graph_info->sealed)
+    return WYRELOG_E_POLICY;
+
+  g_autofree gchar *fact_db_path =
+      fact_db_path_for_graph (graph_info->storage_path);
+  if (fact_db_path == NULL)
+    return WYRELOG_E_NOMEM;
+  if (!g_file_test (fact_db_path, G_FILE_TEST_EXISTS))
+    return WYRELOG_E_NOT_FOUND;
+
+  g_autoptr (wyl_fact_store_t) store = NULL;
+  wyrelog_error_t rc = wyl_fact_store_open (fact_db_path, &store);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  g_autoptr (GPtrArray) relations = NULL;
+  rc = list_replay_relations (policy, store, graph_info, &relations);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  g_autofree gchar *program = build_graph_program (relations);
+  if (program == NULL)
+    return WYRELOG_E_NOMEM;
+
+  WylEngine *engine = NULL;
+  rc = wyl_engine_open_source (program, 1, &engine);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  wyl_engine_set_owner (engine, WYL_ENGINE_OWNER_READ);
+
+  rc = replay_relations_into_engine (store, graph_info, relations, engine);
+  if (rc != WYRELOG_E_OK) {
+    g_object_unref (engine);
+    return rc;
+  }
+
+  *out_engine = engine;
+  return WYRELOG_E_OK;
+}
+
+static gchar *
+graph_key (const gchar *tenant_id, const gchar *graph_id)
+{
+  return g_strdup_printf ("%s\n%s", tenant_id, graph_id);
+}
+
+static wyrelog_error_t
+replay_graph_cb (const wyl_policy_fact_graph_info_t *info, gpointer user_data)
+{
+  PolicyReplayCtx *ctx = user_data;
+  WylEngine *engine = NULL;
+  wyrelog_error_t rc = wyl_fact_replay_open_graph_engine (ctx->policy, info,
+      &engine);
+  ctx->summary->graphs_seen++;
+  if (rc == WYRELOG_E_OK) {
+    g_autofree gchar *key = graph_key (info->tenant_id, info->graph_id);
+    g_hash_table_replace (ctx->graph_engines, g_steal_pointer (&key), engine);
+    ctx->summary->graphs_loaded++;
+  } else {
+    g_autofree gchar *key = graph_key (info->tenant_id, info->graph_id);
+    g_hash_table_remove (ctx->graph_engines, key);
+    ctx->summary->graphs_degraded++;
+  }
+  return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
+wyl_fact_replay_policy_graphs (wyl_policy_store_t *policy,
+    GHashTable *graph_engines, wyl_fact_replay_summary_t *out_summary)
+{
+  if (out_summary != NULL)
+    memset (out_summary, 0, sizeof (*out_summary));
+  if (policy == NULL || graph_engines == NULL)
+    return WYRELOG_E_INVALID;
+
+  wyl_fact_replay_summary_t summary = { 0 };
+  PolicyReplayCtx ctx = {
+    .policy = policy,
+    .graph_engines = graph_engines,
+    .summary = &summary,
+  };
+  wyrelog_error_t rc = wyl_policy_store_foreach_fact_graph (policy, NULL,
+      replay_graph_cb, &ctx);
+  if (out_summary != NULL)
+    *out_summary = summary;
+  return rc;
+}

--- a/wyrelog/meson.build
+++ b/wyrelog/meson.build
@@ -72,7 +72,7 @@ if get_option('enable_audit').allowed()
   wyrelog_c_args += '-DWYL_HAS_AUDIT'
 endif
 if get_option('enable_fact_store').allowed()
-  wyrelog_sources += files('fact/compound.c', 'fact/store.c')
+  wyrelog_sources += files('fact/compound.c', 'fact/replay.c', 'fact/store.c')
   if not get_option('enable_audit').allowed()
     wyrelog_deps += duckdb_dep
   endif

--- a/wyrelog/wyl-engine-private.h
+++ b/wyrelog/wyl-engine-private.h
@@ -88,6 +88,8 @@ wyrelog_error_t wyl_engine_inspect_template_artifact (const gchar *
     gboolean require_manifest, WylTemplateArtifactInfo * info_out);
 wyrelog_error_t wyl_engine_open_with_options (const gchar * template_dir,
     guint32 num_workers, gboolean require_template_manifest, WylEngine ** out);
+wyrelog_error_t wyl_engine_open_source (const gchar * dl_src,
+    guint32 num_workers, WylEngine ** out);
 
 /*
  * wyl_engine_make_compound:

--- a/wyrelog/wyl-engine.c
+++ b/wyrelog/wyl-engine.c
@@ -737,6 +737,36 @@ wyl_engine_open (const gchar *template_dir, guint32 num_workers,
       out);
 }
 
+wyrelog_error_t
+wyl_engine_open_source (const gchar *dl_src, guint32 num_workers,
+    WylEngine **out)
+{
+  if (out != NULL)
+    *out = NULL;
+  if (dl_src == NULL || out == NULL)
+    return WYRELOG_E_INVALID;
+
+  wirelog_easy_open_opts_t opts = {
+    .size = sizeof (wirelog_easy_open_opts_t),
+    .num_workers = num_workers > 0 ? num_workers : 1,
+    .eager_build = true,
+    ._reserved = NULL,
+  };
+  wirelog_easy_session_t *session = NULL;
+  wirelog_error_t wl_rc = wirelog_easy_open_opts (dl_src, &opts, &session);
+  if (wl_rc != WIRELOG_OK) {
+    if (session != NULL)
+      wirelog_easy_close (session);
+    return wyl_engine_map_wirelog_error (wl_rc);
+  }
+
+  WylEngine *engine = g_object_new (WYL_TYPE_ENGINE, NULL);
+  engine->session = session;
+  engine->mode = WYL_ENGINE_MODE_NONE;
+  *out = engine;
+  return WYRELOG_E_OK;
+}
+
 void
 wyl_engine_close (WylEngine *engine)
 {

--- a/wyrelog/wyl-handle-private.h
+++ b/wyrelog/wyl-handle-private.h
@@ -9,6 +9,10 @@
 #include "wyrelog/session.h"
 #include "policy/store-private.h"
 
+#ifdef WYL_HAS_FACT_STORE
+#include "fact/replay-private.h"
+#endif
+
 #ifdef WYL_HAS_AUDIT
 #include "audit/conn-private.h"
 #endif
@@ -59,6 +63,13 @@ wyrelog_error_t wyl_handle_load_policy_store_audit_events (WylHandle * self);
  * valid until wyl_shutdown or g_object_unref.
  */
 wyl_policy_store_t *wyl_handle_get_policy_store (WylHandle * self);
+
+#ifdef WYL_HAS_FACT_STORE
+wyrelog_error_t wyl_handle_replay_fact_graphs (WylHandle * self,
+    wyl_fact_replay_summary_t * out_summary);
+WylEngine *wyl_handle_get_fact_graph_engine (WylHandle * self,
+    const gchar * tenant_id, const gchar * graph_id);
+#endif
 
 /*
  * Mints a fresh, handle-scoped wyl_session_id_t for |session| and stores

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -18,6 +18,10 @@
 #include "wyl-permission-scope-private.h"
 #include "policy/store-private.h"
 
+#ifdef WYL_HAS_FACT_STORE
+#include "fact/replay-private.h"
+#endif
+
 #define WYL_LOGIN_SKIP_MFA_PERMISSION "wr.login.skip_mfa"
 #define WYL_LOGIN_SKIP_MFA_SCOPE "login"
 
@@ -71,6 +75,9 @@ struct _WylHandle
   gpointer delta_callback_user_data;
   GPtrArray *pending_deltas;
   wyl_policy_store_t *policy_store;
+#ifdef WYL_HAS_FACT_STORE
+  GHashTable *fact_graph_engines;
+#endif
   gboolean login_skip_mfa_allowed;
   gboolean engine_pair_poisoned;
   gboolean require_template_manifest;
@@ -168,6 +175,9 @@ wyl_handle_finalize (GObject *object)
   g_clear_object (&self->read_engine);
   g_clear_object (&self->delta_engine);
   g_clear_pointer (&self->engine_symbols_by_id, g_hash_table_unref);
+#ifdef WYL_HAS_FACT_STORE
+  g_clear_pointer (&self->fact_graph_engines, g_hash_table_unref);
+#endif
   g_clear_pointer (&self->template_dir, g_free);
   g_clear_pointer (&self->pending_deltas, g_ptr_array_unref);
   g_clear_pointer (&self->policy_store, wyl_policy_store_close);
@@ -208,6 +218,10 @@ wyl_handle_init (WylHandle *self)
   self->created_at_us = g_get_real_time ();
   self->engine_symbols_by_id =
       g_hash_table_new_full (g_int64_hash, g_int64_equal, g_free, g_free);
+#ifdef WYL_HAS_FACT_STORE
+  self->fact_graph_engines =
+      g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_object_unref);
+#endif
   self->pending_deltas =
       g_ptr_array_new_with_free_func (wyl_pending_delta_free);
   /*
@@ -628,6 +642,13 @@ wyl_handle_open_with_options (const WylHandleOpenOptions *opts,
       return rc;
     }
   }
+#ifdef WYL_HAS_FACT_STORE
+  rc = wyl_handle_replay_fact_graphs (self, NULL);
+  if (rc != WYRELOG_E_OK) {
+    g_object_unref (self);
+    return rc;
+  }
+#endif
 #ifdef WYL_HAS_AUDIT
   /* Open the runtime audit sink and replay durable Policy DB audit rows into
    * it. Public wyl_init() passes NULL and therefore keeps the sink in-memory;
@@ -685,6 +706,10 @@ wyl_shutdown (WylHandle *handle)
   g_clear_pointer (&handle->policy_store, wyl_policy_store_close);
   g_clear_object (&handle->read_engine);
   g_clear_object (&handle->delta_engine);
+#ifdef WYL_HAS_FACT_STORE
+  if (handle->fact_graph_engines != NULL)
+    g_hash_table_remove_all (handle->fact_graph_engines);
+#endif
   handle->engine_pair_poisoned = FALSE;
   clear_pending_deltas (handle);
   g_clear_pointer (&handle->template_dir, g_free);
@@ -880,6 +905,44 @@ wyl_handle_get_policy_store (WylHandle *self)
   g_return_val_if_fail (WYL_IS_HANDLE (self), NULL);
   return self->policy_store;
 }
+
+#ifdef WYL_HAS_FACT_STORE
+static gchar *
+fact_graph_key (const gchar *tenant_id, const gchar *graph_id)
+{
+  return g_strdup_printf ("%s\n%s", tenant_id, graph_id);
+}
+
+wyrelog_error_t
+wyl_handle_replay_fact_graphs (WylHandle *self,
+    wyl_fact_replay_summary_t *out_summary)
+{
+  if (self == NULL || !WYL_IS_HANDLE (self))
+    return WYRELOG_E_INVALID;
+  if (self->policy_store == NULL || self->fact_graph_engines == NULL)
+    return WYRELOG_E_INVALID;
+
+  /*
+   * Generic fact graphs live in separate graph-local read engines rather than
+   * the policy read/delta pair.  Replay therefore happens before graph query
+   * snapshots, and repeated replay replaces the graph engine, making the load
+   * lifecycle idempotent without appending duplicate EDB rows.
+   */
+  return wyl_fact_replay_policy_graphs (self->policy_store,
+      self->fact_graph_engines, out_summary);
+}
+
+WylEngine *
+wyl_handle_get_fact_graph_engine (WylHandle *self, const gchar *tenant_id,
+    const gchar *graph_id)
+{
+  g_return_val_if_fail (WYL_IS_HANDLE (self), NULL);
+  if (tenant_id == NULL || graph_id == NULL || self->fact_graph_engines == NULL)
+    return NULL;
+  g_autofree gchar *key = fact_graph_key (tenant_id, graph_id);
+  return g_hash_table_lookup (self->fact_graph_engines, key);
+}
+#endif
 
 void
 wyl_handle_set_login_skip_mfa_allowed (WylHandle *self, gboolean allowed)


### PR DESCRIPTION
## Summary
- add a fact replay bridge that opens each registered graph fact store and builds a graph-local query engine from durable relation schemas
- replay typed DuckDB projection batches into generated Datalog relations with net assert/retract semantics
- keep compound handles stable across direct and nested durable compound refs during one graph replay
- retain graph-local degradation so one failed graph does not block other graph engines

## Validation
- `meson test -C builddir-issue50-fact --print-errorlogs`
- `meson test -C builddir-issue50-default --print-errorlogs`
- `meson test -C builddir-issue50-fact fact-replay fact-store fact-compound --print-errorlogs`
- `git diff --check`
