### PR TITLE
Upgrade DuckDB pins to 1.5.2

### DIFF
--- a/meson.options
+++ b/meson.options
@@ -57,7 +57,7 @@ option('duckdb_source',
               + '"prebuilt" downloads the upstream-published library '
               + 'binary for the host platform (fast: ~30 MB download '
               + 'and zero compile). "subproject" downloads the '
-              + 'upstream amalgamated source release at v1.5.1 and '
+              + 'upstream amalgamated source release at v1.5.2 and '
               + 'compiles the single 25 MB duckdb.cpp translation unit '
               + 'in tree (slow: multi-minute single-TU compile). '
               + 'Default is prebuilt; main-branch CI overrides to '

--- a/subprojects/duckdb-amalgamated.wrap
+++ b/subprojects/duckdb-amalgamated.wrap
@@ -1,8 +1,8 @@
 [wrap-file]
 directory = duckdb-amalgamated-src
-source_url = https://github.com/duckdb/duckdb/releases/download/v1.5.1/libduckdb-src-v1.5.1.zip
-source_filename = libduckdb-src-v1.5.1.zip
-source_hash = e5b4e9c449bb1ae0e005bb23a48b208efbe813556c12eb7f9cd3e4c9dbe01fdc
+source_url = https://github.com/duckdb/duckdb/releases/download/v1.5.2/libduckdb-src.zip
+source_filename = libduckdb-src-v1.5.2.zip
+source_hash = 36388f54d4e73c7148895f9b075c063189d47df8687db237f765f74a7ff5d8f6
 lead_directory_missing = true
 patch_directory = duckdb-amalgamated
 

--- a/subprojects/duckdb-prebuilt-linux.wrap
+++ b/subprojects/duckdb-prebuilt-linux.wrap
@@ -1,8 +1,8 @@
 [wrap-file]
 directory = duckdb-prebuilt-linux-amd64
-source_url = https://github.com/duckdb/duckdb/releases/download/v1.5.1/libduckdb-linux-amd64.zip
-source_filename = libduckdb-linux-amd64.zip
-source_hash = 21aec66a60eae1696270ba715a481ab066a88d99a62718d0577579ac1a7a4834
+source_url = https://github.com/duckdb/duckdb/releases/download/v1.5.2/libduckdb-linux-amd64.zip
+source_filename = libduckdb-linux-amd64-v1.5.2.zip
+source_hash = 4711438f0fdb04f0441803409bec5430b763d4f2ac3482c1f97cfa6b5ecb4c15
 lead_directory_missing = true
 patch_directory = duckdb-prebuilt-linux
 

--- a/subprojects/duckdb-prebuilt-osx.wrap
+++ b/subprojects/duckdb-prebuilt-osx.wrap
@@ -1,8 +1,8 @@
 [wrap-file]
 directory = duckdb-prebuilt-osx-universal
-source_url = https://github.com/duckdb/duckdb/releases/download/v1.5.1/libduckdb-osx-universal.zip
-source_filename = libduckdb-osx-universal.zip
-source_hash = d9dd723c59f8571202b468f6bf71d4555238544553dd1445e6c9ecb39f54c0f3
+source_url = https://github.com/duckdb/duckdb/releases/download/v1.5.2/libduckdb-osx-universal.zip
+source_filename = libduckdb-osx-universal-v1.5.2.zip
+source_hash = 524f3537330a1b747556a0c98b62a46865a3f48c7ead2b2035c62f1ad3e5ca8b
 lead_directory_missing = true
 patch_directory = duckdb-prebuilt-osx
 

--- a/subprojects/duckdb-prebuilt-windows.wrap
+++ b/subprojects/duckdb-prebuilt-windows.wrap
@@ -1,8 +1,8 @@
 [wrap-file]
 directory = duckdb-prebuilt-windows-amd64
-source_url = https://github.com/duckdb/duckdb/releases/download/v1.5.1/libduckdb-windows-amd64.zip
-source_filename = libduckdb-windows-amd64.zip
-source_hash = b85febb52a7b2e6d6891fcfffd8685ea974012f952cdc8dadef9c81e281d730d
+source_url = https://github.com/duckdb/duckdb/releases/download/v1.5.2/libduckdb-windows-amd64.zip
+source_filename = libduckdb-windows-amd64-v1.5.2.zip
+source_hash = c60bd7deb0ef6c2d5c12a9765b93ed930c34b984d4db79104a8c2955bc57017d
 lead_directory_missing = true
 patch_directory = duckdb-prebuilt-windows
 

--- a/subprojects/packagefiles/duckdb-amalgamated/meson.build
+++ b/subprojects/packagefiles/duckdb-amalgamated/meson.build
@@ -1,5 +1,5 @@
 project('duckdb-amalgamated', 'cpp',
-  version : '1.5.1',
+  version : '1.5.2',
   license : 'MIT',
   default_options : [
     'cpp_std=c++17',

--- a/subprojects/packagefiles/duckdb-prebuilt-linux/meson.build
+++ b/subprojects/packagefiles/duckdb-prebuilt-linux/meson.build
@@ -1,5 +1,5 @@
 project('duckdb-prebuilt-linux', 'c',
-  version : '1.5.1',
+  version : '1.5.2',
   license : 'MIT',
 )
 

--- a/subprojects/packagefiles/duckdb-prebuilt-osx/meson.build
+++ b/subprojects/packagefiles/duckdb-prebuilt-osx/meson.build
@@ -1,5 +1,5 @@
 project('duckdb-prebuilt-osx', 'c',
-  version : '1.5.1',
+  version : '1.5.2',
   license : 'MIT',
 )
 

--- a/subprojects/packagefiles/duckdb-prebuilt-windows/meson.build
+++ b/subprojects/packagefiles/duckdb-prebuilt-windows/meson.build
@@ -1,5 +1,5 @@
 project('duckdb-prebuilt-windows', 'c',
-  version : '1.5.1',
+  version : '1.5.2',
   license : 'MIT',
 )
 

--- a/wyrelog/audit/conn.c
+++ b/wyrelog/audit/conn.c
@@ -235,7 +235,7 @@ static wyrelog_error_t
 ensure_audit_events_request_id_column (wyl_audit_conn_t *conn)
 {
   duckdb_result result = { 0 };
-  /* DuckDB v1.5.1's information_schema.columns view binds an internal
+  /* DuckDB's information_schema.columns view can bind an internal
    * "system" catalog that is not resolvable on an open in-memory database,
    * surfacing as a Binder Error and breaking init for every caller that
    * runs the audit schema migration. pragma_table_info is the portable


### PR DESCRIPTION
## Summary
- bump DuckDB prebuilt and amalgamated wrap pins to 1.5.2
- refresh SHA-256 hashes for Linux, macOS, Windows, and source archives
- use versioned Meson cache filenames for prebuilt archives to avoid stale local packagecache reuse
- keep packagefile versions and DuckDB source-option text in sync with the new pin

## Validation
- prebuilt Linux setup downloaded DuckDB 1.5.2 and linked successfully
- prebuilt audit/fact build compiled successfully
- daemon HTTP fact and packaged install readiness tests passed on the prebuilt build
- fact-store replay passed in a fact-store-only prebuilt build
- amalgamated source setup downloaded DuckDB 1.5.2 and audit connection test passed
- `git diff --check`
