### PR TITLE
Make fact setup executable from client tools

### DIFF
--- a/tests/test-wyctl-policy-daemon.c
+++ b/tests/test-wyctl-policy-daemon.c
@@ -18,7 +18,12 @@
 #include "daemon/delta.h"
 #include "daemon/http.h"
 #include "wyrelog/client.h"
+#ifdef WYL_HAS_FACT_STORE
+#include <duckdb.h>
+#include "wyrelog/fact/store-private.h"
+#endif
 #include "wyrelog/policy/store-private.h"
+#include "wyrelog/wyl-common-private.h"
 #include "wyrelog/wyl-handle-private.h"
 
 #ifndef WYL_TEST_TEMPLATE_DIR
@@ -74,6 +79,131 @@ grant_policy_role_authority (WylHandle *handle, const gchar *subject,
   return wyl_handle_reload_engine_pair (handle);
 }
 
+#ifdef WYL_HAS_FACT_STORE
+typedef struct
+{
+  const gchar *graph_id;
+  gchar *storage_path;
+} GraphPathProbe;
+
+static wyrelog_error_t
+grant_fact_authority (WylHandle *handle, const gchar *subject)
+{
+  static const gchar *const perms[] = {
+    "wr.graph.manage",
+    "wr.schema.manage",
+    "wr.fact.write",
+  };
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  for (gsize i = 0; i < G_N_ELEMENTS (perms); i++) {
+    wyrelog_error_t rc = wyl_policy_store_grant_direct_permission (store,
+        subject, perms[i], WYL_TENANT_DEFAULT);
+    if (rc != WYRELOG_E_OK)
+      return rc;
+    rc = wyl_policy_store_set_permission_state (store, subject, perms[i],
+        WYL_TENANT_DEFAULT, "armed");
+    if (rc != WYRELOG_E_OK)
+      return rc;
+  }
+  wyrelog_error_t rc = wyl_policy_store_set_session_state (store,
+      WYL_TENANT_DEFAULT, "active");
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_handle_reload_engine_pair (handle);
+}
+
+static wyrelog_error_t
+graph_path_cb (const wyl_policy_fact_graph_info_t *info, gpointer user_data)
+{
+  GraphPathProbe *probe = user_data;
+  if (g_strcmp0 (info->graph_id, probe->graph_id) == 0)
+    probe->storage_path = g_strdup (info->storage_path);
+  return WYRELOG_E_OK;
+}
+
+static gchar *
+capture_graph_path (WylHandle *handle, const gchar *graph_id)
+{
+  GraphPathProbe probe = {
+    .graph_id = graph_id,
+  };
+  if (wyl_policy_store_foreach_fact_graph (wyl_handle_get_policy_store
+          (handle), WYL_TENANT_DEFAULT, graph_path_cb, &probe) != WYRELOG_E_OK)
+    return NULL;
+  return probe.storage_path;
+}
+
+static gboolean
+count_i64 (duckdb_connection conn, const gchar *sql, gint64 *out_value)
+{
+  duckdb_result result = { 0 };
+  if (duckdb_query (conn, sql, &result) != DuckDBSuccess) {
+    duckdb_destroy_result (&result);
+    return FALSE;
+  }
+  *out_value = duckdb_value_int64 (&result, 0, 0);
+  duckdb_destroy_result (&result);
+  return TRUE;
+}
+
+static gint
+check_fact_projection_count (WylHandle *handle, gint64 expected)
+{
+  g_autofree gchar *path = capture_graph_path (handle, "orders");
+  if (path == NULL)
+    return 100;
+  g_autofree gchar *db_path = g_build_filename (path, "facts.duckdb", NULL);
+  g_autoptr (wyl_fact_store_t) store = NULL;
+  if (wyl_fact_store_open (db_path, &store) != WYRELOG_E_OK)
+    return 101;
+  const WylClientFactColumn client_columns[] = {
+    {"order_id", "symbol", FALSE, TRUE},
+    {"amount", "int64", FALSE, TRUE},
+  };
+  wyl_policy_fact_relation_schema_column_t columns[] = {
+    {client_columns[0].name, client_columns[0].type, FALSE, TRUE},
+    {client_columns[1].name, client_columns[1].type, FALSE, TRUE},
+  };
+  wyl_policy_fact_relation_schema_options_t schema = {
+    .tenant_id = WYL_TENANT_DEFAULT,
+    .graph_id = "orders",
+    .namespace_id = "shop",
+    .relation_name = "orders",
+    .schema_version = 1,
+    .relation_visible = TRUE,
+    .columns = columns,
+    .n_columns = G_N_ELEMENTS (columns),
+  };
+  g_autofree gchar *table = wyl_fact_store_projection_table_name (&schema);
+  if (table == NULL)
+    return 102;
+  gint64 count = 0;
+  g_autofree gchar *sql = g_strdup_printf ("SELECT COUNT(*) FROM %s;", table);
+  if (!count_i64 (wyl_fact_store_get_connection (store), sql, &count))
+    return 103;
+  return count == expected ? 0 : 104;
+}
+
+static void
+remove_tree (const gchar *path)
+{
+  if (path == NULL)
+    return;
+  g_autoptr (GDir) dir = g_dir_open (path, 0, NULL);
+  if (dir != NULL) {
+    const gchar *name = NULL;
+    while ((name = g_dir_read_name (dir)) != NULL) {
+      g_autofree gchar *child = g_build_filename (path, name, NULL);
+      if (g_file_test (child, G_FILE_TEST_IS_DIR))
+        remove_tree (child);
+      else
+        (void) g_remove (child);
+    }
+  }
+  (void) g_rmdir (path);
+}
+#endif
+
 static gchar *
 write_token_file (const gchar *token)
 {
@@ -120,6 +250,29 @@ assert_wyctl_ok (gchar **argv)
   g_assert_cmpstr (stderr_buf, ==, "");
 }
 
+#ifdef WYL_HAS_FACT_STORE
+static void
+assert_wyctl_stdout (gchar **argv, const gchar *expected_stdout)
+{
+  g_autofree gchar *stdout_buf = NULL;
+  g_autofree gchar *stderr_buf = NULL;
+  gint wait_status = 0;
+  g_autoptr (GError) error = NULL;
+
+  run_wyctl (argv, &stdout_buf, &stderr_buf, &wait_status);
+
+  if (!g_spawn_check_wait_status (wait_status, &error)) {
+    g_printerr ("wyctl exited with status %d\nstdout: %s\nstderr: %s\n",
+        wait_status, stdout_buf ? stdout_buf : "(null)",
+        stderr_buf ? stderr_buf : "(null)");
+    g_clear_error (&error);
+    g_assert_not_reached ();
+  }
+  g_assert_cmpstr (stdout_buf, ==, expected_stdout);
+  g_assert_cmpstr (stderr_buf, ==, "");
+}
+#endif
+
 int
 main (void)
 {
@@ -127,9 +280,22 @@ main (void)
   if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
     return 1;
 
+#ifdef WYL_HAS_FACT_STORE
+  g_autoptr (GError) fact_root_error = NULL;
+  g_autofree gchar *fact_root = g_dir_make_tmp ("wyctl-facts-XXXXXX",
+      &fact_root_error);
+  if (fact_root == NULL)
+    return 101;
+  if (g_chmod (fact_root, 0700) != 0)
+    return 102;
+#endif
+
   WylDaemonOptions opts = {
     .template_dir = WYL_TEST_TEMPLATE_DIR,
     .listen_port = 0,
+#ifdef WYL_HAS_FACT_STORE
+    .fact_root = fact_root,
+#endif
   };
   WylDaemonRuntime runtime = {
     .handle = handle,
@@ -178,6 +344,10 @@ main (void)
   if (grant_policy_role_authority (handle, "wyctl-policy-admin", "tenant-x")
       != WYRELOG_E_OK)
     return 9;
+#ifdef WYL_HAS_FACT_STORE
+  if (grant_fact_authority (handle, "wyctl-policy-admin") != WYRELOG_E_OK)
+    return 103;
+#endif
 
   wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
   if (wyl_policy_store_upsert_permission (store, "site.wyctl.read",
@@ -269,6 +439,79 @@ main (void)
           "site.wyctl.reader", "tenant-x", &exists) != WYRELOG_E_OK || exists)
     return 15;
 
+#ifdef WYL_HAS_FACT_STORE
+  gchar *graph_create_argv[] = {
+    (gchar *) WYL_TEST_WYCTL_PATH,
+    "--daemon-url", (gchar *) base_url,
+    "graph", "create",
+    "--tenant", (gchar *) WYL_TENANT_DEFAULT,
+    "--graph", "orders",
+    "--access-token-file", token_path,
+    "--guard-timestamp", "123",
+    "--guard-loc-class", "trusted",
+    "--guard-risk", "29",
+    NULL,
+  };
+  assert_wyctl_ok (graph_create_argv);
+
+  gchar *schema_register_argv[] = {
+    (gchar *) WYL_TEST_WYCTL_PATH,
+    "--daemon-url", (gchar *) base_url,
+    "fact", "schema", "register",
+    "--tenant", (gchar *) WYL_TENANT_DEFAULT,
+    "--graph", "orders",
+    "--namespace", "shop",
+    "--relation", "orders",
+    "--schema-version", "1",
+    "--columns", "order_id:symbol,amount:int64",
+    "--access-token-file", token_path,
+    "--guard-timestamp", "123",
+    "--guard-loc-class", "trusted",
+    "--guard-risk", "29",
+    NULL,
+  };
+  assert_wyctl_ok (schema_register_argv);
+
+  g_autoptr (GError) input_error = NULL;
+  gchar *input_path = NULL;
+  gint input_fd = g_file_open_tmp ("wyctl-facts-input-XXXXXX", &input_path,
+      &input_error);
+  g_assert_no_error (input_error);
+  g_assert_cmpint (input_fd, >=, 0);
+  g_assert_true (g_close (input_fd, NULL));
+  g_assert_true (g_file_set_contents (input_path,
+          "order_id,amount\no-1,42\n", -1, &input_error));
+  g_assert_no_error (input_error);
+  g_autofree gchar *input_path_autofree = input_path;
+
+  gchar *fact_put_argv[] = {
+    (gchar *) WYL_TEST_WYCTL_PATH,
+    "--daemon-url", (gchar *) base_url,
+    "fact", "put",
+    "--tenant", (gchar *) WYL_TENANT_DEFAULT,
+    "--graph", "orders",
+    "--namespace", "shop",
+    "--relation", "orders",
+    "--schema-version", "1",
+    "--batch-id", "batch-1",
+    "--idempotency-key", "key-1",
+    "--format", "csv",
+    "--input", input_path,
+    "--access-token-file", token_path,
+    "--guard-timestamp", "123",
+    "--guard-loc-class", "trusted",
+    "--guard-risk", "29",
+    NULL,
+  };
+  assert_wyctl_stdout (fact_put_argv, "inserted\n");
+  if (check_fact_projection_count (handle, 1) != 0)
+    return 104;
+  assert_wyctl_stdout (fact_put_argv, "duplicate\n");
+  if (check_fact_projection_count (handle, 1) != 0)
+    return 105;
+  g_unlink (input_path);
+#endif
+
   g_unlink (token_path);
 
   g_main_loop_quit (http.loop);
@@ -276,5 +519,8 @@ main (void)
   soup_server_disconnect (http.server);
   g_clear_object (&http.server);
   g_clear_pointer (&http.loop, g_main_loop_unref);
+#ifdef WYL_HAS_FACT_STORE
+  remove_tree (fact_root);
+#endif
   return 0;
 }

--- a/wyrelog/client.h
+++ b/wyrelog/client.h
@@ -30,6 +30,15 @@ G_DECLARE_FINAL_TYPE (WylAuditIter, wyl_audit_iter, WYL, AUDIT_ITER, GObject);
 #define WYL_TYPE_AUDIT_ITER (wyl_audit_iter_get_type ())
 
 typedef struct _WylClientDecision WylClientDecision;
+typedef struct _WylClientFactAppendResult WylClientFactAppendResult;
+
+typedef struct
+{
+  const gchar *name;
+  const gchar *type;
+  gboolean nullable;
+  gboolean visible;
+} WylClientFactColumn;
 
 /* Lifecycle */
 wyrelog_error_t wyl_client_new (const gchar * base_url,
@@ -57,6 +66,8 @@ gchar *wyl_client_dup_username (const WylClient * client);
 gchar *wyl_client_dup_tenant (const WylClient * client);
 gchar *wyl_client_dup_principal_state (const WylClient * client);
 gchar *wyl_client_dup_session_state (const WylClient * client);
+guint wyl_client_get_last_http_status (const WylClient * client);
+gchar *wyl_client_dup_last_error_code (const WylClient * client);
 wyrelog_error_t wyl_client_token_refresh (WylClient * client);
 wyrelog_error_t wyl_client_mfa_verify (WylClient * client, const gchar * otp);
 
@@ -131,6 +142,41 @@ wyrelog_error_t wyl_client_policy_role_revoke (WylClient * client,
     const gchar * scope,
     gint64 guard_timestamp, const gchar * guard_loc_class, gint64 guard_risk);
 
+/* Fact graph / schema / append */
+wyrelog_error_t wyl_client_graph_create (WylClient * client,
+    const gchar * tenant,
+    const gchar * graph,
+    gint64 guard_timestamp, const gchar * guard_loc_class, gint64 guard_risk);
+wyrelog_error_t wyl_client_fact_schema_register (WylClient * client,
+    const gchar * tenant,
+    const gchar * graph,
+    const gchar * namespace_id,
+    const gchar * relation,
+    guint32 schema_version,
+    const WylClientFactColumn * columns,
+    gsize n_columns,
+    gint64 guard_timestamp, const gchar * guard_loc_class, gint64 guard_risk);
+wyrelog_error_t wyl_client_fact_put_batch (WylClient * client,
+    const gchar * tenant,
+    const gchar * graph,
+    const gchar * namespace_id,
+    const gchar * relation,
+    guint32 schema_version,
+    const gchar * batch_id,
+    const gchar * idempotency_key,
+    const guint8 * tsv_payload,
+    gsize tsv_len,
+    gint64 guard_timestamp,
+    const gchar * guard_loc_class,
+    gint64 guard_risk, WylClientFactAppendResult ** out_result);
+void wyl_client_fact_append_result_free (WylClientFactAppendResult * result);
+gboolean wyl_client_fact_append_result_get_inserted
+    (const WylClientFactAppendResult * result);
+const gchar *wyl_client_fact_append_result_get_batch_id
+    (const WylClientFactAppendResult * result);
+gchar *wyl_client_fact_append_result_dup_batch_id
+    (const WylClientFactAppendResult * result);
+
 gchar *wyl_audit_iter_dup_query_filter (const WylAuditIter * iter);
 gchar *wyl_audit_iter_dup_request_uri (const WylAuditIter * iter);
 WylAuditEvent *wyl_audit_iter_ref_event (const WylAuditIter * iter);
@@ -155,3 +201,5 @@ const gchar *wyrelog_client_version_string (void);
 G_END_DECLS;
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WylClientDecision, wyl_client_decision_free)
+    G_DEFINE_AUTOPTR_CLEANUP_FUNC (WylClientFactAppendResult,
+    wyl_client_fact_append_result_free)

--- a/wyrelog/wyctl/wyctl.c
+++ b/wyrelog/wyctl/wyctl.c
@@ -64,6 +64,47 @@ typedef struct
 
 typedef struct
 {
+  gchar *tenant;
+  gchar *graph;
+  gchar *access_token_file;
+  gchar *guard_timestamp_arg;
+  gchar *guard_loc_class;
+  gchar *guard_risk_arg;
+} WyctlGraphOptions;
+
+typedef struct
+{
+  gchar *tenant;
+  gchar *graph;
+  gchar *namespace_id;
+  gchar *relation;
+  gchar *schema_version_arg;
+  gchar *columns_arg;
+  gchar *access_token_file;
+  gchar *guard_timestamp_arg;
+  gchar *guard_loc_class;
+  gchar *guard_risk_arg;
+} WyctlFactSchemaOptions;
+
+typedef struct
+{
+  gchar *tenant;
+  gchar *graph;
+  gchar *namespace_id;
+  gchar *relation;
+  gchar *schema_version_arg;
+  gchar *batch_id;
+  gchar *idempotency_key;
+  gchar *format;
+  gchar *input;
+  gchar *access_token_file;
+  gchar *guard_timestamp_arg;
+  gchar *guard_loc_class;
+  gchar *guard_risk_arg;
+} WyctlFactPutOptions;
+
+typedef struct
+{
   gchar *keyprovider_path;
   gchar *store_path;
   gchar *from_keyprovider_path;
@@ -141,6 +182,23 @@ parse_nonnegative_int64 (const gchar *raw, gint64 *out_value)
     return FALSE;
 
   *out_value = parsed;
+  return TRUE;
+}
+
+static gboolean
+parse_positive_uint32 (const gchar *raw, guint32 *out_value)
+{
+  if (raw == NULL || raw[0] == '\0' || out_value == NULL)
+    return FALSE;
+
+  errno = 0;
+  gchar *end = NULL;
+  gint64 parsed = g_ascii_strtoll (raw, &end, 10);
+  if (errno != 0 || end == raw || *end != '\0' || parsed < 1 ||
+      parsed > G_MAXUINT32)
+    return FALSE;
+
+  *out_value = (guint32) parsed;
   return TRUE;
 }
 
@@ -1072,6 +1130,427 @@ run_policy (const WyctlOptions *global_opts, gint argc, gchar **argv)
   return 2;
 }
 
+static gboolean
+parse_guard_options (const gchar *timestamp_arg, const gchar *loc_class,
+    const gchar *risk_arg, gint64 *out_timestamp, gint64 *out_risk)
+{
+  if (!parse_nonnegative_int64 (timestamp_arg, out_timestamp)) {
+    g_printerr ("wyctl: invalid --guard-timestamp\n");
+    return FALSE;
+  }
+  if (loc_class == NULL || !wyl_guard_loc_class_is_valid (loc_class)) {
+    g_printerr ("wyctl: invalid --guard-loc-class\n");
+    return FALSE;
+  }
+  if (!parse_nonnegative_int64 (risk_arg, out_risk) || *out_risk > 100) {
+    g_printerr ("wyctl: invalid --guard-risk\n");
+    return FALSE;
+  }
+  return TRUE;
+}
+
+static int
+create_fact_client (const WyctlOptions *global_opts, const gchar *tenant,
+    const gchar *access_token_file, WylClient **out_client)
+{
+  if (out_client == NULL)
+    return 2;
+  *out_client = NULL;
+  if (global_opts->daemon_url == NULL || global_opts->daemon_url[0] == '\0') {
+    g_printerr ("wyctl: missing daemon URL\n");
+    return 2;
+  }
+  if (!daemon_url_is_valid (global_opts->daemon_url)) {
+    g_printerr ("wyctl: invalid daemon URL\n");
+    return 2;
+  }
+  guint timeout_ms = 0;
+  if (!parse_timeout_ms (global_opts->timeout_ms_arg, &timeout_ms)) {
+    g_printerr ("wyctl: invalid timeout\n");
+    return 2;
+  }
+  if (tenant == NULL || tenant[0] == '\0') {
+    g_printerr ("wyctl: missing --tenant\n");
+    return 2;
+  }
+
+  g_autofree gchar *access_token = NULL;
+  int token_rc = load_access_token_file (access_token_file, &access_token);
+  if (token_rc != 0)
+    return token_rc;
+
+  g_autoptr (WylClient) client = NULL;
+  if (wyl_client_new (global_opts->daemon_url, &client) != WYRELOG_E_OK ||
+      wyl_client_set_bearer_credentials (client, access_token, tenant)
+      != WYRELOG_E_OK) {
+    g_printerr ("wyctl: invalid fact credentials\n");
+    return 2;
+  }
+  wyl_client_set_timeout_ms (client, timeout_ms);
+  *out_client = g_steal_pointer (&client);
+  return 0;
+}
+
+static int
+fact_remote_exit (WylClient *client, const gchar *command,
+    wyrelog_error_t rc, const gchar *fallback_code)
+{
+  if (rc == WYRELOG_E_OK)
+    return 0;
+  g_autofree gchar *code = client != NULL ?
+      wyl_client_dup_last_error_code (client) : NULL;
+  const gchar *shown = code != NULL ? code : fallback_code;
+  if (shown == NULL)
+    shown = "failed";
+  g_printerr ("wyctl: %s failed: %s\n", command, shown);
+  guint status = client != NULL ? wyl_client_get_last_http_status (client) : 0;
+  if (rc == WYRELOG_E_INVALID)
+    return status == 0 ? 2 : 3;
+  if (rc == WYRELOG_E_AUTH)
+    return 6;
+  if (rc == WYRELOG_E_POLICY)
+    return 4;
+  return 5;
+}
+
+static int
+run_graph_create (const WyctlOptions *global_opts, gint argc, gchar **argv)
+{
+  WyctlGraphOptions opts = { 0 };
+  GOptionEntry entries[] = {
+    {"tenant", 0, 0, G_OPTION_ARG_STRING, &opts.tenant, "Tenant", "TENANT"},
+    {"graph", 0, 0, G_OPTION_ARG_STRING, &opts.graph, "Graph", "GRAPH"},
+    {"access-token-file", 0, 0, G_OPTION_ARG_STRING, &opts.access_token_file,
+        "Bearer access token file", "PATH"},
+    {"guard-timestamp", 0, 0, G_OPTION_ARG_STRING,
+        &opts.guard_timestamp_arg, "Guard timestamp", "US"},
+    {"guard-loc-class", 0, 0, G_OPTION_ARG_STRING, &opts.guard_loc_class,
+        "Guard location class", "CLASS"},
+    {"guard-risk", 0, 0, G_OPTION_ARG_STRING, &opts.guard_risk_arg,
+        "Guard risk score", "N"},
+    {NULL}
+  };
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GOptionContext) context =
+      g_option_context_new ("- wyrelog graph create");
+  g_option_context_add_main_entries (context, entries, NULL);
+  if (!g_option_context_parse (context, &argc, &argv, &error)) {
+    g_printerr ("wyctl: %s\n", error->message);
+    return 2;
+  }
+  if (argc > 1) {
+    g_printerr ("wyctl: unexpected graph create argument: %s\n", argv[1]);
+    return 2;
+  }
+  if (opts.graph == NULL || opts.graph[0] == '\0') {
+    g_printerr ("wyctl: missing --graph\n");
+    return 2;
+  }
+  gint64 guard_timestamp = 0;
+  gint64 guard_risk = 0;
+  if (!parse_guard_options (opts.guard_timestamp_arg, opts.guard_loc_class,
+          opts.guard_risk_arg, &guard_timestamp, &guard_risk))
+    return 2;
+  g_autoptr (WylClient) client = NULL;
+  int client_rc = create_fact_client (global_opts, opts.tenant,
+      opts.access_token_file, &client);
+  if (client_rc != 0)
+    return client_rc;
+  wyrelog_error_t rc = wyl_client_graph_create (client, opts.tenant,
+      opts.graph, guard_timestamp, opts.guard_loc_class, guard_risk);
+  int exit_rc = fact_remote_exit (client, "graph create", rc,
+      "graph_create_failed");
+  if (exit_rc == 0)
+    g_print ("ok\n");
+  return exit_rc;
+}
+
+static int
+run_graph (const WyctlOptions *global_opts, gint argc, gchar **argv)
+{
+  if (argc < 2) {
+    g_printerr ("wyctl: missing graph command\n");
+    return 2;
+  }
+  if (g_strcmp0 (argv[1], "create") == 0)
+    return run_graph_create (global_opts, argc - 1, argv + 1);
+  g_printerr ("wyctl: unknown graph command: %s\n", argv[1]);
+  return 2;
+}
+
+static void
+client_fact_columns_clear (WylClientFactColumn *columns, gsize n_columns)
+{
+  for (gsize i = 0; i < n_columns; i++) {
+    g_free ((gchar *) columns[i].name);
+    g_free ((gchar *) columns[i].type);
+  }
+  g_free (columns);
+}
+
+static gboolean
+parse_columns_arg (const gchar *raw, WylClientFactColumn **out_columns,
+    gsize *out_n_columns)
+{
+  if (out_columns == NULL || out_n_columns == NULL || raw == NULL ||
+      raw[0] == '\0')
+    return FALSE;
+  *out_columns = NULL;
+  *out_n_columns = 0;
+  g_auto (GStrv) entries = g_strsplit (raw, ",", -1);
+  g_autoptr (GArray) cols = g_array_new (FALSE, TRUE,
+      sizeof (WylClientFactColumn));
+  for (gsize i = 0; entries[i] != NULL; i++) {
+    if (entries[i][0] == '\0')
+      return FALSE;
+    gchar *sep = strchr (entries[i], ':');
+    if (sep == NULL || sep == entries[i] || sep[1] == '\0' ||
+        strchr (sep + 1, ':') != NULL)
+      return FALSE;
+    *sep = '\0';
+    WylClientFactColumn col = {
+      .name = g_strdup (entries[i]),
+      .type = g_strdup (sep + 1),
+      .nullable = FALSE,
+      .visible = TRUE,
+    };
+    g_array_append_val (cols, col);
+  }
+  if (cols->len == 0)
+    return FALSE;
+  *out_n_columns = cols->len;
+  *out_columns = (WylClientFactColumn *) g_array_free (g_steal_pointer (&cols),
+      FALSE);
+  return TRUE;
+}
+
+static int
+run_fact_schema_register (const WyctlOptions *global_opts, gint argc,
+    gchar **argv)
+{
+  WyctlFactSchemaOptions opts = { 0 };
+  GOptionEntry entries[] = {
+    {"tenant", 0, 0, G_OPTION_ARG_STRING, &opts.tenant, "Tenant", "TENANT"},
+    {"graph", 0, 0, G_OPTION_ARG_STRING, &opts.graph, "Graph", "GRAPH"},
+    {"namespace", 0, 0, G_OPTION_ARG_STRING, &opts.namespace_id, "Namespace",
+        "NS"},
+    {"relation", 0, 0, G_OPTION_ARG_STRING, &opts.relation, "Relation",
+        "REL"},
+    {"schema-version", 0, 0, G_OPTION_ARG_STRING, &opts.schema_version_arg,
+        "Schema version", "N"},
+    {"columns", 0, 0, G_OPTION_ARG_STRING, &opts.columns_arg,
+        "Columns as name:type,...", "COLUMNS"},
+    {"access-token-file", 0, 0, G_OPTION_ARG_STRING, &opts.access_token_file,
+        "Bearer access token file", "PATH"},
+    {"guard-timestamp", 0, 0, G_OPTION_ARG_STRING,
+        &opts.guard_timestamp_arg, "Guard timestamp", "US"},
+    {"guard-loc-class", 0, 0, G_OPTION_ARG_STRING, &opts.guard_loc_class,
+        "Guard location class", "CLASS"},
+    {"guard-risk", 0, 0, G_OPTION_ARG_STRING, &opts.guard_risk_arg,
+        "Guard risk score", "N"},
+    {NULL}
+  };
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GOptionContext) context =
+      g_option_context_new ("- wyrelog fact schema register");
+  g_option_context_add_main_entries (context, entries, NULL);
+  if (!g_option_context_parse (context, &argc, &argv, &error)) {
+    g_printerr ("wyctl: %s\n", error->message);
+    return 2;
+  }
+  if (argc > 1) {
+    g_printerr ("wyctl: unexpected fact schema register argument: %s\n",
+        argv[1]);
+    return 2;
+  }
+  if (opts.graph == NULL || opts.graph[0] == '\0' || opts.namespace_id == NULL
+      || opts.namespace_id[0] == '\0' || opts.relation == NULL ||
+      opts.relation[0] == '\0') {
+    g_printerr ("wyctl: missing fact schema target option\n");
+    return 2;
+  }
+  guint32 schema_version = 0;
+  if (!parse_positive_uint32 (opts.schema_version_arg, &schema_version)) {
+    g_printerr ("wyctl: invalid --schema-version\n");
+    return 2;
+  }
+  WylClientFactColumn *columns = NULL;
+  gsize n_columns = 0;
+  if (!parse_columns_arg (opts.columns_arg, &columns, &n_columns)) {
+    g_printerr ("wyctl: invalid --columns\n");
+    return 2;
+  }
+  gint64 guard_timestamp = 0;
+  gint64 guard_risk = 0;
+  if (!parse_guard_options (opts.guard_timestamp_arg, opts.guard_loc_class,
+          opts.guard_risk_arg, &guard_timestamp, &guard_risk)) {
+    client_fact_columns_clear (columns, n_columns);
+    return 2;
+  }
+  g_autoptr (WylClient) client = NULL;
+  int client_rc = create_fact_client (global_opts, opts.tenant,
+      opts.access_token_file, &client);
+  if (client_rc != 0) {
+    client_fact_columns_clear (columns, n_columns);
+    return client_rc;
+  }
+  wyrelog_error_t rc = wyl_client_fact_schema_register (client, opts.tenant,
+      opts.graph, opts.namespace_id, opts.relation, schema_version, columns,
+      n_columns, guard_timestamp, opts.guard_loc_class, guard_risk);
+  client_fact_columns_clear (columns, n_columns);
+  int exit_rc = fact_remote_exit (client, "fact schema register", rc,
+      "schema_register_failed");
+  if (exit_rc == 0)
+    g_print ("ok\n");
+  return exit_rc;
+}
+
+static gchar *
+convert_csv_to_tsv (const gchar *input, gsize size)
+{
+  g_autoptr (GString) out = g_string_sized_new (size);
+  for (gsize i = 0; i < size; i++) {
+    if (input[i] == '"' || input[i] == '\t')
+      return NULL;
+    g_string_append_c (out, input[i] == ',' ? '\t' : input[i]);
+  }
+  return g_string_free (g_steal_pointer (&out), FALSE);
+}
+
+static int
+run_fact_put (const WyctlOptions *global_opts, gint argc, gchar **argv)
+{
+  WyctlFactPutOptions opts = { 0 };
+  GOptionEntry entries[] = {
+    {"tenant", 0, 0, G_OPTION_ARG_STRING, &opts.tenant, "Tenant", "TENANT"},
+    {"graph", 0, 0, G_OPTION_ARG_STRING, &opts.graph, "Graph", "GRAPH"},
+    {"namespace", 0, 0, G_OPTION_ARG_STRING, &opts.namespace_id, "Namespace",
+        "NS"},
+    {"relation", 0, 0, G_OPTION_ARG_STRING, &opts.relation, "Relation",
+        "REL"},
+    {"schema-version", 0, 0, G_OPTION_ARG_STRING, &opts.schema_version_arg,
+        "Schema version", "N"},
+    {"batch-id", 0, 0, G_OPTION_ARG_STRING, &opts.batch_id, "Batch id",
+        "ID"},
+    {"idempotency-key", 0, 0, G_OPTION_ARG_STRING, &opts.idempotency_key,
+        "Idempotency key", "KEY"},
+    {"format", 0, 0, G_OPTION_ARG_STRING, &opts.format, "Input format",
+        "csv|tsv"},
+    {"input", 0, 0, G_OPTION_ARG_STRING, &opts.input, "Input file", "PATH"},
+    {"access-token-file", 0, 0, G_OPTION_ARG_STRING, &opts.access_token_file,
+        "Bearer access token file", "PATH"},
+    {"guard-timestamp", 0, 0, G_OPTION_ARG_STRING,
+        &opts.guard_timestamp_arg, "Guard timestamp", "US"},
+    {"guard-loc-class", 0, 0, G_OPTION_ARG_STRING, &opts.guard_loc_class,
+        "Guard location class", "CLASS"},
+    {"guard-risk", 0, 0, G_OPTION_ARG_STRING, &opts.guard_risk_arg,
+        "Guard risk score", "N"},
+    {NULL}
+  };
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GOptionContext) context = g_option_context_new
+      ("- wyrelog fact put");
+  g_option_context_add_main_entries (context, entries, NULL);
+  if (!g_option_context_parse (context, &argc, &argv, &error)) {
+    g_printerr ("wyctl: %s\n", error->message);
+    return 2;
+  }
+  if (argc > 1) {
+    g_printerr ("wyctl: unexpected fact put argument: %s\n", argv[1]);
+    return 2;
+  }
+  if (opts.graph == NULL || opts.graph[0] == '\0' || opts.namespace_id == NULL
+      || opts.namespace_id[0] == '\0' || opts.relation == NULL ||
+      opts.relation[0] == '\0' || opts.batch_id == NULL ||
+      opts.batch_id[0] == '\0' || opts.idempotency_key == NULL ||
+      opts.idempotency_key[0] == '\0') {
+    g_printerr ("wyctl: missing fact put target option\n");
+    return 2;
+  }
+  guint32 schema_version = 0;
+  if (!parse_positive_uint32 (opts.schema_version_arg, &schema_version)) {
+    g_printerr ("wyctl: invalid --schema-version\n");
+    return 2;
+  }
+  if (opts.format == NULL || (g_strcmp0 (opts.format, "csv") != 0 &&
+          g_strcmp0 (opts.format, "tsv") != 0)) {
+    g_printerr ("wyctl: unsupported --format\n");
+    return 2;
+  }
+  if (opts.input == NULL || opts.input[0] == '\0') {
+    g_printerr ("wyctl: missing --input\n");
+    return 2;
+  }
+  g_autofree gchar *input = NULL;
+  gsize input_size = 0;
+  if (!g_file_get_contents (opts.input, &input, &input_size, &error)) {
+    g_printerr ("wyctl: unable to read fact input\n");
+    return 2;
+  }
+  g_autofree gchar *payload = NULL;
+  gsize payload_size = input_size;
+  if (g_strcmp0 (opts.format, "csv") == 0) {
+    payload = convert_csv_to_tsv (input, input_size);
+    if (payload == NULL) {
+      g_printerr ("wyctl: invalid csv input\n");
+      return 2;
+    }
+    payload_size = strlen (payload);
+  } else {
+    payload = g_steal_pointer (&input);
+  }
+  gint64 guard_timestamp = 0;
+  gint64 guard_risk = 0;
+  if (!parse_guard_options (opts.guard_timestamp_arg, opts.guard_loc_class,
+          opts.guard_risk_arg, &guard_timestamp, &guard_risk))
+    return 2;
+  g_autoptr (WylClient) client = NULL;
+  int client_rc = create_fact_client (global_opts, opts.tenant,
+      opts.access_token_file, &client);
+  if (client_rc != 0)
+    return client_rc;
+  g_autoptr (WylClientFactAppendResult) result = NULL;
+  wyrelog_error_t rc = wyl_client_fact_put_batch (client, opts.tenant,
+      opts.graph, opts.namespace_id, opts.relation, schema_version,
+      opts.batch_id, opts.idempotency_key, (const guint8 *) payload,
+      payload_size, guard_timestamp, opts.guard_loc_class, guard_risk,
+      &result);
+  int exit_rc = fact_remote_exit (client, "fact put", rc,
+      "fact_append_failed");
+  if (exit_rc == 0)
+    g_print ("%s\n", wyl_client_fact_append_result_get_inserted (result) ?
+        "inserted" : "duplicate");
+  return exit_rc;
+}
+
+static int
+run_fact_schema (const WyctlOptions *global_opts, gint argc, gchar **argv)
+{
+  if (argc < 2) {
+    g_printerr ("wyctl: missing fact schema command\n");
+    return 2;
+  }
+  if (g_strcmp0 (argv[1], "register") == 0)
+    return run_fact_schema_register (global_opts, argc - 1, argv + 1);
+  g_printerr ("wyctl: unknown fact schema command: %s\n", argv[1]);
+  return 2;
+}
+
+static int
+run_fact (const WyctlOptions *global_opts, gint argc, gchar **argv)
+{
+  if (argc < 2) {
+    g_printerr ("wyctl: missing fact command\n");
+    return 2;
+  }
+  if (g_strcmp0 (argv[1], "schema") == 0)
+    return run_fact_schema (global_opts, argc - 1, argv + 1);
+  if (g_strcmp0 (argv[1], "put") == 0)
+    return run_fact_put (global_opts, argc - 1, argv + 1);
+  g_printerr ("wyctl: unknown fact command: %s\n", argv[1]);
+  return 2;
+}
+
 static int
 run_audit_query (const WyctlOptions *global_opts, gint argc, gchar **argv)
 {
@@ -1385,6 +1864,10 @@ main (int argc, char **argv)
     return run_status (&opts, argc - 1, argv + 1);
   if (g_strcmp0 (argv[1], "policy") == 0)
     return run_policy (&opts, argc - 1, argv + 1);
+  if (g_strcmp0 (argv[1], "graph") == 0)
+    return run_graph (&opts, argc - 1, argv + 1);
+  if (g_strcmp0 (argv[1], "fact") == 0)
+    return run_fact (&opts, argc - 1, argv + 1);
   if (g_strcmp0 (argv[1], "audit") == 0)
     return run_audit (&opts, argc - 1, argv + 1);
   if (g_strcmp0 (argv[1], "key") == 0)

--- a/wyrelog/wyl-client.c
+++ b/wyrelog/wyl-client.c
@@ -15,6 +15,8 @@ struct _WylClient
   gchar *selected_tenant;
   gchar *principal_state;
   gchar *session_state;
+  gchar *last_error_code;
+  guint last_http_status;
   SoupSession *session;
   guint timeout_ms;
 };
@@ -24,6 +26,12 @@ struct _WylClientDecision
   gint decision;
   gchar *deny_reason;
   gchar *deny_origin;
+};
+
+struct _WylClientFactAppendResult
+{
+  gboolean inserted;
+  gchar *batch_id;
 };
 
 G_DEFINE_FINAL_TYPE (WylClient, wyl_client, G_TYPE_OBJECT);
@@ -54,6 +62,7 @@ wyl_client_finalize (GObject *object)
 
   g_free (self->base_url);
   wyl_client_clear_login_state (self);
+  g_free (self->last_error_code);
   g_clear_object (&self->session);
 
   G_OBJECT_CLASS (wyl_client_parent_class)->finalize (object);
@@ -159,6 +168,20 @@ wyl_client_dup_session_state (const WylClient *client)
 {
   g_return_val_if_fail (WYL_IS_CLIENT ((WylClient *) client), NULL);
   return g_strdup (client->session_state);
+}
+
+guint
+wyl_client_get_last_http_status (const WylClient *client)
+{
+  g_return_val_if_fail (WYL_IS_CLIENT ((WylClient *) client), 0);
+  return client->last_http_status;
+}
+
+gchar *
+wyl_client_dup_last_error_code (const WylClient *client)
+{
+  g_return_val_if_fail (WYL_IS_CLIENT ((WylClient *) client), NULL);
+  return g_strdup (client->last_error_code);
 }
 
 SoupSession *
@@ -569,6 +592,354 @@ wyl_client_policy_role_revoke (WylClient *client, const gchar *subject,
   return client_policy_mutation_request (client, "policy/roles/revoke",
       subject, "role", role, scope, NULL, guard_timestamp, guard_loc_class,
       guard_risk);
+}
+
+static void
+client_clear_last_http_error (WylClient *client)
+{
+  client->last_http_status = 0;
+  g_clear_pointer (&client->last_error_code, g_free);
+}
+
+static gchar *
+parse_simple_json_string_member (const gchar *data, gsize size,
+    const gchar *member)
+{
+  if (data == NULL || member == NULL)
+    return NULL;
+  g_autofree gchar *needle = g_strdup_printf ("\"%s\":\"", member);
+  const gchar *start = g_strstr_len (data, (gssize) size, needle);
+  if (start == NULL)
+    return NULL;
+  start += strlen (needle);
+  const gchar *end = start;
+  const gchar *limit = data + size;
+  while (end < limit && *end != '"') {
+    if (*end == '\\')
+      return NULL;
+    end++;
+  }
+  if (end >= limit)
+    return NULL;
+  return g_strndup (start, (gsize) (end - start));
+}
+
+static gboolean
+parse_simple_json_bool_member (const gchar *data, gsize size,
+    const gchar *member, gboolean *out_value)
+{
+  if (data == NULL || member == NULL || out_value == NULL)
+    return FALSE;
+  g_autofree gchar *needle = g_strdup_printf ("\"%s\":", member);
+  const gchar *start = g_strstr_len (data, (gssize) size, needle);
+  if (start == NULL)
+    return FALSE;
+  start += strlen (needle);
+  gsize remaining = (gsize) (data + size - start);
+  if (remaining >= strlen ("true") && strncmp (start, "true",
+          strlen ("true")) == 0) {
+    *out_value = TRUE;
+    return TRUE;
+  }
+  if (remaining >= strlen ("false") && strncmp (start, "false",
+          strlen ("false")) == 0) {
+    *out_value = FALSE;
+    return TRUE;
+  }
+  return FALSE;
+}
+
+static wyrelog_error_t
+client_send_fact_message (WylClient *client, SoupMessage *message,
+    GBytes **out_body)
+{
+  if (client == NULL || !WYL_IS_CLIENT (client) || message == NULL)
+    return WYRELOG_E_INVALID;
+  if (out_body != NULL)
+    *out_body = NULL;
+  client_clear_last_http_error (client);
+
+  g_autoptr (GError) error = NULL;
+  GBytes *body = soup_session_send_and_read (client->session, message, NULL,
+      &error);
+  if (body == NULL)
+    return WYRELOG_E_IO;
+
+  guint status = soup_message_get_status (message);
+  client->last_http_status = status;
+  if (status >= 200 && status < 300) {
+    if (out_body != NULL)
+      *out_body = body;
+    else
+      g_bytes_unref (body);
+    return WYRELOG_E_OK;
+  }
+
+  gsize size = 0;
+  const gchar *data = g_bytes_get_data (body, &size);
+  client->last_error_code = parse_simple_json_string_member (data, size,
+      "error");
+  g_bytes_unref (body);
+  if (status == 400)
+    return WYRELOG_E_INVALID;
+  if (status == 401)
+    return WYRELOG_E_AUTH;
+  if (status == 403 || status == 409)
+    return WYRELOG_E_POLICY;
+  return WYRELOG_E_IO;
+}
+
+static gboolean
+client_guard_args_are_valid (gint64 guard_timestamp,
+    const gchar *guard_loc_class, gint64 guard_risk)
+{
+  return guard_timestamp >= 0 && guard_loc_class != NULL &&
+      wyl_guard_loc_class_is_valid (guard_loc_class) && guard_risk >= 0 &&
+      guard_risk <= 100;
+}
+
+static wyrelog_error_t
+client_fact_prepare (WylClient *client, const gchar *tenant,
+    gint64 guard_timestamp, const gchar *guard_loc_class, gint64 guard_risk,
+    gchar **out_base_url, gchar **out_access_token, gchar **out_session_token)
+{
+  if (out_base_url == NULL || out_access_token == NULL ||
+      out_session_token == NULL)
+    return WYRELOG_E_INVALID;
+  *out_base_url = NULL;
+  *out_access_token = NULL;
+  *out_session_token = NULL;
+  if (client == NULL || !WYL_IS_CLIENT (client) || tenant == NULL ||
+      tenant[0] == '\0' || !client_guard_args_are_valid (guard_timestamp,
+          guard_loc_class, guard_risk))
+    return WYRELOG_E_INVALID;
+  g_autofree gchar *bound_tenant = wyl_client_dup_tenant (client);
+  if (bound_tenant == NULL || g_strcmp0 (bound_tenant, tenant) != 0)
+    return WYRELOG_E_INVALID;
+
+  g_autofree gchar *base_url = wyl_client_dup_base_url (client);
+  if (base_url == NULL)
+    return WYRELOG_E_INVALID;
+  while (base_url[0] != '\0' && g_str_has_suffix (base_url, "/"))
+    base_url[strlen (base_url) - 1] = '\0';
+  g_autofree gchar *access_token = wyl_client_dup_access_token (client);
+  g_autofree gchar *session_token = wyl_client_dup_session_token (client);
+  gboolean has_access = access_token != NULL && access_token[0] != '\0';
+  gboolean has_session = session_token != NULL && session_token[0] != '\0';
+  if (!has_access && !has_session)
+    return WYRELOG_E_INVALID;
+  *out_base_url = g_steal_pointer (&base_url);
+  *out_access_token = g_steal_pointer (&access_token);
+  *out_session_token = g_steal_pointer (&session_token);
+  return WYRELOG_E_OK;
+}
+
+static void
+client_fact_attach_auth (SoupMessage *message, const gchar *access_token)
+{
+  if (access_token != NULL && access_token[0] != '\0') {
+    g_autofree gchar *authorization = g_strdup_printf ("Bearer %s",
+        access_token);
+    soup_message_headers_replace (soup_message_get_request_headers (message),
+        "Authorization", authorization);
+  }
+}
+
+static gchar *
+client_fact_guard_query (const gchar *tenant, gint64 guard_timestamp,
+    const gchar *guard_loc_class, gint64 guard_risk, const gchar *session_token)
+{
+  g_autofree gchar *escaped_tenant = g_uri_escape_string (tenant, NULL, TRUE);
+  g_autofree gchar *escaped_loc = g_uri_escape_string (guard_loc_class, NULL,
+      TRUE);
+  if (session_token != NULL && session_token[0] != '\0') {
+    g_autofree gchar *escaped_session =
+        g_uri_escape_string (session_token, NULL, TRUE);
+    return g_strdup_printf ("tenant=%s&session_token=%s&guard_timestamp=%"
+        G_GINT64_FORMAT "&guard_loc_class=%s&guard_risk=%" G_GINT64_FORMAT,
+        escaped_tenant, escaped_session, guard_timestamp, escaped_loc,
+        guard_risk);
+  }
+  return g_strdup_printf ("tenant=%s&guard_timestamp=%" G_GINT64_FORMAT
+      "&guard_loc_class=%s&guard_risk=%" G_GINT64_FORMAT, escaped_tenant,
+      guard_timestamp, escaped_loc, guard_risk);
+}
+
+wyrelog_error_t
+wyl_client_graph_create (WylClient *client, const gchar *tenant,
+    const gchar *graph, gint64 guard_timestamp, const gchar *guard_loc_class,
+    gint64 guard_risk)
+{
+  if (graph == NULL || graph[0] == '\0')
+    return WYRELOG_E_INVALID;
+  g_autofree gchar *base_url = NULL;
+  g_autofree gchar *access_token = NULL;
+  g_autofree gchar *session_token = NULL;
+  wyrelog_error_t rc = client_fact_prepare (client, tenant, guard_timestamp,
+      guard_loc_class, guard_risk, &base_url, &access_token, &session_token);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  g_autofree gchar *guard_query = client_fact_guard_query (tenant,
+      guard_timestamp, guard_loc_class, guard_risk,
+      access_token != NULL && access_token[0] != '\0' ? NULL : session_token);
+  g_autofree gchar *escaped_graph = g_uri_escape_string (graph, NULL, TRUE);
+  g_autofree gchar *uri = g_strdup_printf ("%s/graphs/create?%s&graph=%s",
+      base_url, guard_query, escaped_graph);
+  g_autoptr (SoupMessage) message = soup_message_new ("POST", uri);
+  if (message == NULL)
+    return WYRELOG_E_INVALID;
+  client_fact_attach_auth (message, access_token);
+  return client_send_fact_message (client, message, NULL);
+}
+
+wyrelog_error_t
+wyl_client_fact_schema_register (WylClient *client, const gchar *tenant,
+    const gchar *graph, const gchar *namespace_id, const gchar *relation,
+    guint32 schema_version, const WylClientFactColumn *columns,
+    gsize n_columns, gint64 guard_timestamp, const gchar *guard_loc_class,
+    gint64 guard_risk)
+{
+  if (graph == NULL || graph[0] == '\0' || namespace_id == NULL ||
+      namespace_id[0] == '\0' || relation == NULL || relation[0] == '\0' ||
+      schema_version == 0 || columns == NULL || n_columns == 0)
+    return WYRELOG_E_INVALID;
+  g_autoptr (GString) tsv =
+      g_string_new ("column_name\tcolumn_type\tnullable\tvisible\n");
+  for (gsize i = 0; i < n_columns; i++) {
+    if (columns[i].name == NULL || columns[i].name[0] == '\0' ||
+        columns[i].type == NULL || columns[i].type[0] == '\0' ||
+        strchr (columns[i].name, '\t') != NULL ||
+        strchr (columns[i].type, '\t') != NULL)
+      return WYRELOG_E_INVALID;
+    g_string_append_printf (tsv, "%s\t%s\t%s\t%s\n", columns[i].name,
+        columns[i].type, columns[i].nullable ? "true" : "false",
+        columns[i].visible ? "true" : "false");
+  }
+
+  g_autofree gchar *base_url = NULL;
+  g_autofree gchar *access_token = NULL;
+  g_autofree gchar *session_token = NULL;
+  wyrelog_error_t rc = client_fact_prepare (client, tenant, guard_timestamp,
+      guard_loc_class, guard_risk, &base_url, &access_token, &session_token);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  g_autofree gchar *guard_query = client_fact_guard_query (tenant,
+      guard_timestamp, guard_loc_class, guard_risk,
+      access_token != NULL && access_token[0] != '\0' ? NULL : session_token);
+  g_autofree gchar *escaped_graph = g_uri_escape_string (graph, NULL, TRUE);
+  g_autofree gchar *escaped_namespace = g_uri_escape_string (namespace_id,
+      NULL, TRUE);
+  g_autofree gchar *escaped_relation = g_uri_escape_string (relation, NULL,
+      TRUE);
+  g_autofree gchar *uri = g_strdup_printf
+      ("%s/facts/schema/register?%s&graph=%s&namespace=%s&relation=%s"
+      "&schema_version=%u", base_url, guard_query, escaped_graph,
+      escaped_namespace, escaped_relation, schema_version);
+  g_autoptr (SoupMessage) message = soup_message_new ("POST", uri);
+  if (message == NULL)
+    return WYRELOG_E_INVALID;
+  client_fact_attach_auth (message, access_token);
+  g_autoptr (GBytes) body = g_bytes_new (tsv->str, tsv->len);
+  soup_message_set_request_body_from_bytes (message,
+      "text/tab-separated-values", body);
+  return client_send_fact_message (client, message, NULL);
+}
+
+wyrelog_error_t
+wyl_client_fact_put_batch (WylClient *client, const gchar *tenant,
+    const gchar *graph, const gchar *namespace_id, const gchar *relation,
+    guint32 schema_version, const gchar *batch_id,
+    const gchar *idempotency_key, const guint8 *tsv_payload, gsize tsv_len,
+    gint64 guard_timestamp, const gchar *guard_loc_class, gint64 guard_risk,
+    WylClientFactAppendResult **out_result)
+{
+  if (out_result != NULL)
+    *out_result = NULL;
+  if (graph == NULL || graph[0] == '\0' || namespace_id == NULL ||
+      namespace_id[0] == '\0' || relation == NULL || relation[0] == '\0' ||
+      schema_version == 0 || batch_id == NULL || batch_id[0] == '\0' ||
+      idempotency_key == NULL || idempotency_key[0] == '\0' ||
+      tsv_payload == NULL || tsv_len == 0)
+    return WYRELOG_E_INVALID;
+
+  g_autofree gchar *base_url = NULL;
+  g_autofree gchar *access_token = NULL;
+  g_autofree gchar *session_token = NULL;
+  wyrelog_error_t rc = client_fact_prepare (client, tenant, guard_timestamp,
+      guard_loc_class, guard_risk, &base_url, &access_token, &session_token);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  g_autofree gchar *guard_query = client_fact_guard_query (tenant,
+      guard_timestamp, guard_loc_class, guard_risk,
+      access_token != NULL && access_token[0] != '\0' ? NULL : session_token);
+  g_autofree gchar *escaped_tenant = g_uri_escape_string (tenant, NULL, TRUE);
+  g_autofree gchar *escaped_graph = g_uri_escape_string (graph, NULL, TRUE);
+  g_autofree gchar *escaped_namespace = g_uri_escape_string (namespace_id,
+      NULL, TRUE);
+  g_autofree gchar *escaped_relation = g_uri_escape_string (relation, NULL,
+      TRUE);
+  g_autofree gchar *escaped_batch = g_uri_escape_string (batch_id, NULL, TRUE);
+  g_autofree gchar *escaped_key = g_uri_escape_string (idempotency_key, NULL,
+      TRUE);
+  g_autofree gchar *uri = g_strdup_printf
+      ("%s/facts/%s/%s/%s:append?%s&namespace=%s&schema_version=%u"
+      "&batch_id=%s&idempotency_key=%s", base_url, escaped_tenant,
+      escaped_graph, escaped_relation, guard_query, escaped_namespace,
+      schema_version, escaped_batch, escaped_key);
+  g_autoptr (SoupMessage) message = soup_message_new ("POST", uri);
+  if (message == NULL)
+    return WYRELOG_E_INVALID;
+  client_fact_attach_auth (message, access_token);
+  g_autoptr (GBytes) request_body = g_bytes_new (tsv_payload, tsv_len);
+  soup_message_set_request_body_from_bytes (message,
+      "text/tab-separated-values", request_body);
+  g_autoptr (GBytes) response_body = NULL;
+  rc = client_send_fact_message (client, message, &response_body);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if (out_result != NULL) {
+    gsize size = 0;
+    const gchar *data = g_bytes_get_data (response_body, &size);
+    gboolean inserted = FALSE;
+    g_autofree gchar *response_batch = parse_simple_json_string_member (data,
+        size, "batch_id");
+    if (!parse_simple_json_bool_member (data, size, "inserted", &inserted) ||
+        response_batch == NULL)
+      return WYRELOG_E_IO;
+    WylClientFactAppendResult *result = g_new0 (WylClientFactAppendResult, 1);
+    result->inserted = inserted;
+    result->batch_id = g_steal_pointer (&response_batch);
+    *out_result = result;
+  }
+  return WYRELOG_E_OK;
+}
+
+void
+wyl_client_fact_append_result_free (WylClientFactAppendResult *result)
+{
+  if (result == NULL)
+    return;
+  g_free (result->batch_id);
+  g_free (result);
+}
+
+gboolean
+    wyl_client_fact_append_result_get_inserted
+    (const WylClientFactAppendResult * result)
+{
+  return result != NULL && result->inserted;
+}
+
+const gchar *wyl_client_fact_append_result_get_batch_id
+    (const WylClientFactAppendResult * result)
+{
+  return result != NULL ? result->batch_id : NULL;
+}
+
+gchar *wyl_client_fact_append_result_dup_batch_id
+    (const WylClientFactAppendResult * result)
+{
+  return g_strdup (wyl_client_fact_append_result_get_batch_id (result));
 }
 
 typedef struct


### PR DESCRIPTION
## Summary
- Add typed C client APIs for guarded fact graph creation, schema registration, and fact batch append.
- Add `wyctl graph create`, `wyctl fact schema register`, and `wyctl fact put` commands with token-file and guard-context support.
- Extend daemon-backed wyctl tests to run graph setup, schema registration, CSV input conversion, append, and duplicate append verification.

## Validation
- `meson test -C builddir-issue50-fact --print-errorlogs` (71 OK, 1 skipped)
- `meson test -C builddir-issue50-default --print-errorlogs` (67 OK, 1 skipped)
