### PR TITLE
Clarify schema-backed fact retraction contract

### DIFF
--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -333,6 +333,61 @@ wyctl --daemon-url "$BASE_URL" datalog query \
   --guard-timestamp $(date +%s) --guard-loc-class trusted --guard-risk 29
 ```
 
+Fact mutation is schema-registered: append, retract, and forget operate only on
+relations registered through `fact schema register`. The daemon does not support
+raw Datalog atom deletion endpoints such as `DELETE /api/facts/fact(1)` or
+ad-hoc deletion of `fact(1)` without a registered relation schema. Attempts to
+mutate a relation before registering its schema fail with
+`fact_schema_not_found` on the schema-backed `/facts/<tenant>/<graph>/<relation>`
+routes.
+
+The following unary `fact(V)` flow shows the required contract for a registered
+`fact(value:int64)` relation:
+
+```sh
+GRAPH=unary
+
+wyctl --daemon-url "$BASE_URL" graph create \
+  --tenant "$TENANT" --graph "$GRAPH" \
+  --access-token-file "$TOKEN" \
+  --guard-timestamp $(date +%s) --guard-loc-class trusted --guard-risk 29
+
+wyctl --daemon-url "$BASE_URL" fact schema register \
+  --tenant "$TENANT" --graph "$GRAPH" \
+  --namespace examples --relation fact --schema-version 1 \
+  --columns value:int64 --max-rows 1000 \
+  --access-token-file "$TOKEN" \
+  --guard-timestamp $(date +%s) --guard-loc-class trusted --guard-risk 29
+
+printf 'value\n1\n2\n3\n' >/tmp/fact.tsv
+curl -fsS -X POST \
+  -H "Authorization: Bearer $(cat "$TOKEN")" \
+  --data-binary @/tmp/fact.tsv \
+  "$BASE_URL/facts/$TENANT/$GRAPH/fact:append?tenant=$TENANT&namespace=examples&schema_version=1&batch_id=fact-1&idempotency_key=fact-1&guard_timestamp=$(date +%s)&guard_loc_class=trusted&guard_risk=29"
+
+wyctl --daemon-url "$BASE_URL" datalog query \
+  --tenant "$TENANT" --graph "$GRAPH" \
+  --query 'fact(V)' --output json --limit 10 \
+  --access-token-file "$TOKEN" \
+  --guard-timestamp $(date +%s) --guard-loc-class trusted --guard-risk 29
+
+printf 'value\n1\n' >/tmp/fact-retract.tsv
+curl -fsS -X POST \
+  -H "Authorization: Bearer $(cat "$TOKEN")" \
+  --data-binary @/tmp/fact-retract.tsv \
+  "$BASE_URL/facts/$TENANT/$GRAPH/fact:retract?tenant=$TENANT&namespace=examples&schema_version=1&batch_id=fact-r1&idempotency_key=fact-r1&guard_timestamp=$(date +%s)&guard_loc_class=trusted&guard_risk=29"
+
+wyctl --daemon-url "$BASE_URL" datalog query \
+  --tenant "$TENANT" --graph "$GRAPH" \
+  --query 'fact(V)' --output json --limit 10 \
+  --access-token-file "$TOKEN" \
+  --guard-timestamp $(date +%s) --guard-loc-class trusted --guard-risk 29
+```
+
+The first query returns values `1`, `2`, and `3`. The query after the retract
+returns only `2` and `3`; the raw atom `fact(1)` is not deleted through a
+separate `/api/facts` API.
+
 Omit `--max-rows` during schema registration to keep the default 1000-row
 Datalog query cap. Set it explicitly for larger materialized JSON queries;
 accepted values are 1 through 1000000, and `wyctl datalog query --limit`

--- a/tests/test-daemon-http-facts.c
+++ b/tests/test-daemon-http-facts.c
@@ -536,6 +536,95 @@ check_fact_http_contract (WylHandle *handle, const gchar *base_url)
       strstr (body, "\"truncated\":true") == NULL)
     return 354;
 
+  g_clear_pointer (&body, g_free);
+  g_autofree gchar *create_unary_query = g_strdup_printf
+      ("tenant=%s&graph=unary&%s", WYL_TENANT_DEFAULT, FACT_GUARD);
+  rc = send_raw (session, "POST", base_url, "/graphs/create",
+      create_unary_query, admin_token, NULL, &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 200 || strstr (body, "\"created\":true") == NULL)
+    return 360;
+
+  g_clear_pointer (&body, g_free);
+  g_autofree gchar *unary_missing_schema_query = g_strdup_printf
+      ("tenant=%s&namespace=examples&schema_version=1&batch_id=fact-raw-1&"
+      "idempotency_key=fact-raw-1&%s", WYL_TENANT_DEFAULT, FACT_GUARD);
+  rc = send_raw (session, "POST", base_url,
+      "/facts/__wr_default/unary/fact:retract", unary_missing_schema_query,
+      admin_token, "value\n1\n", &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 404 || strstr (body, "\"fact_schema_not_found\"") == NULL)
+    return 361;
+
+  const gchar *unary_schema_body =
+      "column_name\tcolumn_type\tnullable\tvisible\n"
+      "value\tint64\tfalse\ttrue\n";
+  g_clear_pointer (&body, g_free);
+  g_autofree gchar *unary_schema_query = g_strdup_printf
+      ("tenant=%s&graph=unary&namespace=examples&relation=fact&"
+      "schema_version=1&%s", WYL_TENANT_DEFAULT, FACT_GUARD);
+  rc = send_raw (session, "POST", base_url, "/facts/schema/register",
+      unary_schema_query, admin_token, unary_schema_body, &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 200 || strstr (body, "\"ok\":true") == NULL)
+    return 362;
+
+  g_clear_pointer (&body, g_free);
+  g_autofree gchar *unary_append_query = g_strdup_printf
+      ("tenant=%s&namespace=examples&schema_version=1&batch_id=fact-1&"
+      "idempotency_key=fact-1&%s", WYL_TENANT_DEFAULT, FACT_GUARD);
+  rc = send_raw (session, "POST", base_url,
+      "/facts/__wr_default/unary/fact:append", unary_append_query,
+      admin_token, "value\n1\n2\n3\n", &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 200 || strstr (body, "\"inserted\":true") == NULL)
+    return 363;
+
+  g_clear_pointer (&body, g_free);
+  g_autofree gchar *unary_datalog_query = g_strdup_printf ("tenant=%s&%s",
+      WYL_TENANT_DEFAULT, FACT_GUARD);
+  rc = send_raw (session, "POST", base_url,
+      "/datalog/__wr_default/unary/query", unary_datalog_query, admin_token,
+      "{\"query\":\"fact(V)\",\"output\":\"json\",\"limit\":10}",
+      &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 200 || strstr (body, "\"relation\":\"fact\"") == NULL ||
+      strstr (body, "\"columns\":[\"V\"]") == NULL ||
+      strstr (body, "{\"V\":1}") == NULL ||
+      strstr (body, "{\"V\":2}") == NULL ||
+      strstr (body, "{\"V\":3}") == NULL ||
+      strstr (body, "\"row_count\":3") == NULL)
+    return 364;
+
+  g_clear_pointer (&body, g_free);
+  g_autofree gchar *unary_retract_query = g_strdup_printf
+      ("tenant=%s&namespace=examples&schema_version=1&batch_id=fact-r1&"
+      "idempotency_key=fact-r1&%s", WYL_TENANT_DEFAULT, FACT_GUARD);
+  rc = send_raw (session, "POST", base_url,
+      "/facts/__wr_default/unary/fact:retract", unary_retract_query,
+      admin_token, "value\n1\n", &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 200 || strstr (body, "\"inserted\":true") == NULL)
+    return 365;
+
+  g_clear_pointer (&body, g_free);
+  rc = send_raw (session, "POST", base_url,
+      "/datalog/__wr_default/unary/query", unary_datalog_query, admin_token,
+      "{\"query\":\"fact(V)\",\"output\":\"json\",\"limit\":10}",
+      &status, &body);
+  if (rc != 0)
+    return rc;
+  if (status != 200 || strstr (body, "\"row_count\":2") == NULL ||
+      strstr (body, "{\"V\":2}") == NULL ||
+      strstr (body, "{\"V\":3}") == NULL || strstr (body, "{\"V\":1}") != NULL)
+    return 366;
+
   /* Retract case 1: normal retract of o-2 -> 200 inserted=true. */
   g_clear_pointer (&body, g_free);
   g_autofree gchar *retract_query = g_strdup_printf


### PR DESCRIPTION
## Summary
- Document that HTTP fact append/retract/forget operate on schema-registered fact-store relations, not raw Datalog atoms.
- Add a unary fact(V) example showing how to model fact(1), fact(2), fact(3) as a registered fact(value:int64) relation and retract fact(1).
- Add HTTP integration coverage for missing-schema retract and schema-backed unary append/query/retract/query behavior.

Closes #328

## Review flow
- Architect and critic agreed not to implement raw atom deletion or /api/facts/fact(1), because that would require a separate parser, typing, authorization, idempotency, audit, and replay contract.
- Implementer produced one atomic docs/test commit.
- Reviewer reported no findings.
- Architect and critic both approved the final commit.

## Test
- git diff --check
- meson test -C builddir-facts daemon-http-facts --print-errorlogs