### PR TITLE
Bump libchronoid to 1.0.2

### DIFF
--- a/subprojects/libchronoid.wrap
+++ b/subprojects/libchronoid.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 url = https://github.com/semantic-reasoning/libchronoid.git
-revision = v1.0.1
+revision = v1.0.2
 depth = 1


### PR DESCRIPTION
## Summary
- Bump the libchronoid Meson wrap from v1.0.1 to v1.0.2.

## Test
- meson setup builddir --wipe -Denable_tpm=disabled -Denable_audit=enabled -Dduckdb_source=prebuilt
- meson test -C builddir --print-errorlogs --suite wyrelog