### PR TITLE
Expose graph-local fact readiness status

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -123,6 +123,10 @@ if build_client
     libsoup_dep,
     sodium_dep,
   ]
+  if get_option('enable_fact_store').allowed()
+    test_daemon_http_decide_c_args += '-DWYL_HAS_FACT_STORE'
+    test_daemon_http_decide_deps += duckdb_dep
+  endif
   if get_option('enable_audit').allowed()
     test_daemon_http_decide_c_args += '-DWYL_HAS_AUDIT'
     test_daemon_http_decide_deps += duckdb_dep
@@ -131,6 +135,7 @@ if build_client
     'test-daemon-http-decide.c',
     '../wyrelog/daemon/http.c',
     '../wyrelog/daemon/delta.c',
+    '../wyrelog/daemon/fact-status.c',
     c_args : test_daemon_http_decide_c_args,
     include_directories : [wyrelog_inc, include_directories('../wyrelog')],
     dependencies : test_daemon_http_decide_deps,
@@ -143,6 +148,7 @@ if build_client
       'test-daemon-http-decide.c',
       '../wyrelog/daemon/http.c',
       '../wyrelog/daemon/delta.c',
+      '../wyrelog/daemon/fact-status.c',
       c_args : test_daemon_http_decide_c_args + '-DWYL_TEST_VARIANT_AUDIT',
       include_directories : [wyrelog_inc, include_directories('../wyrelog')],
       dependencies : test_daemon_http_decide_deps,
@@ -183,22 +189,29 @@ if build_client and host_machine.system() != 'windows'
   # so the policy mutation subcommands exercise the full client -> HTTP
   # -> handler path, including bearer-only credentials and the privileged
   # operator the daemon CLI cannot seed on its own.
+  test_wyctl_policy_daemon_c_args = [
+    '-DWYL_HAS_DAEMON_HTTP',
+    '-DWYL_TEST_TEMPLATE_DIR="' + meson.project_source_root() / 'templates' / 'access' + '"',
+    '-DWYL_TEST_WYCTL_PATH="' + wyctl_exe.full_path() + '"',
+  ]
+  test_wyctl_policy_daemon_deps = [
+    wyrelog_dep,
+    wyrelog_client_dep,
+    libsoup_dep,
+    sodium_dep,
+  ]
+  if get_option('enable_fact_store').allowed()
+    test_wyctl_policy_daemon_c_args += '-DWYL_HAS_FACT_STORE'
+    test_wyctl_policy_daemon_deps += duckdb_dep
+  endif
   test_wyctl_policy_daemon = executable('test-wyctl-policy-daemon',
     'test-wyctl-policy-daemon.c',
     '../wyrelog/daemon/http.c',
     '../wyrelog/daemon/delta.c',
-    c_args : [
-      '-DWYL_HAS_DAEMON_HTTP',
-      '-DWYL_TEST_TEMPLATE_DIR="' + meson.project_source_root() / 'templates' / 'access' + '"',
-      '-DWYL_TEST_WYCTL_PATH="' + wyctl_exe.full_path() + '"',
-    ],
+    '../wyrelog/daemon/fact-status.c',
+    c_args : test_wyctl_policy_daemon_c_args,
     include_directories : [wyrelog_inc, include_directories('../wyrelog')],
-    dependencies : [
-      wyrelog_dep,
-      wyrelog_client_dep,
-      libsoup_dep,
-      sodium_dep,
-    ],
+    dependencies : test_wyctl_policy_daemon_deps,
   )
 
   test('wyctl-policy-daemon', test_wyctl_policy_daemon,
@@ -298,6 +311,7 @@ if get_option('enable_fact_store').allowed()
 
   test_fact_replay = executable('test-fact-replay',
     'test-fact-replay.c',
+    '../wyrelog/daemon/fact-status.c',
     c_args : ['-DWYL_HAS_FACT_STORE'],
     include_directories : include_directories('../wyrelog'),
     dependencies : [wyrelog_dep, duckdb_dep, sqlite_dep],

--- a/tests/test-daemon-http-decide.c
+++ b/tests/test-daemon-http-decide.c
@@ -320,6 +320,18 @@ check_readyz_runtime_liveness_contract (const gchar *base_url,
     return 1923;
   if (status != 200 || strstr (body, "\"status\":\"ready\"") == NULL)
     return 1924;
+  if (strstr (body, "\"subsystems\"") == NULL
+      || strstr (body, "\"facts\"") == NULL
+      || strstr (body, "\"graphs_total\"") == NULL)
+    return 1929;
+
+  g_clear_pointer (&body, g_free);
+  if (send_raw_path (session, "GET", base_url, "/facts/status", &status,
+          &body) != 0)
+    return 1930;
+  if (status != 200 || strstr (body, "\"graphs_total\"") == NULL
+      || strstr (body, "\"graphs\"") == NULL)
+    return 1931;
 
   g_atomic_int_set (&runtime->delta_session_live, FALSE);
   g_clear_pointer (&body, g_free);

--- a/tests/test-fact-replay.c
+++ b/tests/test-fact-replay.c
@@ -6,6 +6,7 @@
 #include <glib.h>
 #include <glib/gstdio.h>
 
+#include "wyrelog/daemon/fact-status.h"
 #include "wyrelog/fact/compound-private.h"
 #include "wyrelog/fact/replay-private.h"
 #include "wyrelog/fact/store-private.h"
@@ -383,6 +384,62 @@ assert_replayed_order_b_only (WylEngine *engine)
 
 typedef struct
 {
+  guint total;
+  guint ready;
+  guint unavailable;
+  gboolean saw_tenant_a_ready;
+  gboolean saw_tenant_b_unavailable;
+} FactStatusProbe;
+
+static wyrelog_error_t
+fact_status_cb (const wyl_fact_graph_status_t *status, gpointer user_data)
+{
+  FactStatusProbe *probe = user_data;
+  probe->total++;
+  if (status->state == WYL_FACT_GRAPH_STATE_READY)
+    probe->ready++;
+  if (status->state == WYL_FACT_GRAPH_STATE_STORE_UNAVAILABLE)
+    probe->unavailable++;
+  if (g_strcmp0 (status->tenant_id, "tenant-a") == 0
+      && g_strcmp0 (status->graph_id, "orders") == 0
+      && status->state == WYL_FACT_GRAPH_STATE_READY
+      && status->queryable && status->last_error_class == NULL)
+    probe->saw_tenant_a_ready = TRUE;
+  if (g_strcmp0 (status->tenant_id, "tenant-b") == 0
+      && g_strcmp0 (status->graph_id, "orders") == 0
+      && status->state == WYL_FACT_GRAPH_STATE_STORE_UNAVAILABLE
+      && !status->queryable
+      && g_strcmp0 (status->last_error_class, "store_unavailable") == 0)
+    probe->saw_tenant_b_unavailable = TRUE;
+  return WYRELOG_E_OK;
+}
+
+static void
+assert_handle_fact_status (WylHandle *handle)
+{
+  FactStatusProbe probe = { 0 };
+  g_assert_cmpint (wyl_handle_foreach_fact_graph_status (handle,
+          fact_status_cb, &probe), ==, WYRELOG_E_OK);
+  g_assert_cmpuint (probe.total, ==, 2);
+  g_assert_cmpuint (probe.ready, ==, 1);
+  g_assert_cmpuint (probe.unavailable, ==, 1);
+  g_assert_true (probe.saw_tenant_a_ready);
+  g_assert_true (probe.saw_tenant_b_unavailable);
+
+  g_autofree gchar *json = wyl_daemon_fact_status_json (handle, TRUE);
+  g_assert_nonnull (json);
+  g_assert_nonnull (strstr (json, "\"status\":\"degraded\""));
+  g_assert_nonnull (strstr (json, "\"tenant_id\":\"tenant-a\""));
+  g_assert_nonnull (strstr (json, "\"tenant_id\":\"tenant-b\""));
+  g_assert_nonnull (strstr (json, "\"graph_id\":\"orders\""));
+  g_assert_nonnull (strstr (json,
+          "\"last_error_class\":\"store_unavailable\""));
+  g_assert_null (strstr (json, "facts.duckdb"));
+  g_assert_null (strstr (json, "storage_path"));
+}
+
+typedef struct
+{
   const gchar *relation;
   guint count;
   gint64 handle;
@@ -588,6 +645,7 @@ test_handle_replay_is_idempotent_and_graph_local (void)
   g_assert_nonnull (tenant_a);
   g_assert_null (tenant_b);
   assert_replayed_order_b_only (tenant_a);
+  assert_handle_fact_status (handle);
 
   wyl_fact_replay_summary_t summary = { 0 };
   g_assert_cmpint (wyl_handle_replay_fact_graphs (handle, &summary), ==,
@@ -598,6 +656,7 @@ test_handle_replay_is_idempotent_and_graph_local (void)
   tenant_a = wyl_handle_get_fact_graph_engine (handle, "tenant-a", "orders");
   g_assert_nonnull (tenant_a);
   assert_replayed_order_b_only (tenant_a);
+  assert_handle_fact_status (handle);
   remove_tree (root);
 #else
   g_test_skip ("fact graph path isolation is Unix-only in this build");

--- a/wyrelog/daemon/fact-status.c
+++ b/wyrelog/daemon/fact-status.c
@@ -1,0 +1,116 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "daemon/fact-status.h"
+
+#include "wyrelog/wyl-handle-private.h"
+
+typedef struct
+{
+  GString *graphs;
+  guint total;
+  guint ready;
+  guint degraded;
+} FactStatusJsonCtx;
+
+static void
+append_json_string (GString *json, const gchar *value)
+{
+  g_string_append_c (json, '"');
+  for (const guchar * p = (const guchar *)value; p != NULL && *p != '\0'; p++) {
+    switch (*p) {
+      case '"':
+        g_string_append (json, "\\\"");
+        break;
+      case '\\':
+        g_string_append (json, "\\\\");
+        break;
+      case '\b':
+        g_string_append (json, "\\b");
+        break;
+      case '\f':
+        g_string_append (json, "\\f");
+        break;
+      case '\n':
+        g_string_append (json, "\\n");
+        break;
+      case '\r':
+        g_string_append (json, "\\r");
+        break;
+      case '\t':
+        g_string_append (json, "\\t");
+        break;
+      default:
+        if (*p < 0x20)
+          g_string_append_printf (json, "\\u%04x", *p);
+        else
+          g_string_append_c (json, (gchar) * p);
+        break;
+    }
+  }
+  g_string_append_c (json, '"');
+}
+
+#ifdef WYL_HAS_FACT_STORE
+static wyrelog_error_t
+append_graph_status_json (const wyl_fact_graph_status_t *status,
+    gpointer user_data)
+{
+  FactStatusJsonCtx *ctx = user_data;
+  ctx->total++;
+  if (status->state == WYL_FACT_GRAPH_STATE_READY)
+    ctx->ready++;
+  else
+    ctx->degraded++;
+
+  if (ctx->graphs != NULL) {
+    if (ctx->graphs->len > 0)
+      g_string_append_c (ctx->graphs, ',');
+    g_string_append (ctx->graphs, "{\"tenant_id\":");
+    append_json_string (ctx->graphs, status->tenant_id);
+    g_string_append (ctx->graphs, ",\"graph_id\":");
+    append_json_string (ctx->graphs, status->graph_id);
+    g_string_append (ctx->graphs, ",\"state\":");
+    append_json_string (ctx->graphs, wyl_fact_graph_state_name (status->state));
+    g_string_append_printf (ctx->graphs, ",\"queryable\":%s",
+        status->queryable ? "true" : "false");
+    g_string_append (ctx->graphs, ",\"last_error_class\":");
+    if (status->last_error_class == NULL)
+      g_string_append (ctx->graphs, "null");
+    else
+      append_json_string (ctx->graphs, status->last_error_class);
+    g_string_append_c (ctx->graphs, '}');
+  }
+  return WYRELOG_E_OK;
+}
+#endif
+
+gchar *
+wyl_daemon_fact_status_json (WylHandle *handle, gboolean include_graphs)
+{
+  FactStatusJsonCtx ctx = { 0 };
+  g_autoptr (GString) graphs = include_graphs ? g_string_new (NULL) : NULL;
+  ctx.graphs = graphs;
+
+#ifdef WYL_HAS_FACT_STORE
+  if (handle != NULL)
+    (void) wyl_handle_foreach_fact_graph_status (handle,
+        append_graph_status_json, &ctx);
+  const gchar *status = ctx.degraded > 0 ? "degraded" : "ready";
+#else
+  (void) handle;
+  const gchar *status = "disabled";
+#endif
+
+  g_autoptr (GString) body = g_string_new ("{\"status\":");
+  append_json_string (body, status);
+  g_string_append_printf (body,
+      ",\"graphs_total\":%u,\"graphs_ready\":%u,\"graphs_degraded\":%u",
+      ctx.total, ctx.ready, ctx.degraded);
+  if (include_graphs) {
+    g_string_append (body, ",\"graphs\":[");
+    if (graphs != NULL)
+      g_string_append (body, graphs->str);
+    g_string_append_c (body, ']');
+  }
+  g_string_append_c (body, '}');
+  return g_string_free (g_steal_pointer (&body), FALSE);
+}

--- a/wyrelog/daemon/fact-status.h
+++ b/wyrelog/daemon/fact-status.h
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+
+#include <glib.h>
+
+#include "wyrelog/wyrelog.h"
+
+G_BEGIN_DECLS;
+
+gchar *wyl_daemon_fact_status_json (WylHandle * handle,
+    gboolean include_graphs);
+
+G_END_DECLS;

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -7,6 +7,7 @@
 #include <string.h>
 
 #include "daemon/delta.h"
+#include "daemon/fact-status.h"
 #include "wyrelog/wyrelog.h"
 #include "wyrelog/auth/jwt-private.h"
 #include "wyrelog/wyl-common-private.h"
@@ -1233,6 +1234,28 @@ set_status_json (SoupServerMessage *msg, guint status, const gchar *state,
       SOUP_MEMORY_COPY, body->str, body->len);
 }
 
+static void
+set_readyz_json (SoupServerMessage *msg, guint status, const gchar *state,
+    const gchar *reason, WylHandle *handle)
+{
+  attach_request_id_header (msg);
+
+  g_autofree gchar *facts = wyl_daemon_fact_status_json (handle, FALSE);
+  g_autoptr (GString) body = g_string_new ("{\"status\":");
+  append_json_string (body, state);
+  if (reason != NULL) {
+    g_string_append (body, ",\"reason\":");
+    append_json_string (body, reason);
+  }
+  g_string_append (body, ",\"subsystems\":{\"facts\":");
+  g_string_append (body, facts != NULL ? facts : "{\"status\":\"disabled\"}");
+  g_string_append (body, "}}");
+
+  soup_server_message_set_status (msg, status, NULL);
+  soup_server_message_set_response (msg, "application/json",
+      SOUP_MEMORY_COPY, body->str, body->len);
+}
+
 static gboolean
 parse_int64_query_param (const gchar *value, gint64 *out_value)
 {
@@ -1373,7 +1396,7 @@ readyz_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
   const gchar *liveness_error = check_runtime_liveness_ready (ctx->runtime);
   if (liveness_error != NULL) {
     if (json)
-      set_status_json (msg, 503, "not_ready", liveness_error);
+      set_readyz_json (msg, 503, "not_ready", liveness_error, ctx->handle);
     else
       set_json_error (msg, 503, liveness_error);
     return;
@@ -1383,14 +1406,14 @@ readyz_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
   wyrelog_error_t rc = check_runtime_ready (ctx->handle, &readiness_error);
   if (rc != WYRELOG_E_OK) {
     if (json)
-      set_status_json (msg, 503, "not_ready", readiness_error);
+      set_readyz_json (msg, 503, "not_ready", readiness_error, ctx->handle);
     else
       set_json_error (msg, 503, readiness_error);
     return;
   }
 
   if (json) {
-    set_status_json (msg, 200, "ready", NULL);
+    set_readyz_json (msg, 200, "ready", NULL, ctx->handle);
     return;
   }
 
@@ -1399,6 +1422,22 @@ readyz_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
   soup_server_message_set_status (msg, 200, NULL);
   soup_server_message_set_response (msg, "text/plain", SOUP_MEMORY_COPY, body,
       strlen (body));
+}
+
+static void
+facts_status_handler (SoupServer *server, SoupServerMessage *msg,
+    const char *path, GHashTable *query, gpointer user_data)
+{
+  (void) server;
+  (void) path;
+  (void) query;
+
+  WylDaemonHttpContext *ctx = user_data;
+  g_autofree gchar *body = wyl_daemon_fact_status_json (ctx->handle, TRUE);
+  attach_request_id_header (msg);
+  soup_server_message_set_status (msg, 200, NULL);
+  soup_server_message_set_response (msg, "application/json",
+      SOUP_MEMORY_COPY, body, strlen (body));
 }
 
 static void
@@ -2573,6 +2612,8 @@ wyl_daemon_start_http_server_with_runtime (const WylDaemonOptions *opts,
       wyl_daemon_http_context_free);
   soup_server_add_handler (server, "/healthz", healthz_handler, NULL, NULL);
   soup_server_add_handler (server, "/readyz", readyz_handler, ctx, NULL);
+  soup_server_add_handler (server, "/facts/status", facts_status_handler, ctx,
+      NULL);
   soup_server_add_handler (server, "/profile/status", profile_status_handler,
       ctx, NULL);
   soup_server_add_handler (server, "/profile/events", profile_events_handler,

--- a/wyrelog/fact/replay-private.h
+++ b/wyrelog/fact/replay-private.h
@@ -17,6 +17,28 @@ typedef struct
   guint graphs_degraded;
 } wyl_fact_replay_summary_t;
 
+typedef enum
+{
+  WYL_FACT_GRAPH_STATE_READY = 0,
+  WYL_FACT_GRAPH_STATE_DEGRADED,
+  WYL_FACT_GRAPH_STATE_SCHEMA_MISMATCH,
+  WYL_FACT_GRAPH_STATE_REPLAY_FAILED,
+  WYL_FACT_GRAPH_STATE_STORE_UNAVAILABLE,
+} wyl_fact_graph_state_t;
+
+typedef struct
+{
+  gchar *tenant_id;
+  gchar *graph_id;
+  wyl_fact_graph_state_t state;
+  gchar *last_error_class;
+  gboolean queryable;
+  gint64 last_replay_at_us;
+} wyl_fact_graph_status_t;
+
+const gchar *wyl_fact_graph_state_name (wyl_fact_graph_state_t state);
+void wyl_fact_graph_status_free (gpointer data);
+
 gchar *wyl_fact_replay_wirelog_relation_name (const gchar * namespace_id,
     const gchar * relation_name);
 
@@ -24,6 +46,7 @@ wyrelog_error_t wyl_fact_replay_open_graph_engine (wyl_policy_store_t * policy,
     const wyl_policy_fact_graph_info_t * graph_info, WylEngine ** out_engine);
 
 wyrelog_error_t wyl_fact_replay_policy_graphs (wyl_policy_store_t * policy,
-    GHashTable * graph_engines, wyl_fact_replay_summary_t * out_summary);
+    GHashTable * graph_engines, GHashTable * graph_statuses,
+    wyl_fact_replay_summary_t * out_summary);
 
 G_END_DECLS;

--- a/wyrelog/fact/replay.c
+++ b/wyrelog/fact/replay.c
@@ -34,8 +34,40 @@ typedef struct
 {
   wyl_policy_store_t *policy;
   GHashTable *graph_engines;
+  GHashTable *graph_statuses;
   wyl_fact_replay_summary_t *summary;
 } PolicyReplayCtx;
+
+const gchar *
+wyl_fact_graph_state_name (wyl_fact_graph_state_t state)
+{
+  switch (state) {
+    case WYL_FACT_GRAPH_STATE_READY:
+      return "ready";
+    case WYL_FACT_GRAPH_STATE_DEGRADED:
+      return "degraded";
+    case WYL_FACT_GRAPH_STATE_SCHEMA_MISMATCH:
+      return "schema_mismatch";
+    case WYL_FACT_GRAPH_STATE_REPLAY_FAILED:
+      return "replay_failed";
+    case WYL_FACT_GRAPH_STATE_STORE_UNAVAILABLE:
+      return "store_unavailable";
+    default:
+      return "degraded";
+  }
+}
+
+void
+wyl_fact_graph_status_free (gpointer data)
+{
+  wyl_fact_graph_status_t *status = data;
+  if (status == NULL)
+    return;
+  g_free (status->tenant_id);
+  g_free (status->graph_id);
+  g_free (status->last_error_class);
+  g_free (status);
+}
 
 static void
 append_wirelog_identifier (GString *out, const gchar *identifier)
@@ -527,6 +559,38 @@ graph_key (const gchar *tenant_id, const gchar *graph_id)
   return g_strdup_printf ("%s\n%s", tenant_id, graph_id);
 }
 
+static wyl_fact_graph_state_t
+classify_graph_replay_failure (wyrelog_error_t rc)
+{
+  switch (rc) {
+    case WYRELOG_E_NOT_FOUND:
+    case WYRELOG_E_IO:
+      return WYL_FACT_GRAPH_STATE_STORE_UNAVAILABLE;
+    case WYRELOG_E_POLICY:
+      return WYL_FACT_GRAPH_STATE_SCHEMA_MISMATCH;
+    default:
+      return WYL_FACT_GRAPH_STATE_REPLAY_FAILED;
+  }
+}
+
+static void
+record_graph_status (GHashTable *statuses,
+    const wyl_policy_fact_graph_info_t *info, wyl_fact_graph_state_t state)
+{
+  if (statuses == NULL || info == NULL)
+    return;
+  wyl_fact_graph_status_t *status = g_new0 (wyl_fact_graph_status_t, 1);
+  status->tenant_id = g_strdup (info->tenant_id);
+  status->graph_id = g_strdup (info->graph_id);
+  status->state = state;
+  status->queryable = state == WYL_FACT_GRAPH_STATE_READY;
+  status->last_replay_at_us = g_get_real_time ();
+  if (state != WYL_FACT_GRAPH_STATE_READY)
+    status->last_error_class = g_strdup (wyl_fact_graph_state_name (state));
+  g_autofree gchar *key = graph_key (info->tenant_id, info->graph_id);
+  g_hash_table_replace (statuses, g_steal_pointer (&key), status);
+}
+
 static wyrelog_error_t
 replay_graph_cb (const wyl_policy_fact_graph_info_t *info, gpointer user_data)
 {
@@ -538,10 +602,13 @@ replay_graph_cb (const wyl_policy_fact_graph_info_t *info, gpointer user_data)
   if (rc == WYRELOG_E_OK) {
     g_autofree gchar *key = graph_key (info->tenant_id, info->graph_id);
     g_hash_table_replace (ctx->graph_engines, g_steal_pointer (&key), engine);
+    record_graph_status (ctx->graph_statuses, info, WYL_FACT_GRAPH_STATE_READY);
     ctx->summary->graphs_loaded++;
   } else {
     g_autofree gchar *key = graph_key (info->tenant_id, info->graph_id);
     g_hash_table_remove (ctx->graph_engines, key);
+    record_graph_status (ctx->graph_statuses, info,
+        classify_graph_replay_failure (rc));
     ctx->summary->graphs_degraded++;
   }
   return WYRELOG_E_OK;
@@ -549,17 +616,20 @@ replay_graph_cb (const wyl_policy_fact_graph_info_t *info, gpointer user_data)
 
 wyrelog_error_t
 wyl_fact_replay_policy_graphs (wyl_policy_store_t *policy,
-    GHashTable *graph_engines, wyl_fact_replay_summary_t *out_summary)
+    GHashTable *graph_engines, GHashTable *graph_statuses,
+    wyl_fact_replay_summary_t *out_summary)
 {
   if (out_summary != NULL)
     memset (out_summary, 0, sizeof (*out_summary));
-  if (policy == NULL || graph_engines == NULL)
+  if (policy == NULL || graph_engines == NULL || graph_statuses == NULL)
     return WYRELOG_E_INVALID;
 
   wyl_fact_replay_summary_t summary = { 0 };
+  g_hash_table_remove_all (graph_statuses);
   PolicyReplayCtx ctx = {
     .policy = policy,
     .graph_engines = graph_engines,
+    .graph_statuses = graph_statuses,
     .summary = &summary,
   };
   wyrelog_error_t rc = wyl_policy_store_foreach_fact_graph (policy, NULL,

--- a/wyrelog/meson.build
+++ b/wyrelog/meson.build
@@ -169,6 +169,7 @@ wyrelogd_exe = executable('wyrelogd',
   files(
     'daemon/checks.c',
     'daemon/delta.c',
+    'daemon/fact-status.c',
     'daemon/http.c',
     'daemon/options.c',
     'daemon/runtime.c',

--- a/wyrelog/wyctl/wyctl.c
+++ b/wyrelog/wyctl/wyctl.c
@@ -389,6 +389,67 @@ parse_json_code_string (const gchar **inout_p, gchar **out_value)
 }
 
 static gboolean
+skip_json_string_value (const gchar **inout_p)
+{
+  const gchar *p = skip_json_ws (*inout_p);
+  if (p == NULL || *p != '"')
+    return FALSE;
+  p++;
+  while (*p != '\0') {
+    if (*p == '\\') {
+      p++;
+      if (*p == '\0')
+        return FALSE;
+    } else if (*p == '"') {
+      *inout_p = p + 1;
+      return TRUE;
+    }
+    p++;
+  }
+  return FALSE;
+}
+
+static gboolean
+skip_json_value (const gchar **inout_p)
+{
+  const gchar *p = skip_json_ws (*inout_p);
+  if (p == NULL)
+    return FALSE;
+  if (*p == '"')
+    return skip_json_string_value (inout_p);
+  if (*p == '{' || *p == '[') {
+    gchar open = *p;
+    gchar close = open == '{' ? '}' : ']';
+    guint depth = 1;
+    p++;
+    while (*p != '\0') {
+      if (*p == '"') {
+        const gchar *string = p;
+        if (!skip_json_string_value (&string))
+          return FALSE;
+        p = string;
+        continue;
+      }
+      if (*p == open)
+        depth++;
+      else if (*p == close) {
+        depth--;
+        if (depth == 0) {
+          *inout_p = p + 1;
+          return TRUE;
+        }
+      }
+      p++;
+    }
+    return FALSE;
+  }
+  while (*p != '\0' && *p != ',' && *p != '}' && *p != ']')
+    p++;
+  *inout_p = p;
+  return TRUE;
+}
+
+static gboolean
 parse_readiness_json (const gchar *body, gchar **out_status, gchar **out_reason)
 {
   if (body == NULL || out_status == NULL || out_reason == NULL)
@@ -412,17 +473,21 @@ parse_readiness_json (const gchar *body, gchar **out_status, gchar **out_reason)
     return FALSE;
 
   p = skip_json_ws (p);
-  if (*p == ',') {
+  while (*p == ',') {
     p++;
     g_clear_pointer (&key, g_free);
-    if (!parse_json_code_string (&p, &key) || g_strcmp0 (key, "reason") != 0)
+    if (!parse_json_code_string (&p, &key))
       return FALSE;
     p = skip_json_ws (p);
     if (*p != ':')
       return FALSE;
     p++;
-    if (!parse_json_code_string (&p, out_reason))
+    if (g_strcmp0 (key, "reason") == 0) {
+      if (!parse_json_code_string (&p, out_reason))
+        return FALSE;
+    } else if (!skip_json_value (&p)) {
       return FALSE;
+    }
     p = skip_json_ws (p);
   }
 

--- a/wyrelog/wyl-handle-private.h
+++ b/wyrelog/wyl-handle-private.h
@@ -69,6 +69,10 @@ wyrelog_error_t wyl_handle_replay_fact_graphs (WylHandle * self,
     wyl_fact_replay_summary_t * out_summary);
 WylEngine *wyl_handle_get_fact_graph_engine (WylHandle * self,
     const gchar * tenant_id, const gchar * graph_id);
+typedef wyrelog_error_t (*wyl_fact_graph_status_cb) (const
+    wyl_fact_graph_status_t * status, gpointer user_data);
+wyrelog_error_t wyl_handle_foreach_fact_graph_status (WylHandle * self,
+    wyl_fact_graph_status_cb cb, gpointer user_data);
 #endif
 
 /*

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -77,6 +77,8 @@ struct _WylHandle
   wyl_policy_store_t *policy_store;
 #ifdef WYL_HAS_FACT_STORE
   GHashTable *fact_graph_engines;
+  GHashTable *fact_graph_statuses;
+  GMutex fact_graphs_lock;
 #endif
   gboolean login_skip_mfa_allowed;
   gboolean engine_pair_poisoned;
@@ -177,6 +179,8 @@ wyl_handle_finalize (GObject *object)
   g_clear_pointer (&self->engine_symbols_by_id, g_hash_table_unref);
 #ifdef WYL_HAS_FACT_STORE
   g_clear_pointer (&self->fact_graph_engines, g_hash_table_unref);
+  g_clear_pointer (&self->fact_graph_statuses, g_hash_table_unref);
+  g_mutex_clear (&self->fact_graphs_lock);
 #endif
   g_clear_pointer (&self->template_dir, g_free);
   g_clear_pointer (&self->pending_deltas, g_ptr_array_unref);
@@ -221,6 +225,10 @@ wyl_handle_init (WylHandle *self)
 #ifdef WYL_HAS_FACT_STORE
   self->fact_graph_engines =
       g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_object_unref);
+  self->fact_graph_statuses =
+      g_hash_table_new_full (g_str_hash, g_str_equal, g_free,
+      wyl_fact_graph_status_free);
+  g_mutex_init (&self->fact_graphs_lock);
 #endif
   self->pending_deltas =
       g_ptr_array_new_with_free_func (wyl_pending_delta_free);
@@ -709,6 +717,8 @@ wyl_shutdown (WylHandle *handle)
 #ifdef WYL_HAS_FACT_STORE
   if (handle->fact_graph_engines != NULL)
     g_hash_table_remove_all (handle->fact_graph_engines);
+  if (handle->fact_graph_statuses != NULL)
+    g_hash_table_remove_all (handle->fact_graph_statuses);
 #endif
   handle->engine_pair_poisoned = FALSE;
   clear_pending_deltas (handle);
@@ -919,7 +929,8 @@ wyl_handle_replay_fact_graphs (WylHandle *self,
 {
   if (self == NULL || !WYL_IS_HANDLE (self))
     return WYRELOG_E_INVALID;
-  if (self->policy_store == NULL || self->fact_graph_engines == NULL)
+  if (self->policy_store == NULL || self->fact_graph_engines == NULL
+      || self->fact_graph_statuses == NULL)
     return WYRELOG_E_INVALID;
 
   /*
@@ -928,8 +939,11 @@ wyl_handle_replay_fact_graphs (WylHandle *self,
    * snapshots, and repeated replay replaces the graph engine, making the load
    * lifecycle idempotent without appending duplicate EDB rows.
    */
-  return wyl_fact_replay_policy_graphs (self->policy_store,
-      self->fact_graph_engines, out_summary);
+  g_mutex_lock (&self->fact_graphs_lock);
+  wyrelog_error_t rc = wyl_fact_replay_policy_graphs (self->policy_store,
+      self->fact_graph_engines, self->fact_graph_statuses, out_summary);
+  g_mutex_unlock (&self->fact_graphs_lock);
+  return rc;
 }
 
 WylEngine *
@@ -940,7 +954,32 @@ wyl_handle_get_fact_graph_engine (WylHandle *self, const gchar *tenant_id,
   if (tenant_id == NULL || graph_id == NULL || self->fact_graph_engines == NULL)
     return NULL;
   g_autofree gchar *key = fact_graph_key (tenant_id, graph_id);
-  return g_hash_table_lookup (self->fact_graph_engines, key);
+  g_mutex_lock (&self->fact_graphs_lock);
+  WylEngine *engine = g_hash_table_lookup (self->fact_graph_engines, key);
+  g_mutex_unlock (&self->fact_graphs_lock);
+  return engine;
+}
+
+wyrelog_error_t
+wyl_handle_foreach_fact_graph_status (WylHandle *self,
+    wyl_fact_graph_status_cb cb, gpointer user_data)
+{
+  g_return_val_if_fail (WYL_IS_HANDLE (self), WYRELOG_E_INVALID);
+  if (cb == NULL || self->fact_graph_statuses == NULL)
+    return WYRELOG_E_INVALID;
+
+  g_mutex_lock (&self->fact_graphs_lock);
+  GHashTableIter iter;
+  gpointer key = NULL;
+  gpointer value = NULL;
+  wyrelog_error_t rc = WYRELOG_E_OK;
+  g_hash_table_iter_init (&iter, self->fact_graph_statuses);
+  while (rc == WYRELOG_E_OK && g_hash_table_iter_next (&iter, &key, &value)) {
+    (void) key;
+    rc = cb (value, user_data);
+  }
+  g_mutex_unlock (&self->fact_graphs_lock);
+  return rc;
 }
 #endif
 


### PR DESCRIPTION
## Summary
- cache per-graph fact replay status alongside loaded graph engines
- include fact subsystem state in `/readyz?format=json`
- add `/facts/status` for redacted tenant/graph readiness details
- keep `wyctl status --readiness` compatible with extra readiness JSON fields

## Validation
- `meson test -C builddir-issue50-fact --print-errorlogs`
- `meson test -C builddir-issue50-default --print-errorlogs`
- `meson test -C builddir-ci-pr daemon-http-decide daemon-http-decide-audit wyctl-policy-daemon wyctl-basic wyrelogd-healthz wyctl-status-daemon --print-errorlogs`
