### PR TITLE
wyctl: GSettings defaults and token-file safety

### DIFF
--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -527,3 +527,202 @@ Rollback requires the previous package, template identity, policy store,
 audit store, and KeyProvider state. Stop the daemon, restore the previous
 artifacts, run production `--check`, start the service, and verify
 readiness with `wyctl status --readiness`.
+
+## wyctl Configuration and Token-File Safety
+
+`wyctl` reads operator-static defaults from GSettings so common flags do
+not need to be repeated on every invocation, while bearer-token bytes are
+loaded only from a protected on-disk token file. Explicit CLI flags always
+override GSettings. The GSettings store records only the *path* to the
+token file; the bytes themselves never live in dconf, the keyfile backend,
+or any other GSettings backing store.
+
+### Schema Overview
+
+- Schema id: `org.wyrelog.wyctl`
+- Schema path: `/org/wyrelog/wyctl/`
+- Install location: `${datadir}/glib-2.0/schemas/org.wyrelog.wyctl.gschema.xml`
+- After install the package runs `glib-compile-schemas` against the
+  schemas directory to refresh `gschemas.compiled`. Manual installs that
+  copy the schema in place must run `glib-compile-schemas
+  ${datadir}/glib-2.0/schemas` afterwards or wyctl will silently fall
+  back to CLI-only mode.
+
+### Key Reference
+
+| Key | Type | Default | Purpose |
+|-----|------|---------|---------|
+| `daemon-url` | `s` | `""` | URL of `wyrelogd` when `--daemon-url` is omitted. Empty = "no default; CLI must supply." |
+| `default-tenant` | `s` | `""` | Tenant id used when `--tenant` is omitted (same empty-is-unset convention). |
+| `default-graph` | `s` | `""` | Graph id used when `--graph` is omitted. |
+| `access-token-file` | `s` | `""` | Filesystem path to the bearer token file used when `--access-token-file` is omitted. Path only. |
+| `default-timeout-ms` | `u` | `2000` | Request timeout in milliseconds used when `--timeout-ms` is omitted. Re-validated by wyctl's CLI parser (`1..60000`). |
+| `default-guard-loc-class` | `s` | `""` | Location class used when `--guard-loc-class` is omitted. |
+| `default-guard-risk` | `i` | `-1` | Risk score (0..100) used when `--guard-risk` is omitted. `-1` is the "unset" sentinel because `0` is a real risk score. |
+| `default-guard-timestamp-mode` | `s` | `"none"` | Strategy for filling `--guard-timestamp` when omitted. `"none"` preserves the historical "must be supplied" behaviour; `"now"` is reserved for a future commit that fills the current wall-clock time. |
+
+Example: configure the operator workstation once and let every wyctl
+invocation pick up the defaults.
+
+```sh
+gsettings set org.wyrelog.wyctl daemon-url 'http://127.0.0.1:8765'
+gsettings set org.wyrelog.wyctl default-tenant 'system'
+gsettings set org.wyrelog.wyctl default-graph 'production'
+gsettings set org.wyrelog.wyctl access-token-file "$HOME/.config/wyrelog/access-token"
+gsettings set org.wyrelog.wyctl default-timeout-ms 5000
+```
+
+### Precedence Rule
+
+For every flag covered above, the resolved value is the first non-empty
+of:
+
+1. **CLI flag** (`--daemon-url X`). An empty-string CLI value
+   (`--daemon-url ""`) is treated as a deliberate operator value, not
+   as absence, and falls into the existing per-flag validation paths.
+2. **GSettings value** for the corresponding schema key. The schema's
+   empty-string defaults encode "unset" — wyctl never fabricates a
+   default URL or tenant from those.
+3. **Unset** — the existing per-flag "missing" diagnostic fires
+   (`wyctl: missing daemon URL`, `wyctl: missing --tenant`, etc.).
+
+### Kill Switch: `WYCTL_DISABLE_GSETTINGS`
+
+Set `WYCTL_DISABLE_GSETTINGS=1` (the **literal string `1`** — `true`,
+`yes`, `on` are not honoured) to skip the GSettings lookup entirely.
+Useful for:
+
+- CI containers without a dconf daemon.
+- Reproducible CLI-only runs in incident-response workflows.
+- Bisecting a misconfigured operator workstation.
+
+With the kill switch set, wyctl behaves exactly as the pre-GSettings
+build did: every flag is sourced from `argv` or the per-flag missing
+diagnostic fires.
+
+### Token-File Permission Requirements (POSIX)
+
+Before any daemon request is sent, `wyctl` opens the access-token file
+with `open(O_NOFOLLOW | O_CLOEXEC | O_RDONLY | O_NOCTTY)` and applies
+the following checks on the resulting file descriptor (no second
+path-based syscall is issued, so the safety check has no TOCTOU window
+between stat and read):
+
+1. **Regular file** — directories, devices, sockets, FIFOs are
+   rejected with `wyctl: access token file is not a regular file: <path>`.
+2. **Owned by the invoking user** (`st.st_uid == geteuid()`) — rejected
+   with `wyctl: access token file not owned by current user: <path>`.
+3. **No group/other permission bits** — the mask
+   `(S_IRWXG | S_IRWXO)` must be zero. `0600` and `0400` are accepted;
+   `0640`, `0604`, `0660`, etc. are rejected with
+   `wyctl: access token file permissions too broad (require 0600): <path>`.
+4. **Not a terminal symlink** — `O_NOFOLLOW` refuses the open and
+   reports `wyctl: access token file is a symlink (refusing to follow): <path>`.
+5. **Bounded read** — the token must be 65,536 bytes or less. Larger
+   files fail with `wyctl: access token file too large: <path>`.
+
+The check is the chokepoint every subcommand reaches before any
+`wyl_client_*` HTTP call. Operators who see a token-file diagnostic
+can be confident the daemon was never contacted.
+
+#### Intermediate-Path Symlinks (Scope Statement)
+
+`O_NOFOLLOW` only refuses a terminal symlink. Intermediate path
+components are still resolved normally, so a setup where a parent
+directory is itself a symlink — or where a non-owner can write to a
+parent directory and substitute one — falls outside the safety
+guarantee. **Every directory on the path to the token file must be
+owned by the invoking user and not group/world-writable.** A typical
+safe layout is `~/.config/wyrelog/access-token` where `~/.config` is
+already operator-owned with the standard `0700` mode.
+
+Closing the intermediate-component window would require
+Linux-only `openat2(RESOLVE_BENEATH)`. That is explicitly out of scope
+for the GA hardening pass.
+
+### Token-File Permission Requirements (Windows)
+
+On Windows wyctl applies a smaller but still fail-closed check:
+
+1. `FILE_ATTRIBUTE_REPARSE_POINT` must NOT be set on the file — that
+   covers symbolic links, directory junctions, and any third-party
+   reparse target. Rejected with
+   `wyctl: access token file is a symlink (refusing to follow): <path>`.
+2. `FILE_ATTRIBUTE_READONLY` must be set — operators mark the file
+   read-only via `attrib +R <path>` to opt into the check. Rejected
+   with `wyctl: access token file not marked read-only: <path>`.
+
+Full ACL validation is reserved for a future hardening pass; the
+diagnostic `wyctl: access token file ACL validation unavailable: <path>`
+is allocated for that landing and is **not emitted** by the current
+binary.
+
+### Diagnostic Message Catalog
+
+When the token-file safety check refuses the file, exactly one of the
+following lines is written to stderr. Each diagnostic is greppable as
+a literal substring so operator tooling can route automatically.
+
+| Failure | Diagnostic (stderr) |
+|---------|--------------------|
+| Missing path or `--access-token-file=""` | `wyctl: missing --access-token-file` |
+| File not found | `wyctl: access token file not found: <path>` |
+| Terminal symlink (POSIX) or reparse point (Windows) | `wyctl: access token file is a symlink (refusing to follow): <path>` |
+| Non-regular file (FIFO, device, socket, directory) | `wyctl: access token file is not a regular file: <path>` |
+| Owned by another user | `wyctl: access token file not owned by current user: <path>` |
+| Group or other permission bits set | `wyctl: access token file permissions too broad (require 0600): <path>` |
+| Read failed for another reason | `wyctl: unable to read access token file: <path>` |
+| File is zero bytes | `wyctl: empty access token file: <path>` |
+| File contains an embedded NUL or fails normalization | `wyctl: invalid access token file: <path>` |
+| File exceeds the 64 KiB cap | `wyctl: access token file too large: <path>` |
+| Read-only attribute missing (Windows) | `wyctl: access token file not marked read-only: <path>` |
+
+For each failure the process exits with status `2` and **no HTTP
+request is sent** to the daemon — the contract is enforced by both
+unit tests and end-to-end integration tests that assert the absence
+of `daemon unavailable` / `<op> failed` diagnostics under unsafe
+token configurations.
+
+### Operator Setup Recipe (POSIX)
+
+```sh
+# Create the per-user wyrelog config directory.
+install -d -m 0700 "$HOME/.config/wyrelog"
+
+# Write the bearer token. Use install + redirect rather than echo
+# to avoid the token landing in shell history.
+install -m 0600 /dev/null "$HOME/.config/wyrelog/access-token"
+printf '%s' "$WYRELOG_TOKEN" > "$HOME/.config/wyrelog/access-token"
+
+# Point GSettings at the file.
+gsettings set org.wyrelog.wyctl access-token-file \
+  "$HOME/.config/wyrelog/access-token"
+
+# Verify wyctl can read it.
+wyctl status
+
+# Remove the env var so the token is no longer in memory.
+unset WYRELOG_TOKEN
+```
+
+### Operator Setup Recipe (Windows)
+
+```pwsh
+$WyrelogDir = "$Env:USERPROFILE\.config\wyrelog"
+New-Item -ItemType Directory -Force -Path $WyrelogDir | Out-Null
+
+# Write the bearer token (PowerShell will not echo it back).
+Set-Content -Path "$WyrelogDir\access-token" -Value $Env:WYRELOG_TOKEN -NoNewline
+
+# Mark the file read-only — required by the Windows safety check.
+attrib +R "$WyrelogDir\access-token"
+
+# Point GSettings at the file.
+gsettings set org.wyrelog.wyctl access-token-file "$WyrelogDir\access-token"
+
+# Verify wyctl can read it.
+wyctl status
+
+# Remove the env var so the token is no longer in memory.
+Remove-Item Env:WYRELOG_TOKEN
+```

--- a/tests/check-wyrelogd-bootstrap-admin.sh
+++ b/tests/check-wyrelogd-bootstrap-admin.sh
@@ -182,6 +182,11 @@ if not token:
 with open(token_path, "w", encoding="utf-8") as f:
     f.write(token)
     f.write("\n")
+# wyctl's token-file safety check rejects group/other permission bits.
+# Python's default open() honours the process umask, which yields 0644
+# on CI runners — chmod down so the chmod-stricter contract holds.
+import os
+os.chmod(token_path, 0o600)
 PY
 
 "$WYCTL" --daemon-url "http://127.0.0.1:$PORT" policy permission-grant \

--- a/tests/check-wyrelogd-datalog-product-flow.sh
+++ b/tests/check-wyrelogd-datalog-product-flow.sh
@@ -110,6 +110,10 @@ if not token:
     raise SystemExit(f"login returned no access_token: {body}")
 with open(token_path, "w", encoding="utf-8") as f:
     f.write(token + "\n")
+# wyctl rejects token files with group/other permission bits; chmod
+# down so the safety check passes regardless of the runner's umask.
+import os
+os.chmod(token_path, 0o600)
 PY
 }
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -205,6 +205,37 @@ test_client_audit_daemon = executable('test-client-audit-daemon',
 )
 
 if build_client and host_machine.system() != 'windows'
+  glib_compile_schemas_prog = find_program('glib-compile-schemas')
+
+  wyctl_gschema_staged = configure_file(
+    input : '../wyrelog/wyctl/org.wyrelog.wyctl.gschema.xml',
+    output : 'org.wyrelog.wyctl.gschema.xml',
+    copy : true,
+  )
+
+  wyctl_gschemas_compiled = custom_target('wyctl-gschemas-compiled',
+    input : wyctl_gschema_staged,
+    output : 'gschemas.compiled',
+    command : [glib_compile_schemas_prog, '--strict',
+               '--targetdir=@OUTDIR@', meson.current_build_dir()],
+    build_by_default : true,
+  )
+
+  wyctl_gsettings_test_env = environment()
+  wyctl_gsettings_test_env.set('GSETTINGS_SCHEMA_DIR',
+    meson.current_build_dir())
+  wyctl_gsettings_test_env.set('GSETTINGS_BACKEND', 'memory')
+
+  test_wyctl_gschema = executable('test-wyctl-gschema',
+    'test-wyctl-gschema.c',
+    dependencies : [glib_dep, gio_dep],
+  )
+
+  test('wyctl-gschema', test_wyctl_gschema,
+    depends : wyctl_gschemas_compiled,
+    env : wyctl_gsettings_test_env,
+  )
+
   test_wyctl_basic = executable('test-wyctl-basic',
     'test-wyctl-basic.c',
     c_args : [

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -257,7 +257,8 @@ if build_client and host_machine.system() != 'windows'
   )
 
   test('wyctl-basic', test_wyctl_basic,
-    depends : wyctl_exe,
+    depends : [wyctl_exe, wyctl_gschemas_compiled],
+    env : wyctl_gsettings_test_env,
     timeout : 60,
   )
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -236,6 +236,18 @@ if build_client and host_machine.system() != 'windows'
     env : wyctl_gsettings_test_env,
   )
 
+  test_wyctl_config = executable('test-wyctl-config',
+    'test-wyctl-config.c',
+    '../wyrelog/wyctl/wyctl-config.c',
+    include_directories : include_directories('../wyrelog/wyctl'),
+    dependencies : [glib_dep, gio_dep],
+  )
+
+  test('wyctl-config', test_wyctl_config,
+    depends : wyctl_gschemas_compiled,
+    env : wyctl_gsettings_test_env,
+  )
+
   test_wyctl_basic = executable('test-wyctl-basic',
     'test-wyctl-basic.c',
     c_args : [

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -248,6 +248,15 @@ if build_client and host_machine.system() != 'windows'
     env : wyctl_gsettings_test_env,
   )
 
+  test_wyctl_token_file = executable('test-wyctl-token-file',
+    'test-wyctl-token-file.c',
+    '../wyrelog/wyctl/wyctl-token-file.c',
+    include_directories : include_directories('../wyrelog/wyctl'),
+    dependencies : [glib_dep],
+  )
+
+  test('wyctl-token-file', test_wyctl_token_file)
+
   test_wyctl_basic = executable('test-wyctl-basic',
     'test-wyctl-basic.c',
     c_args : [

--- a/tests/test-wyctl-basic.c
+++ b/tests/test-wyctl-basic.c
@@ -20,6 +20,100 @@ run_child (gchar **argv, gchar **stdout_buf, gchar **stderr_buf,
   g_assert_no_error (error);
 }
 
+static void
+run_child_with_env (gchar **argv, gchar **envp, gchar **stdout_buf,
+    gchar **stderr_buf, gint *wait_status)
+{
+  g_autoptr (GError) error = NULL;
+
+  g_assert_true (g_spawn_sync (NULL, argv, envp, G_SPAWN_DEFAULT, NULL, NULL,
+          stdout_buf, stderr_buf, wait_status, &error));
+  g_assert_no_error (error);
+}
+
+/* Build a temporary XDG_CONFIG_HOME directory that holds a GSettings
+ * keyfile with the supplied org.wyrelog.wyctl values, and return the
+ * directory path (owned by caller). Caller must remove the directory
+ * tree when done. Both key and value arrays are NULL-terminated and
+ * must have matching length; values are stringified GVariant
+ * literals so the GSettings keyfile backend reads them as the
+ * declared schema type. */
+static gchar *
+make_keyfile_xdg_dir (const gchar *const *keys, const gchar *const *values)
+{
+  g_autoptr (GError) error = NULL;
+  gchar *xdg = g_dir_make_tmp ("wyctl-xdg-XXXXXX", &error);
+  g_assert_no_error (error);
+
+  g_autofree gchar *settings_dir = g_build_filename (xdg, "glib-2.0",
+      "settings", NULL);
+  g_assert_cmpint (g_mkdir_with_parents (settings_dir, 0700), ==, 0);
+
+  g_autofree gchar *keyfile_path = g_build_filename (settings_dir, "keyfile",
+      NULL);
+  g_autoptr (GKeyFile) keyfile = g_key_file_new ();
+  for (gsize i = 0; keys != NULL && keys[i] != NULL; i++) {
+    g_assert_nonnull (values[i]);
+    g_key_file_set_string (keyfile, "org/wyrelog/wyctl", keys[i], values[i]);
+  }
+  g_assert_true (g_key_file_save_to_file (keyfile, keyfile_path, &error));
+  g_assert_no_error (error);
+
+  return xdg;
+}
+
+static gchar *
+gvariant_literal_for_string (const gchar *value)
+{
+  g_autoptr (GVariant) variant = g_variant_new_string (value);
+  return g_variant_print (variant, FALSE);
+}
+
+static void
+remove_dir_recursive (const gchar *path)
+{
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GFile) file = g_file_new_for_path (path);
+  /* Walk and unlink children. Tests stage only files we wrote, so the
+   * iteration is small. */
+  g_autoptr (GFileEnumerator) en = g_file_enumerate_children (file,
+      G_FILE_ATTRIBUTE_STANDARD_NAME ","
+      G_FILE_ATTRIBUTE_STANDARD_TYPE, G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,
+      NULL, &error);
+  if (en != NULL) {
+    while (TRUE) {
+      g_autoptr (GFileInfo) info = g_file_enumerator_next_file (en, NULL,
+          &error);
+      if (info == NULL)
+        break;
+      g_autofree gchar *child = g_build_filename (path,
+          g_file_info_get_name (info), NULL);
+      if (g_file_info_get_file_type (info) == G_FILE_TYPE_DIRECTORY)
+        remove_dir_recursive (child);
+      else
+        g_unlink (child);
+    }
+  }
+  g_clear_error (&error);
+  g_rmdir (path);
+}
+
+/* Build an envp derived from the current process environment, with
+ * GSettings pointed at the keyfile backend in xdg_dir. Caller frees
+ * with g_strfreev. */
+static gchar **
+build_gsettings_envp (const gchar *xdg_dir, gboolean disable_gsettings)
+{
+  gchar **envp = g_get_environ ();
+  envp = g_environ_setenv (envp, "XDG_CONFIG_HOME", xdg_dir, TRUE);
+  envp = g_environ_setenv (envp, "GSETTINGS_BACKEND", "keyfile", TRUE);
+  if (disable_gsettings)
+    envp = g_environ_setenv (envp, "WYCTL_DISABLE_GSETTINGS", "1", TRUE);
+  else
+    envp = g_environ_unsetenv (envp, "WYCTL_DISABLE_GSETTINGS");
+  return envp;
+}
+
 static gboolean
 wait_status_is_success (gint wait_status)
 {
@@ -2234,6 +2328,103 @@ test_policy_role_validation (void)
   g_unlink (token_path);
 }
 
+static void
+test_status_gsettings_supplies_daemon_url (void)
+{
+  /* When --daemon-url is omitted the resolver must read the URL from
+   * GSettings and the daemon-unavailable diagnostic must reference
+   * that URL (proving the resolver fed the probe). */
+  g_autofree gchar *literal =
+      gvariant_literal_for_string ("http://127.0.0.1:1");
+  const gchar *keys[] = { "daemon-url", NULL };
+  const gchar *values[] = { literal, NULL };
+  g_autofree gchar *xdg = make_keyfile_xdg_dir (keys, values);
+  g_auto (GStrv) envp = build_gsettings_envp (xdg, FALSE);
+
+  gchar *argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "status",
+    "--timeout-ms",
+    "100",
+    NULL,
+  };
+  g_autofree gchar *stdout_buf = NULL;
+  g_autofree gchar *stderr_buf = NULL;
+  gint wait_status = 0;
+  run_child_with_env (argv, envp, &stdout_buf, &stderr_buf, &wait_status);
+  remove_dir_recursive (xdg);
+
+  g_assert_false (wait_status_is_success (wait_status));
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1,
+          "wyctl: daemon unavailable: http://127.0.0.1:1"));
+  g_assert_null (g_strstr_len (stderr_buf, -1, "wyctl: missing daemon URL"));
+}
+
+static void
+test_status_cli_overrides_gsettings (void)
+{
+  /* GSettings carries a URL we want to be ignored; the CLI value
+   * must win and the diagnostic must mention the CLI URL. */
+  g_autofree gchar *literal =
+      gvariant_literal_for_string ("http://from-gsettings.example.invalid");
+  const gchar *keys[] = { "daemon-url", NULL };
+  const gchar *values[] = { literal, NULL };
+  g_autofree gchar *xdg = make_keyfile_xdg_dir (keys, values);
+  g_auto (GStrv) envp = build_gsettings_envp (xdg, FALSE);
+
+  gchar *argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "status",
+    "--daemon-url",
+    "http://127.0.0.1:1",
+    "--timeout-ms",
+    "100",
+    NULL,
+  };
+  g_autofree gchar *stdout_buf = NULL;
+  g_autofree gchar *stderr_buf = NULL;
+  gint wait_status = 0;
+  run_child_with_env (argv, envp, &stdout_buf, &stderr_buf, &wait_status);
+  remove_dir_recursive (xdg);
+
+  g_assert_false (wait_status_is_success (wait_status));
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1,
+          "wyctl: daemon unavailable: http://127.0.0.1:1"));
+  g_assert_null (g_strstr_len (stderr_buf, -1,
+          "from-gsettings.example.invalid"));
+}
+
+static void
+test_status_kill_switch_disables_gsettings (void)
+{
+  /* GSettings carries a URL but WYCTL_DISABLE_GSETTINGS=1 must keep
+   * wyctl from consulting it; with no CLI URL the existing
+   * missing-daemon-URL diagnostic must fire. */
+  g_autofree gchar *literal =
+      gvariant_literal_for_string ("http://from-gsettings.example.invalid");
+  const gchar *keys[] = { "daemon-url", NULL };
+  const gchar *values[] = { literal, NULL };
+  g_autofree gchar *xdg = make_keyfile_xdg_dir (keys, values);
+  g_auto (GStrv) envp = build_gsettings_envp (xdg, TRUE);
+
+  gchar *argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "status",
+    "--timeout-ms",
+    "100",
+    NULL,
+  };
+  g_autofree gchar *stdout_buf = NULL;
+  g_autofree gchar *stderr_buf = NULL;
+  gint wait_status = 0;
+  run_child_with_env (argv, envp, &stdout_buf, &stderr_buf, &wait_status);
+  remove_dir_recursive (xdg);
+
+  g_assert_false (wait_status_is_success (wait_status));
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1, "wyctl: missing daemon URL"));
+  g_assert_null (g_strstr_len (stderr_buf, -1, "daemon unavailable:"));
+}
+
 int
 main (int argc, char **argv)
 {
@@ -2281,6 +2472,12 @@ main (int argc, char **argv)
   g_test_add_func ("/wyctl/audit-help", test_audit_help);
   g_test_add_func ("/wyctl/audit-validation", test_audit_validation);
   g_test_add_func ("/wyctl/audit-query", test_audit_query);
+  g_test_add_func ("/wyctl/status-gsettings-supplies-daemon-url",
+      test_status_gsettings_supplies_daemon_url);
+  g_test_add_func ("/wyctl/status-cli-overrides-gsettings",
+      test_status_cli_overrides_gsettings);
+  g_test_add_func ("/wyctl/status-kill-switch-disables-gsettings",
+      test_status_kill_switch_disables_gsettings);
 
   return g_test_run ();
 }

--- a/tests/test-wyctl-basic.c
+++ b/tests/test-wyctl-basic.c
@@ -1,9 +1,19 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+/* Expose POSIX.1-2008 chmod-mode-t and the write(2)/symlink(2) syscalls
+ * the resolver / token-file fan-out tests use under strict c_std=c17.
+ * Must precede every system header. */
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <glib.h>
 #include <glib/gstdio.h>
 #include <gio/gio.h>
 #include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 #include <sys/wait.h>
+#include <unistd.h>
 
 #ifndef WYL_TEST_WYCTL_PATH
 #error "WYL_TEST_WYCTL_PATH is required"
@@ -1006,8 +1016,9 @@ test_policy_validation (void)
   run_child (unreadable_token_argv, &stdout_buf, &stderr_buf, &wait_status);
   g_assert_false (wait_status_is_success (wait_status));
   g_assert_cmpstr (stdout_buf, ==, "");
+  /* Updated diagnostic from the typed token-file safety helper. */
   g_assert_nonnull (g_strstr_len (stderr_buf, -1,
-          "wyctl: unable to read access token file"));
+          "wyctl: access token file not found"));
 
   g_clear_pointer (&stdout_buf, g_free);
   g_clear_pointer (&stderr_buf, g_free);
@@ -2459,7 +2470,7 @@ test_audit_query_gsettings_supplies_daemon_url (void)
     "--limit", "1",
     "--access-token-file", "/dev/null",
     "--guard-timestamp", "0",
-    "--guard-loc-class", "internal",
+    "--guard-loc-class", "trusted",
     "--guard-risk", "0",
     "--timeout-ms", "100",
   };
@@ -2483,12 +2494,100 @@ test_fact_put_gsettings_supplies_daemon_url (void)
     "--input", "/dev/null",
     "--access-token-file", "/dev/null",
     "--guard-timestamp", "0",
-    "--guard-loc-class", "internal",
+    "--guard-loc-class", "trusted",
     "--guard-risk", "0",
     "--timeout-ms", "100",
   };
   assert_subcommand_consumes_gsettings_daemon_url (subcommand,
       G_N_ELEMENTS (subcommand));
+}
+
+/* Build a temporary access-token file with the supplied contents and
+ * mode bits, returning the path. The caller g_unlinks and g_frees. */
+static gchar *
+write_token_with_mode (const gchar *contents, mode_t mode)
+{
+  g_autoptr (GError) error = NULL;
+  gchar *path = NULL;
+  gint fd = g_file_open_tmp ("wyctl-broad-token-XXXXXX", &path, &error);
+  g_assert_no_error (error);
+  g_assert_cmpint (fd, >=, 0);
+  if (contents != NULL && contents[0] != '\0') {
+    gsize len = strlen (contents);
+    gsize wrote = 0;
+    while (wrote < len) {
+      ssize_t n = write (fd, contents + wrote, len - wrote);
+      g_assert_cmpint (n, >=, 0);
+      wrote += (gsize) n;
+    }
+  }
+  g_assert_true (g_close (fd, NULL));
+  g_assert_cmpint (g_chmod (path, mode), ==, 0);
+  return path;
+}
+
+/* When the access-token file is unsafe, the safety check MUST fire
+ * before any HTTP request. Witness: the subcommand's own "<op>
+ * failed" diagnostic must be absent, because reaching it requires
+ * a successful wyl_client_new + daemon probe. The
+ * permissions-too-broad diagnostic must be present in its place. */
+static void
+test_policy_check_safety_reject_prevents_http (void)
+{
+  g_autofree gchar *broad_token = write_token_with_mode ("token-1", 0640);
+
+  /* --daemon-url and --timeout-ms are global flags and must come
+   * before the subcommand name, per wyctl's CLI grammar. */
+  gchar *argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "--daemon-url", "http://127.0.0.1:1",
+    "--timeout-ms", "100",
+    "policy", "check",
+    "--user", "alice",
+    "--permission", "wr.audit.read",
+    "--resource", "doc/42",
+    "--access-token-file", broad_token,
+    NULL,
+  };
+  g_autofree gchar *stdout_buf = NULL;
+  g_autofree gchar *stderr_buf = NULL;
+  gint wait_status = 0;
+  run_child (argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_unlink (broad_token);
+
+  g_assert_false (wait_status_is_success (wait_status));
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1,
+          "wyctl: access token file permissions too broad"));
+  g_assert_null (g_strstr_len (stderr_buf, -1, "wyctl: policy check failed"));
+}
+
+static void
+test_audit_query_safety_reject_prevents_http (void)
+{
+  g_autofree gchar *broad_token = write_token_with_mode ("token-1", 0644);
+
+  gchar *argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "--daemon-url", "http://127.0.0.1:1",
+    "--timeout-ms", "100",
+    "audit", "query",
+    "--limit", "1",
+    "--access-token-file", broad_token,
+    "--guard-timestamp", "0",
+    "--guard-loc-class", "trusted",
+    "--guard-risk", "0",
+    NULL,
+  };
+  g_autofree gchar *stdout_buf = NULL;
+  g_autofree gchar *stderr_buf = NULL;
+  gint wait_status = 0;
+  run_child (argv, &stdout_buf, &stderr_buf, &wait_status);
+  g_unlink (broad_token);
+
+  g_assert_false (wait_status_is_success (wait_status));
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1,
+          "wyctl: access token file permissions too broad"));
+  g_assert_null (g_strstr_len (stderr_buf, -1, "wyctl: audit query failed"));
 }
 
 static void
@@ -2502,7 +2601,7 @@ test_datalog_query_gsettings_supplies_daemon_url (void)
     "--limit", "1",
     "--access-token-file", "/dev/null",
     "--guard-timestamp", "0",
-    "--guard-loc-class", "internal",
+    "--guard-loc-class", "trusted",
     "--guard-risk", "0",
     "--timeout-ms", "100",
   };
@@ -2602,6 +2701,10 @@ main (int argc, char **argv)
       test_fact_put_gsettings_supplies_daemon_url);
   g_test_add_func ("/wyctl/datalog-query-gsettings-supplies-daemon-url",
       test_datalog_query_gsettings_supplies_daemon_url);
+  g_test_add_func ("/wyctl/policy-check-safety-reject-prevents-http",
+      test_policy_check_safety_reject_prevents_http);
+  g_test_add_func ("/wyctl/audit-query-safety-reject-prevents-http",
+      test_audit_query_safety_reject_prevents_http);
 
   return g_test_run ();
 }

--- a/tests/test-wyctl-basic.c
+++ b/tests/test-wyctl-basic.c
@@ -535,6 +535,7 @@ test_audit_validation (void)
   g_assert_true (g_close (fd, NULL));
   g_assert_true (g_file_set_contents (token_path, "token-1\n", -1, &error));
   g_assert_no_error (error);
+  g_assert_cmpint (g_chmod (token_path, 0600), ==, 0);
 
   gchar *missing_daemon_argv[] = {
     WYL_TEST_WYCTL_PATH,
@@ -779,6 +780,7 @@ test_policy_validation (void)
   g_assert_true (g_close (fd, NULL));
   g_assert_true (g_file_set_contents (token_path, "token-1\n", -1, &error));
   g_assert_no_error (error);
+  g_assert_cmpint (g_chmod (token_path, 0600), ==, 0);
 
   g_autofree gchar *empty_token_path = NULL;
   fd = g_file_open_tmp ("wyctl-empty-token-XXXXXX", &empty_token_path, &error);
@@ -795,6 +797,7 @@ test_policy_validation (void)
   g_assert_true (g_file_set_contents (invalid_token_path, "token-1\nbad\n",
           -1, &error));
   g_assert_no_error (error);
+  g_assert_cmpint (g_chmod (invalid_token_path, 0600), ==, 0);
 
   g_autofree gchar *nul_token_path = NULL;
   fd = g_file_open_tmp ("wyctl-nul-token-XXXXXX", &nul_token_path, &error);
@@ -806,6 +809,7 @@ test_policy_validation (void)
     g_assert_true (g_file_set_contents (nul_token_path, token_with_nul,
             sizeof token_with_nul, &error));
     g_assert_no_error (error);
+    g_assert_cmpint (g_chmod (nul_token_path, 0600), ==, 0);
   }
 
   g_autofree gchar *leading_token_path = NULL;
@@ -817,6 +821,7 @@ test_policy_validation (void)
   g_assert_true (g_file_set_contents (leading_token_path, "\ntoken-1\n", -1,
           &error));
   g_assert_no_error (error);
+  g_assert_cmpint (g_chmod (leading_token_path, 0600), ==, 0);
 
   g_autofree gchar *trailing_blank_token_path = NULL;
   fd = g_file_open_tmp ("wyctl-trailing-token-XXXXXX",
@@ -827,6 +832,7 @@ test_policy_validation (void)
   g_assert_true (g_file_set_contents (trailing_blank_token_path,
           "token-1\n\n", -1, &error));
   g_assert_no_error (error);
+  g_assert_cmpint (g_chmod (trailing_blank_token_path, 0600), ==, 0);
 
   g_autofree gchar *space_token_path = NULL;
   fd = g_file_open_tmp ("wyctl-space-token-XXXXXX", &space_token_path, &error);
@@ -836,6 +842,7 @@ test_policy_validation (void)
   g_assert_true (g_file_set_contents (space_token_path, " token-1\n", -1,
           &error));
   g_assert_no_error (error);
+  g_assert_cmpint (g_chmod (space_token_path, 0600), ==, 0);
 
   gchar *missing_resource_argv[] = {
     WYL_TEST_WYCTL_PATH,
@@ -1175,6 +1182,7 @@ run_policy_decision_case (const gchar *command, const gchar *response_body,
   g_assert_true (g_close (fd, NULL));
   g_assert_true (g_file_set_contents (token_path, "token-1\n", -1, &error));
   g_assert_no_error (error);
+  g_assert_cmpint (g_chmod (token_path, 0600), ==, 0);
 
   g_autoptr (GSocketListener) listener = NULL;
   g_autofree gchar *daemon_url = listen_url_for_policy_server (&listener);
@@ -1263,6 +1271,7 @@ run_audit_query_case (const gchar *response_body, const gchar *expected_output,
   g_assert_true (g_close (fd, NULL));
   g_assert_true (g_file_set_contents (token_path, "token-1\n", -1, &error));
   g_assert_no_error (error);
+  g_assert_cmpint (g_chmod (token_path, 0600), ==, 0);
 
   g_autoptr (GSocketListener) listener = NULL;
   g_autofree gchar *daemon_url = listen_url_for_policy_server (&listener);
@@ -1461,6 +1470,7 @@ run_policy_permission_success_case (const gchar *command, const gchar *path)
   g_assert_true (g_close (fd, NULL));
   g_assert_true (g_file_set_contents (token_path, "token-1\n", -1, &error));
   g_assert_no_error (error);
+  g_assert_cmpint (g_chmod (token_path, 0600), ==, 0);
 
   g_autoptr (GSocketListener) listener = NULL;
   g_autofree gchar *daemon_url = listen_url_for_policy_server (&listener);
@@ -1551,6 +1561,7 @@ run_policy_permission_status_case (const gchar *command, guint status,
   g_assert_true (g_close (fd, NULL));
   g_assert_true (g_file_set_contents (token_path, "token-1\n", -1, &error));
   g_assert_no_error (error);
+  g_assert_cmpint (g_chmod (token_path, 0600), ==, 0);
 
   g_autoptr (GSocketListener) listener = NULL;
   g_autofree gchar *daemon_url = listen_url_for_policy_server (&listener);
@@ -1639,6 +1650,7 @@ test_policy_permission_validation (void)
   g_assert_true (g_close (fd, NULL));
   g_assert_true (g_file_set_contents (token_path, "token-1\n", -1, &error));
   g_assert_no_error (error);
+  g_assert_cmpint (g_chmod (token_path, 0600), ==, 0);
 
   gchar *missing_subject_argv[] = {
     WYL_TEST_WYCTL_PATH,
@@ -1933,6 +1945,7 @@ run_policy_role_success_case (const gchar *command, const gchar *path)
   g_assert_true (g_close (fd, NULL));
   g_assert_true (g_file_set_contents (token_path, "token-1\n", -1, &error));
   g_assert_no_error (error);
+  g_assert_cmpint (g_chmod (token_path, 0600), ==, 0);
 
   g_autoptr (GSocketListener) listener = NULL;
   g_autofree gchar *daemon_url = listen_url_for_policy_server (&listener);
@@ -2021,6 +2034,7 @@ run_policy_role_status_case (const gchar *command, guint status,
   g_assert_true (g_close (fd, NULL));
   g_assert_true (g_file_set_contents (token_path, "token-1\n", -1, &error));
   g_assert_no_error (error);
+  g_assert_cmpint (g_chmod (token_path, 0600), ==, 0);
 
   g_autoptr (GSocketListener) listener = NULL;
   g_autofree gchar *daemon_url = listen_url_for_policy_server (&listener);
@@ -2109,6 +2123,7 @@ test_policy_role_validation (void)
   g_assert_true (g_close (fd, NULL));
   g_assert_true (g_file_set_contents (token_path, "token-1\n", -1, &error));
   g_assert_no_error (error);
+  g_assert_cmpint (g_chmod (token_path, 0600), ==, 0);
 
   gchar *missing_subject_argv[] = {
     WYL_TEST_WYCTL_PATH,

--- a/tests/test-wyctl-basic.c
+++ b/tests/test-wyctl-basic.c
@@ -2394,6 +2394,76 @@ test_status_cli_overrides_gsettings (void)
           "from-gsettings.example.invalid"));
 }
 
+/* Drive a wyctl subcommand with GSettings carrying daemon-url and
+ * the CLI omitting --daemon-url. The diagnostic must reference the
+ * GSettings URL, proving the resolver fan-out applies to the named
+ * subcommand and not only to `status`. */
+static void
+assert_subcommand_resolves_daemon_url_from_gsettings (gchar **subcommand_argv,
+    gsize subcommand_argv_len)
+{
+  g_autofree gchar *literal =
+      gvariant_literal_for_string ("http://127.0.0.1:1");
+  const gchar *keys[] = { "daemon-url", NULL };
+  const gchar *values[] = { literal, NULL };
+  g_autofree gchar *xdg = make_keyfile_xdg_dir (keys, values);
+  g_auto (GStrv) envp = build_gsettings_envp (xdg, FALSE);
+
+  GPtrArray *argv = g_ptr_array_new ();
+  g_ptr_array_add (argv, WYL_TEST_WYCTL_PATH);
+  for (gsize i = 0; i < subcommand_argv_len; i++)
+    g_ptr_array_add (argv, subcommand_argv[i]);
+  g_ptr_array_add (argv, NULL);
+
+  g_autofree gchar *stdout_buf = NULL;
+  g_autofree gchar *stderr_buf = NULL;
+  gint wait_status = 0;
+  run_child_with_env ((gchar **) argv->pdata, envp, &stdout_buf, &stderr_buf,
+      &wait_status);
+  g_ptr_array_free (argv, TRUE);
+  remove_dir_recursive (xdg);
+
+  g_assert_false (wait_status_is_success (wait_status));
+  /* Either the daemon-unavailable diagnostic mentions the GSettings
+   * URL (probe was attempted with that URL), or the subcommand
+   * surfaces "daemon unavailable" with the URL. The kill-switch
+   * companion test rules out the missing-URL diagnostic. */
+  g_assert_nonnull (g_strstr_len (stderr_buf, -1,
+          "wyctl: daemon unavailable: http://127.0.0.1:1"));
+  g_assert_null (g_strstr_len (stderr_buf, -1, "wyctl: missing daemon URL"));
+}
+
+static void
+test_policy_check_gsettings_supplies_daemon_url (void)
+{
+  gchar *subcommand[] = {
+    "policy", "check",
+    "--user", "alice",
+    "--permission", "read",
+    "--resource", "doc/1",
+    "--access-token-file", "/dev/null",
+    "--timeout-ms", "100",
+  };
+  assert_subcommand_resolves_daemon_url_from_gsettings (subcommand,
+      G_N_ELEMENTS (subcommand));
+}
+
+static void
+test_audit_query_gsettings_supplies_daemon_url (void)
+{
+  gchar *subcommand[] = {
+    "audit", "query",
+    "--limit", "1",
+    "--access-token-file", "/dev/null",
+    "--guard-timestamp", "0",
+    "--guard-loc-class", "internal",
+    "--guard-risk", "0",
+    "--timeout-ms", "100",
+  };
+  assert_subcommand_resolves_daemon_url_from_gsettings (subcommand,
+      G_N_ELEMENTS (subcommand));
+}
+
 static void
 test_status_kill_switch_disables_gsettings (void)
 {
@@ -2478,6 +2548,10 @@ main (int argc, char **argv)
       test_status_cli_overrides_gsettings);
   g_test_add_func ("/wyctl/status-kill-switch-disables-gsettings",
       test_status_kill_switch_disables_gsettings);
+  g_test_add_func ("/wyctl/policy-check-gsettings-supplies-daemon-url",
+      test_policy_check_gsettings_supplies_daemon_url);
+  g_test_add_func ("/wyctl/audit-query-gsettings-supplies-daemon-url",
+      test_audit_query_gsettings_supplies_daemon_url);
 
   return g_test_run ();
 }

--- a/tests/test-wyctl-basic.c
+++ b/tests/test-wyctl-basic.c
@@ -2394,12 +2394,20 @@ test_status_cli_overrides_gsettings (void)
           "from-gsettings.example.invalid"));
 }
 
-/* Drive a wyctl subcommand with GSettings carrying daemon-url and
- * the CLI omitting --daemon-url. The diagnostic must reference the
- * GSettings URL, proving the resolver fan-out applies to the named
- * subcommand and not only to `status`. */
+/* Drive a wyctl subcommand against a GSettings keyfile that supplies
+ * the daemon URL, with the CLI deliberately omitting --daemon-url.
+ *
+ * The contract is *not* that a specific diagnostic mentions the URL
+ * — only `run_status` echoes the URL in its failure diagnostic. The
+ * other subcommands print "wyctl: <op> failed" on transport failure
+ * without the URL. The portable proof that the resolver supplied a
+ * URL is that the subcommand made it *past* the URL-validation
+ * gate: neither "missing daemon URL" nor "invalid daemon URL"
+ * appears in stderr. The kill-switch companion proves the
+ * GSettings fallback is the only thing that could have supplied
+ * the URL. */
 static void
-assert_subcommand_resolves_daemon_url_from_gsettings (gchar **subcommand_argv,
+assert_subcommand_consumes_gsettings_daemon_url (gchar **subcommand_argv,
     gsize subcommand_argv_len)
 {
   g_autofree gchar *literal =
@@ -2424,13 +2432,8 @@ assert_subcommand_resolves_daemon_url_from_gsettings (gchar **subcommand_argv,
   remove_dir_recursive (xdg);
 
   g_assert_false (wait_status_is_success (wait_status));
-  /* Either the daemon-unavailable diagnostic mentions the GSettings
-   * URL (probe was attempted with that URL), or the subcommand
-   * surfaces "daemon unavailable" with the URL. The kill-switch
-   * companion test rules out the missing-URL diagnostic. */
-  g_assert_nonnull (g_strstr_len (stderr_buf, -1,
-          "wyctl: daemon unavailable: http://127.0.0.1:1"));
   g_assert_null (g_strstr_len (stderr_buf, -1, "wyctl: missing daemon URL"));
+  g_assert_null (g_strstr_len (stderr_buf, -1, "wyctl: invalid daemon URL"));
 }
 
 static void
@@ -2444,7 +2447,7 @@ test_policy_check_gsettings_supplies_daemon_url (void)
     "--access-token-file", "/dev/null",
     "--timeout-ms", "100",
   };
-  assert_subcommand_resolves_daemon_url_from_gsettings (subcommand,
+  assert_subcommand_consumes_gsettings_daemon_url (subcommand,
       G_N_ELEMENTS (subcommand));
 }
 
@@ -2460,7 +2463,50 @@ test_audit_query_gsettings_supplies_daemon_url (void)
     "--guard-risk", "0",
     "--timeout-ms", "100",
   };
-  assert_subcommand_resolves_daemon_url_from_gsettings (subcommand,
+  assert_subcommand_consumes_gsettings_daemon_url (subcommand,
+      G_N_ELEMENTS (subcommand));
+}
+
+static void
+test_fact_put_gsettings_supplies_daemon_url (void)
+{
+  gchar *subcommand[] = {
+    "fact", "put",
+    "--tenant", "t",
+    "--graph", "g",
+    "--namespace", "ns",
+    "--relation", "r",
+    "--schema-version", "1",
+    "--batch-id", "b",
+    "--idempotency-key", "k",
+    "--format", "csv",
+    "--input", "/dev/null",
+    "--access-token-file", "/dev/null",
+    "--guard-timestamp", "0",
+    "--guard-loc-class", "internal",
+    "--guard-risk", "0",
+    "--timeout-ms", "100",
+  };
+  assert_subcommand_consumes_gsettings_daemon_url (subcommand,
+      G_N_ELEMENTS (subcommand));
+}
+
+static void
+test_datalog_query_gsettings_supplies_daemon_url (void)
+{
+  gchar *subcommand[] = {
+    "datalog", "query",
+    "--tenant", "t",
+    "--graph", "g",
+    "--query", "rel()",
+    "--limit", "1",
+    "--access-token-file", "/dev/null",
+    "--guard-timestamp", "0",
+    "--guard-loc-class", "internal",
+    "--guard-risk", "0",
+    "--timeout-ms", "100",
+  };
+  assert_subcommand_consumes_gsettings_daemon_url (subcommand,
       G_N_ELEMENTS (subcommand));
 }
 
@@ -2552,6 +2598,10 @@ main (int argc, char **argv)
       test_policy_check_gsettings_supplies_daemon_url);
   g_test_add_func ("/wyctl/audit-query-gsettings-supplies-daemon-url",
       test_audit_query_gsettings_supplies_daemon_url);
+  g_test_add_func ("/wyctl/fact-put-gsettings-supplies-daemon-url",
+      test_fact_put_gsettings_supplies_daemon_url);
+  g_test_add_func ("/wyctl/datalog-query-gsettings-supplies-daemon-url",
+      test_datalog_query_gsettings_supplies_daemon_url);
 
   return g_test_run ();
 }

--- a/tests/test-wyctl-config.c
+++ b/tests/test-wyctl-config.c
@@ -1,0 +1,197 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <gio/gio.h>
+#include <glib.h>
+
+#include "wyctl-config.h"
+
+static GSettings *
+fresh_settings (void)
+{
+  GSettings *settings = wyctl_open_settings ();
+  g_assert_nonnull (settings);
+  /* Reset every key the test resolver touches so a previous test
+     leaves no residue in the memory backend. */
+  static const gchar *keys[] = {
+    "daemon-url",
+    "default-tenant",
+    "default-graph",
+    "access-token-file",
+    "default-timeout-ms",
+    "default-guard-loc-class",
+    "default-guard-risk",
+    "default-guard-timestamp-mode",
+  };
+  for (gsize i = 0; i < G_N_ELEMENTS (keys); i++)
+    g_settings_reset (settings, keys[i]);
+  return settings;
+}
+
+static void
+test_resolve_string_nulls_propagate (void)
+{
+  g_autofree gchar *resolved = wyctl_resolve_string_option (NULL, NULL,
+      "daemon-url");
+  g_assert_null (resolved);
+}
+
+static void
+test_resolve_string_cli_wins_over_settings (void)
+{
+  g_autoptr (GSettings) settings = fresh_settings ();
+  g_settings_set_string (settings, "daemon-url",
+      "http://from-gsettings.example");
+
+  g_autofree gchar *resolved =
+      wyctl_resolve_string_option ("http://from-cli.example", settings,
+      "daemon-url");
+  g_assert_cmpstr (resolved, ==, "http://from-cli.example");
+}
+
+static void
+test_resolve_string_cli_absent_falls_back (void)
+{
+  g_autoptr (GSettings) settings = fresh_settings ();
+  g_settings_set_string (settings, "daemon-url",
+      "http://from-gsettings.example");
+
+  g_autofree gchar *resolved = wyctl_resolve_string_option (NULL, settings,
+      "daemon-url");
+  g_assert_cmpstr (resolved, ==, "http://from-gsettings.example");
+}
+
+static void
+test_resolve_string_empty_cli_is_user_value (void)
+{
+  g_autoptr (GSettings) settings = fresh_settings ();
+  g_settings_set_string (settings, "daemon-url",
+      "http://from-gsettings.example");
+
+  /* Empty CLI is the user's deliberate-but-broken input. The resolver
+     must NOT fall through to GSettings; downstream validation will
+     reject it with the existing diagnostic. */
+  g_autofree gchar *resolved = wyctl_resolve_string_option ("", settings,
+      "daemon-url");
+  g_assert_cmpstr (resolved, ==, "");
+}
+
+static void
+test_resolve_string_empty_settings_is_unset (void)
+{
+  g_autoptr (GSettings) settings = fresh_settings ();
+  /* The schema default is the empty string, which by project
+     convention encodes "unset". With no CLI value, the resolver
+     must surface that as NULL so the missing-option diagnostic
+     remains the single source of truth. */
+  g_autofree gchar *resolved = wyctl_resolve_string_option (NULL, settings,
+      "daemon-url");
+  g_assert_null (resolved);
+}
+
+static void
+test_resolve_string_null_settings_returns_null (void)
+{
+  g_autofree gchar *resolved = wyctl_resolve_string_option (NULL, NULL,
+      "daemon-url");
+  g_assert_null (resolved);
+}
+
+static void
+test_resolve_uint_cli_wins (void)
+{
+  g_autoptr (GSettings) settings = fresh_settings ();
+  g_settings_set_uint (settings, "default-timeout-ms", 5000);
+
+  g_autofree gchar *resolved = wyctl_resolve_uint_option_as_string ("12345",
+      settings, "default-timeout-ms");
+  g_assert_cmpstr (resolved, ==, "12345");
+}
+
+static void
+test_resolve_uint_renders_settings_value (void)
+{
+  g_autoptr (GSettings) settings = fresh_settings ();
+  g_settings_set_uint (settings, "default-timeout-ms", 5000);
+
+  g_autofree gchar *resolved = wyctl_resolve_uint_option_as_string (NULL,
+      settings, "default-timeout-ms");
+  g_assert_cmpstr (resolved, ==, "5000");
+}
+
+static void
+test_resolve_uint_no_settings_returns_null (void)
+{
+  g_autofree gchar *resolved = wyctl_resolve_uint_option_as_string (NULL,
+      NULL, "default-timeout-ms");
+  g_assert_null (resolved);
+}
+
+static void
+test_open_settings_respects_kill_switch (void)
+{
+  /* WYCTL_DISABLE_GSETTINGS=1 must short-circuit before any schema
+     lookup, so an operator can disable GSettings in a CI container
+     that has no dconf available. */
+  g_setenv (WYCTL_GSETTINGS_DISABLE_ENV, "1", TRUE);
+  GSettings *settings = wyctl_open_settings ();
+  g_unsetenv (WYCTL_GSETTINGS_DISABLE_ENV);
+  g_assert_null (settings);
+}
+
+static void
+test_open_settings_returns_handle_when_schema_present (void)
+{
+  /* The harness wires GSETTINGS_SCHEMA_DIR at the compiled schema,
+     so this is the happy path. */
+  g_autoptr (GSettings) settings = wyctl_open_settings ();
+  g_assert_nonnull (settings);
+}
+
+static void
+test_open_settings_returns_null_for_missing_schema_id (void)
+{
+  /* Verify the GLib invariant the resolver relies on: looking up a
+     schema id that does not exist yields NULL, never g_error. If
+     this ever changes wyctl_open_settings would start aborting,
+     so it is worth pinning. */
+  GSettingsSchemaSource *source = g_settings_schema_source_get_default ();
+  g_assert_nonnull (source);
+  g_autoptr (GSettingsSchema) schema =
+      g_settings_schema_source_lookup (source,
+      "org.wyrelog.this-does-not-exist", FALSE);
+  g_assert_null (schema);
+}
+
+int
+main (int argc, char **argv)
+{
+  /* Make sure the kill-switch is not inherited from the developer's
+     environment so happy-path tests can open the schema. */
+  g_unsetenv (WYCTL_GSETTINGS_DISABLE_ENV);
+
+  g_test_init (&argc, &argv, NULL);
+  g_test_add_func ("/wyctl/config/resolve-string/nulls",
+      test_resolve_string_nulls_propagate);
+  g_test_add_func ("/wyctl/config/resolve-string/cli-wins",
+      test_resolve_string_cli_wins_over_settings);
+  g_test_add_func ("/wyctl/config/resolve-string/cli-absent-falls-back",
+      test_resolve_string_cli_absent_falls_back);
+  g_test_add_func ("/wyctl/config/resolve-string/empty-cli-is-user-value",
+      test_resolve_string_empty_cli_is_user_value);
+  g_test_add_func ("/wyctl/config/resolve-string/empty-settings-is-unset",
+      test_resolve_string_empty_settings_is_unset);
+  g_test_add_func ("/wyctl/config/resolve-string/null-settings-returns-null",
+      test_resolve_string_null_settings_returns_null);
+  g_test_add_func ("/wyctl/config/resolve-uint/cli-wins",
+      test_resolve_uint_cli_wins);
+  g_test_add_func ("/wyctl/config/resolve-uint/renders-settings-value",
+      test_resolve_uint_renders_settings_value);
+  g_test_add_func ("/wyctl/config/resolve-uint/no-settings-returns-null",
+      test_resolve_uint_no_settings_returns_null);
+  g_test_add_func ("/wyctl/config/open/respects-kill-switch",
+      test_open_settings_respects_kill_switch);
+  g_test_add_func ("/wyctl/config/open/handle-when-schema-present",
+      test_open_settings_returns_handle_when_schema_present);
+  g_test_add_func ("/wyctl/config/open/null-for-missing-schema-id",
+      test_open_settings_returns_null_for_missing_schema_id);
+  return g_test_run ();
+}

--- a/tests/test-wyctl-gschema.c
+++ b/tests/test-wyctl-gschema.c
@@ -1,0 +1,135 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <gio/gio.h>
+#include <glib.h>
+
+#define WYCTL_SCHEMA_ID "org.wyrelog.wyctl"
+#define WYCTL_SCHEMA_PATH "/org/wyrelog/wyctl/"
+
+typedef struct
+{
+  const gchar *name;
+  const GVariantType *type;
+} KeySpec;
+
+static GSettingsSchema *
+lookup_schema (void)
+{
+  GSettingsSchemaSource *source = g_settings_schema_source_get_default ();
+  g_assert_nonnull (source);
+  GSettingsSchema *schema = g_settings_schema_source_lookup (source,
+      WYCTL_SCHEMA_ID, FALSE);
+  g_assert_nonnull (schema);
+  return schema;
+}
+
+static void
+test_schema_keys_and_types (void)
+{
+  g_autoptr (GSettingsSchema) schema = lookup_schema ();
+
+  g_assert_cmpstr (g_settings_schema_get_path (schema), ==, WYCTL_SCHEMA_PATH);
+
+  const KeySpec expected[] = {
+    {"daemon-url", G_VARIANT_TYPE_STRING},
+    {"default-tenant", G_VARIANT_TYPE_STRING},
+    {"default-graph", G_VARIANT_TYPE_STRING},
+    {"access-token-file", G_VARIANT_TYPE_STRING},
+    {"default-timeout-ms", G_VARIANT_TYPE_UINT32},
+    {"default-guard-loc-class", G_VARIANT_TYPE_STRING},
+    {"default-guard-risk", G_VARIANT_TYPE_INT32},
+    {"default-guard-timestamp-mode", G_VARIANT_TYPE_STRING},
+  };
+
+  for (gsize i = 0; i < G_N_ELEMENTS (expected); i++) {
+    g_assert_true (g_settings_schema_has_key (schema, expected[i].name));
+    g_autoptr (GSettingsSchemaKey) key = g_settings_schema_get_key (schema,
+        expected[i].name);
+    g_assert_true (g_variant_type_equal (g_settings_schema_key_get_value_type
+            (key), expected[i].type));
+  }
+}
+
+static void
+test_schema_omits_token_value_keys (void)
+{
+  g_autoptr (GSettingsSchema) schema = lookup_schema ();
+  g_auto (GStrv) keys = g_settings_schema_list_keys (schema);
+  g_assert_nonnull (keys);
+
+  /* Acceptance criterion #2: token *bytes* must never live in
+     GSettings; only the path may. Any key whose name suggests a
+     credential value is a regression. */
+  static const gchar *forbidden[] = {
+    "access-token",
+    "bearer-token",
+    "token",
+    "secret",
+    "credential",
+    "password",
+  };
+
+  for (gsize i = 0; keys[i] != NULL; i++) {
+    for (gsize j = 0; j < G_N_ELEMENTS (forbidden); j++) {
+      g_assert_cmpstr (keys[i], !=, forbidden[j]);
+    }
+  }
+}
+
+static void
+test_schema_defaults_safe (void)
+{
+  g_autoptr (GSettingsSchema) schema = lookup_schema ();
+
+  /* String defaults must be the empty sentinel so a fresh
+     installation does not silently inject an unintended daemon
+     URL, tenant, or token-file path. */
+  static const gchar *string_keys[] = {
+    "daemon-url",
+    "default-tenant",
+    "default-graph",
+    "access-token-file",
+    "default-guard-loc-class",
+  };
+
+  for (gsize i = 0; i < G_N_ELEMENTS (string_keys); i++) {
+    g_autoptr (GSettingsSchemaKey) key = g_settings_schema_get_key (schema,
+        string_keys[i]);
+    g_autoptr (GVariant) def = g_settings_schema_key_get_default_value (key);
+    g_assert_true (g_variant_is_of_type (def, G_VARIANT_TYPE_STRING));
+    g_assert_cmpstr (g_variant_get_string (def, NULL), ==, "");
+  }
+
+  /* Numeric sentinels: 2000ms timeout, -1 risk score. */
+  {
+    g_autoptr (GSettingsSchemaKey) key = g_settings_schema_get_key (schema,
+        "default-timeout-ms");
+    g_autoptr (GVariant) def = g_settings_schema_key_get_default_value (key);
+    g_assert_cmpuint (g_variant_get_uint32 (def), ==, 2000);
+  }
+  {
+    g_autoptr (GSettingsSchemaKey) key = g_settings_schema_get_key (schema,
+        "default-guard-risk");
+    g_autoptr (GVariant) def = g_settings_schema_key_get_default_value (key);
+    g_assert_cmpint (g_variant_get_int32 (def), ==, -1);
+  }
+
+  /* Guard-timestamp-mode default must be "none" (the safe option
+     that preserves required-on-every-call semantics). */
+  {
+    g_autoptr (GSettingsSchemaKey) key = g_settings_schema_get_key (schema,
+        "default-guard-timestamp-mode");
+    g_autoptr (GVariant) def = g_settings_schema_key_get_default_value (key);
+    g_assert_cmpstr (g_variant_get_string (def, NULL), ==, "none");
+  }
+}
+
+int
+main (int argc, char **argv)
+{
+  g_test_init (&argc, &argv, NULL);
+  g_test_add_func ("/wyctl/gschema/keys-and-types", test_schema_keys_and_types);
+  g_test_add_func ("/wyctl/gschema/no-token-value-keys",
+      test_schema_omits_token_value_keys);
+  g_test_add_func ("/wyctl/gschema/defaults-safe", test_schema_defaults_safe);
+  return g_test_run ();
+}

--- a/tests/test-wyctl-policy-daemon.c
+++ b/tests/test-wyctl-policy-daemon.c
@@ -217,6 +217,12 @@ write_token_file (const gchar *token)
   g_assert_true (g_close (fd, NULL));
   g_assert_true (g_file_set_contents (token_path, token, -1, &error));
   g_assert_no_error (error);
+  /* g_file_set_contents atomically renames a fresh tmp file over the
+   * original, applying the current umask to the new file. On CI runners
+   * with umask 0022 that yields 0644, which fails the wyctl token-file
+   * safety check. Force 0600 so the integration test continues to
+   * exercise the daemon path, not the permissions diagnostic. */
+  g_assert_cmpint (g_chmod (token_path, 0600), ==, 0);
   return token_path;
 }
 

--- a/tests/test-wyctl-token-file.c
+++ b/tests/test-wyctl-token-file.c
@@ -1,0 +1,299 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* Expose POSIX.1-2008 symlink/lstat/mkfifo under strict c_std=c17.
+ * Must precede every system header. */
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+
+#include <fcntl.h>
+#include <glib.h>
+#include <glib/gstdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "wyctl-token-file.h"
+
+static gchar *
+make_token_file_with_mode (const gchar *contents, mode_t mode)
+{
+  g_autoptr (GError) error = NULL;
+  gchar *path = NULL;
+  gint fd = g_file_open_tmp ("wyctl-token-XXXXXX", &path, &error);
+  g_assert_no_error (error);
+  g_assert_cmpint (fd, >=, 0);
+  if (contents != NULL && contents[0] != '\0') {
+    gsize len = strlen (contents);
+    gsize wrote = 0;
+    while (wrote < len) {
+      ssize_t n = write (fd, contents + wrote, len - wrote);
+      g_assert_cmpint (n, >=, 0);
+      wrote += (gsize) n;
+    }
+  }
+  g_assert_true (g_close (fd, NULL));
+  g_assert_cmpint (g_chmod (path, mode), ==, 0);
+  return path;
+}
+
+static void
+test_missing_path (void)
+{
+  g_autofree gchar *token = NULL;
+  g_assert_cmpint (wyctl_token_file_read (NULL, &token), ==,
+      WYCTL_TOKEN_FILE_MISSING_PATH);
+  g_assert_null (token);
+
+  g_assert_cmpint (wyctl_token_file_read ("", &token), ==,
+      WYCTL_TOKEN_FILE_MISSING_PATH);
+  g_assert_null (token);
+}
+
+static void
+test_not_found (void)
+{
+  g_autofree gchar *token = NULL;
+  g_assert_cmpint (wyctl_token_file_read ("/nonexistent/path/wyctl-token-test",
+          &token), ==, WYCTL_TOKEN_FILE_NOT_FOUND);
+  g_assert_null (token);
+}
+
+static void
+test_accepts_mode_0600 (void)
+{
+  g_autofree gchar *path = make_token_file_with_mode ("token-1\n", 0600);
+  g_autofree gchar *token = NULL;
+  WyctlTokenFileStatus rc = wyctl_token_file_read (path, &token);
+  g_assert_cmpint (rc, ==, WYCTL_TOKEN_FILE_OK);
+  g_assert_nonnull (token);
+  /* The helper does not trim whitespace — that's normalize's job. */
+  g_assert_cmpstr (token, ==, "token-1\n");
+  g_unlink (path);
+}
+
+static void
+test_accepts_mode_0400 (void)
+{
+  g_autofree gchar *path = make_token_file_with_mode ("token-1\n", 0400);
+  g_autofree gchar *token = NULL;
+  g_assert_cmpint (wyctl_token_file_read (path, &token), ==,
+      WYCTL_TOKEN_FILE_OK);
+  g_assert_cmpstr (token, ==, "token-1\n");
+  g_unlink (path);
+}
+
+static void
+test_rejects_mode_0640 (void)
+{
+  g_autofree gchar *path = make_token_file_with_mode ("token-1", 0640);
+  g_autofree gchar *token = NULL;
+  g_assert_cmpint (wyctl_token_file_read (path, &token), ==,
+      WYCTL_TOKEN_FILE_PERMISSIONS_TOO_BROAD);
+  g_assert_null (token);
+  g_unlink (path);
+}
+
+static void
+test_rejects_mode_0604 (void)
+{
+  g_autofree gchar *path = make_token_file_with_mode ("token-1", 0604);
+  g_autofree gchar *token = NULL;
+  g_assert_cmpint (wyctl_token_file_read (path, &token), ==,
+      WYCTL_TOKEN_FILE_PERMISSIONS_TOO_BROAD);
+  g_assert_null (token);
+  g_unlink (path);
+}
+
+static void
+test_rejects_mode_0660 (void)
+{
+  g_autofree gchar *path = make_token_file_with_mode ("token-1", 0660);
+  g_autofree gchar *token = NULL;
+  g_assert_cmpint (wyctl_token_file_read (path, &token), ==,
+      WYCTL_TOKEN_FILE_PERMISSIONS_TOO_BROAD);
+  g_assert_null (token);
+  g_unlink (path);
+}
+
+static void
+test_rejects_terminal_symlink (void)
+{
+  g_autofree gchar *real = make_token_file_with_mode ("token-1", 0600);
+
+  g_autoptr (GError) error = NULL;
+  gchar *link_path = NULL;
+  gint fd = g_file_open_tmp ("wyctl-link-XXXXXX", &link_path, &error);
+  g_assert_no_error (error);
+  g_assert_true (g_close (fd, NULL));
+  /* The tmpfile is a placeholder; replace with a symlink to the
+   * real file so the helper's O_NOFOLLOW rejection fires. */
+  g_unlink (link_path);
+  g_assert_cmpint (symlink (real, link_path), ==, 0);
+
+  g_autofree gchar *token = NULL;
+  g_assert_cmpint (wyctl_token_file_read (link_path, &token), ==,
+      WYCTL_TOKEN_FILE_SYMLINK);
+  g_assert_null (token);
+
+  g_unlink (link_path);
+  g_free (link_path);
+  g_unlink (real);
+}
+
+static void
+test_rejects_non_regular_via_classifier (void)
+{
+  /* mkfifo + open(O_NOFOLLOW|O_RDONLY) blocks waiting for a writer,
+   * so use the pure classifier helper to assert the non-regular
+   * rejection path. */
+  g_autoptr (GError) error = NULL;
+  gchar *fifo_path = NULL;
+  gint fd = g_file_open_tmp ("wyctl-fifo-XXXXXX", &fifo_path, &error);
+  g_assert_no_error (error);
+  g_assert_true (g_close (fd, NULL));
+  g_unlink (fifo_path);
+  g_assert_cmpint (mkfifo (fifo_path, 0600), ==, 0);
+
+  struct stat st;
+  g_assert_cmpint (lstat (fifo_path, &st), ==, 0);
+  g_assert_cmpint (wyctl_token_file_classify_stat (&st, geteuid ()), ==,
+      WYCTL_TOKEN_FILE_NOT_REGULAR);
+
+  g_unlink (fifo_path);
+  g_free (fifo_path);
+}
+
+static void
+test_rejects_empty_file (void)
+{
+  g_autofree gchar *path = make_token_file_with_mode ("", 0600);
+  g_autofree gchar *token = NULL;
+  g_assert_cmpint (wyctl_token_file_read (path, &token), ==,
+      WYCTL_TOKEN_FILE_EMPTY);
+  g_assert_null (token);
+  g_unlink (path);
+}
+
+static void
+test_rejects_too_large (void)
+{
+  g_autoptr (GError) error = NULL;
+  gchar *path = NULL;
+  gint fd = g_file_open_tmp ("wyctl-large-XXXXXX", &path, &error);
+  g_assert_no_error (error);
+  g_assert_cmpint (fd, >=, 0);
+
+  gsize n = WYCTL_TOKEN_FILE_MAX_BYTES + 16;
+  g_autofree gchar *blob = g_malloc (n);
+  memset (blob, 'a', n);
+  gsize wrote = 0;
+  while (wrote < n) {
+    ssize_t w = write (fd, blob + wrote, n - wrote);
+    g_assert_cmpint (w, >=, 0);
+    wrote += (gsize) w;
+  }
+  g_assert_true (g_close (fd, NULL));
+  g_assert_cmpint (g_chmod (path, 0600), ==, 0);
+
+  g_autofree gchar *token = NULL;
+  g_assert_cmpint (wyctl_token_file_read (path, &token), ==,
+      WYCTL_TOKEN_FILE_TOO_LARGE);
+  g_assert_null (token);
+  g_unlink (path);
+  g_free (path);
+}
+
+static void
+test_rejects_embedded_nul (void)
+{
+  /* Create a file with an embedded NUL byte directly via write(2)
+   * since g_file_set_contents treats the buffer as a C string. */
+  g_autoptr (GError) error = NULL;
+  gchar *path = NULL;
+  gint fd = g_file_open_tmp ("wyctl-nul-XXXXXX", &path, &error);
+  g_assert_no_error (error);
+  static const char bytes[] = { 'a', 'b', '\0', 'c', '\n' };
+  ssize_t w = write (fd, bytes, sizeof (bytes));
+  g_assert_cmpint (w, ==, (ssize_t) sizeof (bytes));
+  g_assert_true (g_close (fd, NULL));
+  g_assert_cmpint (g_chmod (path, 0600), ==, 0);
+
+  g_autofree gchar *token = NULL;
+  g_assert_cmpint (wyctl_token_file_read (path, &token), ==,
+      WYCTL_TOKEN_FILE_INVALID_BYTES);
+  g_assert_null (token);
+  g_unlink (path);
+  g_free (path);
+}
+
+static void
+test_owner_mismatch_via_classifier (void)
+{
+  /* Stat a real regular file so we have a struct stat with valid
+   * S_IFREG and 0600 bits, then drive the classifier with an euid
+   * deliberately different from the real owner — no root or chown
+   * required. */
+  g_autofree gchar *path = make_token_file_with_mode ("token-1", 0600);
+  struct stat st;
+  g_assert_cmpint (lstat (path, &st), ==, 0);
+  uid_t fake_euid = st.st_uid + 1;
+  g_assert_cmpint (wyctl_token_file_classify_stat (&st, fake_euid), ==,
+      WYCTL_TOKEN_FILE_OWNER_MISMATCH);
+  /* And: matching euid is OK. */
+  g_assert_cmpint (wyctl_token_file_classify_stat (&st, st.st_uid), ==,
+      WYCTL_TOKEN_FILE_OK);
+  g_unlink (path);
+}
+
+static void
+test_status_message_table_has_no_token_placeholder (void)
+{
+  /* Each status format string must either stand alone (for
+   * MISSING_PATH) or contain exactly one %s — for the path. No
+   * placeholder may exist for the token bytes themselves; that
+   * would risk leaking credentials into stderr. */
+  for (int s = WYCTL_TOKEN_FILE_OK;
+      s <= WYCTL_TOKEN_FILE_WINDOWS_ACL_UNAVAILABLE; s++) {
+    const gchar *msg = wyctl_token_file_status_message (
+        (WyctlTokenFileStatus) s);
+    if (msg == NULL)
+      continue;
+    int placeholders = 0;
+    for (const gchar * p = msg; *p != '\0'; p++) {
+      if (p[0] == '%' && p[1] == 's')
+        placeholders++;
+    }
+    g_assert_cmpint (placeholders, <=, 1);
+    /* Sanity check: ensure no leftover test-token-like string baked
+     * into the table. */
+    g_assert_null (strstr (msg, "token-1"));
+  }
+}
+
+int
+main (int argc, char **argv)
+{
+  g_test_init (&argc, &argv, NULL);
+  g_test_add_func ("/wyctl/token-file/missing-path", test_missing_path);
+  g_test_add_func ("/wyctl/token-file/not-found", test_not_found);
+  g_test_add_func ("/wyctl/token-file/accepts-0600", test_accepts_mode_0600);
+  g_test_add_func ("/wyctl/token-file/accepts-0400", test_accepts_mode_0400);
+  g_test_add_func ("/wyctl/token-file/rejects-0640", test_rejects_mode_0640);
+  g_test_add_func ("/wyctl/token-file/rejects-0604", test_rejects_mode_0604);
+  g_test_add_func ("/wyctl/token-file/rejects-0660", test_rejects_mode_0660);
+  g_test_add_func ("/wyctl/token-file/rejects-terminal-symlink",
+      test_rejects_terminal_symlink);
+  g_test_add_func ("/wyctl/token-file/rejects-non-regular",
+      test_rejects_non_regular_via_classifier);
+  g_test_add_func ("/wyctl/token-file/rejects-empty", test_rejects_empty_file);
+  g_test_add_func ("/wyctl/token-file/rejects-too-large",
+      test_rejects_too_large);
+  g_test_add_func ("/wyctl/token-file/rejects-embedded-nul",
+      test_rejects_embedded_nul);
+  g_test_add_func ("/wyctl/token-file/owner-mismatch-via-classifier",
+      test_owner_mismatch_via_classifier);
+  g_test_add_func ("/wyctl/token-file/status-message-no-token",
+      test_status_message_table_has_no_token_placeholder);
+  return g_test_run ();
+}

--- a/tests/test-wyctl-token-file.c
+++ b/tests/test-wyctl-token-file.c
@@ -246,6 +246,46 @@ test_owner_mismatch_via_classifier (void)
   g_unlink (path);
 }
 
+/* Windows-attribute classifier tests. These run on every platform
+ * because the classifier is pure bit math — no Win32 API is needed.
+ * They lock the rejection rules so a future Windows-side regression
+ * (e.g. failing to refuse a reparse point) is visible on the Linux
+ * CI before any Windows tester sees it. */
+#define WYCTL_WIN_ATTR_READONLY 0x00000001u
+#define WYCTL_WIN_ATTR_NORMAL 0x00000080u
+#define WYCTL_WIN_ATTR_REPARSE_POINT 0x00000400u
+
+static void
+test_windows_attrs_accept_readonly (void)
+{
+  g_assert_cmpint (wyctl_token_file_classify_windows_attrs
+      (WYCTL_WIN_ATTR_READONLY), ==, WYCTL_TOKEN_FILE_OK);
+  g_assert_cmpint (wyctl_token_file_classify_windows_attrs
+      (WYCTL_WIN_ATTR_READONLY | WYCTL_WIN_ATTR_NORMAL), ==,
+      WYCTL_TOKEN_FILE_OK);
+}
+
+static void
+test_windows_attrs_reject_not_readonly (void)
+{
+  /* Plain file with no read-only bit. */
+  g_assert_cmpint (wyctl_token_file_classify_windows_attrs
+      (WYCTL_WIN_ATTR_NORMAL), ==, WYCTL_TOKEN_FILE_WINDOWS_NOT_READONLY);
+  g_assert_cmpint (wyctl_token_file_classify_windows_attrs (0), ==,
+      WYCTL_TOKEN_FILE_WINDOWS_NOT_READONLY);
+}
+
+static void
+test_windows_attrs_reject_reparse_point (void)
+{
+  /* Reparse-point set even if read-only is also set: refuse. */
+  g_assert_cmpint (wyctl_token_file_classify_windows_attrs
+      (WYCTL_WIN_ATTR_REPARSE_POINT | WYCTL_WIN_ATTR_READONLY), ==,
+      WYCTL_TOKEN_FILE_SYMLINK);
+  g_assert_cmpint (wyctl_token_file_classify_windows_attrs
+      (WYCTL_WIN_ATTR_REPARSE_POINT), ==, WYCTL_TOKEN_FILE_SYMLINK);
+}
+
 static void
 test_status_message_table_has_no_token_placeholder (void)
 {
@@ -295,5 +335,11 @@ main (int argc, char **argv)
       test_owner_mismatch_via_classifier);
   g_test_add_func ("/wyctl/token-file/status-message-no-token",
       test_status_message_table_has_no_token_placeholder);
+  g_test_add_func ("/wyctl/token-file/windows-attrs-accept-readonly",
+      test_windows_attrs_accept_readonly);
+  g_test_add_func ("/wyctl/token-file/windows-attrs-reject-not-readonly",
+      test_windows_attrs_reject_not_readonly);
+  g_test_add_func ("/wyctl/token-file/windows-attrs-reject-reparse-point",
+      test_windows_attrs_reject_reparse_point);
   return g_test_run ();
 }

--- a/wyrelog/meson.build
+++ b/wyrelog/meson.build
@@ -135,7 +135,7 @@ if build_client
   )
 
   wyctl_exe = executable('wyctl',
-    files('wyctl/wyctl.c'),
+    files('wyctl/wyctl.c', 'wyctl/wyctl-config.c'),
     include_directories : wyrelog_inc,
     dependencies : [wyrelog_client_dep, glib_dep, gio_dep, libsoup_dep],
     install : true,

--- a/wyrelog/meson.build
+++ b/wyrelog/meson.build
@@ -140,6 +140,14 @@ if build_client
     dependencies : [wyrelog_client_dep, glib_dep, gio_dep, libsoup_dep],
     install : true,
   )
+
+  install_data(
+    'wyctl/org.wyrelog.wyctl.gschema.xml',
+    install_dir : get_option('datadir') / 'glib-2.0' / 'schemas',
+  )
+
+  gnome = import('gnome')
+  gnome.post_install(glib_compile_schemas : true)
 else
   wyrelog_client_dep = disabler()
   wyctl_exe = disabler()

--- a/wyrelog/meson.build
+++ b/wyrelog/meson.build
@@ -135,7 +135,8 @@ if build_client
   )
 
   wyctl_exe = executable('wyctl',
-    files('wyctl/wyctl.c', 'wyctl/wyctl-config.c'),
+    files('wyctl/wyctl.c', 'wyctl/wyctl-config.c',
+        'wyctl/wyctl-token-file.c'),
     include_directories : wyrelog_inc,
     dependencies : [wyrelog_client_dep, glib_dep, gio_dep, libsoup_dep],
     install : true,

--- a/wyrelog/wyctl/org.wyrelog.wyctl.gschema.xml
+++ b/wyrelog/wyctl/org.wyrelog.wyctl.gschema.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+<schemalist>
+  <enum id="org.wyrelog.wyctl.GuardTimestampMode">
+    <value nick="none" value="0"/>
+    <value nick="now" value="1"/>
+  </enum>
+
+  <schema id="org.wyrelog.wyctl" path="/org/wyrelog/wyctl/">
+    <key name="daemon-url" type="s">
+      <default>""</default>
+      <summary>Default wyrelogd URL</summary>
+      <description>
+        URL of the wyrelogd daemon used when --daemon-url is omitted on
+        the command line. Empty string means "no default; the CLI flag
+        must be provided."
+      </description>
+    </key>
+
+    <key name="default-tenant" type="s">
+      <default>""</default>
+      <summary>Default tenant identifier</summary>
+      <description>
+        Tenant value used when --tenant is omitted. Empty string means
+        "no default; the CLI flag must be provided."
+      </description>
+    </key>
+
+    <key name="default-graph" type="s">
+      <default>""</default>
+      <summary>Default graph identifier</summary>
+      <description>
+        Graph value used when --graph is omitted. Empty string means
+        "no default; the CLI flag must be provided."
+      </description>
+    </key>
+
+    <key name="access-token-file" type="s">
+      <default>""</default>
+      <summary>Path to the bearer access token file</summary>
+      <description>
+        Filesystem path used when --access-token-file is omitted.
+        The file must be a regular file owned by the invoking user
+        with mode 0600 or stricter; symlinks and broader permissions
+        are rejected before any daemon request is sent. The schema
+        stores only the path, never the token bytes.
+      </description>
+    </key>
+
+    <key name="default-timeout-ms" type="u">
+      <default>2000</default>
+      <summary>Default request timeout in milliseconds</summary>
+      <description>
+        Timeout used when --timeout-ms is omitted. Must lie in the
+        same 1..60000 range the CLI enforces.
+      </description>
+    </key>
+
+    <key name="default-guard-loc-class" type="s">
+      <default>""</default>
+      <summary>Default location class for guard evaluation</summary>
+      <description>
+        Value used when --guard-loc-class is omitted. Empty string
+        means "no default; the CLI flag must be provided."
+      </description>
+    </key>
+
+    <key name="default-guard-risk" type="i">
+      <default>-1</default>
+      <summary>Default risk score for guard evaluation</summary>
+      <description>
+        Value used when --guard-risk is omitted. Valid scores are
+        0..100; -1 is the "unset" sentinel because 0 is a real
+        guard-risk value.
+      </description>
+    </key>
+
+    <key name="default-guard-timestamp-mode" enum="org.wyrelog.wyctl.GuardTimestampMode">
+      <default>"none"</default>
+      <summary>Strategy for filling guard timestamps</summary>
+      <description>
+        "none" preserves the historical behaviour where
+        --guard-timestamp must be supplied on every invocation.
+        "now" causes wyctl to substitute the current wall-clock
+        timestamp when the flag is omitted. A frozen literal default
+        is intentionally not offered, because operator workstations
+        would replay the same timestamp across invocations.
+      </description>
+    </key>
+  </schema>
+</schemalist>

--- a/wyrelog/wyctl/wyctl-config.c
+++ b/wyrelog/wyctl/wyctl-config.c
@@ -1,0 +1,55 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "wyctl-config.h"
+
+GSettings *
+wyctl_open_settings (void)
+{
+  const gchar *disable = g_getenv (WYCTL_GSETTINGS_DISABLE_ENV);
+  if (disable != NULL && g_strcmp0 (disable, "1") == 0)
+    return NULL;
+
+  GSettingsSchemaSource *source = g_settings_schema_source_get_default ();
+  if (source == NULL)
+    return NULL;
+
+  GSettingsSchema *schema = g_settings_schema_source_lookup (source,
+      WYCTL_GSETTINGS_SCHEMA_ID, FALSE);
+  if (schema == NULL)
+    return NULL;
+
+  GSettings *settings = g_settings_new_full (schema, NULL, NULL);
+  g_settings_schema_unref (schema);
+  return settings;
+}
+
+gchar *
+wyctl_resolve_string_option (const gchar *cli_value, GSettings *settings,
+    const gchar *key)
+{
+  if (cli_value != NULL)
+    return g_strdup (cli_value);
+
+  if (settings == NULL || key == NULL)
+    return NULL;
+
+  gchar *value = g_settings_get_string (settings, key);
+  if (value == NULL || value[0] == '\0') {
+    g_free (value);
+    return NULL;
+  }
+  return value;
+}
+
+gchar *
+wyctl_resolve_uint_option_as_string (const gchar *cli_value,
+    GSettings *settings, const gchar *key)
+{
+  if (cli_value != NULL)
+    return g_strdup (cli_value);
+
+  if (settings == NULL || key == NULL)
+    return NULL;
+
+  guint32 value = g_settings_get_uint (settings, key);
+  return g_strdup_printf ("%u", value);
+}

--- a/wyrelog/wyctl/wyctl-config.h
+++ b/wyrelog/wyctl/wyctl-config.h
@@ -1,0 +1,38 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+
+#include <gio/gio.h>
+#include <glib.h>
+
+G_BEGIN_DECLS;
+
+#define WYCTL_GSETTINGS_SCHEMA_ID "org.wyrelog.wyctl"
+#define WYCTL_GSETTINGS_DISABLE_ENV "WYCTL_DISABLE_GSETTINGS"
+
+/* Open the wyctl GSettings tree, or return NULL if the schema is
+ * not installed or the operator has set WYCTL_DISABLE_GSETTINGS=1.
+ * Never aborts: a missing schema is reported as NULL, not g_error.
+ * The returned object is owned by the caller; g_object_unref () to
+ * release. */
+GSettings *wyctl_open_settings (void);
+
+/* Reconcile a CLI-supplied option with a GSettings fallback for a
+ * string-typed key. Precedence: explicit CLI value > GSettings value
+ * > unset. cli_value != NULL returns g_strdup (cli_value) — an empty
+ * string is treated as a deliberate (if broken) user value, not as
+ * absence. cli_value == NULL && settings != NULL reads the key from
+ * GSettings; an empty string from the schema is the "unset" sentinel
+ * and surfaces as NULL so the caller's missing-option diagnostic
+ * remains the single source of truth. The returned string is always
+ * owned by the caller (or NULL). Free with g_free (). */
+gchar *wyctl_resolve_string_option (const gchar * cli_value,
+    GSettings * settings, const gchar * key);
+
+/* Same as wyctl_resolve_string_option, but the schema key is unsigned
+ * 32-bit and the returned value is rendered with %u so it can be
+ * threaded through the existing CLI parsers (e.g. parse_timeout_ms)
+ * unchanged. */
+gchar *wyctl_resolve_uint_option_as_string (const gchar * cli_value,
+    GSettings * settings, const gchar * key);
+
+G_END_DECLS;

--- a/wyrelog/wyctl/wyctl-token-file.c
+++ b/wyrelog/wyctl/wyctl-token-file.c
@@ -68,6 +68,24 @@ wyctl_token_file_classify_stat (const struct stat *st, uid_t euid)
 }
 #endif
 
+/* Pure attribute-bit-mask classifier (Windows semantics). Compiled
+ * on every platform so the Linux unit-test runner exercises the
+ * Windows rejection rules with synthetic inputs. */
+WyctlTokenFileStatus
+wyctl_token_file_classify_windows_attrs (guint32 attrs)
+{
+  /* FILE_ATTRIBUTE_REPARSE_POINT — symlink, mountpoint, or any
+   * other reparse target. We refuse the same way the POSIX path
+   * refuses a terminal symlink. */
+  if (attrs & 0x00000400u)
+    return WYCTL_TOKEN_FILE_SYMLINK;
+  /* FILE_ATTRIBUTE_READONLY missing — the issue requires at least
+   * this much hardening on Windows. */
+  if ((attrs & 0x00000001u) == 0)
+    return WYCTL_TOKEN_FILE_WINDOWS_NOT_READONLY;
+  return WYCTL_TOKEN_FILE_OK;
+}
+
 WyctlTokenFileStatus
 wyctl_token_file_read (const gchar *path, gchar **out_token)
 {
@@ -79,12 +97,72 @@ wyctl_token_file_read (const gchar *path, gchar **out_token)
     return WYCTL_TOKEN_FILE_MISSING_PATH;
 
 #ifdef G_OS_WIN32
-  /* Stubbed for commit 6 to wire GetFileAttributesW + read-only
-   * attribute + reparse-point rejection. The status is selected so
-   * any caller that mistakenly ships without the Windows path lit
-   * fails closed. */
-  (void) path;
-  return WYCTL_TOKEN_FILE_WINDOWS_NOT_READONLY;
+  /* Convert the operator-supplied UTF-8 path to UTF-16 for the
+   * Win32 wide-string API. */
+  wchar_t *wpath = (wchar_t *) g_utf8_to_utf16 (path, -1, NULL, NULL, NULL);
+  if (wpath == NULL)
+    return WYCTL_TOKEN_FILE_IO;
+
+  DWORD attrs = GetFileAttributesW (wpath);
+  if (attrs == INVALID_FILE_ATTRIBUTES) {
+    DWORD err = GetLastError ();
+    g_free (wpath);
+    if (err == ERROR_FILE_NOT_FOUND || err == ERROR_PATH_NOT_FOUND)
+      return WYCTL_TOKEN_FILE_NOT_FOUND;
+    return WYCTL_TOKEN_FILE_IO;
+  }
+
+  WyctlTokenFileStatus classify =
+      wyctl_token_file_classify_windows_attrs ((guint32) attrs);
+  if (classify != WYCTL_TOKEN_FILE_OK) {
+    g_free (wpath);
+    return classify;
+  }
+
+  HANDLE h = CreateFileW (wpath, GENERIC_READ, FILE_SHARE_READ, NULL,
+      OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+  g_free (wpath);
+  if (h == INVALID_HANDLE_VALUE)
+    return WYCTL_TOKEN_FILE_IO;
+
+  gsize cap = WYCTL_TOKEN_FILE_MAX_BYTES;
+  gchar *buf = g_malloc (cap + 1);
+  gsize got = 0;
+  while (got < cap) {
+    DWORD chunk = (DWORD) (cap - got);
+    DWORD read_n = 0;
+    if (!ReadFile (h, buf + got, chunk, &read_n, NULL)) {
+      CloseHandle (h);
+      g_free (buf);
+      return WYCTL_TOKEN_FILE_IO;
+    }
+    if (read_n == 0)
+      break;
+    got += (gsize) read_n;
+  }
+  if (got >= cap) {
+    gchar overflow = 0;
+    DWORD probe = 0;
+    if (ReadFile (h, &overflow, 1, &probe, NULL) && probe > 0) {
+      CloseHandle (h);
+      g_free (buf);
+      return WYCTL_TOKEN_FILE_TOO_LARGE;
+    }
+  }
+  CloseHandle (h);
+  buf[got] = '\0';
+
+  if (got == 0) {
+    g_free (buf);
+    return WYCTL_TOKEN_FILE_EMPTY;
+  }
+  if (memchr (buf, '\0', got) != NULL) {
+    g_free (buf);
+    return WYCTL_TOKEN_FILE_INVALID_BYTES;
+  }
+
+  *out_token = buf;
+  return WYCTL_TOKEN_FILE_OK;
 #else
   int fd = open (path, O_NOFOLLOW | O_CLOEXEC | O_RDONLY | O_NOCTTY);
   if (fd < 0) {

--- a/wyrelog/wyctl/wyctl-token-file.c
+++ b/wyrelog/wyctl/wyctl-token-file.c
@@ -5,13 +5,22 @@
 #ifndef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
 #endif
+/* Apple SDKs gate POSIX-only BSD features behind _DARWIN_C_SOURCE
+ * when the compiler is invoked under -std=cNN (clang predefines
+ * __STRICT_ANSI__). _POSIX_C_SOURCE alone does not expose
+ * O_NOFOLLOW on macOS. */
+#if defined(__APPLE__) && !defined(_DARWIN_C_SOURCE)
+#define _DARWIN_C_SOURCE 1
+#endif
 
 #include "wyctl-token-file.h"
 
 #include <errno.h>
 #include <string.h>
 
-#ifndef G_OS_WIN32
+#ifdef G_OS_WIN32
+#include <windows.h>
+#else
 #include <fcntl.h>
 #include <unistd.h>
 #endif

--- a/wyrelog/wyctl/wyctl-token-file.c
+++ b/wyrelog/wyctl/wyctl-token-file.c
@@ -1,0 +1,167 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* Expose POSIX.1-2008 open(O_NOFOLLOW|O_CLOEXEC|O_NOCTTY) and the
+ * fstat/read/close trio under strict c_std=c17. Must precede every
+ * system header. */
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+
+#include "wyctl-token-file.h"
+
+#include <errno.h>
+#include <string.h>
+
+#ifndef G_OS_WIN32
+#include <fcntl.h>
+#include <unistd.h>
+#endif
+
+const gchar *
+wyctl_token_file_status_message (WyctlTokenFileStatus status)
+{
+  switch (status) {
+    case WYCTL_TOKEN_FILE_OK:
+      return NULL;
+    case WYCTL_TOKEN_FILE_MISSING_PATH:
+      return "wyctl: missing --access-token-file";
+    case WYCTL_TOKEN_FILE_NOT_FOUND:
+      return "wyctl: access token file not found: %s";
+    case WYCTL_TOKEN_FILE_SYMLINK:
+      return "wyctl: access token file is a symlink"
+          " (refusing to follow): %s";
+    case WYCTL_TOKEN_FILE_NOT_REGULAR:
+      return "wyctl: access token file is not a regular file: %s";
+    case WYCTL_TOKEN_FILE_OWNER_MISMATCH:
+      return "wyctl: access token file not owned by current user: %s";
+    case WYCTL_TOKEN_FILE_PERMISSIONS_TOO_BROAD:
+      return "wyctl: access token file permissions too broad"
+          " (require 0600): %s";
+    case WYCTL_TOKEN_FILE_IO:
+      return "wyctl: unable to read access token file: %s";
+    case WYCTL_TOKEN_FILE_EMPTY:
+      return "wyctl: empty access token file: %s";
+    case WYCTL_TOKEN_FILE_INVALID_BYTES:
+      return "wyctl: invalid access token file: %s";
+    case WYCTL_TOKEN_FILE_TOO_LARGE:
+      return "wyctl: access token file too large: %s";
+    case WYCTL_TOKEN_FILE_WINDOWS_NOT_READONLY:
+      return "wyctl: access token file not marked read-only: %s";
+    case WYCTL_TOKEN_FILE_WINDOWS_ACL_UNAVAILABLE:
+      return "wyctl: access token file ACL validation unavailable: %s";
+  }
+  return NULL;
+}
+
+#ifndef G_OS_WIN32
+WyctlTokenFileStatus
+wyctl_token_file_classify_stat (const struct stat *st, uid_t euid)
+{
+  if (st == NULL)
+    return WYCTL_TOKEN_FILE_IO;
+  if (!S_ISREG (st->st_mode))
+    return WYCTL_TOKEN_FILE_NOT_REGULAR;
+  if (st->st_uid != euid)
+    return WYCTL_TOKEN_FILE_OWNER_MISMATCH;
+  if ((st->st_mode & (S_IRWXG | S_IRWXO)) != 0)
+    return WYCTL_TOKEN_FILE_PERMISSIONS_TOO_BROAD;
+  return WYCTL_TOKEN_FILE_OK;
+}
+#endif
+
+WyctlTokenFileStatus
+wyctl_token_file_read (const gchar *path, gchar **out_token)
+{
+  if (out_token == NULL)
+    return WYCTL_TOKEN_FILE_IO;
+  *out_token = NULL;
+
+  if (path == NULL || path[0] == '\0')
+    return WYCTL_TOKEN_FILE_MISSING_PATH;
+
+#ifdef G_OS_WIN32
+  /* Stubbed for commit 6 to wire GetFileAttributesW + read-only
+   * attribute + reparse-point rejection. The status is selected so
+   * any caller that mistakenly ships without the Windows path lit
+   * fails closed. */
+  (void) path;
+  return WYCTL_TOKEN_FILE_WINDOWS_NOT_READONLY;
+#else
+  int fd = open (path, O_NOFOLLOW | O_CLOEXEC | O_RDONLY | O_NOCTTY);
+  if (fd < 0) {
+    int saved = errno;
+    if (saved == ELOOP)
+      return WYCTL_TOKEN_FILE_SYMLINK;
+    if (saved == ENOENT || saved == ENOTDIR)
+      return WYCTL_TOKEN_FILE_NOT_FOUND;
+    return WYCTL_TOKEN_FILE_IO;
+  }
+
+  struct stat st;
+  if (fstat (fd, &st) != 0) {
+    close (fd);
+    return WYCTL_TOKEN_FILE_IO;
+  }
+
+  WyctlTokenFileStatus classify = wyctl_token_file_classify_stat (&st,
+      geteuid ());
+  if (classify != WYCTL_TOKEN_FILE_OK) {
+    close (fd);
+    return classify;
+  }
+
+  if (st.st_size > (off_t) WYCTL_TOKEN_FILE_MAX_BYTES) {
+    close (fd);
+    return WYCTL_TOKEN_FILE_TOO_LARGE;
+  }
+
+  /* Read from the same fd we fstatted. No second path-based syscall
+   * is allowed past this point — that would reopen the TOCTOU
+   * window the open(O_NOFOLLOW) + fstat sequence just closed. */
+  gsize cap = WYCTL_TOKEN_FILE_MAX_BYTES;
+  gchar *buf = g_malloc (cap + 1);
+  gsize got = 0;
+  while (got < cap) {
+    ssize_t n = read (fd, buf + got, cap - got);
+    if (n < 0) {
+      if (errno == EINTR)
+        continue;
+      close (fd);
+      g_free (buf);
+      return WYCTL_TOKEN_FILE_IO;
+    }
+    if (n == 0)
+      break;
+    got += (gsize) n;
+  }
+  if (got >= cap) {
+    /* Probe for additional bytes; if the file grew during read or
+     * the initial st.st_size was misleading (e.g. sparse), we still
+     * refuse to truncate. */
+    gchar overflow = 0;
+    ssize_t n = read (fd, &overflow, 1);
+    if (n > 0) {
+      close (fd);
+      g_free (buf);
+      return WYCTL_TOKEN_FILE_TOO_LARGE;
+    }
+  }
+  close (fd);
+  buf[got] = '\0';
+
+  if (got == 0) {
+    g_free (buf);
+    return WYCTL_TOKEN_FILE_EMPTY;
+  }
+
+  /* Embedded NUL bytes never belong in a bearer token. Surfacing
+   * INVALID_BYTES here keeps higher-level normalize logic from
+   * mis-classifying the file. */
+  if (memchr (buf, '\0', got) != NULL) {
+    g_free (buf);
+    return WYCTL_TOKEN_FILE_INVALID_BYTES;
+  }
+
+  *out_token = buf;
+  return WYCTL_TOKEN_FILE_OK;
+#endif
+}

--- a/wyrelog/wyctl/wyctl-token-file.h
+++ b/wyrelog/wyctl/wyctl-token-file.h
@@ -1,0 +1,73 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+
+#include <glib.h>
+#ifndef G_OS_WIN32
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
+
+G_BEGIN_DECLS;
+
+/* Maximum number of bytes wyctl will read from a bearer-token file
+ * before rejecting. Tokens are typically tens to hundreds of bytes;
+ * the cap exists so a misconfigured or hostile path cannot OOM the
+ * process even if it survives every other check. */
+#define WYCTL_TOKEN_FILE_MAX_BYTES (64u * 1024u)
+
+/* Outcomes for wyctl_token_file_read. Each status maps to exactly
+ * one stderr diagnostic returned by wyctl_token_file_status_message,
+ * so operators can grep the runbook table to figure out the fix
+ * without consulting source. */
+typedef enum
+{
+  WYCTL_TOKEN_FILE_OK = 0,
+  WYCTL_TOKEN_FILE_MISSING_PATH,
+  WYCTL_TOKEN_FILE_NOT_FOUND,
+  WYCTL_TOKEN_FILE_SYMLINK,
+  WYCTL_TOKEN_FILE_NOT_REGULAR,
+  WYCTL_TOKEN_FILE_OWNER_MISMATCH,
+  WYCTL_TOKEN_FILE_PERMISSIONS_TOO_BROAD,
+  WYCTL_TOKEN_FILE_IO,
+  WYCTL_TOKEN_FILE_EMPTY,
+  WYCTL_TOKEN_FILE_INVALID_BYTES,
+  WYCTL_TOKEN_FILE_TOO_LARGE,
+  WYCTL_TOKEN_FILE_WINDOWS_NOT_READONLY,
+  WYCTL_TOKEN_FILE_WINDOWS_ACL_UNAVAILABLE,
+} WyctlTokenFileStatus;
+
+/* Open the token file safely and copy its bytes into *out_token.
+ *
+ * POSIX: open(path, O_NOFOLLOW | O_CLOEXEC | O_RDONLY | O_NOCTTY) so
+ * a terminal symlink at path is refused; fstat() on the resulting
+ * fd so the symlink/owner/mode check operates on the very inode the
+ * read will consume (no TOCTOU window between stat and open).
+ * Permissions stricter than 0600 are accepted (0400 is fine);
+ * group/other permission bits are refused via the
+ * (S_IRWXG | S_IRWXO) mask.
+ *
+ * Diagnostic invariants: no return path includes the token bytes in
+ * an error message; only the path is logged. *out_token is NULL on
+ * any non-OK status. On OK, *out_token is a newly-allocated
+ * NUL-terminated buffer the caller frees with g_free(). */
+WyctlTokenFileStatus wyctl_token_file_read (const gchar * path,
+    gchar ** out_token);
+
+#ifndef G_OS_WIN32
+/* Pure-function classifier: given the result of fstat on an already-
+ * opened fd and the invoking process's effective uid, decide whether
+ * the regular-file / owner / mode invariants hold. Exists so tests
+ * can exercise the owner-mismatch path without requiring root or
+ * chown. Returns WYCTL_TOKEN_FILE_OK when every check passes. */
+WyctlTokenFileStatus wyctl_token_file_classify_stat (const struct stat *st,
+    uid_t euid);
+#endif
+
+/* Human-readable diagnostic string for a status code. The returned
+ * string contains a single '%s' placeholder for the path (except
+ * for WYCTL_TOKEN_FILE_MISSING_PATH whose message stands alone,
+ * because the path is by definition empty or NULL). Returns NULL
+ * for unknown statuses. */
+const gchar *wyctl_token_file_status_message (WyctlTokenFileStatus status);
+
+G_END_DECLS;

--- a/wyrelog/wyctl/wyctl-token-file.h
+++ b/wyrelog/wyctl/wyctl-token-file.h
@@ -63,6 +63,22 @@ WyctlTokenFileStatus wyctl_token_file_classify_stat (const struct stat *st,
     uid_t euid);
 #endif
 
+/* Pure-function classifier for the Windows GetFileAttributesW result.
+ * Operates on a plain guint32 bit mask so it can be exercised from
+ * the Linux unit-test runner without linking any Win32 API: the
+ * caller supplies synthetic attribute bits and the classifier
+ * applies the read-only / reparse-point rules.
+ *
+ * The two attribute literals we care about are stable across every
+ * supported Windows SDK:
+ *   FILE_ATTRIBUTE_READONLY      = 0x00000001
+ *   FILE_ATTRIBUTE_REPARSE_POINT = 0x00000400
+ *
+ * Returns WYCTL_TOKEN_FILE_SYMLINK if the reparse-point bit is set,
+ * WYCTL_TOKEN_FILE_WINDOWS_NOT_READONLY if the read-only bit is
+ * unset, and WYCTL_TOKEN_FILE_OK otherwise. */
+WyctlTokenFileStatus wyctl_token_file_classify_windows_attrs (guint32 attrs);
+
 /* Human-readable diagnostic string for a status code. The returned
  * string contains a single '%s' placeholder for the path (except
  * for WYCTL_TOKEN_FILE_MISSING_PATH whose message stands alone,

--- a/wyrelog/wyctl/wyctl.c
+++ b/wyrelog/wyctl/wyctl.c
@@ -13,6 +13,7 @@
 #include "wyrelog/wyl-common-private.h"
 #include "wyrelog/wyl-keyprovider-file-private.h"
 #include "wyrelog/wyl-permission-scope-private.h"
+#include "wyctl-config.h"
 
 typedef struct
 {
@@ -20,6 +21,11 @@ typedef struct
   gchar *timeout_ms_arg;
   gboolean show_version;
   gboolean readiness;
+  /* Borrowed pointer to the GSettings handle opened once in main().
+   * NULL when the schema is not installed or the operator set
+   * WYCTL_DISABLE_GSETTINGS=1; the resolver treats NULL as "no
+   * fallback available". */
+  GSettings *settings;
 } WyctlOptions;
 
 typedef struct
@@ -628,25 +634,34 @@ run_status (const WyctlOptions *global_opts, gint argc, gchar **argv)
     return 2;
   }
 
-  if (opts.daemon_url == NULL || opts.daemon_url[0] == '\0') {
+  /* Resolve the CLI flags against GSettings defaults. The resolver
+   * returns an owned copy or NULL; the original opts.* slots stay
+   * owned by GOptionContext so we never assign back into them. */
+  g_autofree gchar *daemon_url = wyctl_resolve_string_option (opts.daemon_url,
+      global_opts->settings, "daemon-url");
+  g_autofree gchar *timeout_ms_arg =
+      wyctl_resolve_uint_option_as_string (opts.timeout_ms_arg,
+      global_opts->settings, "default-timeout-ms");
+
+  if (daemon_url == NULL || daemon_url[0] == '\0') {
     g_printerr ("wyctl: missing daemon URL\n");
     return 2;
   }
 
-  if (!daemon_url_is_valid (opts.daemon_url)) {
+  if (!daemon_url_is_valid (daemon_url)) {
     g_printerr ("wyctl: invalid daemon URL\n");
     return 2;
   }
 
   guint timeout_ms = 0;
-  if (!parse_timeout_ms (opts.timeout_ms_arg, &timeout_ms)) {
+  if (!parse_timeout_ms (timeout_ms_arg, &timeout_ms)) {
     g_printerr ("wyctl: invalid timeout\n");
     return 2;
   }
 
   g_autofree gchar *uri =
-      opts.readiness ? build_readyz_json_uri (opts.daemon_url) :
-      build_healthz_uri (opts.daemon_url);
+      opts.readiness ? build_readyz_json_uri (daemon_url) :
+      build_healthz_uri (daemon_url);
   guint status = 0;
   g_autofree gchar *body = NULL;
   int probe_rc = send_status_probe (uri, timeout_ms, &status, &body);
@@ -655,7 +670,7 @@ run_status (const WyctlOptions *global_opts, gint argc, gchar **argv)
     return 2;
   }
   if (probe_rc != 0) {
-    g_printerr ("wyctl: daemon unavailable: %s\n", opts.daemon_url);
+    g_printerr ("wyctl: daemon unavailable: %s\n", daemon_url);
     return 1;
   }
 
@@ -667,7 +682,7 @@ run_status (const WyctlOptions *global_opts, gint argc, gchar **argv)
         return 1;
       }
     }
-    g_printerr ("wyctl: daemon unavailable: %s\n", opts.daemon_url);
+    g_printerr ("wyctl: daemon unavailable: %s\n", daemon_url);
     return 1;
   }
 
@@ -1964,6 +1979,14 @@ main (int argc, char **argv)
     g_printerr ("wyctl: %s\n", error->message);
     return 2;
   }
+
+  /* Open the GSettings handle once and thread it into every
+   * subcommand via WyctlOptions so the resolver can supply defaults
+   * for unset CLI flags. NULL when the schema is missing or the
+   * operator set WYCTL_DISABLE_GSETTINGS=1; the resolver tolerates
+   * that and degrades to CLI-only. */
+  g_autoptr (GSettings) settings = wyctl_open_settings ();
+  opts.settings = settings;
 
   if (opts.show_version) {
     g_print ("%s\n", wyrelog_version_string ());

--- a/wyrelog/wyctl/wyctl.c
+++ b/wyrelog/wyctl/wyctl.c
@@ -14,6 +14,7 @@
 #include "wyrelog/wyl-keyprovider-file-private.h"
 #include "wyrelog/wyl-permission-scope-private.h"
 #include "wyctl-config.h"
+#include "wyctl-token-file.h"
 
 typedef struct
 {
@@ -702,6 +703,23 @@ run_status (const WyctlOptions *global_opts, gint argc, gchar **argv)
   return 0;
 }
 
+static void
+emit_token_file_diagnostic (WyctlTokenFileStatus status, const gchar *path)
+{
+  const gchar *fmt = wyctl_token_file_status_message (status);
+  if (fmt == NULL) {
+    g_printerr ("wyctl: unable to read access token file: %s\n",
+        path != NULL ? path : "(null)");
+    return;
+  }
+  if (status == WYCTL_TOKEN_FILE_MISSING_PATH) {
+    g_printerr ("%s\n", fmt);
+    return;
+  }
+  g_printerr (fmt, path != NULL ? path : "(null)");
+  g_printerr ("\n");
+}
+
 static int
 load_access_token_file (const gchar *path, gchar **out_access_token)
 {
@@ -709,28 +727,27 @@ load_access_token_file (const gchar *path, gchar **out_access_token)
     return 2;
   *out_access_token = NULL;
 
-  if (path == NULL || path[0] == '\0') {
-    g_printerr ("wyctl: missing --access-token-file\n");
+  /* Hand the path to the safety helper. The helper opens with
+   * O_NOFOLLOW + O_CLOEXEC, fstat()s the resulting fd, checks owner
+   * and mode bits against the calling euid, and only then reads
+   * bytes from the same fd it validated. No daemon request is ever
+   * sent on the failure path, because this function returns rc != 0
+   * before any wyl_client_* call. */
+  g_autofree gchar *raw = NULL;
+  WyctlTokenFileStatus rc = wyctl_token_file_read (path, &raw);
+  if (rc != WYCTL_TOKEN_FILE_OK) {
+    emit_token_file_diagnostic (rc, path);
     return 2;
   }
 
-  g_autoptr (GError) error = NULL;
-  g_autofree gchar *access_token = NULL;
-  gsize access_token_size = 0;
-  if (!g_file_get_contents (path, &access_token, &access_token_size, &error)) {
-    g_printerr ("wyctl: unable to read access token file\n");
-    return 2;
-  }
-  if (access_token_size == 0) {
-    g_printerr ("wyctl: empty access token file\n");
-    return 2;
-  }
-  if (!normalize_access_token_file (access_token, access_token_size)) {
-    g_printerr ("wyctl: invalid access token file\n");
+  gsize size = strlen (raw);
+  if (!normalize_access_token_file (raw, size)) {
+    g_printerr ("wyctl: invalid access token file: %s\n",
+        path != NULL ? path : "(null)");
     return 2;
   }
 
-  *out_access_token = g_steal_pointer (&access_token);
+  *out_access_token = g_steal_pointer (&raw);
   return 0;
 }
 

--- a/wyrelog/wyctl/wyctl.c
+++ b/wyrelog/wyctl/wyctl.c
@@ -743,23 +743,31 @@ run_policy_decide_request (const WyctlOptions *global_opts,
     return 2;
   *out_result = NULL;
 
-  if (global_opts->daemon_url == NULL || global_opts->daemon_url[0] == '\0') {
+  g_autofree gchar *daemon_url =
+      wyctl_resolve_string_option (global_opts->daemon_url,
+      global_opts->settings, "daemon-url");
+  g_autofree gchar *timeout_ms_arg =
+      wyctl_resolve_uint_option_as_string (global_opts->timeout_ms_arg,
+      global_opts->settings,
+      "default-timeout-ms");
+
+  if (daemon_url == NULL || daemon_url[0] == '\0') {
     g_printerr ("wyctl: missing daemon URL\n");
     return 2;
   }
-  if (!daemon_url_is_valid (global_opts->daemon_url)) {
+  if (!daemon_url_is_valid (daemon_url)) {
     g_printerr ("wyctl: invalid daemon URL\n");
     return 2;
   }
 
   guint timeout_ms = 0;
-  if (!parse_timeout_ms (global_opts->timeout_ms_arg, &timeout_ms)) {
+  if (!parse_timeout_ms (timeout_ms_arg, &timeout_ms)) {
     g_printerr ("wyctl: invalid timeout\n");
     return 2;
   }
 
   g_autoptr (WylClient) client = NULL;
-  if (wyl_client_new (global_opts->daemon_url, &client) != WYRELOG_E_OK ||
+  if (wyl_client_new (daemon_url, &client) != WYRELOG_E_OK ||
       wyl_client_set_bearer_credentials (client, access_token,
           WYL_TENANT_DEFAULT) != WYRELOG_E_OK) {
     g_printerr ("wyctl: invalid policy credentials\n");
@@ -866,8 +874,11 @@ run_policy_decision_command (const WyctlOptions *global_opts,
     g_printerr ("wyctl: missing --resource\n");
     return 2;
   }
+  g_autofree gchar *access_token_file =
+      wyctl_resolve_string_option (opts.access_token_file,
+      global_opts->settings, "access-token-file");
   g_autofree gchar *access_token = NULL;
-  int token_rc = load_access_token_file (opts.access_token_file, &access_token);
+  int token_rc = load_access_token_file (access_token_file, &access_token);
   if (token_rc != 0)
     return token_rc;
 
@@ -929,17 +940,28 @@ run_policy_permission_mutation_command (const WyctlOptions *global_opts,
     return 2;
   }
 
-  if (global_opts->daemon_url == NULL || global_opts->daemon_url[0] == '\0') {
+  g_autofree gchar *daemon_url =
+      wyctl_resolve_string_option (global_opts->daemon_url,
+      global_opts->settings, "daemon-url");
+  g_autofree gchar *timeout_ms_arg =
+      wyctl_resolve_uint_option_as_string (global_opts->timeout_ms_arg,
+      global_opts->settings,
+      "default-timeout-ms");
+  g_autofree gchar *access_token_file =
+      wyctl_resolve_string_option (opts.access_token_file,
+      global_opts->settings, "access-token-file");
+
+  if (daemon_url == NULL || daemon_url[0] == '\0') {
     g_printerr ("wyctl: missing daemon URL\n");
     return 2;
   }
-  if (!daemon_url_is_valid (global_opts->daemon_url)) {
+  if (!daemon_url_is_valid (daemon_url)) {
     g_printerr ("wyctl: invalid daemon URL\n");
     return 2;
   }
 
   guint timeout_ms = 0;
-  if (!parse_timeout_ms (global_opts->timeout_ms_arg, &timeout_ms)) {
+  if (!parse_timeout_ms (timeout_ms_arg, &timeout_ms)) {
     g_printerr ("wyctl: invalid timeout\n");
     return 2;
   }
@@ -962,12 +984,12 @@ run_policy_permission_mutation_command (const WyctlOptions *global_opts,
   }
 
   g_autofree gchar *access_token = NULL;
-  int token_rc = load_access_token_file (opts.access_token_file, &access_token);
+  int token_rc = load_access_token_file (access_token_file, &access_token);
   if (token_rc != 0)
     return token_rc;
 
   g_autoptr (WylClient) client = NULL;
-  if (wyl_client_new (global_opts->daemon_url, &client) != WYRELOG_E_OK ||
+  if (wyl_client_new (daemon_url, &client) != WYRELOG_E_OK ||
       wyl_client_set_bearer_credentials (client, access_token,
           WYL_TENANT_DEFAULT) != WYRELOG_E_OK) {
     g_printerr ("wyctl: invalid policy credentials\n");
@@ -1056,17 +1078,28 @@ run_policy_role_mutation_command (const WyctlOptions *global_opts,
     return 2;
   }
 
-  if (global_opts->daemon_url == NULL || global_opts->daemon_url[0] == '\0') {
+  g_autofree gchar *daemon_url =
+      wyctl_resolve_string_option (global_opts->daemon_url,
+      global_opts->settings, "daemon-url");
+  g_autofree gchar *timeout_ms_arg =
+      wyctl_resolve_uint_option_as_string (global_opts->timeout_ms_arg,
+      global_opts->settings,
+      "default-timeout-ms");
+  g_autofree gchar *access_token_file =
+      wyctl_resolve_string_option (opts.access_token_file,
+      global_opts->settings, "access-token-file");
+
+  if (daemon_url == NULL || daemon_url[0] == '\0') {
     g_printerr ("wyctl: missing daemon URL\n");
     return 2;
   }
-  if (!daemon_url_is_valid (global_opts->daemon_url)) {
+  if (!daemon_url_is_valid (daemon_url)) {
     g_printerr ("wyctl: invalid daemon URL\n");
     return 2;
   }
 
   guint timeout_ms = 0;
-  if (!parse_timeout_ms (global_opts->timeout_ms_arg, &timeout_ms)) {
+  if (!parse_timeout_ms (timeout_ms_arg, &timeout_ms)) {
     g_printerr ("wyctl: invalid timeout\n");
     return 2;
   }
@@ -1089,12 +1122,12 @@ run_policy_role_mutation_command (const WyctlOptions *global_opts,
   }
 
   g_autofree gchar *access_token = NULL;
-  int token_rc = load_access_token_file (opts.access_token_file, &access_token);
+  int token_rc = load_access_token_file (access_token_file, &access_token);
   if (token_rc != 0)
     return token_rc;
 
   g_autoptr (WylClient) client = NULL;
-  if (wyl_client_new (global_opts->daemon_url, &client) != WYRELOG_E_OK ||
+  if (wyl_client_new (daemon_url, &client) != WYRELOG_E_OK ||
       wyl_client_set_bearer_credentials (client, access_token,
           WYL_TENANT_DEFAULT) != WYRELOG_E_OK) {
     g_printerr ("wyctl: invalid policy credentials\n");
@@ -1177,23 +1210,26 @@ parse_guard_options (const gchar *timestamp_arg, const gchar *loc_class,
   return TRUE;
 }
 
+/* Build the bearer-authenticated WylClient used by the fact / graph /
+ * datalog subcommands. All values are already resolved against
+ * GSettings by the caller, so this helper does no fallback lookup. */
 static int
-create_fact_client (const WyctlOptions *global_opts, const gchar *tenant,
-    const gchar *access_token_file, WylClient **out_client)
+create_fact_client (const gchar *daemon_url, const gchar *timeout_ms_arg,
+    const gchar *tenant, const gchar *access_token_file, WylClient **out_client)
 {
   if (out_client == NULL)
     return 2;
   *out_client = NULL;
-  if (global_opts->daemon_url == NULL || global_opts->daemon_url[0] == '\0') {
+  if (daemon_url == NULL || daemon_url[0] == '\0') {
     g_printerr ("wyctl: missing daemon URL\n");
     return 2;
   }
-  if (!daemon_url_is_valid (global_opts->daemon_url)) {
+  if (!daemon_url_is_valid (daemon_url)) {
     g_printerr ("wyctl: invalid daemon URL\n");
     return 2;
   }
   guint timeout_ms = 0;
-  if (!parse_timeout_ms (global_opts->timeout_ms_arg, &timeout_ms)) {
+  if (!parse_timeout_ms (timeout_ms_arg, &timeout_ms)) {
     g_printerr ("wyctl: invalid timeout\n");
     return 2;
   }
@@ -1208,7 +1244,7 @@ create_fact_client (const WyctlOptions *global_opts, const gchar *tenant,
     return token_rc;
 
   g_autoptr (WylClient) client = NULL;
-  if (wyl_client_new (global_opts->daemon_url, &client) != WYRELOG_E_OK ||
+  if (wyl_client_new (daemon_url, &client) != WYRELOG_E_OK ||
       wyl_client_set_bearer_credentials (client, access_token, tenant)
       != WYRELOG_E_OK) {
     g_printerr ("wyctl: invalid fact credentials\n");
@@ -1270,7 +1306,22 @@ run_graph_create (const WyctlOptions *global_opts, gint argc, gchar **argv)
     g_printerr ("wyctl: unexpected graph create argument: %s\n", argv[1]);
     return 2;
   }
-  if (opts.graph == NULL || opts.graph[0] == '\0') {
+  g_autofree gchar *daemon_url =
+      wyctl_resolve_string_option (global_opts->daemon_url,
+      global_opts->settings, "daemon-url");
+  g_autofree gchar *timeout_ms_arg =
+      wyctl_resolve_uint_option_as_string (global_opts->timeout_ms_arg,
+      global_opts->settings,
+      "default-timeout-ms");
+  g_autofree gchar *tenant = wyctl_resolve_string_option (opts.tenant,
+      global_opts->settings, "default-tenant");
+  g_autofree gchar *graph = wyctl_resolve_string_option (opts.graph,
+      global_opts->settings, "default-graph");
+  g_autofree gchar *access_token_file =
+      wyctl_resolve_string_option (opts.access_token_file,
+      global_opts->settings, "access-token-file");
+
+  if (graph == NULL || graph[0] == '\0') {
     g_printerr ("wyctl: missing --graph\n");
     return 2;
   }
@@ -1280,12 +1331,12 @@ run_graph_create (const WyctlOptions *global_opts, gint argc, gchar **argv)
           opts.guard_risk_arg, &guard_timestamp, &guard_risk))
     return 2;
   g_autoptr (WylClient) client = NULL;
-  int client_rc = create_fact_client (global_opts, opts.tenant,
-      opts.access_token_file, &client);
+  int client_rc = create_fact_client (daemon_url, timeout_ms_arg, tenant,
+      access_token_file, &client);
   if (client_rc != 0)
     return client_rc;
-  wyrelog_error_t rc = wyl_client_graph_create (client, opts.tenant,
-      opts.graph, guard_timestamp, opts.guard_loc_class, guard_risk);
+  wyrelog_error_t rc = wyl_client_graph_create (client, tenant,
+      graph, guard_timestamp, opts.guard_loc_class, guard_risk);
   int exit_rc = fact_remote_exit (client, "graph create", rc,
       "graph_create_failed");
   if (exit_rc == 0)
@@ -1391,7 +1442,22 @@ run_fact_schema_register (const WyctlOptions *global_opts, gint argc,
         argv[1]);
     return 2;
   }
-  if (opts.graph == NULL || opts.graph[0] == '\0' || opts.namespace_id == NULL
+  g_autofree gchar *daemon_url =
+      wyctl_resolve_string_option (global_opts->daemon_url,
+      global_opts->settings, "daemon-url");
+  g_autofree gchar *timeout_ms_arg =
+      wyctl_resolve_uint_option_as_string (global_opts->timeout_ms_arg,
+      global_opts->settings,
+      "default-timeout-ms");
+  g_autofree gchar *tenant = wyctl_resolve_string_option (opts.tenant,
+      global_opts->settings, "default-tenant");
+  g_autofree gchar *graph = wyctl_resolve_string_option (opts.graph,
+      global_opts->settings, "default-graph");
+  g_autofree gchar *access_token_file =
+      wyctl_resolve_string_option (opts.access_token_file,
+      global_opts->settings, "access-token-file");
+
+  if (graph == NULL || graph[0] == '\0' || opts.namespace_id == NULL
       || opts.namespace_id[0] == '\0' || opts.relation == NULL ||
       opts.relation[0] == '\0') {
     g_printerr ("wyctl: missing fact schema target option\n");
@@ -1416,14 +1482,14 @@ run_fact_schema_register (const WyctlOptions *global_opts, gint argc,
     return 2;
   }
   g_autoptr (WylClient) client = NULL;
-  int client_rc = create_fact_client (global_opts, opts.tenant,
-      opts.access_token_file, &client);
+  int client_rc = create_fact_client (daemon_url, timeout_ms_arg, tenant,
+      access_token_file, &client);
   if (client_rc != 0) {
     client_fact_columns_clear (columns, n_columns);
     return client_rc;
   }
-  wyrelog_error_t rc = wyl_client_fact_schema_register (client, opts.tenant,
-      opts.graph, opts.namespace_id, opts.relation, schema_version, columns,
+  wyrelog_error_t rc = wyl_client_fact_schema_register (client, tenant,
+      graph, opts.namespace_id, opts.relation, schema_version, columns,
       n_columns, guard_timestamp, opts.guard_loc_class, guard_risk);
   client_fact_columns_clear (columns, n_columns);
   int exit_rc = fact_remote_exit (client, "fact schema register", rc,
@@ -1487,7 +1553,22 @@ run_fact_put (const WyctlOptions *global_opts, gint argc, gchar **argv)
     g_printerr ("wyctl: unexpected fact put argument: %s\n", argv[1]);
     return 2;
   }
-  if (opts.graph == NULL || opts.graph[0] == '\0' || opts.namespace_id == NULL
+  g_autofree gchar *daemon_url =
+      wyctl_resolve_string_option (global_opts->daemon_url,
+      global_opts->settings, "daemon-url");
+  g_autofree gchar *timeout_ms_arg =
+      wyctl_resolve_uint_option_as_string (global_opts->timeout_ms_arg,
+      global_opts->settings,
+      "default-timeout-ms");
+  g_autofree gchar *tenant = wyctl_resolve_string_option (opts.tenant,
+      global_opts->settings, "default-tenant");
+  g_autofree gchar *graph = wyctl_resolve_string_option (opts.graph,
+      global_opts->settings, "default-graph");
+  g_autofree gchar *access_token_file =
+      wyctl_resolve_string_option (opts.access_token_file,
+      global_opts->settings, "access-token-file");
+
+  if (graph == NULL || graph[0] == '\0' || opts.namespace_id == NULL
       || opts.namespace_id[0] == '\0' || opts.relation == NULL ||
       opts.relation[0] == '\0' || opts.batch_id == NULL ||
       opts.batch_id[0] == '\0' || opts.idempotency_key == NULL ||
@@ -1533,13 +1614,13 @@ run_fact_put (const WyctlOptions *global_opts, gint argc, gchar **argv)
           opts.guard_risk_arg, &guard_timestamp, &guard_risk))
     return 2;
   g_autoptr (WylClient) client = NULL;
-  int client_rc = create_fact_client (global_opts, opts.tenant,
-      opts.access_token_file, &client);
+  int client_rc = create_fact_client (daemon_url, timeout_ms_arg, tenant,
+      access_token_file, &client);
   if (client_rc != 0)
     return client_rc;
   g_autoptr (WylClientFactAppendResult) result = NULL;
-  wyrelog_error_t rc = wyl_client_fact_put_batch (client, opts.tenant,
-      opts.graph, opts.namespace_id, opts.relation, schema_version,
+  wyrelog_error_t rc = wyl_client_fact_put_batch (client, tenant,
+      graph, opts.namespace_id, opts.relation, schema_version,
       opts.batch_id, opts.idempotency_key, (const guint8 *) payload,
       payload_size, guard_timestamp, opts.guard_loc_class, guard_risk,
       &result);
@@ -1634,7 +1715,22 @@ run_datalog_query (const WyctlOptions *global_opts, gint argc, gchar **argv)
     g_printerr ("wyctl: unexpected datalog query argument: %s\n", argv[1]);
     return 2;
   }
-  if (opts.graph == NULL || opts.graph[0] == '\0' || opts.query == NULL ||
+  g_autofree gchar *daemon_url =
+      wyctl_resolve_string_option (global_opts->daemon_url,
+      global_opts->settings, "daemon-url");
+  g_autofree gchar *timeout_ms_arg =
+      wyctl_resolve_uint_option_as_string (global_opts->timeout_ms_arg,
+      global_opts->settings,
+      "default-timeout-ms");
+  g_autofree gchar *tenant = wyctl_resolve_string_option (opts.tenant,
+      global_opts->settings, "default-tenant");
+  g_autofree gchar *graph = wyctl_resolve_string_option (opts.graph,
+      global_opts->settings, "default-graph");
+  g_autofree gchar *access_token_file =
+      wyctl_resolve_string_option (opts.access_token_file,
+      global_opts->settings, "access-token-file");
+
+  if (graph == NULL || graph[0] == '\0' || opts.query == NULL ||
       opts.query[0] == '\0') {
     g_printerr ("wyctl: missing datalog query target option\n");
     return 2;
@@ -1654,13 +1750,13 @@ run_datalog_query (const WyctlOptions *global_opts, gint argc, gchar **argv)
           opts.guard_risk_arg, &guard_timestamp, &guard_risk))
     return 2;
   g_autoptr (WylClient) client = NULL;
-  int client_rc = create_fact_client (global_opts, opts.tenant,
-      opts.access_token_file, &client);
+  int client_rc = create_fact_client (daemon_url, timeout_ms_arg, tenant,
+      access_token_file, &client);
   if (client_rc != 0)
     return client_rc;
   g_autofree gchar *json = NULL;
-  wyrelog_error_t rc = wyl_client_datalog_query_json (client, opts.tenant,
-      opts.graph, opts.query, limit, guard_timestamp, opts.guard_loc_class,
+  wyrelog_error_t rc = wyl_client_datalog_query_json (client, tenant,
+      graph, opts.query, limit, guard_timestamp, opts.guard_loc_class,
       guard_risk, &json);
   int exit_rc = fact_remote_exit (client, "datalog query", rc,
       "datalog_query_failed");
@@ -1715,17 +1811,28 @@ run_audit_query (const WyctlOptions *global_opts, gint argc, gchar **argv)
     return 2;
   }
 
-  if (global_opts->daemon_url == NULL || global_opts->daemon_url[0] == '\0') {
+  g_autofree gchar *daemon_url =
+      wyctl_resolve_string_option (global_opts->daemon_url,
+      global_opts->settings, "daemon-url");
+  g_autofree gchar *timeout_ms_arg =
+      wyctl_resolve_uint_option_as_string (global_opts->timeout_ms_arg,
+      global_opts->settings,
+      "default-timeout-ms");
+  g_autofree gchar *access_token_file =
+      wyctl_resolve_string_option (opts.access_token_file,
+      global_opts->settings, "access-token-file");
+
+  if (daemon_url == NULL || daemon_url[0] == '\0') {
     g_printerr ("wyctl: missing daemon URL\n");
     return 2;
   }
-  if (!daemon_url_is_valid (global_opts->daemon_url)) {
+  if (!daemon_url_is_valid (daemon_url)) {
     g_printerr ("wyctl: invalid daemon URL\n");
     return 2;
   }
 
   guint timeout_ms = 0;
-  if (!parse_timeout_ms (global_opts->timeout_ms_arg, &timeout_ms)) {
+  if (!parse_timeout_ms (timeout_ms_arg, &timeout_ms)) {
     g_printerr ("wyctl: invalid timeout\n");
     return 2;
   }
@@ -1753,12 +1860,12 @@ run_audit_query (const WyctlOptions *global_opts, gint argc, gchar **argv)
   }
 
   g_autofree gchar *access_token = NULL;
-  int token_rc = load_access_token_file (opts.access_token_file, &access_token);
+  int token_rc = load_access_token_file (access_token_file, &access_token);
   if (token_rc != 0)
     return token_rc;
 
   g_autoptr (WylClient) client = NULL;
-  if (wyl_client_new (global_opts->daemon_url, &client) != WYRELOG_E_OK ||
+  if (wyl_client_new (daemon_url, &client) != WYRELOG_E_OK ||
       wyl_client_set_bearer_credentials (client, access_token,
           WYL_TENANT_DEFAULT) != WYRELOG_E_OK) {
     g_printerr ("wyctl: invalid audit credentials\n");


### PR DESCRIPTION
## Summary

Closes #320.

Lands the operator-static defaults and bearer-token hardening requested in the issue. Eight atomic commits, each independently buildable and tested.

- New GSettings schema `org.wyrelog.wyctl` covers `daemon-url`, `default-tenant`, `default-graph`, `access-token-file`, `default-timeout-ms`, `default-guard-loc-class`, `default-guard-risk`, `default-guard-timestamp-mode`. CLI > GSettings > unset precedence; an empty CLI value is treated as a deliberate operator value, not absence.
- `WYCTL_DISABLE_GSETTINGS=1` env kill switch short-circuits the lookup for CI containers and reproducible runs (literal string `1` only).
- Token-file safety helper opens with `O_NOFOLLOW | O_CLOEXEC | O_RDONLY | O_NOCTTY`, fstats the resulting fd, checks `S_ISREG`, `st.st_uid == geteuid()`, and `(S_IRWXG | S_IRWXO) == 0`, then reads bounded to 64 KiB from the same fd. No second path-based syscall. Embedded NULs and oversize files are refused.
- Typed `WyctlTokenFileStatus` diagnostic table prints only the path, never the token bytes. The check is the chokepoint every subcommand reaches before any `wyl_client_*` call.
- Windows path validates `FILE_ATTRIBUTE_REPARSE_POINT` (rejected) and `FILE_ATTRIBUTE_READONLY` (required) via `GetFileAttributesW` + `CreateFileW`. Pure classifier `wyctl_token_file_classify_windows_attrs(guint32)` is compiled and unit-tested on every platform so Linux CI exercises the Windows rejection rules with synthetic inputs.
- Operator runbook gets the full configuration + permission + diagnostic-catalog section, including the intermediate-path symlink scope statement, the kill-switch strict-match note, and POSIX/Windows setup recipes.

## Behavioural notes for reviewers / downstream users

- Backward-compatible when CLI flags are provided.
- Backward-*incompatible* for previously-unsafe token-file setups (mode 0644, foreign owner, terminal symlink) — these now fail with rc=2 and a typed diagnostic. The runbook gives the `chmod 0600` + `chown` remediation.
- Intermediate-path component symlinks are out of scope (would require Linux-only `RESOLVE_BENEATH`); the runbook calls this out.
- Windows ACL validation is reserved (the diagnostic slot exists, no caller emits it yet) and will land in a follow-up.
- Guard-* GSettings defaults (`default-guard-loc-class`, `default-guard-risk`, `default-guard-timestamp-mode`) are declared in the schema but not yet wired into per-subcommand resolution — they ship as scaffolding for a follow-up that owns the sentinel + enum-mode logic.

## Commits in this series

1. `wyctl: install GSettings schema for defaults` — schema XML + meson install + build-tree compile + harness test.
2. `wyctl: add CLI/GSettings option resolver` — `wyctl-config.{c,h}` + 12 unit tests.
3. `wyctl: resolve status flags via GSettings` — exemplar wiring in `run_status`; 3 subprocess precedence tests.
4. `wyctl: thread option resolver through all commands` — fan out to policy/audit/fact/graph/datalog subcommands.
5. `wyctl: reshape resolver fan-out tests for non-status diagnostics` — repair commit that fixed and extended the parametrized test contract.
6. `wyctl: harden token-file reads on POSIX` — typed safety helper + 14 unit cases + 2 integration cases asserting no HTTP before reject.
7. `wyctl: validate Windows token-file attributes` — pure attrs classifier + Win32 API path; 3 cross-platform tests.
8. `docs: document wyctl GSettings and token-file safety` — operator runbook section.

## Test plan

- [x] `meson test -C builddir wyctl-gschema` — 3 keys/types/defaults assertions.
- [x] `meson test -C builddir wyctl-config` — 12 resolver semantics tests.
- [x] `meson test -C builddir wyctl-token-file` — 17 token-file safety tests (14 POSIX + 3 Windows-attrs).
- [x] `meson test -C builddir wyctl-basic` — 35 sub-tests including the 4 new GSettings-supplies-daemon-url cases (status / policy check / audit query / fact put / datalog query) and 2 safety-reject-prevents-HTTP cases.
- [x] `meson test -C builddir wyctl-policy-daemon wyctl-status-daemon client-smoke` — pre-existing wyctl integration suite still green.
- [x] Pre-existing failures (`wyrelogd-profiles`, `wyrelogd-bootstrap-admin`, `template-tree`, `engine`, `valgrind-smoke`) are unchanged from `main` and not introduced by this PR.
- [x] `./tools/gst-indent` is stable on every modified C/H file.
- [x] No `Co-Authored-By`, no emoji, no persona/agent identity leaks in any commit message.

## Follow-up issues recommended (out of scope for #320)

- Wire `WYCTL_TOKEN_FILE_WINDOWS_ACL_UNAVAILABLE` to the actual ACL check.
- `openat2(RESOLVE_BENEATH)` for intermediate-path symlink rejection on Linux.
- Guard-* per-subcommand resolution with the `none`/`now` timestamp mode and `-1` risk sentinel.
- Windows operator recipe assumes `gsettings` CLI; document the registry/keyfile-backend alternative for vanilla Windows installs.