### PR TITLE
Expose guarded Datalog relation queries

### DIFF
--- a/tests/test-daemon-http-facts.c
+++ b/tests/test-daemon-http-facts.c
@@ -133,6 +133,7 @@ grant_fact_http_authority (WylHandle *handle, const gchar *subject)
     "wr.graph.manage",
     "wr.schema.manage",
     "wr.fact.write",
+    "wr.datalog.query",
   };
   wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
   for (gsize i = 0; i < G_N_ELEMENTS (perms); i++) {
@@ -353,6 +354,107 @@ check_fact_http_contract (WylHandle *handle, const gchar *base_url)
     return rc;
 
   g_clear_pointer (&body, g_free);
+  g_autofree gchar *datalog_query = g_strdup_printf ("tenant=%s&%s",
+      WYL_TENANT_DEFAULT, FACT_GUARD);
+  rc = send_raw (session, "POST", base_url,
+      "/datalog/__wr_default/orders/query", datalog_query, NULL,
+      "{\"query\":\"orders(O,A)\",\"output\":\"json\",\"limit\":10}",
+      &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 401 || strstr (body, "\"datalog_auth_required\"") == NULL)
+    return 330;
+
+  g_clear_pointer (&body, g_free);
+  rc = send_raw (session, "POST", base_url,
+      "/datalog/__wr_default/orders/query", datalog_query, deny_token,
+      "{\"query\":\"orders(O,A)\",\"output\":\"json\",\"limit\":10}",
+      &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 403 || strstr (body, "\"datalog_denied\"") == NULL)
+    return 331;
+
+  const gchar *invalid_datalog_bodies[] = {
+    "{\"query\":\"orders(O,A) :- orders(O,A)\",\"output\":\"json\"}",
+    "{\"query\":\".decl orders(O:symbol,A:int64)\",\"output\":\"json\"}",
+    "{\"query\":\"orders(O,A);orders(O,A)\",\"output\":\"json\"}",
+    "{\"query\":\"SELECT * FROM orders\",\"output\":\"json\"}",
+  };
+  for (gsize i = 0; i < G_N_ELEMENTS (invalid_datalog_bodies); i++) {
+    g_clear_pointer (&body, g_free);
+    rc = send_raw (session, "POST", base_url,
+        "/datalog/__wr_default/orders/query", datalog_query, admin_token,
+        invalid_datalog_bodies[i], &status, &body);
+    if (rc != 0)
+      return rc;
+    if (status != 400 || strstr (body, "\"invalid_datalog_request\"") == NULL)
+      return 340 + (gint) i;
+  }
+
+  g_clear_pointer (&body, g_free);
+  rc = send_raw (session, "POST", base_url,
+      "/datalog/__wr_default/orders/query", datalog_query, admin_token,
+      "{\"query\":\"orders(O,A)\",\"output\":\"json\",\"limit\":10}",
+      &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 200 || strstr (body, "\"relation\":\"orders\"") == NULL ||
+      strstr (body, "\"columns\":[\"O\",\"A\"]") == NULL ||
+      strstr (body, "{\"O\":\"o-1\",\"A\":42}") == NULL ||
+      strstr (body, "facts.duckdb") != NULL)
+    return 332;
+
+  g_clear_pointer (&body, g_free);
+  rc = send_raw (session, "POST", base_url,
+      "/datalog/__wr_default/orders/query", datalog_query, admin_token,
+      "{\"query\":\"payments(P)\",\"output\":\"json\",\"limit\":10}",
+      &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 403 || strstr (body, "\"datalog_relation_denied\"") == NULL)
+    return 333;
+
+  if (wyl_handle_replay_fact_graphs (handle, NULL) != WYRELOG_E_OK)
+    return 334;
+  g_clear_pointer (&body, g_free);
+  rc = send_raw (session, "POST", base_url,
+      "/datalog/__wr_default/orders/query", datalog_query, admin_token,
+      "{\"query\":\"orders(\\\"o-1\\\",A)\",\"output\":\"json\",\"limit\":10}",
+      &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 200 || strstr (body, "{\"A\":42}") == NULL ||
+      strstr (body, "\"row_count\":1") == NULL)
+    return 335;
+
+  g_clear_pointer (&body, g_free);
+  g_autofree gchar *append_query_2 = g_strdup_printf
+      ("tenant=%s&namespace=shop&schema_version=1&batch_id=batch-7&"
+      "idempotency_key=key-7&%s", WYL_TENANT_DEFAULT, FACT_GUARD);
+  rc = send_raw (session, "POST", base_url,
+      "/facts/__wr_default/orders/orders:append", append_query_2,
+      admin_token, "order_id\tamount\no-2\t84\n", &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 200 || strstr (body, "\"inserted\":true") == NULL)
+    return 336;
+  rc = check_fact_projection_row_count (handle, "orders", 2);
+  if (rc != 0)
+    return rc;
+
+  g_clear_pointer (&body, g_free);
+  rc = send_raw (session, "POST", base_url,
+      "/datalog/__wr_default/orders/query", datalog_query, admin_token,
+      "{\"query\":\"orders(O,A)\",\"output\":\"json\",\"limit\":1}",
+      &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 200 || strstr (body, "\"row_count\":1") == NULL ||
+      strstr (body, "\"truncated\":true") == NULL)
+    return 337;
+
+  g_clear_pointer (&body, g_free);
   g_autofree gchar *bad_append_query = g_strdup_printf
       ("tenant=%s&namespace=shop&schema_version=1&batch_id=batch-2&"
       "idempotency_key=key-2&%s", WYL_TENANT_DEFAULT, FACT_GUARD);
@@ -363,7 +465,7 @@ check_fact_http_contract (WylHandle *handle, const gchar *base_url)
     return rc;
   if (status != 400 || strstr (body, "\"invalid_fact_payload\"") == NULL)
     return 29;
-  rc = check_fact_projection_row_count (handle, "orders", 1);
+  rc = check_fact_projection_row_count (handle, "orders", 2);
   if (rc != 0)
     return rc;
 

--- a/tests/test-wyctl-policy-daemon.c
+++ b/tests/test-wyctl-policy-daemon.c
@@ -93,6 +93,7 @@ grant_fact_authority (WylHandle *handle, const gchar *subject)
     "wr.graph.manage",
     "wr.schema.manage",
     "wr.fact.write",
+    "wr.datalog.query",
   };
   wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
   for (gsize i = 0; i < G_N_ELEMENTS (perms); i++) {
@@ -269,6 +270,27 @@ assert_wyctl_stdout (gchar **argv, const gchar *expected_stdout)
     g_assert_not_reached ();
   }
   g_assert_cmpstr (stdout_buf, ==, expected_stdout);
+  g_assert_cmpstr (stderr_buf, ==, "");
+}
+
+static void
+assert_wyctl_stdout_contains (gchar **argv, const gchar *needle)
+{
+  g_autofree gchar *stdout_buf = NULL;
+  g_autofree gchar *stderr_buf = NULL;
+  gint wait_status = 0;
+  g_autoptr (GError) error = NULL;
+
+  run_wyctl (argv, &stdout_buf, &stderr_buf, &wait_status);
+
+  if (!g_spawn_check_wait_status (wait_status, &error)) {
+    g_printerr ("wyctl exited with status %d\nstdout: %s\nstderr: %s\n",
+        wait_status, stdout_buf ? stdout_buf : "(null)",
+        stderr_buf ? stderr_buf : "(null)");
+    g_clear_error (&error);
+    g_assert_not_reached ();
+  }
+  g_assert_nonnull (strstr (stdout_buf, needle));
   g_assert_cmpstr (stderr_buf, ==, "");
 }
 #endif
@@ -506,6 +528,23 @@ main (void)
   assert_wyctl_stdout (fact_put_argv, "inserted\n");
   if (check_fact_projection_count (handle, 1) != 0)
     return 104;
+  gchar *datalog_query_argv[] = {
+    (gchar *) WYL_TEST_WYCTL_PATH,
+    "--daemon-url", (gchar *) base_url,
+    "datalog", "query",
+    "--tenant", (gchar *) WYL_TENANT_DEFAULT,
+    "--graph", "orders",
+    "--query", "orders(O,A)",
+    "--output", "json",
+    "--limit", "10",
+    "--access-token-file", token_path,
+    "--guard-timestamp", "123",
+    "--guard-loc-class", "trusted",
+    "--guard-risk", "29",
+    NULL,
+  };
+  assert_wyctl_stdout_contains (datalog_query_argv,
+      "\"rows\":[{\"O\":\"o-1\",\"A\":42}]");
   assert_wyctl_stdout (fact_put_argv, "duplicate\n");
   if (check_fact_projection_count (handle, 1) != 0)
     return 105;

--- a/wyrelog/client.h
+++ b/wyrelog/client.h
@@ -169,6 +169,13 @@ wyrelog_error_t wyl_client_fact_put_batch (WylClient * client,
     gint64 guard_timestamp,
     const gchar * guard_loc_class,
     gint64 guard_risk, WylClientFactAppendResult ** out_result);
+wyrelog_error_t wyl_client_datalog_query_json (WylClient * client,
+    const gchar * tenant,
+    const gchar * graph,
+    const gchar * query,
+    guint limit,
+    gint64 guard_timestamp,
+    const gchar * guard_loc_class, gint64 guard_risk, gchar ** out_json);
 void wyl_client_fact_append_result_free (WylClientFactAppendResult * result);
 gboolean wyl_client_fact_append_result_get_inserted
     (const WylClientFactAppendResult * result);

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -11,6 +11,7 @@
 #include "wyrelog/wyrelog.h"
 #include "wyrelog/auth/jwt-private.h"
 #ifdef WYL_HAS_FACT_STORE
+#include "wyrelog/fact/query-private.h"
 #include "wyrelog/fact/schema-private.h"
 #include "wyrelog/fact/store-private.h"
 #endif
@@ -2635,6 +2636,262 @@ parse_fact_append_path (const gchar *path, gchar **out_tenant,
   return *out_tenant != NULL && *out_graph != NULL && *out_relation != NULL;
 }
 
+static gboolean
+parse_datalog_query_path (const gchar *path, gchar **out_tenant,
+    gchar **out_graph)
+{
+  *out_tenant = NULL;
+  *out_graph = NULL;
+  if (path == NULL || !g_str_has_prefix (path, "/datalog/") ||
+      !g_str_has_suffix (path, "/query"))
+    return FALSE;
+  const gchar *tail = path + strlen ("/datalog/");
+  g_autofree gchar *inner = g_strndup (tail,
+      strlen (tail) - strlen ("/query"));
+  g_auto (GStrv) parts = g_strsplit (inner, "/", 2);
+  if (g_strv_length (parts) != 2 || parts[0][0] == '\0' || parts[1][0] == '\0')
+    return FALSE;
+  *out_tenant = g_strdup (parts[0]);
+  *out_graph = g_strdup (parts[1]);
+  return *out_tenant != NULL && *out_graph != NULL;
+}
+
+static const gchar *
+skip_ascii_spaces (const gchar *p)
+{
+  while (p != NULL && g_ascii_isspace (*p))
+    p++;
+  return p;
+}
+
+static gchar *
+json_dup_simple_string_member (const gchar *json, const gchar *member)
+{
+  if (json == NULL || member == NULL)
+    return NULL;
+  g_autofree gchar *needle = g_strdup_printf ("\"%s\"", member);
+  const gchar *p = strstr (json, needle);
+  if (p == NULL)
+    return NULL;
+  p += strlen (needle);
+  p = skip_ascii_spaces (p);
+  if (*p != ':')
+    return NULL;
+  p = skip_ascii_spaces (p + 1);
+  if (*p != '"')
+    return NULL;
+  p++;
+  g_autoptr (GString) value = g_string_new (NULL);
+  while (*p != '\0' && *p != '"') {
+    if ((guchar) * p < 0x20)
+      return NULL;
+    if (*p == '\\') {
+      p++;
+      switch (*p) {
+        case '"':
+        case '\\':
+        case '/':
+          g_string_append_c (value, *p++);
+          break;
+        case 'n':
+          g_string_append_c (value, '\n');
+          p++;
+          break;
+        case 'r':
+          g_string_append_c (value, '\r');
+          p++;
+          break;
+        case 't':
+          g_string_append_c (value, '\t');
+          p++;
+          break;
+        default:
+          return NULL;
+      }
+      continue;
+    }
+    g_string_append_c (value, *p++);
+  }
+  if (*p != '"')
+    return NULL;
+  return g_string_free (g_steal_pointer (&value), FALSE);
+}
+
+static gboolean
+json_parse_simple_uint_member (const gchar *json, const gchar *member,
+    guint *out_value, gboolean *out_present)
+{
+  if (out_present != NULL)
+    *out_present = FALSE;
+  if (json == NULL || member == NULL || out_value == NULL)
+    return FALSE;
+  g_autofree gchar *needle = g_strdup_printf ("\"%s\"", member);
+  const gchar *p = strstr (json, needle);
+  if (p == NULL)
+    return TRUE;
+  if (out_present != NULL)
+    *out_present = TRUE;
+  p += strlen (needle);
+  p = skip_ascii_spaces (p);
+  if (*p != ':')
+    return FALSE;
+  p = skip_ascii_spaces (p + 1);
+  if (!g_ascii_isdigit (*p))
+    return FALSE;
+  errno = 0;
+  gchar *end = NULL;
+  guint64 parsed = g_ascii_strtoull (p, &end, 10);
+  if (errno != 0 || end == p || parsed > G_MAXUINT)
+    return FALSE;
+  *out_value = (guint) parsed;
+  return TRUE;
+}
+
+static wyrelog_error_t
+emit_datalog_query_audit (WylDaemonHttpContext *ctx, const gchar *actor,
+    const gchar *tenant, const gchar *graph, const gchar *query_name,
+    const gchar *decision, guint row_count, gboolean truncated,
+    const gchar *request_id)
+{
+#ifdef WYL_HAS_AUDIT
+  g_autoptr (WylAuditEvent) ev = wyl_audit_event_new ();
+  g_autofree gchar *resource = g_strdup_printf ("%s/%s/%s", tenant, graph,
+      query_name != NULL ? query_name : "unknown");
+  g_autofree gchar *origin = g_strdup_printf ("rows=%u truncated=%s",
+      row_count, truncated ? "true" : "false");
+  wyl_audit_event_set_subject_id (ev, actor);
+  wyl_audit_event_set_action (ev, "datalog_query");
+  wyl_audit_event_set_resource_id (ev, resource);
+  wyl_audit_event_set_deny_reason (ev, decision);
+  wyl_audit_event_set_deny_origin (ev, origin);
+  wyl_audit_event_set_request_id (ev, request_id);
+  wyl_audit_event_set_decision (ev,
+      g_strcmp0 (decision, "allow") == 0 ? WYL_DECISION_ALLOW :
+      WYL_DECISION_DENY);
+  return wyl_audit_emit (ctx->handle, ev);
+#else
+  (void) ctx;
+  (void) actor;
+  (void) tenant;
+  (void) graph;
+  (void) query_name;
+  (void) decision;
+  (void) row_count;
+  (void) truncated;
+  (void) request_id;
+  return WYRELOG_E_OK;
+#endif
+}
+
+static void
+datalog_query_handler (SoupServer *server, SoupServerMessage *msg,
+    const char *path, GHashTable *query, gpointer user_data)
+{
+  if (g_strcmp0 (soup_server_message_get_method (msg), "POST") != 0) {
+    set_json_error (msg, 405, "method_not_allowed");
+    return;
+  }
+
+  g_autofree gchar *tenant = NULL;
+  g_autofree gchar *graph = NULL;
+  if (!parse_datalog_query_path (path, &tenant, &graph) ||
+      !wyl_policy_store_tenant_id_is_valid (tenant) ||
+      !fact_http_customer_name_is_valid (graph)) {
+    set_json_error (msg, 400, "invalid_datalog_request");
+    return;
+  }
+  if (!query_tenant_matches (msg, query, tenant))
+    return;
+
+  WylDaemonHttpContext *ctx = user_data;
+  g_autoptr (GHashTable) auth_query = copy_query_with_tenant (query, tenant);
+  g_autofree gchar *actor = NULL;
+  if (!authorize_guarded_session_action (server, msg, auth_query, ctx,
+          "wr.datalog.query", tenant, "datalog_auth_required",
+          "invalid_datalog_auth", "datalog_denied", "datalog_auth_failed",
+          &actor))
+    return;
+
+  GraphLookupCtx lookup = { 0 };
+  wyrelog_error_t rc = lookup_fact_graph (wyl_handle_get_policy_store
+      (ctx->handle), tenant, graph, &lookup);
+  if (rc != WYRELOG_E_OK) {
+    set_json_error (msg, 500, "datalog_query_failed");
+    return;
+  }
+  if (!lookup.found) {
+    graph_lookup_clear (&lookup);
+    set_json_error (msg, 404, "graph_not_found");
+    return;
+  }
+  if (lookup.info.sealed) {
+    graph_lookup_clear (&lookup);
+    set_json_error (msg, 409, "graph_not_queryable");
+    return;
+  }
+  graph_lookup_clear (&lookup);
+
+  g_autofree gchar *body = NULL;
+  if (!request_body_dup (msg, 16 * 1024, &body)) {
+    set_json_error (msg, 400, "invalid_datalog_request");
+    return;
+  }
+  g_autofree gchar *query_atom = json_dup_simple_string_member (body, "query");
+  g_autofree gchar *output = json_dup_simple_string_member (body, "output");
+  guint limit = 0;
+  gboolean limit_present = FALSE;
+  if (query_atom == NULL || (output != NULL && g_strcmp0 (output, "json") != 0)
+      || !json_parse_simple_uint_member (body, "limit", &limit,
+          &limit_present) || (limit_present && limit == 0)) {
+    set_json_error (msg, 400, "invalid_datalog_request");
+    return;
+  }
+
+  const gchar *request_id = ensure_request_id_header (msg);
+  g_autofree gchar *json = NULL;
+  g_autofree gchar *query_name = NULL;
+  gboolean truncated = FALSE;
+  guint row_count = 0;
+  wyl_fact_datalog_query_options_t opts = {
+    .tenant_id = tenant,
+    .graph_id = graph,
+    .query = query_atom,
+    .limit = limit,
+    .query_id = request_id,
+  };
+  rc = wyl_fact_datalog_query_json (ctx->handle, &opts, &json, &truncated,
+      &row_count, &query_name);
+  if (rc == WYRELOG_E_INVALID) {
+    (void) emit_datalog_query_audit (ctx, actor, tenant, graph, query_name,
+        "invalid", 0, FALSE, request_id);
+    set_json_error (msg, 400, "invalid_datalog_request");
+    return;
+  }
+  if (rc == WYRELOG_E_POLICY || rc == WYRELOG_E_NOT_FOUND) {
+    (void) emit_datalog_query_audit (ctx, actor, tenant, graph, query_name,
+        "deny", 0, FALSE, request_id);
+    set_json_error (msg, 403, "datalog_relation_denied");
+    return;
+  }
+  if (rc != WYRELOG_E_OK) {
+    (void) emit_datalog_query_audit (ctx, actor, tenant, graph, query_name,
+        "failed", 0, FALSE, request_id);
+    set_json_error (msg, 500, "datalog_query_failed");
+    return;
+  }
+  rc = emit_datalog_query_audit (ctx, actor, tenant, graph, query_name,
+      "allow", row_count, truncated, request_id);
+  if (rc != WYRELOG_E_OK) {
+    set_json_error (msg, 500, "datalog_query_failed");
+    return;
+  }
+
+  attach_request_id_header (msg);
+  soup_server_message_set_status (msg, 200, NULL);
+  soup_server_message_set_response (msg, "application/json",
+      SOUP_MEMORY_COPY, json, strlen (json));
+}
+
 static wyrelog_error_t
 emit_fact_append_audit (WylDaemonHttpContext *ctx, const gchar *actor,
     const gchar *tenant, const gchar *graph, const gchar *namespace_id,
@@ -2884,6 +3141,18 @@ facts_route_handler (SoupServer *server, SoupServerMessage *msg,
     const char *path, GHashTable *query, gpointer user_data)
 {
   (void) server;
+  (void) path;
+  (void) query;
+  (void) user_data;
+  set_json_error (msg, 503, "fact_store_disabled");
+}
+
+static void
+datalog_query_handler (SoupServer *server, SoupServerMessage *msg,
+    const char *path, GHashTable *query, gpointer user_data)
+{
+  (void) server;
+  (void) msg;
   (void) path;
   (void) query;
   (void) user_data;
@@ -3611,6 +3880,8 @@ wyl_daemon_start_http_server_with_runtime (const WylDaemonOptions *opts,
   soup_server_add_handler (server, "/facts/schema/register",
       schema_register_handler, ctx, NULL);
   soup_server_add_handler (server, "/facts", facts_route_handler, ctx, NULL);
+  soup_server_add_handler (server, "/datalog", datalog_query_handler, ctx,
+      NULL);
   soup_server_add_handler (server, "/profile/status", profile_status_handler,
       ctx, NULL);
   soup_server_add_handler (server, "/profile/events", profile_events_handler,

--- a/wyrelog/fact/query-private.h
+++ b/wyrelog/fact/query-private.h
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+
+#include <glib.h>
+
+#include "wyrelog/error.h"
+#include "wyrelog/wyl-handle-private.h"
+
+G_BEGIN_DECLS;
+
+typedef struct
+{
+  const gchar *tenant_id;
+  const gchar *graph_id;
+  const gchar *query;
+  guint limit;
+  const gchar *query_id;
+} wyl_fact_datalog_query_options_t;
+
+wyrelog_error_t wyl_fact_datalog_query_json (WylHandle * handle,
+    const wyl_fact_datalog_query_options_t * opts, gchar ** out_json,
+    gboolean * out_truncated, guint * out_row_count, gchar ** out_query_name);
+
+G_END_DECLS;

--- a/wyrelog/fact/query.c
+++ b/wyrelog/fact/query.c
@@ -1,0 +1,501 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "query-private.h"
+
+#include <errno.h>
+#include <string.h>
+
+#include "replay-private.h"
+#include "wyrelog/wyl-engine-private.h"
+#include "wyrelog/policy/store-private.h"
+
+#define WYL_FACT_DATALOG_QUERY_MAX_LEN 512
+#define WYL_FACT_DATALOG_MAX_ARGS 32
+#define WYL_FACT_DATALOG_HARD_ROW_LIMIT 1000
+
+typedef enum
+{
+  QUERY_ARG_VARIABLE,
+  QUERY_ARG_WILDCARD,
+  QUERY_ARG_STRING,
+  QUERY_ARG_INT64,
+  QUERY_ARG_BOOL,
+} QueryArgKind;
+
+typedef struct
+{
+  QueryArgKind kind;
+  gchar *text;
+  gint64 i64;
+  gboolean boolean;
+} QueryArg;
+
+typedef struct
+{
+  gchar *name;
+  QueryArg args[WYL_FACT_DATALOG_MAX_ARGS];
+  gsize n_args;
+} ParsedQuery;
+
+typedef struct
+{
+  const ParsedQuery *parsed;
+  const wyl_policy_fact_relation_schema_column_info_t *columns;
+  gsize n_columns;
+  guint limit;
+  GString *rows_json;
+  guint row_count;
+  gboolean truncated;
+} CollectCtx;
+
+static void
+append_json_string_local (GString *json, const gchar *value)
+{
+  g_string_append_c (json, '"');
+  for (const guchar * p = (const guchar *)(value != NULL ? value : "");
+      *p != '\0'; p++) {
+    switch (*p) {
+      case '"':
+        g_string_append (json, "\\\"");
+        break;
+      case '\\':
+        g_string_append (json, "\\\\");
+        break;
+      case '\b':
+        g_string_append (json, "\\b");
+        break;
+      case '\f':
+        g_string_append (json, "\\f");
+        break;
+      case '\n':
+        g_string_append (json, "\\n");
+        break;
+      case '\r':
+        g_string_append (json, "\\r");
+        break;
+      case '\t':
+        g_string_append (json, "\\t");
+        break;
+      default:
+        if (*p < 0x20)
+          g_string_append_printf (json, "\\u%04x", *p);
+        else
+          g_string_append_c (json, (gchar) * p);
+        break;
+    }
+  }
+  g_string_append_c (json, '"');
+}
+
+static gboolean
+customer_name_is_valid (const gchar *value)
+{
+  if (value == NULL || value[0] == '\0' || g_str_has_prefix (value, "wr."))
+    return FALSE;
+  for (const gchar * p = value; *p != '\0'; p++) {
+    if (!(g_ascii_isalnum (*p) || *p == '_' || *p == '-' || *p == '.'))
+      return FALSE;
+  }
+  return TRUE;
+}
+
+static void
+parsed_query_clear (ParsedQuery *parsed)
+{
+  if (parsed == NULL)
+    return;
+  g_free (parsed->name);
+  for (gsize i = 0; i < parsed->n_args; i++)
+    g_free (parsed->args[i].text);
+  memset (parsed, 0, sizeof (*parsed));
+}
+
+static const gchar *
+skip_ws (const gchar *p)
+{
+  while (p != NULL && g_ascii_isspace (*p))
+    p++;
+  return p;
+}
+
+static gboolean
+parse_identifier (const gchar **cursor, gchar **out_ident)
+{
+  const gchar *p = *cursor;
+  if (!(g_ascii_isalpha (*p) || *p == '_'))
+    return FALSE;
+  const gchar *start = p++;
+  while (g_ascii_isalnum (*p) || *p == '_' || *p == '-' || *p == '.')
+    p++;
+  *out_ident = g_strndup (start, (gsize) (p - start));
+  *cursor = p;
+  return *out_ident != NULL;
+}
+
+static gboolean
+parse_quoted_string (const gchar **cursor, gchar **out)
+{
+  const gchar *p = *cursor;
+  if (*p != '"')
+    return FALSE;
+  p++;
+  g_autoptr (GString) value = g_string_new (NULL);
+  while (*p != '\0' && *p != '"') {
+    if ((guchar) * p < 0x20 || *p == '\\')
+      return FALSE;
+    g_string_append_c (value, *p++);
+  }
+  if (*p != '"')
+    return FALSE;
+  *cursor = p + 1;
+  *out = g_string_free (g_steal_pointer (&value), FALSE);
+  return *out != NULL;
+}
+
+static gboolean
+parse_int64_literal (const gchar **cursor, gint64 *out)
+{
+  const gchar *p = *cursor;
+  if (*p != '-' && !g_ascii_isdigit (*p))
+    return FALSE;
+  errno = 0;
+  gchar *end = NULL;
+  gint64 value = g_ascii_strtoll (p, &end, 10);
+  if (errno != 0 || end == p)
+    return FALSE;
+  *cursor = end;
+  *out = value;
+  return TRUE;
+}
+
+static gboolean
+parse_query_arg (const gchar **cursor, QueryArg *arg)
+{
+  const gchar *p = skip_ws (*cursor);
+  memset (arg, 0, sizeof (*arg));
+  if (*p == '_') {
+    arg->kind = QUERY_ARG_WILDCARD;
+    *cursor = p + 1;
+    return TRUE;
+  }
+  if (*p == '"') {
+    arg->kind = QUERY_ARG_STRING;
+    if (!parse_quoted_string (&p, &arg->text))
+      return FALSE;
+    *cursor = p;
+    return TRUE;
+  }
+  if (g_str_has_prefix (p, "true") && !g_ascii_isalnum (p[4]) && p[4] != '_') {
+    arg->kind = QUERY_ARG_BOOL;
+    arg->boolean = TRUE;
+    *cursor = p + 4;
+    return TRUE;
+  }
+  if (g_str_has_prefix (p, "false") && !g_ascii_isalnum (p[5]) && p[5] != '_') {
+    arg->kind = QUERY_ARG_BOOL;
+    arg->boolean = FALSE;
+    *cursor = p + 5;
+    return TRUE;
+  }
+  if (*p == '-' || g_ascii_isdigit (*p)) {
+    arg->kind = QUERY_ARG_INT64;
+    if (!parse_int64_literal (&p, &arg->i64))
+      return FALSE;
+    *cursor = p;
+    return TRUE;
+  }
+  if (g_ascii_isupper (*p)) {
+    arg->kind = QUERY_ARG_VARIABLE;
+    if (!parse_identifier (&p, &arg->text))
+      return FALSE;
+    *cursor = p;
+    return TRUE;
+  }
+  return FALSE;
+}
+
+static gboolean
+parse_relation_atom (const gchar *query, ParsedQuery *out)
+{
+  if (query == NULL || strlen (query) > WYL_FACT_DATALOG_QUERY_MAX_LEN)
+    return FALSE;
+  if (strstr (query, ":-") != NULL || strstr (query, ".decl") != NULL ||
+      strchr (query, ';') != NULL)
+    return FALSE;
+
+  const gchar *p = skip_ws (query);
+  memset (out, 0, sizeof (*out));
+  if (!parse_identifier (&p, &out->name) || !customer_name_is_valid (out->name))
+    goto fail;
+  p = skip_ws (p);
+  if (*p != '(')
+    goto fail;
+  p++;
+  p = skip_ws (p);
+  if (*p == ')')
+    goto fail;
+  while (*p != '\0') {
+    if (out->n_args >= WYL_FACT_DATALOG_MAX_ARGS)
+      goto fail;
+    if (!parse_query_arg (&p, &out->args[out->n_args]))
+      goto fail;
+    out->n_args++;
+    p = skip_ws (p);
+    if (*p == ',') {
+      p++;
+      continue;
+    }
+    if (*p == ')') {
+      p++;
+      break;
+    }
+    goto fail;
+  }
+  p = skip_ws (p);
+  if (*p != '\0')
+    goto fail;
+  return TRUE;
+
+fail:
+  parsed_query_clear (out);
+  return FALSE;
+}
+
+static gboolean
+schema_value_matches (WylEngine *engine,
+    const wyl_policy_fact_relation_schema_column_info_t *column,
+    const QueryArg *arg, gint64 cell)
+{
+  if (arg->kind == QUERY_ARG_WILDCARD || arg->kind == QUERY_ARG_VARIABLE)
+    return TRUE;
+  if (g_strcmp0 (column->column_type, "symbol") == 0 ||
+      g_strcmp0 (column->column_type, "string") == 0) {
+    if (arg->kind != QUERY_ARG_STRING)
+      return FALSE;
+    g_autofree gchar *value = wyl_engine_owned_dup_interned_symbol (engine,
+        cell);
+    return g_strcmp0 (value, arg->text) == 0;
+  }
+  if (g_strcmp0 (column->column_type, "int64") == 0)
+    return arg->kind == QUERY_ARG_INT64 && arg->i64 == cell;
+  if (g_strcmp0 (column->column_type, "bool") == 0)
+    return arg->kind == QUERY_ARG_BOOL && (arg->boolean ? 1 : 0) == cell;
+  return FALSE;
+}
+
+static gboolean
+row_satisfies_query (WylEngine *engine, const CollectCtx *ctx,
+    const gint64 *row)
+{
+  g_autoptr (GHashTable) variable_values =
+      g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
+  for (gsize i = 0; i < ctx->n_columns; i++) {
+    const QueryArg *arg = &ctx->parsed->args[i];
+    if (!schema_value_matches (engine, &ctx->columns[i], arg, row[i]))
+      return FALSE;
+    if (arg->kind == QUERY_ARG_VARIABLE) {
+      gint64 *existing = g_hash_table_lookup (variable_values, arg->text);
+      if (existing != NULL) {
+        if (*existing != row[i])
+          return FALSE;
+      } else {
+        gint64 *copy = g_new (gint64, 1);
+        *copy = row[i];
+        g_hash_table_insert (variable_values, g_strdup (arg->text), copy);
+      }
+    }
+  }
+  return TRUE;
+}
+
+static void
+append_cell_json (GString *json, WylEngine *engine,
+    const wyl_policy_fact_relation_schema_column_info_t *column, gint64 cell)
+{
+  if (g_strcmp0 (column->column_type, "symbol") == 0 ||
+      g_strcmp0 (column->column_type, "string") == 0) {
+    g_autofree gchar *value = wyl_engine_owned_dup_interned_symbol (engine,
+        cell);
+    append_json_string_local (json, value != NULL ? value : "");
+  } else if (g_strcmp0 (column->column_type, "bool") == 0) {
+    g_string_append (json, cell != 0 ? "true" : "false");
+  } else {
+    g_string_append_printf (json, "%" G_GINT64_FORMAT, cell);
+  }
+}
+
+static gboolean
+query_arg_is_emitted_variable (const ParsedQuery *parsed, gsize index)
+{
+  if (parsed->args[index].kind != QUERY_ARG_VARIABLE)
+    return FALSE;
+  for (gsize i = 0; i < index; i++) {
+    if (parsed->args[i].kind == QUERY_ARG_VARIABLE &&
+        g_strcmp0 (parsed->args[i].text, parsed->args[index].text) == 0)
+      return FALSE;
+  }
+  return TRUE;
+}
+
+static void
+collect_tuple (WylEngine *engine, const gchar *relation, const gint64 *row,
+    guint ncols, gpointer user_data)
+{
+  (void) relation;
+  CollectCtx *ctx = user_data;
+  if (ctx->truncated || ncols != ctx->n_columns)
+    return;
+  if (!row_satisfies_query (engine, ctx, row))
+    return;
+  if (ctx->row_count >= ctx->limit) {
+    ctx->truncated = TRUE;
+    return;
+  }
+  if (ctx->row_count > 0)
+    g_string_append_c (ctx->rows_json, ',');
+  g_string_append_c (ctx->rows_json, '{');
+  gboolean first = TRUE;
+  for (gsize i = 0; i < ctx->n_columns; i++) {
+    if (!query_arg_is_emitted_variable (ctx->parsed, i))
+      continue;
+    if (!first)
+      g_string_append_c (ctx->rows_json, ',');
+    first = FALSE;
+    append_json_string_local (ctx->rows_json, ctx->parsed->args[i].text);
+    g_string_append_c (ctx->rows_json, ':');
+    append_cell_json (ctx->rows_json, engine, &ctx->columns[i], row[i]);
+  }
+  g_string_append_c (ctx->rows_json, '}');
+  ctx->row_count++;
+}
+
+static gboolean
+schema_is_query_visible (const wyl_policy_fact_relation_schema_column_info_t
+    *cols, gsize n_cols)
+{
+  for (gsize i = 0; i < n_cols; i++) {
+    if (!cols[i].visible)
+      return FALSE;
+    if (g_strcmp0 (cols[i].column_type, "compound_ref") == 0)
+      return FALSE;
+  }
+  return TRUE;
+}
+
+wyrelog_error_t
+wyl_fact_datalog_query_json (WylHandle *handle,
+    const wyl_fact_datalog_query_options_t *opts, gchar **out_json,
+    gboolean *out_truncated, guint *out_row_count, gchar **out_query_name)
+{
+  if (out_json != NULL)
+    *out_json = NULL;
+  if (out_truncated != NULL)
+    *out_truncated = FALSE;
+  if (out_row_count != NULL)
+    *out_row_count = 0;
+  if (out_query_name != NULL)
+    *out_query_name = NULL;
+  if (handle == NULL || opts == NULL || out_json == NULL ||
+      opts->tenant_id == NULL || opts->graph_id == NULL || opts->query == NULL)
+    return WYRELOG_E_INVALID;
+
+  ParsedQuery parsed = { 0 };
+  if (!parse_relation_atom (opts->query, &parsed))
+    return WYRELOG_E_INVALID;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  wyl_policy_fact_relation_query_info_t query_info = { 0 };
+  wyrelog_error_t rc = wyl_policy_store_load_fact_relation_query (store,
+      opts->tenant_id, opts->graph_id, parsed.name, &query_info);
+  if (rc != WYRELOG_E_OK) {
+    parsed_query_clear (&parsed);
+    return rc == WYRELOG_E_NOT_FOUND ? WYRELOG_E_POLICY : rc;
+  }
+  if (g_strcmp0 (query_info.required_permission_id, "wr.datalog.query") != 0) {
+    wyl_policy_fact_relation_query_info_clear (&query_info);
+    parsed_query_clear (&parsed);
+    return WYRELOG_E_POLICY;
+  }
+
+  gboolean relation_visible = FALSE;
+  wyl_policy_fact_relation_schema_column_info_t *columns = NULL;
+  gsize n_columns = 0;
+  rc = wyl_policy_store_load_fact_relation_schema_columns (store,
+      opts->tenant_id, opts->graph_id, query_info.namespace_id,
+      query_info.relation_name, query_info.schema_version, &relation_visible,
+      &columns, &n_columns);
+  if (rc != WYRELOG_E_OK) {
+    wyl_policy_fact_relation_query_info_clear (&query_info);
+    parsed_query_clear (&parsed);
+    return rc;
+  }
+  if (!relation_visible || parsed.n_args != n_columns ||
+      !schema_is_query_visible (columns, n_columns)) {
+    wyl_policy_fact_relation_schema_columns_free (columns, n_columns);
+    wyl_policy_fact_relation_query_info_clear (&query_info);
+    parsed_query_clear (&parsed);
+    return WYRELOG_E_POLICY;
+  }
+
+  guint limit = opts->limit == 0 ? query_info.max_rows : opts->limit;
+  limit = MIN (limit, query_info.max_rows);
+  limit = MIN (limit, (guint) WYL_FACT_DATALOG_HARD_ROW_LIMIT);
+  if (limit == 0)
+    limit = 1;
+
+  g_autoptr (GString) rows = g_string_new (NULL);
+  CollectCtx ctx = {
+    .parsed = &parsed,
+    .columns = columns,
+    .n_columns = n_columns,
+    .limit = limit,
+    .rows_json = rows,
+  };
+  g_autofree gchar *wire_relation = wyl_fact_replay_wirelog_relation_name
+      (query_info.namespace_id, query_info.relation_name);
+  g_autofree gchar *snapshot_relation =
+      wire_relation != NULL ? g_strdup_printf ("%s_observed", wire_relation) :
+      NULL;
+  if (wire_relation == NULL)
+    rc = WYRELOG_E_NOMEM;
+  else
+    rc = wyl_handle_snapshot_fact_graph_relation (handle, opts->tenant_id,
+        opts->graph_id, snapshot_relation, collect_tuple, &ctx);
+
+  if (rc == WYRELOG_E_OK) {
+    g_autoptr (GString) body = g_string_new ("{\"ok\":true,\"tenant_id\":");
+    append_json_string_local (body, opts->tenant_id);
+    g_string_append (body, ",\"graph_id\":");
+    append_json_string_local (body, opts->graph_id);
+    g_string_append (body, ",\"query_id\":");
+    append_json_string_local (body,
+        opts->query_id != NULL ? opts->query_id : "");
+    g_string_append (body, ",\"relation\":");
+    append_json_string_local (body, parsed.name);
+    g_string_append (body, ",\"columns\":[");
+    gboolean first = TRUE;
+    for (gsize i = 0; i < n_columns; i++) {
+      if (!query_arg_is_emitted_variable (&parsed, i))
+        continue;
+      if (!first)
+        g_string_append_c (body, ',');
+      first = FALSE;
+      append_json_string_local (body, parsed.args[i].text);
+    }
+    g_string_append (body, "],\"rows\":[");
+    g_string_append_len (body, rows->str, rows->len);
+    g_string_append_printf (body, "],\"row_count\":%u,\"truncated\":%s}",
+        ctx.row_count, ctx.truncated ? "true" : "false");
+    *out_json = g_string_free (g_steal_pointer (&body), FALSE);
+    if (out_truncated != NULL)
+      *out_truncated = ctx.truncated;
+    if (out_row_count != NULL)
+      *out_row_count = ctx.row_count;
+    if (out_query_name != NULL)
+      *out_query_name = g_strdup (parsed.name);
+  }
+
+  wyl_policy_fact_relation_schema_columns_free (columns, n_columns);
+  wyl_policy_fact_relation_query_info_clear (&query_info);
+  parsed_query_clear (&parsed);
+  return rc;
+}

--- a/wyrelog/meson.build
+++ b/wyrelog/meson.build
@@ -72,7 +72,8 @@ if get_option('enable_audit').allowed()
   wyrelog_c_args += '-DWYL_HAS_AUDIT'
 endif
 if get_option('enable_fact_store').allowed()
-  wyrelog_sources += files('fact/compound.c', 'fact/replay.c', 'fact/store.c')
+  wyrelog_sources += files('fact/compound.c', 'fact/query.c',
+    'fact/replay.c', 'fact/store.c')
   if not get_option('enable_audit').allowed()
     wyrelog_deps += duckdb_dep
   endif

--- a/wyrelog/policy/store-private.h
+++ b/wyrelog/policy/store-private.h
@@ -151,8 +151,20 @@ typedef struct
   gboolean visible;
 } wyl_policy_fact_relation_schema_column_info_t;
 
+typedef struct
+{
+  gchar *namespace_id;
+  gchar *relation_name;
+  guint32 schema_version;
+  gchar *query_name;
+  gchar *required_permission_id;
+  guint max_rows;
+} wyl_policy_fact_relation_query_info_t;
+
 void wyl_policy_fact_relation_schema_columns_free
     (wyl_policy_fact_relation_schema_column_info_t * columns, gsize n_columns);
+void wyl_policy_fact_relation_query_info_clear
+    (wyl_policy_fact_relation_query_info_t * info);
 
 /*
  * Policy authority store lifecycle wrapper.
@@ -226,6 +238,10 @@ wyrelog_error_t wyl_policy_store_load_fact_relation_schema_columns
     gboolean * out_relation_visible,
     wyl_policy_fact_relation_schema_column_info_t ** out_columns,
     gsize * out_n_columns);
+wyrelog_error_t wyl_policy_store_load_fact_relation_query
+    (wyl_policy_store_t * store, const gchar * tenant_id,
+    const gchar * graph_id, const gchar * query_name,
+    wyl_policy_fact_relation_query_info_t * out_info);
 wyrelog_error_t wyl_policy_store_upsert_role (wyl_policy_store_t * store,
     const gchar * role_id, const gchar * role_name);
 wyrelog_error_t wyl_policy_store_upsert_permission (wyl_policy_store_t * store,

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -3060,6 +3060,14 @@ wyl_policy_store_register_fact_relation_schema (wyl_policy_store_t *store,
     rc = insert_fact_relation_schema_column_metadata (store, opts, i);
   for (gsize i = 0; rc == WYRELOG_E_OK && i < opts->n_queries; i++)
     rc = insert_fact_relation_query_metadata (store, opts, &opts->queries[i]);
+  if (rc == WYRELOG_E_OK && opts->n_queries == 0 && opts->relation_visible) {
+    const wyl_policy_fact_relation_schema_query_t default_query = {
+      .query_name = opts->relation_name,
+      .required_permission_id = "wr.datalog.query",
+      .max_rows = 1000,
+    };
+    rc = insert_fact_relation_query_metadata (store, opts, &default_query);
+  }
   if (rc != WYRELOG_E_OK) {
     wyl_policy_store_rollback_mutation (store);
     return rc;
@@ -3160,6 +3168,80 @@ wyl_policy_store_load_fact_relation_schema_columns (wyl_policy_store_t *store,
 
   *out_columns = columns;
   *out_n_columns = len;
+  return WYRELOG_E_OK;
+}
+
+void wyl_policy_fact_relation_query_info_clear
+    (wyl_policy_fact_relation_query_info_t * info)
+{
+  if (info == NULL)
+    return;
+  g_clear_pointer (&info->namespace_id, g_free);
+  g_clear_pointer (&info->relation_name, g_free);
+  g_clear_pointer (&info->query_name, g_free);
+  g_clear_pointer (&info->required_permission_id, g_free);
+  memset (info, 0, sizeof (*info));
+}
+
+wyrelog_error_t
+wyl_policy_store_load_fact_relation_query (wyl_policy_store_t *store,
+    const gchar *tenant_id, const gchar *graph_id, const gchar *query_name,
+    wyl_policy_fact_relation_query_info_t *out_info)
+{
+  sqlite3_stmt *stmt = NULL;
+
+  if (out_info != NULL)
+    memset (out_info, 0, sizeof (*out_info));
+  if (store == NULL || store->db == NULL || out_info == NULL
+      || !wyl_policy_store_tenant_id_is_valid (tenant_id)
+      || !fact_graph_component_is_valid (tenant_id)
+      || !fact_graph_customer_name_is_valid (graph_id)
+      || !fact_graph_customer_name_is_valid (query_name))
+    return WYRELOG_E_INVALID;
+
+  static const gchar *sql =
+      "SELECT namespace_id, relation_name, schema_version, query_name, "
+      "required_permission_id, max_rows "
+      "FROM fact_relation_query_allowlist "
+      "WHERE tenant_id = ? AND graph_id = ? AND query_name = ?;";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if ((rc = bind_text (stmt, 1, tenant_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 2, graph_id)) != WYRELOG_E_OK
+      || (rc = bind_text (stmt, 3, query_name)) != WYRELOG_E_OK) {
+    sqlite3_finalize (stmt);
+    return rc;
+  }
+
+  int step_rc = sqlite3_step (stmt);
+  if (step_rc == SQLITE_DONE) {
+    sqlite3_finalize (stmt);
+    return WYRELOG_E_NOT_FOUND;
+  }
+  if (step_rc != SQLITE_ROW) {
+    sqlite3_finalize (stmt);
+    return WYRELOG_E_IO;
+  }
+
+  out_info->namespace_id =
+      g_strdup ((const gchar *) sqlite3_column_text (stmt, 0));
+  out_info->relation_name =
+      g_strdup ((const gchar *) sqlite3_column_text (stmt, 1));
+  out_info->schema_version = (guint32) sqlite3_column_int64 (stmt, 2);
+  out_info->query_name =
+      g_strdup ((const gchar *) sqlite3_column_text (stmt, 3));
+  out_info->required_permission_id =
+      g_strdup ((const gchar *) sqlite3_column_text (stmt, 4));
+  out_info->max_rows = (guint) sqlite3_column_int64 (stmt, 5);
+  sqlite3_finalize (stmt);
+
+  if (out_info->namespace_id == NULL || out_info->relation_name == NULL
+      || out_info->query_name == NULL || out_info->required_permission_id
+      == NULL || out_info->schema_version == 0 || out_info->max_rows == 0) {
+    wyl_policy_fact_relation_query_info_clear (out_info);
+    return WYRELOG_E_NOMEM;
+  }
   return WYRELOG_E_OK;
 }
 

--- a/wyrelog/wyctl/wyctl.c
+++ b/wyrelog/wyctl/wyctl.c
@@ -105,6 +105,19 @@ typedef struct
 
 typedef struct
 {
+  gchar *tenant;
+  gchar *graph;
+  gchar *query;
+  gchar *output;
+  gchar *limit_arg;
+  gchar *access_token_file;
+  gchar *guard_timestamp_arg;
+  gchar *guard_loc_class;
+  gchar *guard_risk_arg;
+} WyctlDatalogQueryOptions;
+
+typedef struct
+{
   gchar *keyprovider_path;
   gchar *store_path;
   gchar *from_keyprovider_path;
@@ -1551,6 +1564,109 @@ run_fact (const WyctlOptions *global_opts, gint argc, gchar **argv)
   return 2;
 }
 
+static gboolean
+parse_query_limit (const gchar *raw, guint *out_limit)
+{
+  if (out_limit == NULL)
+    return FALSE;
+  if (raw == NULL) {
+    *out_limit = 0;
+    return TRUE;
+  }
+  if (raw[0] == '\0')
+    return FALSE;
+  errno = 0;
+  gchar *end = NULL;
+  guint64 parsed = g_ascii_strtoull (raw, &end, 10);
+  if (errno != 0 || end == raw || *end != '\0' || parsed == 0 ||
+      parsed > G_MAXUINT)
+    return FALSE;
+  *out_limit = (guint) parsed;
+  return TRUE;
+}
+
+static int
+run_datalog_query (const WyctlOptions *global_opts, gint argc, gchar **argv)
+{
+  WyctlDatalogQueryOptions opts = { 0 };
+  GOptionEntry entries[] = {
+    {"tenant", 0, 0, G_OPTION_ARG_STRING, &opts.tenant, "Tenant", "TENANT"},
+    {"graph", 0, 0, G_OPTION_ARG_STRING, &opts.graph, "Graph", "GRAPH"},
+    {"query", 0, 0, G_OPTION_ARG_STRING, &opts.query, "Relation query",
+        "ATOM"},
+    {"output", 0, 0, G_OPTION_ARG_STRING, &opts.output, "Output format",
+        "json"},
+    {"limit", 0, 0, G_OPTION_ARG_STRING, &opts.limit_arg, "Row limit", "N"},
+    {"access-token-file", 0, 0, G_OPTION_ARG_STRING, &opts.access_token_file,
+        "Bearer access token file", "PATH"},
+    {"guard-timestamp", 0, 0, G_OPTION_ARG_STRING,
+        &opts.guard_timestamp_arg, "Guard timestamp", "US"},
+    {"guard-loc-class", 0, 0, G_OPTION_ARG_STRING, &opts.guard_loc_class,
+        "Guard location class", "CLASS"},
+    {"guard-risk", 0, 0, G_OPTION_ARG_STRING, &opts.guard_risk_arg,
+        "Guard risk score", "N"},
+    {NULL}
+  };
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GOptionContext) context =
+      g_option_context_new ("- wyrelog datalog query");
+  g_option_context_add_main_entries (context, entries, NULL);
+  if (!g_option_context_parse (context, &argc, &argv, &error)) {
+    g_printerr ("wyctl: %s\n", error->message);
+    return 2;
+  }
+  if (argc > 1) {
+    g_printerr ("wyctl: unexpected datalog query argument: %s\n", argv[1]);
+    return 2;
+  }
+  if (opts.graph == NULL || opts.graph[0] == '\0' || opts.query == NULL ||
+      opts.query[0] == '\0') {
+    g_printerr ("wyctl: missing datalog query target option\n");
+    return 2;
+  }
+  if (opts.output != NULL && g_strcmp0 (opts.output, "json") != 0) {
+    g_printerr ("wyctl: unsupported --output\n");
+    return 2;
+  }
+  guint limit = 0;
+  if (!parse_query_limit (opts.limit_arg, &limit)) {
+    g_printerr ("wyctl: invalid --limit\n");
+    return 2;
+  }
+  gint64 guard_timestamp = 0;
+  gint64 guard_risk = 0;
+  if (!parse_guard_options (opts.guard_timestamp_arg, opts.guard_loc_class,
+          opts.guard_risk_arg, &guard_timestamp, &guard_risk))
+    return 2;
+  g_autoptr (WylClient) client = NULL;
+  int client_rc = create_fact_client (global_opts, opts.tenant,
+      opts.access_token_file, &client);
+  if (client_rc != 0)
+    return client_rc;
+  g_autofree gchar *json = NULL;
+  wyrelog_error_t rc = wyl_client_datalog_query_json (client, opts.tenant,
+      opts.graph, opts.query, limit, guard_timestamp, opts.guard_loc_class,
+      guard_risk, &json);
+  int exit_rc = fact_remote_exit (client, "datalog query", rc,
+      "datalog_query_failed");
+  if (exit_rc == 0)
+    g_print ("%s\n", json);
+  return exit_rc;
+}
+
+static int
+run_datalog (const WyctlOptions *global_opts, gint argc, gchar **argv)
+{
+  if (argc < 2) {
+    g_printerr ("wyctl: missing datalog command\n");
+    return 2;
+  }
+  if (g_strcmp0 (argv[1], "query") == 0)
+    return run_datalog_query (global_opts, argc - 1, argv + 1);
+  g_printerr ("wyctl: unknown datalog command: %s\n", argv[1]);
+  return 2;
+}
+
 static int
 run_audit_query (const WyctlOptions *global_opts, gint argc, gchar **argv)
 {
@@ -1868,6 +1984,8 @@ main (int argc, char **argv)
     return run_graph (&opts, argc - 1, argv + 1);
   if (g_strcmp0 (argv[1], "fact") == 0)
     return run_fact (&opts, argc - 1, argv + 1);
+  if (g_strcmp0 (argv[1], "datalog") == 0)
+    return run_datalog (&opts, argc - 1, argv + 1);
   if (g_strcmp0 (argv[1], "audit") == 0)
     return run_audit (&opts, argc - 1, argv + 1);
   if (g_strcmp0 (argv[1], "key") == 0)

--- a/wyrelog/wyl-client.c
+++ b/wyrelog/wyl-client.c
@@ -43,6 +43,39 @@ static gboolean parse_login_response_json (const gchar * data, gsize size,
     gchar ** out_session_state);
 
 static void
+append_json_string (GString *json, const gchar *value)
+{
+  g_string_append_c (json, '"');
+  for (const guchar * p = (const guchar *)(value != NULL ? value : "");
+      *p != '\0'; p++) {
+    switch (*p) {
+      case '"':
+        g_string_append (json, "\\\"");
+        break;
+      case '\\':
+        g_string_append (json, "\\\\");
+        break;
+      case '\n':
+        g_string_append (json, "\\n");
+        break;
+      case '\r':
+        g_string_append (json, "\\r");
+        break;
+      case '\t':
+        g_string_append (json, "\\t");
+        break;
+      default:
+        if (*p < 0x20)
+          g_string_append_printf (json, "\\u%04x", *p);
+        else
+          g_string_append_c (json, (gchar) * p);
+        break;
+    }
+  }
+  g_string_append_c (json, '"');
+}
+
+static void
 wyl_client_clear_login_state (WylClient *self)
 {
   g_clear_pointer (&self->session_token, g_free);
@@ -912,6 +945,57 @@ wyl_client_fact_put_batch (WylClient *client, const gchar *tenant,
     *out_result = result;
   }
   return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
+wyl_client_datalog_query_json (WylClient *client, const gchar *tenant,
+    const gchar *graph, const gchar *query, guint limit,
+    gint64 guard_timestamp, const gchar *guard_loc_class, gint64 guard_risk,
+    gchar **out_json)
+{
+  if (out_json != NULL)
+    *out_json = NULL;
+  if (graph == NULL || graph[0] == '\0' || query == NULL ||
+      query[0] == '\0' || out_json == NULL)
+    return WYRELOG_E_INVALID;
+
+  g_autofree gchar *base_url = NULL;
+  g_autofree gchar *access_token = NULL;
+  g_autofree gchar *session_token = NULL;
+  wyrelog_error_t rc = client_fact_prepare (client, tenant, guard_timestamp,
+      guard_loc_class, guard_risk, &base_url, &access_token, &session_token);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  g_autofree gchar *guard_query = client_fact_guard_query (tenant,
+      guard_timestamp, guard_loc_class, guard_risk,
+      access_token != NULL && access_token[0] != '\0' ? NULL : session_token);
+  g_autofree gchar *escaped_tenant = g_uri_escape_string (tenant, NULL, TRUE);
+  g_autofree gchar *escaped_graph = g_uri_escape_string (graph, NULL, TRUE);
+  g_autofree gchar *uri = g_strdup_printf ("%s/datalog/%s/%s/query?%s",
+      base_url, escaped_tenant, escaped_graph, guard_query);
+  g_autoptr (SoupMessage) message = soup_message_new ("POST", uri);
+  if (message == NULL)
+    return WYRELOG_E_INVALID;
+  client_fact_attach_auth (message, access_token);
+
+  g_autoptr (GString) json = g_string_new ("{\"query\":");
+  append_json_string (json, query);
+  g_string_append (json, ",\"output\":\"json\"");
+  if (limit > 0)
+    g_string_append_printf (json, ",\"limit\":%u", limit);
+  g_string_append_c (json, '}');
+  g_autoptr (GBytes) request_body = g_bytes_new (json->str, json->len);
+  soup_message_set_request_body_from_bytes (message, "application/json",
+      request_body);
+
+  g_autoptr (GBytes) response_body = NULL;
+  rc = client_send_fact_message (client, message, &response_body);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  gsize size = 0;
+  const gchar *data = g_bytes_get_data (response_body, &size);
+  *out_json = g_strndup (data, size);
+  return *out_json != NULL ? WYRELOG_E_OK : WYRELOG_E_NOMEM;
 }
 
 void

--- a/wyrelog/wyl-engine-private.h
+++ b/wyrelog/wyl-engine-private.h
@@ -44,6 +44,7 @@ struct _WylEngine
   wirelog_easy_session_t *session;
   /* Logical path strings for diagnostic logging only; freed in finalize. */
   gchar *dl_src_logical_paths[WYL_ENGINE_TEMPLATE_COUNT];
+  GHashTable *symbols_by_id;    /* gint64* -> gchar*, private reverse map. */
   wyl_engine_mode_t mode;       /* Latched at first step or snapshot. */
   wyl_engine_owner_t owner;     /* Handle pair role, or standalone. */
   WylDeltaCookie *delta_cookie; /* Heap-owned, NULL when no cb. */
@@ -114,6 +115,7 @@ wyrelog_error_t wyl_engine_make_compound (WylEngine * self,
 void wyl_engine_set_owner (WylEngine * self, wyl_engine_owner_t owner);
 wyrelog_error_t wyl_engine_owned_intern_symbol (WylEngine * self,
     const gchar * symbol, gint64 * out_id);
+gchar *wyl_engine_owned_dup_interned_symbol (WylEngine * self, gint64 id);
 wyrelog_error_t wyl_engine_owned_make_compound (WylEngine * self,
     const gchar * functor, const wirelog_compound_arg_t * args, gsize nargs,
     gint64 * out_id);

--- a/wyrelog/wyl-engine.c
+++ b/wyrelog/wyl-engine.c
@@ -528,6 +528,7 @@ wyl_engine_finalize (GObject *object)
 
   g_clear_pointer (&self->session, wirelog_easy_close);
   g_clear_pointer (&self->delta_cookie, g_free);
+  g_clear_pointer (&self->symbols_by_id, g_hash_table_unref);
 
   for (gsize i = 0; i < WYL_ENGINE_TEMPLATE_COUNT; i++)
     g_clear_pointer (&self->dl_src_logical_paths[i], g_free);
@@ -547,6 +548,8 @@ static void
 wyl_engine_init (WylEngine *self)
 {
   self->session = NULL;
+  self->symbols_by_id =
+      g_hash_table_new_full (g_int64_hash, g_int64_equal, g_free, g_free);
   self->mode = WYL_ENGINE_MODE_NONE;
   for (gsize i = 0; i < WYL_ENGINE_TEMPLATE_COUNT; i++)
     self->dl_src_logical_paths[i] = NULL;
@@ -794,6 +797,10 @@ wyl_engine_intern_symbol_unchecked (WylEngine *self, const gchar *symbol,
     return WYRELOG_E_INTERNAL;
   }
 
+  gint64 *key = g_new (gint64, 1);
+  *key = id;
+  g_hash_table_replace (self->symbols_by_id, key, g_strdup (symbol));
+
   *out_id = id;
   return WYRELOG_E_OK;
 }
@@ -814,6 +821,15 @@ wyl_engine_owned_intern_symbol (WylEngine *self, const gchar *symbol,
     gint64 *out_id)
 {
   return wyl_engine_intern_symbol_unchecked (self, symbol, out_id);
+}
+
+gchar *
+wyl_engine_owned_dup_interned_symbol (WylEngine *self, gint64 id)
+{
+  if (self == NULL || !WYL_IS_ENGINE (self) || self->symbols_by_id == NULL)
+    return NULL;
+  const gchar *symbol = g_hash_table_lookup (self->symbols_by_id, &id);
+  return g_strdup (symbol);
 }
 
 static wyrelog_error_t

--- a/wyrelog/wyl-handle-private.h
+++ b/wyrelog/wyl-handle-private.h
@@ -69,6 +69,12 @@ wyrelog_error_t wyl_handle_replay_fact_graphs (WylHandle * self,
     wyl_fact_replay_summary_t * out_summary);
 WylEngine *wyl_handle_get_fact_graph_engine (WylHandle * self,
     const gchar * tenant_id, const gchar * graph_id);
+typedef void (*wyl_fact_graph_tuple_cb) (WylEngine * engine,
+    const gchar * relation, const gint64 * row, guint ncols,
+    gpointer user_data);
+wyrelog_error_t wyl_handle_snapshot_fact_graph_relation (WylHandle * self,
+    const gchar * tenant_id, const gchar * graph_id, const gchar * relation,
+    wyl_fact_graph_tuple_cb cb, gpointer user_data);
 typedef wyrelog_error_t (*wyl_fact_graph_status_cb) (const
     wyl_fact_graph_status_t * status, gpointer user_data);
 wyrelog_error_t wyl_handle_foreach_fact_graph_status (WylHandle * self,

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -960,6 +960,60 @@ wyl_handle_get_fact_graph_engine (WylHandle *self, const gchar *tenant_id,
   return engine;
 }
 
+typedef struct
+{
+  WylEngine *engine;
+  wyl_fact_graph_tuple_cb cb;
+  gpointer user_data;
+} FactGraphSnapshotCtx;
+
+static void
+fact_graph_snapshot_tuple_trampoline (const gchar *relation,
+    const gint64 *row, guint ncols, gpointer user_data)
+{
+  FactGraphSnapshotCtx *ctx = user_data;
+  ctx->cb (ctx->engine, relation, row, ncols, ctx->user_data);
+}
+
+wyrelog_error_t
+wyl_handle_snapshot_fact_graph_relation (WylHandle *self,
+    const gchar *tenant_id, const gchar *graph_id, const gchar *relation,
+    wyl_fact_graph_tuple_cb cb, gpointer user_data)
+{
+  if (self == NULL || !WYL_IS_HANDLE (self) || tenant_id == NULL
+      || graph_id == NULL || relation == NULL || cb == NULL
+      || self->fact_graph_engines == NULL || self->fact_graph_statuses == NULL)
+    return WYRELOG_E_INVALID;
+
+  g_autofree gchar *key = fact_graph_key (tenant_id, graph_id);
+  g_mutex_lock (&self->fact_graphs_lock);
+  wyl_fact_graph_status_t *status =
+      g_hash_table_lookup (self->fact_graph_statuses, key);
+  if (status == NULL) {
+    g_mutex_unlock (&self->fact_graphs_lock);
+    return WYRELOG_E_NOT_FOUND;
+  }
+  if (!status->queryable) {
+    g_mutex_unlock (&self->fact_graphs_lock);
+    return WYRELOG_E_POLICY;
+  }
+  WylEngine *engine = g_hash_table_lookup (self->fact_graph_engines, key);
+  if (engine == NULL) {
+    g_mutex_unlock (&self->fact_graphs_lock);
+    return WYRELOG_E_NOT_FOUND;
+  }
+
+  FactGraphSnapshotCtx ctx = {
+    .engine = engine,
+    .cb = cb,
+    .user_data = user_data,
+  };
+  wyrelog_error_t rc = wyl_engine_snapshot (engine, relation,
+      fact_graph_snapshot_tuple_trampoline, &ctx);
+  g_mutex_unlock (&self->fact_graphs_lock);
+  return rc;
+}
+
 wyrelog_error_t
 wyl_handle_foreach_fact_graph_status (WylHandle *self,
     wyl_fact_graph_status_cb cb, gpointer user_data)


### PR DESCRIPTION
## Summary
- add a guarded HTTP relation-atom query endpoint for replayed fact graphs
- expose matching C client and wyctl datalog query support
- enforce allowlist resolution, tenant/auth checks, row limits, truncation, and invalid program rejection

## Validation
- meson test -C fact-enabled build --print-errorlogs
- meson test -C default build --print-errorlogs