### PR TITLE
Prove Datalog product flow through packaged runtime

### DIFF
--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -15,10 +15,12 @@ support files from `packaging/`.
   systemd as credential `wyrelog-system-policy-key`
 - System policy store: `/var/lib/wyrelog/system/policy.sqlite`
 - System audit store: `/var/log/wyrelog/system/audit.duckdb`
+- System Datalog fact root: `/var/lib/wyrelog/system/facts`
 - Service KeyProvider root: `/etc/wyrelog/service/policy.key` loaded by
   systemd as credential `wyrelog-service-policy-key`
 - Service policy store: `/var/lib/wyrelog/service/policy.sqlite`
 - Service audit store: `/var/log/wyrelog/service/audit.duckdb`
+- Service Datalog fact root: `/var/lib/wyrelog/service/facts`
 - Runtime directory: `/run/wyrelog`
 - HTTP listen port: `127.0.0.1:8765` unless overridden by the service file
 - Production log policy: compile release builds with
@@ -40,9 +42,11 @@ Packaged profile paths:
 - System policy store: `/var/lib/wyrelog/system/policy.sqlite`
 - System KeyProvider root: `/etc/wyrelog/system/policy.key`
 - System audit store: `/var/log/wyrelog/system/audit.duckdb`
+- System Datalog fact root: `/var/lib/wyrelog/system/facts`
 - Service policy store: `/var/lib/wyrelog/service/policy.sqlite`
 - Service KeyProvider root: `/etc/wyrelog/service/policy.key`
 - Service audit store: `/var/log/wyrelog/service/audit.duckdb`
+- Service Datalog fact root: `/var/lib/wyrelog/service/facts`
 - Service event spool: `/var/lib/wyrelog/service/event-spool`
 
 Inspect the resolved profile contract with:
@@ -86,6 +90,7 @@ PY
      --policy-db /var/lib/wyrelog/system/policy.sqlite \
      --policy-keyprovider file:/etc/wyrelog/system/policy.key \
      --audit-db /var/log/wyrelog/system/audit.duckdb \
+     --fact-root /var/lib/wyrelog/system/facts \
      --check
    wyrelogd --template-info --template-dir /usr/share/wyrelog/access
    wyctl key status --keyprovider /etc/wyrelog/system/policy.key
@@ -234,6 +239,113 @@ wyctl --daemon-url http://127.0.0.1:8765 audit query \
   --filter 'action=permission_revoke' --limit 10 \
   --access-token-file /run/wyrelog/operator.token
 ```
+
+## Datalog Product Flow
+
+Wyrelog is a Datalog storage and inference engine. The packaged access-control
+policy is the default policy template for the daemon, while Datalog facts live in
+separate per-tenant, per-graph stores. Keep these paths physically separate:
+
+- Policy DB: encrypted SQLite authority store, for example
+  `/var/lib/wyrelog/system/policy.sqlite`.
+- Audit DB: DuckDB audit sink, for example
+  `/var/log/wyrelog/system/audit.duckdb`.
+- Fact DBs: DuckDB files below the fact root, for example
+  `/var/lib/wyrelog/system/facts/<tenant>/<graph>/facts.duckdb`.
+
+Back up and restore those stores as separate artifacts. Do not place the policy
+or audit DB under the fact root. The static packaged units rely on the daemon's
+profile defaults for the fact root so the same unit files remain valid for
+builds with and without fact-store support; pass `--fact-root` explicitly in
+manual checks or local deployments that enable Datalog fact storage.
+
+The commands below show a complete local product flow on the default tenant.
+Replace `alice` and the paths for your deployment.
+
+```sh
+BASE_URL=http://127.0.0.1:8765
+TOKEN=/run/wyrelog/operator.token
+TENANT=__wr_default
+GRAPH=orders
+
+wyrelogd --production \
+  --profile system \
+  --template-dir /usr/share/wyrelog/access \
+  --policy-db /var/lib/wyrelog/system/policy.sqlite \
+  --policy-keyprovider file:/etc/wyrelog/system/policy.key \
+  --audit-db /var/log/wyrelog/system/audit.duckdb \
+  --fact-root /var/lib/wyrelog/system/facts \
+  --bootstrap-admin-subject alice \
+  --bootstrap-admin-allow-skip-mfa \
+  --listen-port 8765
+```
+
+Mint the first token and arm the packaged administrator's Datalog authorities on
+the tenant scope. The bootstrap role already grants these permissions; the
+permission-state transition records that the operator intentionally armed them
+for this scope.
+
+```sh
+python3 - <<'PY'
+import json, urllib.request
+url = "http://127.0.0.1:8765/auth/login?username=alice&tenant=__wr_default&skip_mfa=true"
+req = urllib.request.Request(url, method="POST")
+with urllib.request.urlopen(req) as response:
+    token = json.load(response)["access_token"]
+open("/run/wyrelog/operator.token", "w", encoding="utf-8").write(token + "\n")
+PY
+
+for perm in wr.graph.manage wr.schema.manage wr.fact.write wr.datalog.query; do
+  curl -fsS -X POST \
+    -H "Authorization: Bearer $(cat "$TOKEN")" \
+    "$BASE_URL/policy/permissions/transition?subject=alice&perm=$perm&scope=$TENANT&event=grant&guard_timestamp=$(date +%s)&guard_loc_class=trusted&guard_risk=29"
+done
+```
+
+Run the graph, schema, fact, and query commands through `wyctl`:
+
+```sh
+wyctl --daemon-url "$BASE_URL" graph create \
+  --tenant "$TENANT" --graph "$GRAPH" \
+  --access-token-file "$TOKEN" \
+  --guard-timestamp $(date +%s) --guard-loc-class trusted --guard-risk 29
+
+wyctl --daemon-url "$BASE_URL" fact schema register \
+  --tenant "$TENANT" --graph "$GRAPH" \
+  --namespace shop --relation orders --schema-version 1 \
+  --columns order_id:symbol,amount:int64 \
+  --access-token-file "$TOKEN" \
+  --guard-timestamp $(date +%s) --guard-loc-class trusted --guard-risk 29
+
+printf 'order_id,amount\no-1,42\n' >/tmp/orders.csv
+wyctl --daemon-url "$BASE_URL" fact put \
+  --tenant "$TENANT" --graph "$GRAPH" \
+  --namespace shop --relation orders --schema-version 1 \
+  --batch-id orders-1 --idempotency-key orders-1 \
+  --format csv --input /tmp/orders.csv \
+  --access-token-file "$TOKEN" \
+  --guard-timestamp $(date +%s) --guard-loc-class trusted --guard-risk 29
+
+wyctl --daemon-url "$BASE_URL" datalog query \
+  --tenant "$TENANT" --graph "$GRAPH" \
+  --query 'orders(O,A)' --output json --limit 10 \
+  --access-token-file "$TOKEN" \
+  --guard-timestamp $(date +%s) --guard-loc-class trusted --guard-risk 29
+```
+
+To verify recovery, restart `wyrelogd` with the same policy DB, audit DB, key,
+and fact root. Mint a fresh token after restart and run the same
+`wyctl datalog query`; the fact graph is replayed from the per-graph DuckDB fact
+store. Check graph health with:
+
+```sh
+curl -fsS "$BASE_URL/facts/status"
+```
+
+A single corrupted graph should report a degraded graph entry while unrelated
+graphs remain queryable. Stop the daemon before repairing or replacing a damaged
+`facts.duckdb`, restore only the affected `<tenant>/<graph>` fact directory,
+restart, then confirm `/facts/status` returns `"status":"ready"`.
 
 ## Day-2 Operations
 

--- a/tests/check-packaged-install-readiness.sh
+++ b/tests/check-packaged-install-readiness.sh
@@ -78,12 +78,76 @@ if ! grep -q -- "/var/lib/wyrelog/service/facts" \
   echo "tmpfiles does not create the service fact root" >&2
   exit 1
 fi
+if ! grep -q '^d /var/lib/wyrelog/system/facts 0700 wyrelog wyrelog -$' \
+    "$SOURCE_ROOT/packaging/tmpfiles.d/wyrelog.conf"; then
+  echo "tmpfiles system fact root does not enforce 0700 wyrelog ownership" >&2
+  exit 1
+fi
+if ! grep -q '^d /var/lib/wyrelog/service/facts 0700 wyrelog wyrelog -$' \
+    "$SOURCE_ROOT/packaging/tmpfiles.d/wyrelog.conf"; then
+  echo "tmpfiles service fact root does not enforce 0700 wyrelog ownership" >&2
+  exit 1
+fi
+if ! grep -q -- "ReadWritePaths=/var/lib/wyrelog/system" \
+    "$SOURCE_ROOT/packaging/systemd/wyrelog-system.service"; then
+  echo "system unit does not allow writes under the system state root" >&2
+  exit 1
+fi
+if ! grep -q -- "ReadWritePaths=/var/lib/wyrelog/service" \
+    "$SOURCE_ROOT/packaging/systemd/wyrelog-service.service"; then
+  echo "service unit does not allow writes under the service state root" >&2
+  exit 1
+fi
 if ! grep -q "WYL_LOG=warn" \
     "$SOURCE_ROOT/packaging/systemd/wyrelog.service"; then
   echo "service unit does not set production log ceiling" >&2
   exit 1
 fi
 
+if grep -q -- "--fact-root" "$SOURCE_ROOT/packaging/systemd/wyrelog.service" \
+    "$SOURCE_ROOT/packaging/systemd/wyrelog-system.service" \
+    "$SOURCE_ROOT/packaging/systemd/wyrelog-service.service"; then
+  echo "static units must rely on profile fact-root defaults for build compatibility" >&2
+  exit 1
+fi
+
+SYSTEM_PROFILE_INFO="$TMPDIR/system-profile-info.out"
+SERVICE_PROFILE_INFO="$TMPDIR/service-profile-info.out"
+"$WYRELOGD" --profile=system --profile-info --production >"$SYSTEM_PROFILE_INFO"
+"$WYRELOGD" --profile=service --profile-info --production >"$SERVICE_PROFILE_INFO"
+grep -q '^policy_db=/var/lib/wyrelog/system/policy.sqlite$' "$SYSTEM_PROFILE_INFO"
+grep -q '^audit_db=/var/log/wyrelog/system/audit.duckdb$' "$SYSTEM_PROFILE_INFO"
+grep -q '^policy_db=/var/lib/wyrelog/service/policy.sqlite$' "$SERVICE_PROFILE_INFO"
+grep -q '^audit_db=/var/log/wyrelog/service/audit.duckdb$' "$SERVICE_PROFILE_INFO"
+if grep -q '^fact_root=.' "$SYSTEM_PROFILE_INFO"; then
+  grep -q '^fact_root=/var/lib/wyrelog/system/facts$' "$SYSTEM_PROFILE_INFO"
+  grep -q '^fact_root=/var/lib/wyrelog/service/facts$' "$SERVICE_PROFILE_INFO"
+fi
+"$PYTHON" - "$SYSTEM_PROFILE_INFO" "$SERVICE_PROFILE_INFO" <<'EOF2'
+import sys
+
+def load(path):
+    out = {}
+    for line in open(path, encoding='utf-8'):
+        line = line.strip()
+        if '=' in line:
+            k, v = line.split('=', 1)
+            out[k] = v
+    return out
+for path in sys.argv[1:]:
+    info = load(path)
+    values = [info['policy_db'], info['audit_db']]
+    fact_root = info.get('fact_root')
+    if fact_root:
+        values.append(fact_root)
+    if len(set(values)) != len(values):
+        raise SystemExit(f'profile paths overlap in {path}: {values}')
+    if fact_root:
+        fact = fact_root.rstrip('/') + '/'
+        for key in ('policy_db', 'audit_db'):
+            if info[key].startswith(fact):
+                raise SystemExit(f'{key} is inside fact root in {path}')
+EOF2
 INSTALL_ROOT="$TMPDIR/install"
 mkdir -p "$INSTALL_ROOT/usr/share/wyrelog" \
   "$INSTALL_ROOT/usr/share/wyrelog/tools" \

--- a/tests/check-wyrelogd-datalog-product-flow.sh
+++ b/tests/check-wyrelogd-datalog-product-flow.sh
@@ -1,0 +1,276 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+set -eu
+
+WYRELOGD=$1
+WYCTL=$2
+TEMPLATE_DIR=$3
+PYTHON=$4
+
+TMPDIR=$(mktemp -d)
+POLICY_DB="$TMPDIR/policy.sqlite"
+KEY_FILE="$TMPDIR/policy.key"
+AUDIT_DB="$TMPDIR/audit.duckdb"
+FACT_ROOT="$TMPDIR/facts"
+LOG_OUT="$TMPDIR/daemon.out"
+LOG_ERR="$TMPDIR/daemon.err"
+PID=
+PORT=
+BASE_URL=
+
+cleanup() {
+  if [ -n "$PID" ]; then
+    kill -TERM "$PID" 2>/dev/null || true
+    wait "$PID" 2>/dev/null || true
+  fi
+  rm -rf "$TMPDIR"
+}
+trap cleanup EXIT INT TERM
+
+mkdir -p "$FACT_ROOT"
+chmod 0700 "$FACT_ROOT"
+"$PYTHON" - "$KEY_FILE" <<'PY'
+import os
+import sys
+with open(sys.argv[1], "wb") as f:
+    f.write(os.urandom(32))
+os.chmod(sys.argv[1], 0o600)
+PY
+
+pick_port() {
+  "$PYTHON" - <<'PY'
+import socket
+with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+    sock.bind(("127.0.0.1", 0))
+    print(sock.getsockname()[1])
+PY
+}
+
+start_daemon() {
+  PORT=$(pick_port)
+  BASE_URL="http://127.0.0.1:$PORT"
+  : >"$LOG_OUT"
+  : >"$LOG_ERR"
+  "$WYRELOGD" \
+    --production \
+    --template-dir "$TEMPLATE_DIR" \
+    --policy-db "$POLICY_DB" \
+    --policy-keyprovider "file:$KEY_FILE" \
+    --audit-db "$AUDIT_DB" \
+    --fact-root "$FACT_ROOT" \
+    --listen-port "$PORT" \
+    --bootstrap-admin-subject admin1 \
+    --bootstrap-admin-allow-skip-mfa \
+    >"$LOG_OUT" 2>"$LOG_ERR" &
+  PID=$!
+
+  i=0
+  while [ "$i" -lt 200 ]; do
+    i=$((i + 1))
+    if "$WYCTL" --daemon-url "$BASE_URL" --timeout-ms 500 status \
+        >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.1
+  done
+  echo "daemon did not become ready" >&2
+  cat "$LOG_ERR" >&2 || true
+  exit 1
+}
+
+stop_daemon() {
+  if [ -n "$PID" ]; then
+    kill -TERM "$PID" 2>/dev/null || true
+    wait "$PID" 2>/dev/null || true
+    PID=
+  fi
+}
+
+login_token() {
+  token_file=$1
+  "$PYTHON" - "$BASE_URL" "$token_file" <<'PY'
+import json
+import sys
+import urllib.error
+import urllib.request
+base, token_path = sys.argv[1:]
+url = f"{base}/auth/login?username=admin1&tenant=__wr_default&skip_mfa=true"
+req = urllib.request.Request(url, method="POST")
+try:
+    with urllib.request.urlopen(req, timeout=3) as response:
+        body = json.load(response)
+except urllib.error.HTTPError as exc:
+    sys.stderr.write(f"login failed: HTTP {exc.code}\n")
+    sys.stderr.write(exc.read().decode("utf-8", "replace"))
+    sys.stderr.write("\n")
+    raise SystemExit(1)
+token = body.get("access_token")
+if not token:
+    raise SystemExit(f"login returned no access_token: {body}")
+with open(token_path, "w", encoding="utf-8") as f:
+    f.write(token + "\n")
+PY
+}
+
+http_post_with_token() {
+  token_file=$1
+  path=$2
+  "$PYTHON" - "$BASE_URL" "$token_file" "$path" <<'PY'
+import sys
+import urllib.error
+import urllib.request
+base, token_file, path = sys.argv[1:]
+token = open(token_file, encoding="utf-8").read().strip()
+req = urllib.request.Request(base + path, method="POST")
+req.add_header("Authorization", f"Bearer {token}")
+try:
+    with urllib.request.urlopen(req, timeout=3) as response:
+        response.read()
+except urllib.error.HTTPError as exc:
+    sys.stderr.write(f"POST {path} failed: HTTP {exc.code}\n")
+    sys.stderr.write(exc.read().decode("utf-8", "replace"))
+    sys.stderr.write("\n")
+    raise SystemExit(1)
+PY
+}
+
+arm_permission() {
+  token_file=$1
+  perm=$2
+  http_post_with_token "$token_file" "/policy/permissions/transition?subject=admin1&perm=$perm&scope=__wr_default&event=grant&guard_timestamp=123&guard_loc_class=trusted&guard_risk=29"
+}
+
+create_graph_schema_and_facts() {
+  token_file=$1
+  graph=$2
+  order_id=$3
+  amount=$4
+  csv="$TMPDIR/$graph-orders.csv"
+  printf 'order_id,amount\n%s,%s\n' "$order_id" "$amount" >"$csv"
+
+  "$WYCTL" --daemon-url "$BASE_URL" graph create \
+    --tenant __wr_default \
+    --graph "$graph" \
+    --access-token-file "$token_file" \
+    --guard-timestamp 123 \
+    --guard-loc-class trusted \
+    --guard-risk 29 >/dev/null
+  "$WYCTL" --daemon-url "$BASE_URL" fact schema register \
+    --tenant __wr_default \
+    --graph "$graph" \
+    --namespace shop \
+    --relation orders \
+    --schema-version 1 \
+    --columns order_id:symbol,amount:int64 \
+    --access-token-file "$token_file" \
+    --guard-timestamp 123 \
+    --guard-loc-class trusted \
+    --guard-risk 29 >/dev/null
+  result=$("$WYCTL" --daemon-url "$BASE_URL" fact put \
+    --tenant __wr_default \
+    --graph "$graph" \
+    --namespace shop \
+    --relation orders \
+    --schema-version 1 \
+    --batch-id "$graph-batch-1" \
+    --idempotency-key "$graph-key-1" \
+    --format csv \
+    --input "$csv" \
+    --access-token-file "$token_file" \
+    --guard-timestamp 123 \
+    --guard-loc-class trusted \
+    --guard-risk 29)
+  if [ "$result" != "inserted" ]; then
+    echo "unexpected fact put result for $graph: $result" >&2
+    exit 1
+  fi
+}
+
+assert_query_row() {
+  token_file=$1
+  graph=$2
+  order_id=$3
+  amount=$4
+  output="$TMPDIR/$graph-query.json"
+  "$WYCTL" --daemon-url "$BASE_URL" datalog query \
+    --tenant __wr_default \
+    --graph "$graph" \
+    --query 'orders(O,A)' \
+    --output json \
+    --limit 10 \
+    --access-token-file "$token_file" \
+    --guard-timestamp 123 \
+    --guard-loc-class trusted \
+    --guard-risk 29 >"$output"
+  "$PYTHON" - "$output" "$order_id" "$amount" <<'PY'
+import json
+import sys
+text = open(sys.argv[1], encoding="utf-8").read()
+if "storage_path" in text or "facts.duckdb" in text:
+    raise SystemExit("query response leaked storage details")
+body = json.loads(text)
+expected = {"O": sys.argv[2], "A": int(sys.argv[3])}
+if expected not in body.get("rows", []):
+    raise SystemExit(f"missing {expected}: {body}")
+PY
+}
+
+assert_fact_status() {
+  expected=$1
+  "$PYTHON" - "$BASE_URL" "$expected" <<'PY'
+import json
+import sys
+import urllib.request
+base, expected = sys.argv[1:]
+text = urllib.request.urlopen(f"{base}/facts/status", timeout=3).read().decode()
+if "storage_path" in text or "facts.duckdb" in text:
+    raise SystemExit("facts status leaked storage details")
+body = json.loads(text)
+if body.get("status") != expected:
+    raise SystemExit(body)
+graphs = {(g.get("tenant_id"), g.get("graph_id")): g for g in body.get("graphs", [])}
+if expected == "ready":
+    if body.get("graphs_total") != 2 or body.get("graphs_ready") != 2 or body.get("graphs_degraded") != 0:
+        raise SystemExit(body)
+else:
+    a = graphs.get(("__wr_default", "orders-a"))
+    b = graphs.get(("__wr_default", "orders-b"))
+    if not a or not b:
+        raise SystemExit(body)
+    if a.get("state") != "ready" or a.get("queryable") is not True:
+        raise SystemExit(body)
+    if b.get("state") == "ready" or b.get("queryable") is not False:
+        raise SystemExit(body)
+    if b.get("last_error_class") not in ("store_unavailable", "replay_failed"):
+        raise SystemExit(body)
+PY
+}
+
+TOKEN_FILE="$TMPDIR/admin.token"
+
+start_daemon
+login_token "$TOKEN_FILE"
+for perm in wr.graph.manage wr.schema.manage wr.fact.write wr.datalog.query; do
+  arm_permission "$TOKEN_FILE" "$perm"
+done
+create_graph_schema_and_facts "$TOKEN_FILE" orders-a order-a 42
+create_graph_schema_and_facts "$TOKEN_FILE" orders-b order-b 7
+assert_query_row "$TOKEN_FILE" orders-a order-a 42
+assert_query_row "$TOKEN_FILE" orders-b order-b 7
+assert_fact_status ready
+
+stop_daemon
+start_daemon
+login_token "$TOKEN_FILE"
+assert_query_row "$TOKEN_FILE" orders-a order-a 42
+assert_query_row "$TOKEN_FILE" orders-b order-b 7
+assert_fact_status ready
+
+stop_daemon
+printf 'not a database\n' >"$FACT_ROOT/__wr_default/orders-b/facts.duckdb"
+start_daemon
+login_token "$TOKEN_FILE"
+assert_query_row "$TOKEN_FILE" orders-a order-a 42
+assert_fact_status degraded
+stop_daemon

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -283,6 +283,21 @@ if host_machine.system() != 'windows' and build_client
     timeout : 60,
   )
 
+  if get_option('enable_audit').allowed() and get_option('enable_fact_store').allowed()
+    test('wyrelogd-datalog-product-flow', sh,
+      args : [
+        meson.current_source_dir() / 'check-wyrelogd-datalog-product-flow.sh',
+        wyrelogd_exe.full_path(),
+        wyctl_exe.full_path(),
+        meson.project_source_root() / 'templates' / 'access',
+        python3.full_path(),
+      ],
+      depends : [wyctl_exe, wyrelogd_exe],
+      is_parallel : false,
+      timeout : 90,
+    )
+  endif
+
   test('client-audit-daemon', sh,
     args : [
       meson.current_source_dir() / 'check-client-audit-daemon.sh',


### PR DESCRIPTION
## Summary
- add an installed-daemon Datalog product-flow regression that exercises graph creation, schema registration, fact writes, queries, replay, and degraded graph isolation through the packaged runtime and client
- tighten packaged install readiness so static systemd units remain compatible with builds that omit fact-store support
- document the tested operator flow and the required separation of policy, audit, and fact stores

## Validation
- product-flow packaged runtime suite
- packaged readiness coverage for builds with and without fact-store support
- default full test suite
- fact-store replay coverage
