### PR TITLE
feat(auth): TOTP MFA validator + admin enrollment flow

### DIFF
--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -240,6 +240,234 @@ wyctl --daemon-url http://127.0.0.1:8765 audit query \
   --access-token-file /run/wyrelog/operator.token
 ```
 
+## TOTP Multi-Factor Authentication (MFA)
+
+Wyrelog ships a built-in RFC 6238 TOTP validator so a fresh install can
+reach an authenticated bearer token without an external IdP. Enrollments
+live as `totp_enrollment` facts in the encrypted policy store, sealed
+through the same KeyProvider as every other policy fact. There is no
+separate MFA database, no shared secret leaves the policy store, and no
+user-side backup codes are supported in v0 — recovery is admin reset only.
+
+The flow assumes the policy store, KeyProvider, and audit subsystem are
+already configured per the sections above.
+
+### First-Install Bootstrap
+
+The supported first-install path threads MFA enrollment off the
+bootstrap admin grant. Start `wyrelogd` with both bootstrap flags:
+
+```sh
+wyrelogd --production \
+  --profile system \
+  --template-dir /usr/share/wyrelog/access \
+  --policy-db /var/lib/wyrelog/system/policy.sqlite \
+  --policy-keyprovider file:/etc/wyrelog/system/policy.key \
+  --audit-db /var/log/wyrelog/system/audit.duckdb \
+  --bootstrap-admin-subject=alice \
+  --bootstrap-admin-allow-skip-mfa
+```
+
+At this point `alice` can log in through `/auth/login?…&skip_mfa=true`
+because the bootstrap flag installed the `wr.login.skip_mfa` direct
+permission. Enroll `alice`'s TOTP factor from an operator shell that has
+read access to the policy store and the KeyProvider:
+
+```sh
+wyctl mfa enroll \
+  --subject alice \
+  --store /var/lib/wyrelog/system/policy.sqlite \
+  --keyprovider file:/etc/wyrelog/system/policy.key
+```
+
+`wyctl mfa enroll` prints the `otpauth://` URI and the base32 secret on
+stdout, then prompts on stderr for the current 6-digit code. The
+operator scans the URI in an authenticator app (Google Authenticator,
+Authy, 1Password, Bitwarden — all consume the same URI format) and
+types the displayed code. On a valid code the enrollment fact lands,
+and the `wr.login.skip_mfa` permission on the bootstrap subject is
+**auto-revoked in the same transaction**. From this point on, `alice`
+must present a TOTP code to log in; the bootstrap escape no longer
+works for that subject.
+
+The bootstrap auto-revoke step is intentionally one-shot. Enrolling any
+non-bootstrap subject is a no-op for the revoke step because they
+never held `wr.login.skip_mfa` in the first place.
+
+### Enrolling Additional Admins
+
+Use the same command for every subsequent admin. The bootstrap
+auto-revoke branch is skipped silently for subjects that do not hold
+`wr.login.skip_mfa`:
+
+```sh
+wyctl mfa enroll \
+  --subject bob \
+  --store /var/lib/wyrelog/system/policy.sqlite \
+  --keyprovider file:/etc/wyrelog/system/policy.key
+```
+
+The subject must already exist as a principal in the policy store
+(typically through `wyctl policy role-grant`). Enrollment does not
+create principals — it only attaches a TOTP factor to one.
+
+### Recovery and Reset
+
+There are no user-side backup codes in v0. The only recovery path is
+an operator with direct access to the policy store and the KeyProvider
+running `wyctl mfa reset`:
+
+```sh
+wyctl mfa reset \
+  --subject alice \
+  --store /var/lib/wyrelog/system/policy.sqlite \
+  --keyprovider file:/etc/wyrelog/system/policy.key
+```
+
+`wyctl mfa reset` deletes the existing enrollment fact and runs a fresh
+enroll flow against the same subject. The new seed and otpauth URI are
+emitted on stdout exactly as in the first-install case. Because the
+enrollment row is replaced, the failure counter and any active lockout
+state are implicitly reset.
+
+**Abort semantics**: if the operator aborts mid-reset — EOF on the
+prompt, an invalid code, or any other non-zero exit — the subject is
+left **unenrolled**. The reset is not "undone" back to the previous
+seed; the previous enrollment was already deleted by the first
+mutation. Operators should not assume an aborted reset preserves the
+old enrollment. Re-run `wyctl mfa enroll` against the same subject to
+finish the recovery.
+
+### Atomicity and Re-run Safety
+
+`wyctl mfa enroll` wraps every mutation (enrollment fact insert,
+bootstrap permission revoke, audit row) in a single policy-store
+savepoint. Partial failure rolls back cleanly: if the enroll command
+exits non-zero, no state changed.
+
+`wyctl mfa reset` does **not** have that property. The reset path
+deletes the prior enrollment row as its first action and commits that
+delete independently, **before** the new enroll flow's savepoint
+opens. This is a deliberate contract, not a UX edge case: the moment
+an operator runs `wyctl mfa reset`, the prior TOTP seed is gone and
+cannot be recovered. If the follow-on enroll is aborted — EOF on the
+prompt, a wrong code, any non-zero exit — the subject is left
+**unenrolled**, exactly as documented under "Abort semantics" above.
+Operators running `wyctl mfa reset` during incident response must
+treat the delete as irreversible.
+
+The contract is:
+
+- If `wyctl mfa enroll` exits non-zero, re-run the command. No state
+  changed; the bootstrap auto-revoke step is idempotent for an
+  already-revoked subject and a no-op for non-bootstrap subjects.
+- If `wyctl mfa reset` exits non-zero, the prior enrollment row has
+  already been deleted. The subject is unenrolled. Re-run `wyctl mfa
+  enroll` against the same subject to finish the recovery.
+
+There is no separate "rollback" command — re-running `wyctl mfa
+enroll` is the recovery path for both failure modes.
+
+### Lockout Behavior
+
+The TOTP validator drives the existing principal FSM:
+
+- After **5 consecutive wrong codes** the principal transitions to
+  `LOCKED`. `/auth/mfa/verify` returns `429 mfa_locked` until the lock
+  expires.
+- After **15 minutes**, the lock auto-clears and the principal state
+  returns to `UNVERIFIED`. The user must re-login from `/auth/login`
+  to obtain a fresh `mfa_required` session token before retrying
+  `/auth/mfa/verify`.
+- `wyctl mfa reset` implicitly clears the failure counter because the
+  enrollment row is replaced. Operators do not have a separate
+  "unlock without reseed" command in v0.
+
+Lockout state is durable across daemon restarts — it lives in the
+policy store, not in process memory.
+
+### HTTP API Summary
+
+The login flow is two HTTP calls. `/auth/login` returns a short-lived
+session token that cannot mint access or refresh tokens on its own;
+`/auth/mfa/verify` exchanges that session token plus a current TOTP
+code for the access and refresh tokens.
+
+```
+POST /auth/login?username=<subject>&tenant=<tenant>
+  -> 200 { session_token, principal_state: "mfa_required" }
+
+POST /auth/mfa/verify?session_token=<token>&code=NNNNNN
+  -> 200 { access_token, refresh_token, principal_state: "authenticated" }
+  -> 400 invalid_mfa_request   (malformed query)
+  -> 400 tenant_sealed | tenant_invalid
+                               (session's tenant no longer active)
+  -> 401 mfa_auth_required     (missing or unknown session token)
+  -> 401 mfa_invalid           (wrong code)
+  -> 401 enrollment_required   (subject has no totp_enrollment fact)
+  -> 429 mfa_locked            (5+ failures within 15 min)
+  -> 500 mfa_verify_failed     (counter persistence IO error)
+```
+
+`/auth/login` does not enumerate enrolled vs unenrolled subjects: an
+unenrolled but otherwise-valid subject still receives an `mfa_required`
+session, and only `/auth/mfa/verify` surfaces `enrollment_required`.
+
+**Bootstrap escape**: `POST /auth/login?…&skip_mfa=true` works **only**
+for subjects holding the `wr.login.skip_mfa` permission. After the
+bootstrap admin completes `wyctl mfa enroll`, that permission is
+auto-revoked and the escape no longer works for the bootstrap subject.
+Any other subject that has never held `wr.login.skip_mfa` is
+unaffected — the escape was never a general login mode.
+
+### Stdout Secrecy
+
+`wyctl mfa enroll` and `wyctl mfa reset` write the `otpauth://` URI and
+the base32 secret to **stdout**. The prompt for the current code and
+all diagnostics go to **stderr**. Do not pipe stdout to a log file, a
+journal, or a CI artifact — the seed bytes leak through that path.
+
+A typical safe operator session keeps stdout attached to the
+controlling terminal and lets the authenticator app consume the
+displayed URI directly. If stdout must be captured for tooling, treat
+the captured file as a sealed secret with the same handling as the
+KeyProvider key file.
+
+### otpauth URI Compatibility
+
+The emitted URI follows the Google Authenticator key-URI format:
+
+```
+otpauth://totp/wyrelog:<subject>?secret=BASE32&issuer=wyrelog&algorithm=SHA1&digits=6&period=30
+```
+
+`algorithm=SHA1`, `digits=6`, `period=30`, ±1 step skew. The format is
+consumed without modification by Google Authenticator, Authy,
+1Password, Bitwarden, and any other authenticator that accepts the
+Google key-URI shape. ASCII QR rendering inside `wyctl` is intentionally
+out of scope — operators who want a QR can pipe the URI through
+`qrencode -t ANSI` or paste it into the authenticator app's manual
+import flow.
+
+### Threat-Model Notes
+
+- **Scope**: the built-in validator handles only the TOTP factor.
+  Bearer-token issuance, storage, and revocation are unchanged from
+  the rest of the daemon's auth path — access and refresh tokens are
+  minted by the daemon and held in its in-memory state map. Token
+  revocation is still "restart the daemon"; there is no
+  per-token revoke API in v0.
+- **Backup codes**: explicitly not supported in v0. The lost-device
+  recovery path is a privileged operator running `wyctl mfa reset`.
+  Operators should plan for that access (a second admin with store +
+  KeyProvider access, or a documented break-glass procedure) before
+  enrolling MFA on the only admin account.
+- **Store-access privilege**: anyone with write access to the policy
+  store path AND the KeyProvider can mint or reset any subject's TOTP
+  enrollment. The encrypted policy store is the trust anchor for MFA;
+  protect the KeyProvider key file with the same care as the bootstrap
+  marker.
+
 ## Datalog Product Flow
 
 Wyrelog is a Datalog storage and inference engine. The packaged access-control

--- a/templates/access/sqlite-schema.sql
+++ b/templates/access/sqlite-schema.sql
@@ -542,3 +542,26 @@ CREATE TABLE IF NOT EXISTS policy_signatures (
     signed_by      TEXT    NOT NULL,   -- security_officer identifier
     signed_at      INTEGER NOT NULL    -- Unix epoch (seconds)
 );
+
+-- ---------------------------------------------------------------------------
+-- Table: totp_enrollments
+-- Per-principal TOTP enrollment (issue #331).  One row per subject
+-- holds the RFC 6238 SHA-1 seed plus the replay watermark.  The seed
+-- is the raw 20-byte BLOB; encryption-at-rest is provided by the
+-- enclosing policy-store XChaCha20-Poly1305 envelope.
+--
+--   subject_id          principal that owns this enrollment (PK)
+--   secret_blob         20-byte SHA-1 seed
+--   last_verified_step  replay watermark; INT64_MIN sentinel means
+--                       "never verified" (no native u64 in SQLite, so
+--                       the u64 step counter is cast to gint64)
+--   enrolled_at         unix seconds at enrollment time
+--   id_uuidv7           libchronoid UUIDv7 minted via wyl_id_new
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS totp_enrollments (
+    subject_id         TEXT    PRIMARY KEY,
+    secret_blob        BLOB    NOT NULL,
+    last_verified_step INTEGER NOT NULL,
+    enrolled_at        INTEGER NOT NULL,
+    id_uuidv7          TEXT    NOT NULL
+);

--- a/templates/access/sqlite-schema.sql
+++ b/templates/access/sqlite-schema.sql
@@ -227,9 +227,15 @@ CREATE INDEX IF NOT EXISTS idx_permission_state_events_event
 -- Durable principal authentication state mirrored into principal_state/2.
 -- ---------------------------------------------------------------------------
 CREATE TABLE IF NOT EXISTS principal_states (
-    subject_id TEXT PRIMARY KEY,
-    state      TEXT    NOT NULL,
-    updated_at INTEGER
+    subject_id           TEXT    PRIMARY KEY,
+    state                TEXT    NOT NULL,
+    updated_at           INTEGER,
+    -- Issue #331 commit 5: failed_attempt_count is the count of
+    -- consecutive verify failures since the last successful MFA verify
+    -- (or admin reset); locked_at is the unix-epoch seconds the row
+    -- entered the LOCKED state (NULL when not locked).
+    failed_attempt_count INTEGER NOT NULL DEFAULT 0,
+    locked_at            INTEGER
 );
 
 CREATE INDEX IF NOT EXISTS idx_principal_states_state

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -619,6 +619,14 @@ test_jwt = executable('test-jwt',
 
 test('jwt', test_jwt)
 
+test_totp = executable('test-totp',
+  'test-totp.c',
+  include_directories : [wyrelog_inc, include_directories('../wyrelog')],
+  dependencies : [wyrelog_dep, sodium_dep],
+)
+
+test('totp', test_totp)
+
 test_handle_id = executable('test-handle-id',
   'test-handle-id.c',
   dependencies : [wyrelog_dep],

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -159,6 +159,38 @@ if build_client
     )
   endif
 
+  test_daemon_http_mfa_c_args = [
+    '-DWYL_HAS_DAEMON_HTTP',
+    '-DWYL_TEST_DAEMON_HTTP',
+    '-DWYL_TEST_TEMPLATE_DIR="' + meson.project_source_root() / 'templates' / 'access' + '"',
+  ]
+  test_daemon_http_mfa_deps = [
+    wyrelog_dep,
+    wyrelog_client_dep,
+    libsoup_dep,
+    sodium_dep,
+    sqlite_dep,
+  ]
+  if get_option('enable_fact_store').allowed()
+    test_daemon_http_mfa_c_args += '-DWYL_HAS_FACT_STORE'
+    test_daemon_http_mfa_deps += duckdb_dep
+  endif
+  if get_option('enable_audit').allowed()
+    test_daemon_http_mfa_c_args += '-DWYL_HAS_AUDIT'
+    test_daemon_http_mfa_deps += duckdb_dep
+  endif
+  test_daemon_http_mfa = executable('test-daemon-http-mfa',
+    'test-daemon-http-mfa.c',
+    '../wyrelog/daemon/http.c',
+    '../wyrelog/daemon/delta.c',
+    '../wyrelog/daemon/fact-status.c',
+    c_args : test_daemon_http_mfa_c_args,
+    include_directories : [wyrelog_inc, include_directories('../wyrelog')],
+    dependencies : test_daemon_http_mfa_deps,
+  )
+
+  test('daemon-http-mfa', test_daemon_http_mfa, timeout : 60)
+
   if get_option('enable_fact_store').allowed()
     test_daemon_http_facts_c_args = [
       '-DWYL_HAS_DAEMON_HTTP',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -303,6 +303,20 @@ if build_client and host_machine.system() != 'windows'
     timeout : 60,
   )
 
+  test_wyctl_mfa = executable('test-wyctl-mfa',
+    'test-wyctl-mfa.c',
+    c_args : [
+      '-DWYL_TEST_WYCTL_PATH="' + wyctl_exe.full_path() + '"',
+    ],
+    include_directories : [wyrelog_inc, include_directories('../wyrelog')],
+    dependencies : [wyrelog_dep, glib_dep, gio_dep, sqlite_dep, sodium_dep],
+  )
+
+  test('wyctl-mfa', test_wyctl_mfa,
+    depends : [wyctl_exe],
+    timeout : 60,
+  )
+
   # End-to-end: drives wyctl as a subprocess against an in-process daemon
   # so the policy mutation subcommands exercise the full client -> HTTP
   # -> handler path, including bearer-only credentials and the privileged

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -436,6 +436,17 @@ test_policy_store_totp = executable('test-policy-store-totp',
 
 test('policy-store-totp', test_policy_store_totp)
 
+test_daemon_mfa_validator = executable('test-daemon-mfa-validator',
+  'test-daemon-mfa-validator.c',
+  c_args : [
+    '-DWYL_TEST_TEMPLATE_DIR="' + meson.project_source_root() / 'templates' / 'access' + '"',
+  ],
+  include_directories : [wyrelog_inc, include_directories('../wyrelog')],
+  dependencies : [wyrelog_dep, sqlite_dep, sodium_dep],
+)
+
+test('daemon-mfa-validator', test_daemon_mfa_validator)
+
 test_dl_static = executable('test-dl-static',
   'test-dl-static.c',
   dependencies : [wyrelog_dep],

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -428,6 +428,14 @@ test_policy_store_toctou = executable('test-policy-store-toctou',
 
 test('policy-store-toctou', test_policy_store_toctou)
 
+test_policy_store_totp = executable('test-policy-store-totp',
+  'test-policy-store-totp.c',
+  include_directories : include_directories('../wyrelog'),
+  dependencies : [wyrelog_dep, sqlite_dep],
+)
+
+test('policy-store-totp', test_policy_store_totp)
+
 test_dl_static = executable('test-dl-static',
   'test-dl-static.c',
   dependencies : [wyrelog_dep],

--- a/tests/test-daemon-http-mfa.c
+++ b/tests/test-daemon-http-mfa.c
@@ -1,0 +1,627 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+/*
+ * HTTP integration tests for /auth/mfa/verify (issue #331 commit 4).
+ *
+ * The handler under test is mfa_verify_handler in wyrelog/daemon/http.c.
+ * The route is registered next to the other auth handlers so this
+ * test boots the same SoupServer harness as test-daemon-http-decide.
+ *
+ * Footgun coverage these tests exist to lock down:
+ *   F2 (no secret echo): error JSON bodies surface only error codes;
+ *     this file asserts the submitted code never appears in the body.
+ *   F3 (replay): two verifies with the same code on the same session
+ *     must yield (200, 401) and never (200, 200).
+ *   F5 (enumeration): any session_token that fails to resolve to a
+ *     live mfa_required session returns the SAME error code, regardless
+ *     of whether the token is unknown, malformed, or in a wrong state.
+ */
+
+#if !defined(_WIN32) && !defined(_XOPEN_SOURCE)
+#define _XOPEN_SOURCE 700
+#endif
+
+#include <stdint.h>
+#include <string.h>
+#include <time.h>
+
+#include <glib.h>
+#include <libsoup/soup.h>
+
+#include "auth/mfa-validator.h"
+#include "auth/totp.h"
+#include "daemon/delta.h"
+#include "daemon/http.h"
+#include "wyrelog/policy/store-private.h"
+#include "wyrelog/session.h"
+#include "wyrelog/wyl-common-private.h"
+#include "wyrelog/wyl-handle-private.h"
+#include "wyrelog/wyrelog.h"
+
+#ifndef WYL_TEST_TEMPLATE_DIR
+#error "WYL_TEST_TEMPLATE_DIR must be defined by the build."
+#endif
+
+typedef struct
+{
+  SoupServer *server;
+  GMainLoop *loop;
+} TestHttpServer;
+
+static const guint8 MFA_TEST_SEED[WYL_TOTP_SEED_BYTES] = {
+  0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38,
+  0x39, 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36,
+  0x37, 0x38, 0x39, 0x30,
+};
+
+static gpointer
+test_http_server_thread (gpointer data)
+{
+  TestHttpServer *http = data;
+  g_main_loop_run (http->loop);
+  return NULL;
+}
+
+static gchar *
+extract_json_string (const gchar *body, const gchar *name)
+{
+  g_autofree gchar *prefix = g_strdup_printf ("\"%s\":\"", name);
+  const gchar *start = strstr (body, prefix);
+  if (start == NULL)
+    return NULL;
+  start += strlen (prefix);
+  const gchar *end = strchr (start, '"');
+  if (end == NULL)
+    return NULL;
+  return g_strndup (start, (gsize) (end - start));
+}
+
+static gint
+send_raw (SoupSession *session, const gchar *method, const gchar *base_url,
+    const gchar *path_and_query, guint *out_status, gchar **out_body)
+{
+  if (out_status == NULL || out_body == NULL)
+    return 1;
+  *out_status = 0;
+  *out_body = NULL;
+
+  g_autofree gchar *root = g_strdup (base_url);
+  while (root[0] != '\0' && g_str_has_suffix (root, "/"))
+    root[strlen (root) - 1] = '\0';
+  g_autofree gchar *uri = g_strdup_printf ("%s%s", root, path_and_query);
+  g_autoptr (SoupMessage) msg = soup_message_new (method, uri);
+  if (msg == NULL)
+    return 2;
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GBytes) bytes = soup_session_send_and_read (session, msg, NULL,
+      &error);
+  if (bytes == NULL)
+    return 3;
+  gsize size = 0;
+  const gchar *data = g_bytes_get_data (bytes, &size);
+  *out_status = soup_message_get_status (msg);
+  *out_body = g_strndup (data, size);
+  return 0;
+}
+
+static gint
+do_login (SoupSession *session, const gchar *base_url, const gchar *username,
+    gchar **out_session_token)
+{
+  *out_session_token = NULL;
+  g_autofree gchar *path = g_strdup_printf ("/auth/login?username=%s",
+      username);
+  guint status = 0;
+  g_autofree gchar *body = NULL;
+  if (send_raw (session, "POST", base_url, path, &status, &body) != 0)
+    return -1;
+  if (status != 200)
+    return -2;
+  *out_session_token = extract_json_string (body, "session_token");
+  if (*out_session_token == NULL)
+    return -3;
+  return 0;
+}
+
+static gint
+seed_enrollment (WylHandle *handle, const gchar *subject_id)
+{
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  WylTotpEnrollment enr = { 0 };
+  enr.subject_id = g_strdup (subject_id);
+  memcpy (enr.secret, MFA_TEST_SEED, WYL_TOTP_SEED_BYTES);
+  enr.last_verified_step = INT64_MIN;
+  enr.enrolled_at = 1700000000;
+  wyrelog_error_t rc = wyl_policy_store_totp_enrollment_insert (store, &enr);
+  wyl_totp_enrollment_clear (&enr);
+  return (rc == WYRELOG_E_OK) ? 0 : -1;
+}
+
+static gint
+compute_current_code (gchar out_proof[8])
+{
+  gint64 now = (gint64) time (NULL);
+  guint64 step = (guint64) (now / WYL_TOTP_STEP_SECONDS);
+  guint code = 0;
+  if (wyl_totp_code_at_step (MFA_TEST_SEED, sizeof MFA_TEST_SEED, step, &code,
+          NULL) != WYRELOG_E_OK)
+    return -1;
+  g_snprintf (out_proof, 8, "%06u", code);
+  return 0;
+}
+
+static gint
+check_happy_path (SoupServer *server, WylHandle *handle, const gchar *base_url)
+{
+  g_autoptr (SoupSession) session = soup_session_new ();
+  g_autofree gchar *session_token = NULL;
+  if (do_login (session, base_url, "mfa.happy", &session_token) != 0)
+    return 100;
+  if (seed_enrollment (handle, "mfa.happy") != 0)
+    return 101;
+  gchar proof[8];
+  if (compute_current_code (proof) != 0)
+    return 102;
+
+  g_autofree gchar *path =
+      g_strdup_printf ("/auth/mfa/verify?session_token=%s&code=%s",
+      session_token, proof);
+  guint status = 0;
+  g_autofree gchar *body = NULL;
+  if (send_raw (session, "POST", base_url, path, &status, &body) != 0)
+    return 103;
+  if (status != 200)
+    return 104;
+  if (strstr (body, "\"principal_state\":\"authenticated\"") == NULL)
+    return 105;
+  if (strstr (body, "\"access_token\":\"") == NULL)
+    return 106;
+  if (strstr (body, "\"refresh_token\":\"") == NULL)
+    return 107;
+  g_autofree gchar *body_session = extract_json_string (body, "session_token");
+  if (body_session == NULL || g_strcmp0 (body_session, session_token) != 0)
+    return 108;
+  /* F2: the submitted code MUST NOT appear in the body. */
+  if (strstr (body, proof) != NULL)
+    return 109;
+  /* The stored WylSession must remain refable for subsequent calls. */
+  g_autoptr (WylSession) stored =
+      wyl_daemon_http_ref_session (server, session_token);
+  if (stored == NULL)
+    return 110;
+  return 0;
+}
+
+static gint
+check_wrong_code_rejected (SoupServer *server, WylHandle *handle,
+    const gchar *base_url)
+{
+  (void) server;
+  g_autoptr (SoupSession) session = soup_session_new ();
+  g_autofree gchar *session_token = NULL;
+  if (do_login (session, base_url, "mfa.wrong", &session_token) != 0)
+    return 200;
+  if (seed_enrollment (handle, "mfa.wrong") != 0)
+    return 201;
+  /* Pick a guaranteed-different code. */
+  gchar correct[8];
+  if (compute_current_code (correct) != 0)
+    return 202;
+  guint c = (guint) g_ascii_strtoull (correct, NULL, 10);
+  guint wrong = (c + 1) % 1000000;
+  gchar proof[8];
+  g_snprintf (proof, sizeof proof, "%06u", wrong);
+
+  g_autofree gchar *path =
+      g_strdup_printf ("/auth/mfa/verify?session_token=%s&code=%s",
+      session_token, proof);
+  guint status = 0;
+  g_autofree gchar *body = NULL;
+  if (send_raw (session, "POST", base_url, path, &status, &body) != 0)
+    return 203;
+  if (status != 401)
+    return 204;
+  if (strstr (body, "\"mfa_invalid\"") == NULL)
+    return 205;
+  /* F2: don't leak the submitted code. */
+  if (strstr (body, proof) != NULL)
+    return 206;
+  return 0;
+}
+
+static gint
+check_no_enrollment_returns_enrollment_required (SoupServer *server,
+    WylHandle *handle, const gchar *base_url)
+{
+  (void) server;
+  (void) handle;
+  g_autoptr (SoupSession) session = soup_session_new ();
+  g_autofree gchar *session_token = NULL;
+  if (do_login (session, base_url, "mfa.no-enroll", &session_token) != 0)
+    return 300;
+  /* Intentionally do NOT seed an enrollment row. */
+  g_autofree gchar *path =
+      g_strdup_printf ("/auth/mfa/verify?session_token=%s&code=000000",
+      session_token);
+  guint status = 0;
+  g_autofree gchar *body = NULL;
+  if (send_raw (session, "POST", base_url, path, &status, &body) != 0)
+    return 301;
+  if (status != 401)
+    return 302;
+  if (strstr (body, "\"enrollment_required\"") == NULL)
+    return 303;
+  return 0;
+}
+
+static gint
+check_missing_session_token (SoupServer *server, const gchar *base_url)
+{
+  (void) server;
+  g_autoptr (SoupSession) session = soup_session_new ();
+  guint status = 0;
+  g_autofree gchar *body = NULL;
+
+  if (send_raw (session, "POST", base_url,
+          "/auth/mfa/verify?code=000000", &status, &body) != 0)
+    return 400;
+  if (status != 401 || strstr (body, "\"mfa_auth_required\"") == NULL)
+    return 401;
+  g_clear_pointer (&body, g_free);
+
+  if (send_raw (session, "POST", base_url,
+          "/auth/mfa/verify?session_token=&code=000000", &status, &body) != 0)
+    return 402;
+  if (status != 401 || strstr (body, "\"mfa_auth_required\"") == NULL)
+    return 403;
+  return 0;
+}
+
+static gint
+check_unknown_session_token (SoupServer *server, const gchar *base_url)
+{
+  (void) server;
+  g_autoptr (SoupSession) session = soup_session_new ();
+  guint status = 0;
+  g_autofree gchar *body = NULL;
+
+  if (send_raw (session, "POST", base_url,
+          "/auth/mfa/verify?session_token=bogus-token&code=000000",
+          &status, &body) != 0)
+    return 500;
+  /* F5: same error code as missing-token; never leak existence. */
+  if (status != 401 || strstr (body, "\"mfa_auth_required\"") == NULL)
+    return 501;
+  return 0;
+}
+
+static gint
+check_wrong_state_session (SoupServer *server, WylHandle *handle,
+    const gchar *base_url)
+{
+  (void) server;
+  /* Acquire an already-authenticated session via skip_mfa. */
+  wyl_handle_set_login_skip_mfa_allowed (handle, TRUE);
+  g_autoptr (SoupSession) session = soup_session_new ();
+  g_autofree gchar *path =
+      g_strdup_printf ("/auth/login?username=mfa.skip&skip_mfa=true");
+  guint status = 0;
+  g_autofree gchar *body = NULL;
+  if (send_raw (session, "POST", base_url, path, &status, &body) != 0) {
+    wyl_handle_set_login_skip_mfa_allowed (handle, FALSE);
+    return 600;
+  }
+  if (status != 200) {
+    wyl_handle_set_login_skip_mfa_allowed (handle, FALSE);
+    return 601;
+  }
+  g_autofree gchar *session_token = extract_json_string (body,
+      "session_token");
+  wyl_handle_set_login_skip_mfa_allowed (handle, FALSE);
+  if (session_token == NULL)
+    return 602;
+  g_clear_pointer (&body, g_free);
+
+  g_autofree gchar *verify_path =
+      g_strdup_printf ("/auth/mfa/verify?session_token=%s&code=000000",
+      session_token);
+  if (send_raw (session, "POST", base_url, verify_path, &status, &body) != 0)
+    return 603;
+  /* F5: wrong-state session must return the same code as
+   * unknown-session, not a distinguishable one. */
+  if (status != 401 || strstr (body, "\"mfa_auth_required\"") == NULL)
+    return 604;
+  return 0;
+}
+
+static gint
+check_missing_code (SoupServer *server, const gchar *base_url)
+{
+  (void) server;
+  g_autoptr (SoupSession) session = soup_session_new ();
+  g_autofree gchar *session_token = NULL;
+  if (do_login (session, base_url, "mfa.missing-code", &session_token) != 0)
+    return 700;
+  guint status = 0;
+  g_autofree gchar *body = NULL;
+  g_autofree gchar *path =
+      g_strdup_printf ("/auth/mfa/verify?session_token=%s", session_token);
+  if (send_raw (session, "POST", base_url, path, &status, &body) != 0)
+    return 701;
+  if (status != 400 || strstr (body, "\"invalid_mfa_request\"") == NULL)
+    return 702;
+  g_clear_pointer (&body, g_free);
+
+  g_autofree gchar *path_empty =
+      g_strdup_printf ("/auth/mfa/verify?session_token=%s&code=",
+      session_token);
+  if (send_raw (session, "POST", base_url, path_empty, &status, &body) != 0)
+    return 703;
+  if (status != 400 || strstr (body, "\"invalid_mfa_request\"") == NULL)
+    return 704;
+  return 0;
+}
+
+static gint
+check_malformed_codes (SoupServer *server, const gchar *base_url)
+{
+  (void) server;
+  g_autoptr (SoupSession) session = soup_session_new ();
+  g_autofree gchar *session_token = NULL;
+  if (do_login (session, base_url, "mfa.malformed", &session_token) != 0)
+    return 800;
+
+  static const struct
+  {
+    const gchar *code;
+  } cases[] = {
+    {"12345"},                  /* 5 chars */
+    {"1234567"},                /* 7 chars */
+    {"12345a"},                 /* non-digit at end */
+    {"a12345"},                 /* non-digit at front */
+    {"%201234"},                /* url-encoded leading space */
+    {"+12345"},                 /* leading plus */
+  };
+
+  for (gsize i = 0; i < G_N_ELEMENTS (cases); i++) {
+    g_autofree gchar *path =
+        g_strdup_printf ("/auth/mfa/verify?session_token=%s&code=%s",
+        session_token, cases[i].code);
+    guint status = 0;
+    g_autofree gchar *body = NULL;
+    if (send_raw (session, "POST", base_url, path, &status, &body) != 0)
+      return 801 + (gint) i *10;
+    if (status != 400 || strstr (body, "\"invalid_mfa_request\"") == NULL)
+      return 802 + (gint) i *10;
+  }
+  return 0;
+}
+
+static gint
+check_method_gate (SoupServer *server, const gchar *base_url)
+{
+  (void) server;
+  g_autoptr (SoupSession) session = soup_session_new ();
+  static const gchar *methods[] = { "GET", "PUT", "DELETE" };
+  for (gsize i = 0; i < G_N_ELEMENTS (methods); i++) {
+    guint status = 0;
+    g_autofree gchar *body = NULL;
+    if (send_raw (session, methods[i], base_url,
+            "/auth/mfa/verify?session_token=t&code=123456", &status,
+            &body) != 0)
+      return 900 + (gint) i *10;
+    if (status != 405 || strstr (body, "\"method_not_allowed\"") == NULL)
+      return 901 + (gint) i *10;
+  }
+  return 0;
+}
+
+static gint
+check_replay_rejection (SoupServer *server, WylHandle *handle,
+    const gchar *base_url)
+{
+  (void) server;
+  g_autoptr (SoupSession) session = soup_session_new ();
+  g_autofree gchar *session_token = NULL;
+  if (do_login (session, base_url, "mfa.replay", &session_token) != 0)
+    return 1000;
+  if (seed_enrollment (handle, "mfa.replay") != 0)
+    return 1001;
+  gchar proof[8];
+  if (compute_current_code (proof) != 0)
+    return 1002;
+
+  g_autofree gchar *path =
+      g_strdup_printf ("/auth/mfa/verify?session_token=%s&code=%s",
+      session_token, proof);
+  guint status = 0;
+  g_autofree gchar *body = NULL;
+  if (send_raw (session, "POST", base_url, path, &status, &body) != 0)
+    return 1003;
+  if (status != 200)
+    return 1004;
+  g_clear_pointer (&body, g_free);
+
+  /* Second call with the SAME code on the SAME session. The validator
+   * persisted last_verified_step on the first call; the second call
+   * must be rejected as a replay.  The session-state gate will catch
+   * this first (it is now authenticated, not mfa_required), so the
+   * surfaced code is the uniform mfa_auth_required. */
+  if (send_raw (session, "POST", base_url, path, &status, &body) != 0)
+    return 1005;
+  if (status != 401)
+    return 1006;
+  if (strstr (body, "\"mfa_auth_required\"") == NULL &&
+      strstr (body, "\"mfa_invalid\"") == NULL)
+    return 1007;
+  return 0;
+}
+
+static gint
+check_tenant_sealed_between_login_and_verify (SoupServer *server,
+    WylHandle *handle, const gchar *base_url)
+{
+  (void) server;
+  /* Use a non-default tenant: the policy store explicitly refuses to
+   * seal __wr_default (see wyl_policy_store_set_tenant_sealed). */
+  static const gchar *tenant_id = "mfa-sealed-tenant";
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  gboolean created = FALSE;
+  if (wyl_policy_store_create_tenant (store, tenant_id, &created) !=
+      WYRELOG_E_OK)
+    return 1100;
+
+  g_autoptr (SoupSession) session = soup_session_new ();
+  g_autofree gchar *login_path =
+      g_strdup_printf ("/auth/login?username=mfa.sealed&tenant=%s", tenant_id);
+  guint status = 0;
+  g_autofree gchar *body = NULL;
+  if (send_raw (session, "POST", base_url, login_path, &status, &body) != 0)
+    return 1101;
+  if (status != 200)
+    return 1102;
+  g_autofree gchar *session_token = extract_json_string (body,
+      "session_token");
+  if (session_token == NULL)
+    return 1103;
+  g_clear_pointer (&body, g_free);
+  if (seed_enrollment (handle, "mfa.sealed") != 0)
+    return 1104;
+
+  if (wyl_policy_store_set_tenant_sealed (store, tenant_id, TRUE)
+      != WYRELOG_E_OK)
+    return 1105;
+
+  gchar proof[8];
+  if (compute_current_code (proof) != 0) {
+    (void) wyl_policy_store_set_tenant_sealed (store, tenant_id, FALSE);
+    return 1106;
+  }
+  g_autofree gchar *path =
+      g_strdup_printf ("/auth/mfa/verify?session_token=%s&code=%s",
+      session_token, proof);
+  gint send_rc = send_raw (session, "POST", base_url, path, &status, &body);
+  /* Unseal before asserting so a failure does not leave the harness
+   * with a sealed tenant for any follow-up test. */
+  (void) wyl_policy_store_set_tenant_sealed (store, tenant_id, FALSE);
+  if (send_rc != 0)
+    return 1107;
+  if (status != 400)
+    return 1108;
+  if (strstr (body, "\"tenant_sealed\"") == NULL)
+    return 1109;
+  return 0;
+}
+
+static gint
+check_locked_principal_returns_locked (SoupServer *server, WylHandle *handle,
+    const gchar *base_url)
+{
+  (void) server;
+  /* Structural coverage of the "principal LOCKED -> 429 mfa_locked"
+   * branch. Commit 5 introduces the FSM-driven lockout; here we
+   * directly write principal_state=locked for the subject AFTER login
+   * so the handler observes a locked principal at verify time. */
+  g_autoptr (SoupSession) session = soup_session_new ();
+  g_autofree gchar *session_token = NULL;
+  if (do_login (session, base_url, "mfa.locked", &session_token) != 0)
+    return 1200;
+  if (seed_enrollment (handle, "mfa.locked") != 0)
+    return 1201;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (wyl_policy_store_set_principal_state (store, "mfa.locked",
+          "locked") != WYRELOG_E_OK)
+    return 1202;
+
+  gchar proof[8];
+  if (compute_current_code (proof) != 0)
+    return 1203;
+  g_autofree gchar *path =
+      g_strdup_printf ("/auth/mfa/verify?session_token=%s&code=%s",
+      session_token, proof);
+  guint status = 0;
+  g_autofree gchar *body = NULL;
+  if (send_raw (session, "POST", base_url, path, &status, &body) != 0)
+    return 1204;
+  /* Per issue #331 spec: HTTP 429 with mfa_locked code. */
+  if (status != 429)
+    return 1205;
+  if (strstr (body, "\"mfa_locked\"") == NULL)
+    return 1206;
+  return 0;
+}
+
+int
+main (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 1;
+
+  /* Install the TOTP validator on the handle so the HTTP route can
+   * resolve it via wyl_handle_get_mfa_validator. The daemon init
+   * path wires this in production; the test wires it explicitly. */
+  wyl_handle_set_mfa_validator (handle, wyl_mfa_validator_totp, NULL);
+
+  WylDaemonOptions opts = {
+    .template_dir = WYL_TEST_TEMPLATE_DIR,
+    .listen_port = 0,
+  };
+  WylDaemonRuntime runtime = {
+    .handle = handle,
+  };
+  if (wyl_daemon_start_delta_callbacks (handle, &runtime) != WYRELOG_E_OK)
+    return 2;
+  TestHttpServer http = { 0 };
+  http.loop = g_main_loop_new (NULL, FALSE);
+  g_autoptr (GError) error = NULL;
+  http.server = wyl_daemon_start_http_server_with_runtime (&opts, handle,
+      &runtime, &error);
+  if (http.server == NULL)
+    return 3;
+  GThread *thread = g_thread_new ("daemon-http-mfa",
+      test_http_server_thread, &http);
+
+  GSList *uris = soup_server_get_uris (http.server);
+  if (uris == NULL)
+    return 4;
+  g_autofree gchar *base_url = g_uri_to_string (uris->data);
+  g_slist_free_full (uris, (GDestroyNotify) g_uri_unref);
+
+  gint rc;
+  if ((rc = check_method_gate (http.server, base_url)) != 0)
+    goto out;
+  if ((rc = check_missing_session_token (http.server, base_url)) != 0)
+    goto out;
+  if ((rc = check_unknown_session_token (http.server, base_url)) != 0)
+    goto out;
+  if ((rc = check_missing_code (http.server, base_url)) != 0)
+    goto out;
+  if ((rc = check_malformed_codes (http.server, base_url)) != 0)
+    goto out;
+  if ((rc = check_no_enrollment_returns_enrollment_required (http.server,
+              handle, base_url)) != 0)
+    goto out;
+  if ((rc = check_wrong_code_rejected (http.server, handle, base_url)) != 0)
+    goto out;
+  if ((rc = check_wrong_state_session (http.server, handle, base_url)) != 0)
+    goto out;
+  if ((rc = check_happy_path (http.server, handle, base_url)) != 0)
+    goto out;
+  if ((rc = check_replay_rejection (http.server, handle, base_url)) != 0)
+    goto out;
+  if ((rc = check_tenant_sealed_between_login_and_verify (http.server, handle,
+              base_url)) != 0)
+    goto out;
+  if ((rc = check_locked_principal_returns_locked (http.server, handle,
+              base_url)) != 0)
+    goto out;
+
+out:
+  g_main_loop_quit (http.loop);
+  g_thread_join (thread);
+  soup_server_disconnect (http.server);
+  g_clear_object (&http.server);
+  g_clear_pointer (&http.loop, g_main_loop_unref);
+  return rc;
+}

--- a/tests/test-daemon-mfa-validator.c
+++ b/tests/test-daemon-mfa-validator.c
@@ -406,6 +406,272 @@ check_validator_rejects_replay_across_restart (void)
 }
 
 static gint
+read_principal_state (WylHandle *handle, const gchar *subject_id,
+    gchar **out_state, gint64 *out_count, gint64 *out_locked_at)
+{
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  gboolean found = FALSE;
+  wyrelog_error_t rc = wyl_policy_store_get_principal_lock_info (store,
+      subject_id, out_state, out_count, out_locked_at, &found);
+  if (rc != WYRELOG_E_OK || !found)
+    return -1;
+  return 0;
+}
+
+static gint
+check_validator_locks_after_five_failures (void)
+{
+  /* Commit-5 architect rule: five consecutive failures must transition
+   * the principal to LOCKED.  The state move is durable - it lands in
+   * the policy store's principal_states row - and the failure counter
+   * is exactly 5 on the threshold step. */
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 200;
+  g_autoptr (WylSession) session = NULL;
+  if (login_mfa_required_session (handle, "validator.lockout-five",
+          &session) != 0)
+    return 201;
+  if (seed_enrollment (handle, "validator.lockout-five") != 0)
+    return 202;
+
+  guint correct = 0;
+  gint64 now = 0;
+  guint64 step = 0;
+  if (compute_code_for_now (&correct, &now, &step) != 0)
+    return 203;
+  guint wrong = (correct + 1) % 1000000;
+  gchar proof[8];
+  g_snprintf (proof, sizeof proof, "%06u", wrong);
+
+  /* Five wrong attempts.  After the 5th the validator must transition
+   * the principal_state row to 'locked' atomically with the counter
+   * increment.  All five calls return E_POLICY (uniform negative). */
+  for (int i = 0; i < 5; i++) {
+    if (wyl_mfa_validator_totp (handle, session, proof, NULL)
+        != WYRELOG_E_POLICY)
+      return 210 + i;
+  }
+  g_autofree gchar *st = NULL;
+  gint64 count = -1;
+  gint64 locked_at = 0;
+  if (read_principal_state (handle, "validator.lockout-five", &st, &count,
+          &locked_at) != 0)
+    return 220;
+  if (g_strcmp0 (st, "locked") != 0)
+    return 221;
+  if (count != 5)
+    return 222;
+  if (locked_at == G_MININT64)
+    return 223;
+  return 0;
+}
+
+static gint
+check_validator_locked_principal_rejects_without_hmac (void)
+{
+  /* When the principal is already LOCKED and the auto-unlock window is
+   * not elapsed, the validator must fail closed without consulting the
+   * TOTP enrollment (no HMAC computation, no replay-watermark advance).
+   * We assert state stays LOCKED and last_verified_step is unchanged. */
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 230;
+  g_autoptr (WylSession) session = NULL;
+  if (login_mfa_required_session (handle, "validator.locked-now",
+          &session) != 0)
+    return 231;
+  if (seed_enrollment (handle, "validator.locked-now") != 0)
+    return 232;
+
+  /* Drive 5 organic FAILED_ATTEMPTs to transition the principal row to
+   * LOCKED with locked_at = now (so the auto-unlock grace has not yet
+   * elapsed).  The set_principal_state("locked") shortcut used in the
+   * earlier iteration would now collide with the commit-5 iteration
+   * defensive guard (apply_principal_failure refuses to mutate a row
+   * that is already LOCKED); driving the threshold organically gives
+   * the same setup state without bypassing the helper's contract. */
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  for (int i = 0; i < 5; i++) {
+    g_autofree gchar *st = NULL;
+    gint64 c = 0, l = 0;
+    if (wyl_policy_store_apply_principal_failure (store,
+            "validator.locked-now", 5, (gint64) time (NULL),
+            &st, &c, &l) != WYRELOG_E_OK)
+      return 234;
+  }
+
+  guint correct = 0;
+  gint64 now = 0;
+  guint64 step = 0;
+  if (compute_code_for_now (&correct, &now, &step) != 0)
+    return 235;
+  gchar proof[8];
+  g_snprintf (proof, sizeof proof, "%06u", correct);
+
+  /* Submitting the CORRECT code must still be rejected because the
+   * principal is locked. */
+  if (wyl_mfa_validator_totp (handle, session, proof, NULL)
+      != WYRELOG_E_POLICY)
+    return 236;
+  /* State must still be locked. */
+  g_autofree gchar *st = NULL;
+  gint64 count = -1;
+  gint64 locked_at = 0;
+  if (read_principal_state (handle, "validator.locked-now", &st, &count,
+          &locked_at) != 0)
+    return 237;
+  if (g_strcmp0 (st, "locked") != 0)
+    return 238;
+  /* last_verified_step on the enrollment row must NOT have advanced
+   * (validator never consulted the secret). */
+  gint64 step_after = 0;
+  if (load_last_verified_step (handle, "validator.locked-now",
+          &step_after) != 0)
+    return 239;
+  if (step_after != INT64_MIN)
+    return 240;
+  return 0;
+}
+
+static gint
+check_validator_auto_unlocks_after_window (void)
+{
+  /* Inject a locked principal whose locked_at is 16 minutes in the past
+   * (well past the 15-min auto-unlock window).  The next validate call
+   * must transition the row LOCKED -> UNVERIFIED via the FSM UNLOCK
+   * event and return E_POLICY (the caller's session-state gate will then
+   * send the user back to re-login). */
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 250;
+  g_autoptr (WylSession) session = NULL;
+  if (login_mfa_required_session (handle, "validator.auto-unlock",
+          &session) != 0)
+    return 251;
+  if (seed_enrollment (handle, "validator.auto-unlock") != 0)
+    return 252;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (wyl_policy_store_set_principal_state (store, "validator.auto-unlock",
+          "mfa_required") != WYRELOG_E_OK)
+    return 253;
+  /* Drive 5 failures with locked_at = now - (16 minutes). */
+  gint64 ago = (gint64) time (NULL) - (16 * 60);
+  for (int i = 0; i < 5; i++) {
+    g_autofree gchar *st = NULL;
+    gint64 c = 0, l = 0;
+    if (wyl_policy_store_apply_principal_failure (store,
+            "validator.auto-unlock", 5, ago, &st, &c, &l) != WYRELOG_E_OK)
+      return 254;
+  }
+  /* Confirm precondition: row is locked. */
+  g_autofree gchar *pre_state = NULL;
+  gint64 pre_count = 0;
+  gint64 pre_locked_at = 0;
+  if (read_principal_state (handle, "validator.auto-unlock", &pre_state,
+          &pre_count, &pre_locked_at) != 0)
+    return 255;
+  if (g_strcmp0 (pre_state, "locked") != 0)
+    return 256;
+
+  guint correct = 0;
+  gint64 now = 0;
+  guint64 step = 0;
+  if (compute_code_for_now (&correct, &now, &step) != 0)
+    return 257;
+  gchar proof[8];
+  g_snprintf (proof, sizeof proof, "%06u", correct);
+
+  /* Call validator: must auto-unlock and return E_POLICY (session no
+   * longer in mfa_required; the verify-with-proof contract bounces
+   * because the principal is now UNVERIFIED). */
+  if (wyl_mfa_validator_totp (handle, session, proof, NULL)
+      != WYRELOG_E_POLICY)
+    return 258;
+  /* Row is now in UNVERIFIED with counter=0, locked_at NULL. */
+  g_autofree gchar *post_state = NULL;
+  gint64 post_count = -1;
+  gint64 post_locked_at = 0;
+  if (read_principal_state (handle, "validator.auto-unlock", &post_state,
+          &post_count, &post_locked_at) != 0)
+    return 259;
+  if (g_strcmp0 (post_state, "unverified") != 0)
+    return 260;
+  if (post_count != 0)
+    return 261;
+  if (post_locked_at != G_MININT64)
+    return 262;
+  return 0;
+}
+
+static gint
+check_validator_resets_counter_on_success (void)
+{
+  /* 4 failures then 1 success: the counter resets to 0 on success, so
+   * a subsequent failure starts the counter at 1, not 5. */
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 270;
+  g_autoptr (WylSession) session = NULL;
+  if (login_mfa_required_session (handle, "validator.reset-on-ok",
+          &session) != 0)
+    return 271;
+  if (seed_enrollment (handle, "validator.reset-on-ok") != 0)
+    return 272;
+
+  guint correct = 0;
+  gint64 now = 0;
+  guint64 step = 0;
+  if (compute_code_for_now (&correct, &now, &step) != 0)
+    return 273;
+  guint wrong = (correct + 1) % 1000000;
+  gchar wrong_proof[8];
+  g_snprintf (wrong_proof, sizeof wrong_proof, "%06u", wrong);
+  gchar good_proof[8];
+  g_snprintf (good_proof, sizeof good_proof, "%06u", correct);
+
+  /* 4 failures. */
+  for (int i = 0; i < 4; i++) {
+    if (wyl_mfa_validator_totp (handle, session, wrong_proof, NULL)
+        != WYRELOG_E_POLICY)
+      return 274;
+  }
+  /* Counter must be 4, not locked. */
+  g_autofree gchar *st = NULL;
+  gint64 count = -1;
+  gint64 locked_at = 0;
+  if (read_principal_state (handle, "validator.reset-on-ok", &st, &count,
+          &locked_at) != 0)
+    return 275;
+  if (count != 4 || g_strcmp0 (st, "mfa_required") != 0)
+    return 276;
+
+  /* Success: counter goes to 0. */
+  if (wyl_mfa_validator_totp (handle, session, good_proof, NULL)
+      != WYRELOG_E_OK)
+    return 277;
+  g_clear_pointer (&st, g_free);
+  if (read_principal_state (handle, "validator.reset-on-ok", &st, &count,
+          &locked_at) != 0)
+    return 278;
+  if (count != 0)
+    return 279;
+
+  /* Next failure: counter starts at 1. */
+  if (wyl_mfa_validator_totp (handle, session, wrong_proof, NULL)
+      != WYRELOG_E_POLICY)
+    return 280;
+  g_clear_pointer (&st, g_free);
+  if (read_principal_state (handle, "validator.reset-on-ok", &st, &count,
+          &locked_at) != 0)
+    return 281;
+  if (count != 1)
+    return 282;
+  return 0;
+}
+
+static gint
 check_validator_rejects_null_handle_or_session (void)
 {
   g_autoptr (WylHandle) handle = NULL;
@@ -478,6 +744,14 @@ main (void)
   if ((rc = check_validator_rejects_replay_same_session ()) != 0)
     return rc;
   if ((rc = check_validator_rejects_replay_across_restart ()) != 0)
+    return rc;
+  if ((rc = check_validator_locks_after_five_failures ()) != 0)
+    return rc;
+  if ((rc = check_validator_locked_principal_rejects_without_hmac ()) != 0)
+    return rc;
+  if ((rc = check_validator_auto_unlocks_after_window ()) != 0)
+    return rc;
+  if ((rc = check_validator_resets_counter_on_success ()) != 0)
     return rc;
   if ((rc = check_validator_rejects_null_handle_or_session ()) != 0)
     return rc;

--- a/tests/test-daemon-mfa-validator.c
+++ b/tests/test-daemon-mfa-validator.c
@@ -1,0 +1,487 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+/*
+ * Unit tests for the daemon-side TOTP MFA validator
+ * (wyrelog/auth/mfa-validator.{c,h}).
+ *
+ * The validator implements the WylMfaValidator callback shape
+ * (wyrelog/session.h) used by wyl_session_mfa_verify_with_proof. It
+ * resolves the per-subject TOTP enrollment in the handle-owned policy
+ * store, evaluates the submitted 6-digit code against the seed at the
+ * current step (with the +/-1 skew already encoded by the commit-1
+ * TOTP core), and enforces a strict replay watermark using > (NOT >=)
+ * against last_verified_step.
+ *
+ * Footgun coverage these tests exist to lock down:
+ *   F1 (timing): malformed proof, missing enrollment, and a wrong code
+ *     all walk the same final-return path through the validator. The
+ *     tests assert the error code is identical for the missing-enrollment
+ *     and wrong-code paths (WYRELOG_E_POLICY), and that NULL/short/long
+ *     proofs all return WYRELOG_E_INVALID before the policy store is
+ *     touched.
+ *   F2 (secret-in-audit): no audit emission is expected from the
+ *     validator itself; the only audit row comes from the FSM
+ *     transition the caller drives after validator returns
+ *     WYRELOG_E_OK. (This file does not poke audit; it only verifies
+ *     that last_verified_step is the only mutation the validator
+ *     produces.)
+ *   F3 (replay): the same submitted code MUST be rejected on a second
+ *     call, because the validator advances last_verified_step before
+ *     returning. A restart-style test writes last_verified_step
+ *     directly via the store helper and confirms a follow-up call
+ *     with the same code is rejected.
+ */
+
+#if !defined(_WIN32) && !defined(_XOPEN_SOURCE)
+#define _XOPEN_SOURCE 700
+#endif
+
+#include <stdint.h>
+#include <string.h>
+#include <time.h>
+
+#include <glib.h>
+
+#include "auth/mfa-validator.h"
+#include "auth/totp.h"
+#include "wyrelog/policy/store-private.h"
+#include "wyrelog/session.h"
+#include "wyrelog/wyl-handle-private.h"
+#include "wyrelog/wyrelog.h"
+
+#ifndef WYL_TEST_TEMPLATE_DIR
+#error "WYL_TEST_TEMPLATE_DIR must be defined by the build."
+#endif
+
+static const guint8 TEST_SEED[WYL_TOTP_SEED_BYTES] = {
+  0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38,
+  0x39, 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36,
+  0x37, 0x38, 0x39, 0x30,
+};
+
+static void
+fill_seed_copy (guint8 *dst)
+{
+  memcpy (dst, TEST_SEED, WYL_TOTP_SEED_BYTES);
+}
+
+static gint
+login_mfa_required_session (WylHandle *handle, const gchar *username,
+    WylSession **out_session)
+{
+  g_autoptr (wyl_login_req_t) req = wyl_login_req_new ();
+  wyl_login_req_set_username (req, username);
+  if (wyl_session_login (handle, req, out_session) != WYRELOG_E_OK)
+    return -1;
+  if (*out_session == NULL)
+    return -1;
+  return 0;
+}
+
+static gint
+seed_enrollment (WylHandle *handle, const gchar *subject_id)
+{
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  WylTotpEnrollment enr = { 0 };
+  enr.subject_id = g_strdup (subject_id);
+  fill_seed_copy (enr.secret);
+  enr.last_verified_step = INT64_MIN;
+  enr.enrolled_at = 1700000000;
+  wyrelog_error_t rc = wyl_policy_store_totp_enrollment_insert (store, &enr);
+  wyl_totp_enrollment_clear (&enr);
+  return (rc == WYRELOG_E_OK) ? 0 : -1;
+}
+
+static gint
+load_last_verified_step (WylHandle *handle, const gchar *subject_id,
+    gint64 *out_step)
+{
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  WylTotpEnrollment out = { 0 };
+  gboolean found = FALSE;
+  wyrelog_error_t rc = wyl_policy_store_totp_enrollment_lookup (store,
+      subject_id, &out, &found);
+  if (rc != WYRELOG_E_OK || !found) {
+    wyl_totp_enrollment_clear (&out);
+    return -1;
+  }
+  *out_step = out.last_verified_step;
+  wyl_totp_enrollment_clear (&out);
+  return 0;
+}
+
+static gint
+compute_code_for_now (guint *out_code, gint64 *out_unix_time, guint64 *out_step)
+{
+  gint64 now = (gint64) time (NULL);
+  guint64 step = (guint64) (now / WYL_TOTP_STEP_SECONDS);
+  guint code = 0;
+  if (wyl_totp_code_at_step (TEST_SEED, sizeof TEST_SEED, step, &code, NULL)
+      != WYRELOG_E_OK)
+    return -1;
+  *out_code = code;
+  *out_unix_time = now;
+  *out_step = step;
+  return 0;
+}
+
+static gint
+check_validator_rejects_null_proof (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 10;
+
+  g_autoptr (WylSession) session = NULL;
+  if (login_mfa_required_session (handle, "validator.null-proof",
+          &session) != 0)
+    return 11;
+
+  if (wyl_mfa_validator_totp (handle, session, NULL, NULL)
+      != WYRELOG_E_INVALID)
+    return 12;
+  return 0;
+}
+
+static gint
+check_validator_rejects_short_proof (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 20;
+  g_autoptr (WylSession) session = NULL;
+  if (login_mfa_required_session (handle, "validator.short-proof",
+          &session) != 0)
+    return 21;
+  if (wyl_mfa_validator_totp (handle, session, "12345", NULL)
+      != WYRELOG_E_INVALID)
+    return 22;
+  return 0;
+}
+
+static gint
+check_validator_rejects_long_proof (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 30;
+  g_autoptr (WylSession) session = NULL;
+  if (login_mfa_required_session (handle, "validator.long-proof",
+          &session) != 0)
+    return 31;
+  if (wyl_mfa_validator_totp (handle, session, "1234567", NULL)
+      != WYRELOG_E_INVALID)
+    return 32;
+  return 0;
+}
+
+static gint
+check_validator_rejects_huge_proof (void)
+{
+  /* F-2 regression guard: a 1024-byte all-digit, NUL-terminated proof
+   * must be rejected by the shape check before any read can run past
+   * the WYL_TOTP_DIGITS window.  Locks down the strnlen length guard
+   * in proof_shape_is_valid against future "optimisations" that would
+   * re-introduce the OOB read fixed during commit-3 iteration. */
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 35;
+  g_autoptr (WylSession) session = NULL;
+  if (login_mfa_required_session (handle, "validator.huge-proof",
+          &session) != 0)
+    return 36;
+  gchar proof[1025];
+  memset (proof, '1', 1024);
+  proof[1024] = '\0';
+  if (wyl_mfa_validator_totp (handle, session, proof, NULL)
+      != WYRELOG_E_INVALID)
+    return 37;
+  return 0;
+}
+
+static gint
+check_validator_rejects_non_digit_proof (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 40;
+  g_autoptr (WylSession) session = NULL;
+  if (login_mfa_required_session (handle, "validator.non-digit-proof",
+          &session) != 0)
+    return 41;
+  if (wyl_mfa_validator_totp (handle, session, "abcdef", NULL)
+      != WYRELOG_E_INVALID)
+    return 42;
+  if (wyl_mfa_validator_totp (handle, session, "12345 ", NULL)
+      != WYRELOG_E_INVALID)
+    return 43;
+  /* Embedded NUL: also a shape failure. */
+  const gchar embedded_nul[7] = { '1', '2', '3', '\0', '5', '6', '\0' };
+  if (wyl_mfa_validator_totp (handle, session, embedded_nul, NULL)
+      != WYRELOG_E_INVALID)
+    return 44;
+  return 0;
+}
+
+static gint
+check_validator_rejects_when_no_enrollment (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 50;
+  g_autoptr (WylSession) session = NULL;
+  if (login_mfa_required_session (handle, "validator.no-enroll", &session) != 0)
+    return 51;
+  /* No enrollment row inserted: validator must fail closed with POLICY. */
+  if (wyl_mfa_validator_totp (handle, session, "000000", NULL)
+      != WYRELOG_E_POLICY)
+    return 52;
+  /* Confirm no enrollment row was created as a side effect. */
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  WylTotpEnrollment out = { 0 };
+  gboolean found = TRUE;
+  if (wyl_policy_store_totp_enrollment_lookup (store, "validator.no-enroll",
+          &out, &found) != WYRELOG_E_OK) {
+    wyl_totp_enrollment_clear (&out);
+    return 53;
+  }
+  if (found) {
+    wyl_totp_enrollment_clear (&out);
+    return 54;
+  }
+  wyl_totp_enrollment_clear (&out);
+  return 0;
+}
+
+static gint
+check_validator_rejects_wrong_code (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 60;
+  g_autoptr (WylSession) session = NULL;
+  if (login_mfa_required_session (handle, "validator.wrong-code",
+          &session) != 0)
+    return 61;
+  if (seed_enrollment (handle, "validator.wrong-code") != 0)
+    return 62;
+
+  guint correct = 0;
+  gint64 now = 0;
+  guint64 step = 0;
+  if (compute_code_for_now (&correct, &now, &step) != 0)
+    return 63;
+  /* Pick a value guaranteed to differ from the correct code. */
+  guint wrong = (correct + 1) % 1000000;
+  gchar proof[8];
+  g_snprintf (proof, sizeof proof, "%06u", wrong);
+
+  if (wyl_mfa_validator_totp (handle, session, proof, NULL)
+      != WYRELOG_E_POLICY)
+    return 64;
+  /* last_verified_step must NOT have advanced. */
+  gint64 step_after = 0;
+  if (load_last_verified_step (handle, "validator.wrong-code",
+          &step_after) != 0)
+    return 65;
+  if (step_after != INT64_MIN)
+    return 66;
+  return 0;
+}
+
+static gint
+check_validator_accepts_correct_code (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 70;
+  g_autoptr (WylSession) session = NULL;
+  if (login_mfa_required_session (handle, "validator.happy", &session) != 0)
+    return 71;
+  if (seed_enrollment (handle, "validator.happy") != 0)
+    return 72;
+
+  guint code = 0;
+  gint64 now = 0;
+  guint64 step = 0;
+  if (compute_code_for_now (&code, &now, &step) != 0)
+    return 73;
+  gchar proof[8];
+  g_snprintf (proof, sizeof proof, "%06u", code);
+
+  if (wyl_mfa_validator_totp (handle, session, proof, NULL)
+      != WYRELOG_E_OK)
+    return 74;
+
+  gint64 step_after = 0;
+  if (load_last_verified_step (handle, "validator.happy", &step_after) != 0)
+    return 75;
+  if (step_after != (gint64) step)
+    return 76;
+  return 0;
+}
+
+static gint
+check_validator_rejects_replay_same_session (void)
+{
+  /* F3: a successful verify must persist the matched step BEFORE the
+   * caller advances the FSM, so a re-submission of the same code
+   * during the same session window is rejected. */
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 80;
+  g_autoptr (WylSession) session = NULL;
+  if (login_mfa_required_session (handle, "validator.replay", &session) != 0)
+    return 81;
+  if (seed_enrollment (handle, "validator.replay") != 0)
+    return 82;
+
+  guint code = 0;
+  gint64 now = 0;
+  guint64 step = 0;
+  if (compute_code_for_now (&code, &now, &step) != 0)
+    return 83;
+  gchar proof[8];
+  g_snprintf (proof, sizeof proof, "%06u", code);
+
+  /* First call: success. */
+  if (wyl_mfa_validator_totp (handle, session, proof, NULL)
+      != WYRELOG_E_OK)
+    return 84;
+
+  /* Second call with the SAME code: must be rejected as replay. */
+  if (wyl_mfa_validator_totp (handle, session, proof, NULL)
+      != WYRELOG_E_POLICY)
+    return 85;
+
+  /* last_verified_step should still equal the matched step (not
+   * regressed). */
+  gint64 step_after = 0;
+  if (load_last_verified_step (handle, "validator.replay", &step_after) != 0)
+    return 86;
+  if (step_after != (gint64) step)
+    return 87;
+  return 0;
+}
+
+static gint
+check_validator_rejects_replay_across_restart (void)
+{
+  /* F3 restart simulation: write last_verified_step directly via the
+   * store helper (mirroring a crash-recovery case where the watermark
+   * was persisted but the FSM transition was lost), then call the
+   * validator with the SAME code that produced that watermark. The
+   * validator must fail closed because matched_step <= stored
+   * last_verified_step. */
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 90;
+  g_autoptr (WylSession) session = NULL;
+  if (login_mfa_required_session (handle, "validator.restart", &session) != 0)
+    return 91;
+  if (seed_enrollment (handle, "validator.restart") != 0)
+    return 92;
+
+  guint code = 0;
+  gint64 now = 0;
+  guint64 step = 0;
+  if (compute_code_for_now (&code, &now, &step) != 0)
+    return 93;
+  gchar proof[8];
+  g_snprintf (proof, sizeof proof, "%06u", code);
+
+  /* Simulate restart-after-watermark-write: bump last_verified_step to
+   * the step our code lives in, without driving the validator. */
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (wyl_policy_store_totp_enrollment_update_step (store,
+          "validator.restart", (gint64) step) != WYRELOG_E_OK)
+    return 94;
+
+  /* Now call the validator with the same code. Must be rejected: the
+   * matched step would be == stored watermark, and the rule is strict
+   * > not >=. */
+  if (wyl_mfa_validator_totp (handle, session, proof, NULL)
+      != WYRELOG_E_POLICY)
+    return 95;
+  return 0;
+}
+
+static gint
+check_validator_rejects_null_handle_or_session (void)
+{
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 100;
+  g_autoptr (WylSession) session = NULL;
+  if (login_mfa_required_session (handle, "validator.null-args", &session) != 0)
+    return 101;
+  if (wyl_mfa_validator_totp (NULL, session, "000000", NULL)
+      != WYRELOG_E_INVALID)
+    return 102;
+  if (wyl_mfa_validator_totp (handle, NULL, "000000", NULL)
+      != WYRELOG_E_INVALID)
+    return 103;
+  return 0;
+}
+
+static gint
+check_handle_default_validator_is_wired (void)
+{
+  /* The daemon init path (runtime.c) installs wyl_mfa_validator_totp
+   * as the default validator on every WylHandle so the HTTP /auth/mfa
+   * route (commit 4) can resolve it without an out-of-band reference.
+   * wyl_handle_get_mfa_validator must return the same function pointer
+   * for any handle that has been through wyl_daemon_install_mfa_validator. */
+  g_autoptr (WylHandle) handle = NULL;
+  if (wyl_init (WYL_TEST_TEMPLATE_DIR, &handle) != WYRELOG_E_OK)
+    return 110;
+  /* By default no validator is set; the daemon installs it. */
+  if (wyl_handle_get_mfa_validator (handle, NULL) != NULL)
+    return 111;
+  wyl_handle_set_mfa_validator (handle, wyl_mfa_validator_totp, NULL);
+  gpointer ud = (gpointer) 0xdeadbeef;
+  WylMfaValidator v = wyl_handle_get_mfa_validator (handle, &ud);
+  if (v != wyl_mfa_validator_totp)
+    return 112;
+  if (ud != NULL)
+    return 113;
+  /* Calling through the handle-stored pointer must behave identically
+   * to calling the symbol directly: invalid proof shape -> INVALID. */
+  g_autoptr (WylSession) session = NULL;
+  if (login_mfa_required_session (handle, "validator.wired", &session) != 0)
+    return 114;
+  if (v (handle, session, "x", NULL) != WYRELOG_E_INVALID)
+    return 115;
+  return 0;
+}
+
+int
+main (void)
+{
+  gint rc;
+
+  if ((rc = check_validator_rejects_null_proof ()) != 0)
+    return rc;
+  if ((rc = check_validator_rejects_short_proof ()) != 0)
+    return rc;
+  if ((rc = check_validator_rejects_long_proof ()) != 0)
+    return rc;
+  if ((rc = check_validator_rejects_huge_proof ()) != 0)
+    return rc;
+  if ((rc = check_validator_rejects_non_digit_proof ()) != 0)
+    return rc;
+  if ((rc = check_validator_rejects_when_no_enrollment ()) != 0)
+    return rc;
+  if ((rc = check_validator_rejects_wrong_code ()) != 0)
+    return rc;
+  if ((rc = check_validator_accepts_correct_code ()) != 0)
+    return rc;
+  if ((rc = check_validator_rejects_replay_same_session ()) != 0)
+    return rc;
+  if ((rc = check_validator_rejects_replay_across_restart ()) != 0)
+    return rc;
+  if ((rc = check_validator_rejects_null_handle_or_session ()) != 0)
+    return rc;
+  if ((rc = check_handle_default_validator_is_wired ()) != 0)
+    return rc;
+  return 0;
+}

--- a/tests/test-policy-store-totp.c
+++ b/tests/test-policy-store-totp.c
@@ -1,0 +1,696 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+/*
+ * Unit tests for the policy-store totp_enrollment fact schema and
+ * helpers (wyrelog/policy/store.c).
+ *
+ * Each subject can hold a single TOTP enrollment row carrying:
+ *   - secret_blob: raw 20-byte SHA-1 seed (BLOB)
+ *   - last_verified_step: replay watermark (gint64, INT64_MIN = never
+ *     verified)
+ *   - enrolled_at: unix seconds at enroll time
+ *   - id_uuidv7: minted via wyl_id_new (libchronoid UUIDv7)
+ *
+ * The helpers under test are the persistence primitives; higher-level
+ * enroll/verify wiring lives in later commits in the #331 series.
+ *
+ * Footgun coverage these tests exist to lock down:
+ *   F2 (secret leak): round-trip preserves seed bytes verbatim, and
+ *     the helpers never expose the seed except through the explicit
+ *     out_secret buffer.
+ *   F3 (replay): update_step persists the watermark monotonically and
+ *     it survives a close+reopen of the encrypted store.
+ *   F4 (zeroing): the wyl_totp_enrollment_clear helper zeroes the
+ *     secret buffer regardless of caller state.
+ */
+
+#if !defined(_WIN32) && !defined(_XOPEN_SOURCE)
+#define _XOPEN_SOURCE 700
+#endif
+
+#include <stdint.h>
+#include <string.h>
+
+#include <glib.h>
+#include <glib/gstdio.h>
+
+#include "wyrelog/wyrelog.h"
+#include "wyrelog/policy/store-private.h"
+#include "wyrelog/wyl-keyprovider-file-private.h"
+
+#ifndef G_OS_WIN32
+#include <unistd.h>
+#endif
+
+static gboolean
+write_policy_key (const gchar *path, guint8 seed)
+{
+  guint8 key[32];
+  for (gsize i = 0; i < sizeof key; i++)
+    key[i] = (guint8) (seed + i);
+  return g_file_set_contents (path, (const gchar *) key, sizeof key, NULL);
+}
+
+static wyrelog_error_t
+open_encrypted_policy_store (const gchar *store_path, const gchar *key_path,
+    wyl_policy_store_t **out_store)
+{
+  wyl_keyprovider_file_t *keyprovider = wyl_keyprovider_file_new (key_path);
+  if (keyprovider == NULL)
+    return WYRELOG_E_IO;
+  wyl_policy_store_open_options_t opts = {
+    .path = store_path,
+    .keyprovider_vtable = wyl_keyprovider_file_get_vtable (),
+    .keyprovider_state = keyprovider,
+    .keyprovider_state_free = (void (*)(gpointer)) wyl_keyprovider_file_free,
+    .require_encrypted = TRUE,
+  };
+  return wyl_policy_store_open_with_options (&opts, out_store);
+}
+
+static void
+fill_seed (guint8 *seed, guint8 base)
+{
+  for (gsize i = 0; i < WYL_TOTP_ENROLLMENT_SECRET_BYTES; i++)
+    seed[i] = (guint8) (base + i);
+}
+
+static gint
+check_totp_enrollment_table_is_created_on_fresh_store (void)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 10;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 11;
+
+  gboolean exists = FALSE;
+  if (wyl_policy_store_table_exists (store, "totp_enrollments", &exists)
+      != WYRELOG_E_OK)
+    return 12;
+  if (!exists)
+    return 13;
+  return 0;
+}
+
+static gint
+check_totp_enrollment_migration_is_idempotent (void)
+{
+  /* Simulate a pre-#331 store: open a fresh store, create the schema,
+   * then DROP the totp_enrollments table to mimic an upgrade path.
+   * Re-invoking create_schema must restore the table; a second
+   * invocation must remain a no-op (the IF NOT EXISTS contract). */
+  g_autoptr (wyl_policy_store_t) store = NULL;
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 20;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 21;
+
+  if (sqlite3_exec (wyl_policy_store_get_db (store),
+          "DROP TABLE totp_enrollments;", NULL, NULL, NULL) != SQLITE_OK)
+    return 22;
+
+  gboolean exists = TRUE;
+  if (wyl_policy_store_table_exists (store, "totp_enrollments", &exists)
+      != WYRELOG_E_OK)
+    return 23;
+  if (exists)
+    return 24;
+
+  /* First re-application of create_schema: must restore the table. */
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 25;
+  if (wyl_policy_store_table_exists (store, "totp_enrollments", &exists)
+      != WYRELOG_E_OK)
+    return 26;
+  if (!exists)
+    return 27;
+
+  /* Second application: no-op, still green. */
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 28;
+  if (wyl_policy_store_table_exists (store, "totp_enrollments", &exists)
+      != WYRELOG_E_OK)
+    return 29;
+  if (!exists)
+    return 30;
+  return 0;
+}
+
+static gint
+check_totp_enrollment_insert_lookup_round_trip (void)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 40;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 41;
+
+  WylTotpEnrollment enr = { 0 };
+  enr.subject_id = g_strdup ("alice.root");
+  fill_seed (enr.secret, 0x10);
+  enr.last_verified_step = INT64_MIN;
+  enr.enrolled_at = 1700000000;
+  if (wyl_policy_store_totp_enrollment_insert (store, &enr) != WYRELOG_E_OK) {
+    wyl_totp_enrollment_clear (&enr);
+    return 42;
+  }
+  /* Insert must have assigned an id_uuidv7. */
+  if (enr.id_uuidv7 == NULL || strlen (enr.id_uuidv7) != 36) {
+    wyl_totp_enrollment_clear (&enr);
+    return 43;
+  }
+  gchar *minted_id = g_strdup (enr.id_uuidv7);
+  wyl_totp_enrollment_clear (&enr);
+
+  WylTotpEnrollment out = { 0 };
+  gboolean found = FALSE;
+  if (wyl_policy_store_totp_enrollment_lookup (store, "alice.root", &out,
+          &found) != WYRELOG_E_OK) {
+    g_free (minted_id);
+    wyl_totp_enrollment_clear (&out);
+    return 44;
+  }
+  if (!found) {
+    g_free (minted_id);
+    wyl_totp_enrollment_clear (&out);
+    return 45;
+  }
+  if (g_strcmp0 (out.subject_id, "alice.root") != 0) {
+    g_free (minted_id);
+    wyl_totp_enrollment_clear (&out);
+    return 46;
+  }
+  guint8 expected[WYL_TOTP_ENROLLMENT_SECRET_BYTES];
+  fill_seed (expected, 0x10);
+  if (memcmp (out.secret, expected, sizeof expected) != 0) {
+    g_free (minted_id);
+    wyl_totp_enrollment_clear (&out);
+    return 47;
+  }
+  if (out.last_verified_step != INT64_MIN) {
+    g_free (minted_id);
+    wyl_totp_enrollment_clear (&out);
+    return 48;
+  }
+  if (out.enrolled_at != 1700000000) {
+    g_free (minted_id);
+    wyl_totp_enrollment_clear (&out);
+    return 49;
+  }
+  if (g_strcmp0 (out.id_uuidv7, minted_id) != 0) {
+    g_free (minted_id);
+    wyl_totp_enrollment_clear (&out);
+    return 50;
+  }
+  g_free (minted_id);
+  wyl_totp_enrollment_clear (&out);
+  return 0;
+}
+
+static gint
+check_totp_enrollment_lookup_unknown_subject (void)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 60;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 61;
+
+  WylTotpEnrollment out = { 0 };
+  gboolean found = TRUE;
+  if (wyl_policy_store_totp_enrollment_lookup (store, "nobody", &out,
+          &found) != WYRELOG_E_OK) {
+    wyl_totp_enrollment_clear (&out);
+    return 62;
+  }
+  if (found) {
+    wyl_totp_enrollment_clear (&out);
+    return 63;
+  }
+  /* The out struct must remain a zero-initialised shell on miss. */
+  if (out.subject_id != NULL || out.id_uuidv7 != NULL) {
+    wyl_totp_enrollment_clear (&out);
+    return 64;
+  }
+  wyl_totp_enrollment_clear (&out);
+  return 0;
+}
+
+static gint
+check_totp_enrollment_delete_then_lookup_miss (void)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 70;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 71;
+
+  WylTotpEnrollment enr = { 0 };
+  enr.subject_id = g_strdup ("carol.svc");
+  fill_seed (enr.secret, 0x20);
+  enr.last_verified_step = INT64_MIN;
+  enr.enrolled_at = 1700000100;
+  if (wyl_policy_store_totp_enrollment_insert (store, &enr) != WYRELOG_E_OK) {
+    wyl_totp_enrollment_clear (&enr);
+    return 72;
+  }
+  wyl_totp_enrollment_clear (&enr);
+
+  if (wyl_policy_store_totp_enrollment_delete (store, "carol.svc")
+      != WYRELOG_E_OK)
+    return 73;
+
+  WylTotpEnrollment out = { 0 };
+  gboolean found = TRUE;
+  if (wyl_policy_store_totp_enrollment_lookup (store, "carol.svc", &out,
+          &found) != WYRELOG_E_OK) {
+    wyl_totp_enrollment_clear (&out);
+    return 74;
+  }
+  if (found) {
+    wyl_totp_enrollment_clear (&out);
+    return 75;
+  }
+  wyl_totp_enrollment_clear (&out);
+
+  /* Re-deleting an absent row is a no-op, not an error. */
+  if (wyl_policy_store_totp_enrollment_delete (store, "carol.svc")
+      != WYRELOG_E_OK)
+    return 76;
+  return 0;
+}
+
+static gint
+check_totp_enrollment_update_step_durability (void)
+{
+  g_autoptr (GError) error = NULL;
+  g_autofree gchar *tmpdir = g_dir_make_tmp ("wyl-policy-totp-XXXXXX", &error);
+  if (tmpdir == NULL)
+    return 80;
+  g_autofree gchar *store_path =
+      g_build_filename (tmpdir, "policy.store", NULL);
+  g_autofree gchar *key_path = g_build_filename (tmpdir, "policy.key", NULL);
+  if (!write_policy_key (key_path, 17))
+    return 81;
+
+  /* Pass 1: insert an enrollment, advance the replay watermark. */
+  {
+    g_autoptr (wyl_policy_store_t) store = NULL;
+    if (open_encrypted_policy_store (store_path, key_path, &store)
+        != WYRELOG_E_OK)
+      return 82;
+    if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+      return 83;
+
+    WylTotpEnrollment enr = { 0 };
+    enr.subject_id = g_strdup ("bob.admin");
+    fill_seed (enr.secret, 0x30);
+    enr.last_verified_step = INT64_MIN;
+    enr.enrolled_at = 1700000200;
+    if (wyl_policy_store_totp_enrollment_insert (store, &enr)
+        != WYRELOG_E_OK) {
+      wyl_totp_enrollment_clear (&enr);
+      return 84;
+    }
+    wyl_totp_enrollment_clear (&enr);
+
+    if (wyl_policy_store_totp_enrollment_update_step (store, "bob.admin",
+            56700000) != WYRELOG_E_OK)
+      return 85;
+  }
+
+  /* Pass 2: reopen and confirm the watermark survived. */
+  {
+    g_autoptr (wyl_policy_store_t) store = NULL;
+    if (open_encrypted_policy_store (store_path, key_path, &store)
+        != WYRELOG_E_OK)
+      return 86;
+    if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+      return 87;
+    WylTotpEnrollment out = { 0 };
+    gboolean found = FALSE;
+    if (wyl_policy_store_totp_enrollment_lookup (store, "bob.admin", &out,
+            &found) != WYRELOG_E_OK) {
+      wyl_totp_enrollment_clear (&out);
+      return 88;
+    }
+    if (!found) {
+      wyl_totp_enrollment_clear (&out);
+      return 89;
+    }
+    if (out.last_verified_step != 56700000) {
+      wyl_totp_enrollment_clear (&out);
+      return 90;
+    }
+    guint8 expected[WYL_TOTP_ENROLLMENT_SECRET_BYTES];
+    fill_seed (expected, 0x30);
+    if (memcmp (out.secret, expected, sizeof expected) != 0) {
+      wyl_totp_enrollment_clear (&out);
+      return 91;
+    }
+    wyl_totp_enrollment_clear (&out);
+  }
+
+  (void) g_remove (store_path);
+  (void) g_remove (key_path);
+  (void) g_rmdir (tmpdir);
+  return 0;
+}
+
+static gint
+check_totp_enrollment_two_subjects_isolated (void)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 100;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 101;
+
+  WylTotpEnrollment enr_a = { 0 };
+  enr_a.subject_id = g_strdup ("subject.a");
+  fill_seed (enr_a.secret, 0x40);
+  enr_a.last_verified_step = INT64_MIN;
+  enr_a.enrolled_at = 1700000300;
+  if (wyl_policy_store_totp_enrollment_insert (store, &enr_a)
+      != WYRELOG_E_OK) {
+    wyl_totp_enrollment_clear (&enr_a);
+    return 102;
+  }
+  wyl_totp_enrollment_clear (&enr_a);
+
+  WylTotpEnrollment enr_b = { 0 };
+  enr_b.subject_id = g_strdup ("subject.b");
+  fill_seed (enr_b.secret, 0x70);
+  enr_b.last_verified_step = INT64_MIN;
+  enr_b.enrolled_at = 1700000400;
+  if (wyl_policy_store_totp_enrollment_insert (store, &enr_b)
+      != WYRELOG_E_OK) {
+    wyl_totp_enrollment_clear (&enr_b);
+    return 103;
+  }
+  wyl_totp_enrollment_clear (&enr_b);
+
+  /* Advance only subject.a; subject.b must remain at INT64_MIN. */
+  if (wyl_policy_store_totp_enrollment_update_step (store, "subject.a", 42)
+      != WYRELOG_E_OK)
+    return 104;
+
+  WylTotpEnrollment out_a = { 0 };
+  WylTotpEnrollment out_b = { 0 };
+  gboolean found_a = FALSE;
+  gboolean found_b = FALSE;
+  if (wyl_policy_store_totp_enrollment_lookup (store, "subject.a", &out_a,
+          &found_a) != WYRELOG_E_OK || !found_a) {
+    wyl_totp_enrollment_clear (&out_a);
+    return 105;
+  }
+  if (wyl_policy_store_totp_enrollment_lookup (store, "subject.b", &out_b,
+          &found_b) != WYRELOG_E_OK || !found_b) {
+    wyl_totp_enrollment_clear (&out_a);
+    wyl_totp_enrollment_clear (&out_b);
+    return 106;
+  }
+  if (out_a.last_verified_step != 42 || out_b.last_verified_step != INT64_MIN) {
+    wyl_totp_enrollment_clear (&out_a);
+    wyl_totp_enrollment_clear (&out_b);
+    return 107;
+  }
+  guint8 exp_a[WYL_TOTP_ENROLLMENT_SECRET_BYTES];
+  guint8 exp_b[WYL_TOTP_ENROLLMENT_SECRET_BYTES];
+  fill_seed (exp_a, 0x40);
+  fill_seed (exp_b, 0x70);
+  if (memcmp (out_a.secret, exp_a, sizeof exp_a) != 0
+      || memcmp (out_b.secret, exp_b, sizeof exp_b) != 0) {
+    wyl_totp_enrollment_clear (&out_a);
+    wyl_totp_enrollment_clear (&out_b);
+    return 108;
+  }
+  if (g_strcmp0 (out_a.id_uuidv7, out_b.id_uuidv7) == 0) {
+    /* IDs must differ. */
+    wyl_totp_enrollment_clear (&out_a);
+    wyl_totp_enrollment_clear (&out_b);
+    return 109;
+  }
+  wyl_totp_enrollment_clear (&out_a);
+  wyl_totp_enrollment_clear (&out_b);
+  return 0;
+}
+
+static gint
+check_totp_enrollment_utf8_subject_id (void)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 120;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 121;
+
+  /* U+00E9 LATIN SMALL LETTER E WITH ACUTE plus a CJK ideograph; the
+   * helpers must round-trip the bytes verbatim through SQLite TEXT. */
+  const gchar *subject = "user.\xc3\xa9.\xe4\xb8\xad";
+
+  WylTotpEnrollment enr = { 0 };
+  enr.subject_id = g_strdup (subject);
+  fill_seed (enr.secret, 0x55);
+  enr.last_verified_step = INT64_MIN;
+  enr.enrolled_at = 1700000500;
+  if (wyl_policy_store_totp_enrollment_insert (store, &enr) != WYRELOG_E_OK) {
+    wyl_totp_enrollment_clear (&enr);
+    return 122;
+  }
+  wyl_totp_enrollment_clear (&enr);
+
+  WylTotpEnrollment out = { 0 };
+  gboolean found = FALSE;
+  if (wyl_policy_store_totp_enrollment_lookup (store, subject, &out, &found)
+      != WYRELOG_E_OK) {
+    wyl_totp_enrollment_clear (&out);
+    return 123;
+  }
+  if (!found) {
+    wyl_totp_enrollment_clear (&out);
+    return 124;
+  }
+  if (g_strcmp0 (out.subject_id, subject) != 0) {
+    wyl_totp_enrollment_clear (&out);
+    return 125;
+  }
+  wyl_totp_enrollment_clear (&out);
+  return 0;
+}
+
+static gint
+check_totp_enrollment_clear_zeros_secret (void)
+{
+  /* wyl_totp_enrollment_clear must zero the secret buffer even when
+   * subject_id/id_uuidv7 are NULL (i.e. on an uninitialised stack
+   * struct) and must tolerate a NULL pointer. */
+  wyl_totp_enrollment_clear (NULL);
+
+  WylTotpEnrollment enr = { 0 };
+  fill_seed (enr.secret, 0x77);
+  wyl_totp_enrollment_clear (&enr);
+  for (gsize i = 0; i < WYL_TOTP_ENROLLMENT_SECRET_BYTES; i++) {
+    if (enr.secret[i] != 0)
+      return 130;
+  }
+  return 0;
+}
+
+static gint
+check_totp_enrollment_rejects_invalid_args (void)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 140;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 141;
+
+  WylTotpEnrollment enr = { 0 };
+  enr.subject_id = g_strdup ("victim");
+  fill_seed (enr.secret, 0x88);
+  if (wyl_policy_store_totp_enrollment_insert (NULL, &enr)
+      != WYRELOG_E_INVALID) {
+    wyl_totp_enrollment_clear (&enr);
+    return 142;
+  }
+  if (wyl_policy_store_totp_enrollment_insert (store, NULL)
+      != WYRELOG_E_INVALID) {
+    wyl_totp_enrollment_clear (&enr);
+    return 143;
+  }
+  wyl_totp_enrollment_clear (&enr);
+
+  WylTotpEnrollment with_empty_subject = { 0 };
+  with_empty_subject.subject_id = g_strdup ("");
+  fill_seed (with_empty_subject.secret, 0x99);
+  if (wyl_policy_store_totp_enrollment_insert (store, &with_empty_subject)
+      != WYRELOG_E_INVALID) {
+    wyl_totp_enrollment_clear (&with_empty_subject);
+    return 144;
+  }
+  wyl_totp_enrollment_clear (&with_empty_subject);
+
+  WylTotpEnrollment out = { 0 };
+  gboolean found = FALSE;
+  if (wyl_policy_store_totp_enrollment_lookup (NULL, "x", &out, &found)
+      != WYRELOG_E_INVALID)
+    return 145;
+  if (wyl_policy_store_totp_enrollment_lookup (store, NULL, &out, &found)
+      != WYRELOG_E_INVALID)
+    return 146;
+  if (wyl_policy_store_totp_enrollment_lookup (store, "x", NULL, &found)
+      != WYRELOG_E_INVALID)
+    return 147;
+  if (wyl_policy_store_totp_enrollment_lookup (store, "x", &out, NULL)
+      != WYRELOG_E_INVALID)
+    return 148;
+
+  if (wyl_policy_store_totp_enrollment_update_step (NULL, "x", 0)
+      != WYRELOG_E_INVALID)
+    return 149;
+  if (wyl_policy_store_totp_enrollment_update_step (store, NULL, 0)
+      != WYRELOG_E_INVALID)
+    return 150;
+
+  if (wyl_policy_store_totp_enrollment_delete (NULL, "x")
+      != WYRELOG_E_INVALID)
+    return 151;
+  if (wyl_policy_store_totp_enrollment_delete (store, NULL)
+      != WYRELOG_E_INVALID)
+    return 152;
+  return 0;
+}
+
+static gint
+check_totp_enrollment_insert_replaces_existing (void)
+{
+  /* Re-enrolling the same subject overwrites the prior row in place
+   * (subject_id is the primary key). This is the contract that the
+   * eventual wyctl mfa reset path relies on. */
+  g_autoptr (wyl_policy_store_t) store = NULL;
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 160;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 161;
+
+  WylTotpEnrollment first = { 0 };
+  first.subject_id = g_strdup ("rotator");
+  fill_seed (first.secret, 0xA0);
+  first.last_verified_step = INT64_MIN;
+  first.enrolled_at = 1700000600;
+  if (wyl_policy_store_totp_enrollment_insert (store, &first)
+      != WYRELOG_E_OK) {
+    wyl_totp_enrollment_clear (&first);
+    return 162;
+  }
+  wyl_totp_enrollment_clear (&first);
+
+  /* Advance the step so we can prove the replace resets it. */
+  if (wyl_policy_store_totp_enrollment_update_step (store, "rotator", 100)
+      != WYRELOG_E_OK)
+    return 163;
+
+  WylTotpEnrollment second = { 0 };
+  second.subject_id = g_strdup ("rotator");
+  fill_seed (second.secret, 0xB0);
+  second.last_verified_step = INT64_MIN;
+  second.enrolled_at = 1700000700;
+  if (wyl_policy_store_totp_enrollment_insert (store, &second)
+      != WYRELOG_E_OK) {
+    wyl_totp_enrollment_clear (&second);
+    return 164;
+  }
+  wyl_totp_enrollment_clear (&second);
+
+  WylTotpEnrollment out = { 0 };
+  gboolean found = FALSE;
+  if (wyl_policy_store_totp_enrollment_lookup (store, "rotator", &out,
+          &found) != WYRELOG_E_OK || !found) {
+    wyl_totp_enrollment_clear (&out);
+    return 165;
+  }
+  guint8 expected[WYL_TOTP_ENROLLMENT_SECRET_BYTES];
+  fill_seed (expected, 0xB0);
+  if (memcmp (out.secret, expected, sizeof expected) != 0) {
+    wyl_totp_enrollment_clear (&out);
+    return 166;
+  }
+  /* The replay watermark must reset to INT64_MIN: the new seed has no
+   * prior verifications. */
+  if (out.last_verified_step != INT64_MIN) {
+    wyl_totp_enrollment_clear (&out);
+    return 167;
+  }
+  if (out.enrolled_at != 1700000700) {
+    wyl_totp_enrollment_clear (&out);
+    return 168;
+  }
+  wyl_totp_enrollment_clear (&out);
+  return 0;
+}
+
+static gint
+check_totp_enrollment_update_step_absent_subject_is_noop (void)
+{
+  /* Locks the documented contract at store-private.h:533-542:
+   * update_step against a subject with no enrollment row returns
+   * WYRELOG_E_OK without creating a row.  The commit-3 transactional
+   * verify path layers on top of this no-op behaviour. */
+  g_autoptr (wyl_policy_store_t) store = NULL;
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 180;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 181;
+
+  if (wyl_policy_store_totp_enrollment_update_step (store, "never-enrolled", 5)
+      != WYRELOG_E_OK)
+    return 182;
+
+  WylTotpEnrollment out = { 0 };
+  gboolean found = TRUE;
+  if (wyl_policy_store_totp_enrollment_lookup (store, "never-enrolled", &out,
+          &found) != WYRELOG_E_OK) {
+    wyl_totp_enrollment_clear (&out);
+    return 183;
+  }
+  if (found) {
+    wyl_totp_enrollment_clear (&out);
+    return 184;
+  }
+  wyl_totp_enrollment_clear (&out);
+  return 0;
+}
+
+int
+main (void)
+{
+  gint rc;
+
+  if ((rc = check_totp_enrollment_table_is_created_on_fresh_store ()) != 0)
+    return rc;
+  if ((rc = check_totp_enrollment_migration_is_idempotent ()) != 0)
+    return rc;
+  if ((rc = check_totp_enrollment_insert_lookup_round_trip ()) != 0)
+    return rc;
+  if ((rc = check_totp_enrollment_lookup_unknown_subject ()) != 0)
+    return rc;
+  if ((rc = check_totp_enrollment_delete_then_lookup_miss ()) != 0)
+    return rc;
+  if ((rc = check_totp_enrollment_update_step_durability ()) != 0)
+    return rc;
+  if ((rc = check_totp_enrollment_two_subjects_isolated ()) != 0)
+    return rc;
+  if ((rc = check_totp_enrollment_utf8_subject_id ()) != 0)
+    return rc;
+  if ((rc = check_totp_enrollment_clear_zeros_secret ()) != 0)
+    return rc;
+  if ((rc = check_totp_enrollment_rejects_invalid_args ()) != 0)
+    return rc;
+  if ((rc = check_totp_enrollment_insert_replaces_existing ()) != 0)
+    return rc;
+  if ((rc = check_totp_enrollment_update_step_absent_subject_is_noop ()) != 0)
+    return rc;
+  return 0;
+}

--- a/tests/test-policy-store.c
+++ b/tests/test-policy-store.c
@@ -1681,8 +1681,13 @@ check_store_grants_role_inheritance (void)
 
   if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
     return 48;
-  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
-    return 49;
+  {
+    wyrelog_error_t _dbg_rc = wyl_policy_store_create_schema (store);
+    if (_dbg_rc != WYRELOG_E_OK) {
+      g_printerr ("DEBUG inheritance create_schema rc=%d\n", (int) _dbg_rc);
+      return 49;
+    }
+  }
   if (wyl_policy_store_upsert_role (store, "site.child-role", "child role")
       != WYRELOG_E_OK)
     return 58;
@@ -2580,6 +2585,588 @@ check_store_sets_principal_state (void)
     return 84;
   if (expect.matches != 1)
     return 85;
+  return 0;
+}
+
+static gint
+check_store_get_principal_state_round_trip (void)
+{
+  /* Commit-5: forward flag from architect.  The new public accessor
+   * wyl_policy_store_get_principal_state replaces the historical
+   * foreach-based two-step lookup in daemon/http.c.  This test
+   * exercises: (a) the missing-row branch returns out_found=FALSE with
+   * *out_state=NULL, (b) the row-present branch round-trips state, and
+   * (c) the helper rejects NULL pointers without touching the store. */
+  g_autoptr (wyl_policy_store_t) store = NULL;
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 1500;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 1501;
+
+  /* Missing row: out_found=FALSE, *out_state=NULL, return OK. */
+  g_autofree gchar *missing = (gchar *) 0x1;    /* deliberate sentinel */
+  gboolean found = TRUE;
+  if (wyl_policy_store_get_principal_state (store, "no-such-subject",
+          &missing, &found) != WYRELOG_E_OK)
+    return 1502;
+  if (found)
+    return 1503;
+  if (missing != NULL)
+    return 1504;
+
+  /* Row present: round-trip a value via the existing set_principal_state. */
+  if (wyl_policy_store_set_principal_state (store, "subject-A",
+          "mfa_required") != WYRELOG_E_OK)
+    return 1505;
+  g_autofree gchar *state_a = NULL;
+  gboolean found_a = FALSE;
+  if (wyl_policy_store_get_principal_state (store, "subject-A", &state_a,
+          &found_a) != WYRELOG_E_OK)
+    return 1506;
+  if (!found_a)
+    return 1507;
+  if (g_strcmp0 (state_a, "mfa_required") != 0)
+    return 1508;
+
+  /* Updated row: re-read picks up the new value. */
+  if (wyl_policy_store_set_principal_state (store, "subject-A",
+          "authenticated") != WYRELOG_E_OK)
+    return 1509;
+  g_clear_pointer (&state_a, g_free);
+  if (wyl_policy_store_get_principal_state (store, "subject-A", &state_a,
+          &found_a) != WYRELOG_E_OK)
+    return 1510;
+  if (!found_a)
+    return 1511;
+  if (g_strcmp0 (state_a, "authenticated") != 0)
+    return 1512;
+
+  /* NULL-input shape check. */
+  if (wyl_policy_store_get_principal_state (NULL, "subject-A", &state_a,
+          &found_a) != WYRELOG_E_INVALID)
+    return 1513;
+  if (wyl_policy_store_get_principal_state (store, NULL, &state_a,
+          &found_a) != WYRELOG_E_INVALID)
+    return 1514;
+  if (wyl_policy_store_get_principal_state (store, "subject-A", NULL,
+          &found_a) != WYRELOG_E_INVALID)
+    return 1515;
+  if (wyl_policy_store_get_principal_state (store, "subject-A", &state_a,
+          NULL) != WYRELOG_E_INVALID)
+    return 1516;
+  return 0;
+}
+
+static gint
+check_store_apply_principal_failure_increments_counter (void)
+{
+  /* Commit-5: each call increments the failure counter atomically.
+   * Below the |threshold| the row stays in mfa_required; locked_at
+   * remains NULL (surfaced as INT64_MIN). */
+  g_autoptr (wyl_policy_store_t) store = NULL;
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 1520;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 1521;
+  if (wyl_policy_store_set_principal_state (store, "lockout.below",
+          "mfa_required") != WYRELOG_E_OK)
+    return 1522;
+
+  for (gint64 expected = 1; expected <= 4; expected++) {
+    g_autofree gchar *st = NULL;
+    gint64 count = -1;
+    gint64 locked_at = 0;
+    if (wyl_policy_store_apply_principal_failure (store, "lockout.below",
+            5, 100000, &st, &count, &locked_at) != WYRELOG_E_OK)
+      return 1523;
+    if (g_strcmp0 (st, "mfa_required") != 0)
+      return 1524;
+    if (count != expected)
+      return 1525;
+    if (locked_at != G_MININT64)
+      return 1526;
+  }
+  return 0;
+}
+
+static gint
+check_store_apply_principal_failure_transitions_to_locked (void)
+{
+  /* Threshold hit on the 5th call: state moves to locked, locked_at is
+   * the |now_secs| passed in, and the counter equals the threshold. */
+  g_autoptr (wyl_policy_store_t) store = NULL;
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 1530;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 1531;
+  if (wyl_policy_store_set_principal_state (store, "lockout.cross",
+          "mfa_required") != WYRELOG_E_OK)
+    return 1532;
+
+  gint64 final_locked_at = 0;
+  for (gint64 i = 1; i <= 5; i++) {
+    g_autofree gchar *st = NULL;
+    gint64 count = -1;
+    gint64 locked_at = 0;
+    if (wyl_policy_store_apply_principal_failure (store, "lockout.cross",
+            5, 200000 + i, &st, &count, &locked_at) != WYRELOG_E_OK)
+      return 1533;
+    if (i < 5) {
+      if (g_strcmp0 (st, "mfa_required") != 0)
+        return 1534;
+      if (locked_at != G_MININT64)
+        return 1535;
+    } else {
+      if (g_strcmp0 (st, "locked") != 0)
+        return 1536;
+      if (count != 5)
+        return 1537;
+      if (locked_at != 200000 + 5)
+        return 1538;
+      final_locked_at = locked_at;
+    }
+  }
+
+  /* Reload the row via the new public accessor: still locked, same
+   * counter, same locked_at.  The persistence guarantee is verified by
+   * walking the row through a separate read. */
+  g_autofree gchar *st = NULL;
+  gint64 count = -1;
+  gint64 locked_at = -1;
+  gboolean found = FALSE;
+  if (wyl_policy_store_get_principal_lock_info (store, "lockout.cross", &st,
+          &count, &locked_at, &found) != WYRELOG_E_OK)
+    return 1539;
+  if (!found)
+    return 1540;
+  if (g_strcmp0 (st, "locked") != 0)
+    return 1541;
+  if (count != 5)
+    return 1542;
+  if (locked_at != final_locked_at)
+    return 1543;
+  return 0;
+}
+
+static gint
+check_store_apply_principal_failure_survives_reopen (void)
+{
+  /* Critic-flagged invariant: lockout state durable across daemon
+   * restart.  Drive 5 failures, close the store, reopen, assert state
+   * is still locked with locked_at preserved.  Uses an encrypted store
+   * on disk so the reopen actually touches the same SQLite file. */
+  g_autofree gchar *root = g_dir_make_tmp ("wyl-store-lockout-XXXXXX", NULL);
+  if (root == NULL)
+    return 1550;
+  g_autofree gchar *db_path = g_build_filename (root, "policy-store.db", NULL);
+  gint rc_inner = 0;
+
+  /* Phase 1: open, populate. */
+  {
+    g_autoptr (wyl_policy_store_t) store = NULL;
+    wyl_policy_store_open_options_t opts = {
+      .path = db_path,
+      .require_encrypted = FALSE,
+    };
+    if (wyl_policy_store_open_with_options (&opts, &store) != WYRELOG_E_OK) {
+      rc_inner = 1551;
+      goto cleanup;
+    }
+    if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK) {
+      rc_inner = 1552;
+      goto cleanup;
+    }
+    if (wyl_policy_store_set_principal_state (store, "lockout.persist",
+            "mfa_required") != WYRELOG_E_OK) {
+      rc_inner = 1553;
+      goto cleanup;
+    }
+    for (gint64 i = 1; i <= 5; i++) {
+      g_autofree gchar *st = NULL;
+      gint64 count = -1;
+      gint64 locked_at = 0;
+      if (wyl_policy_store_apply_principal_failure (store, "lockout.persist",
+              5, 300000 + i, &st, &count, &locked_at) != WYRELOG_E_OK) {
+        rc_inner = 1554;
+        goto cleanup;
+      }
+    }
+  }
+
+  /* Phase 2: reopen, assert lockout is still present. */
+  {
+    g_autoptr (wyl_policy_store_t) store2 = NULL;
+    wyl_policy_store_open_options_t opts = {
+      .path = db_path,
+      .require_encrypted = FALSE,
+    };
+    if (wyl_policy_store_open_with_options (&opts, &store2) != WYRELOG_E_OK) {
+      rc_inner = 1555;
+      goto cleanup;
+    }
+    g_autofree gchar *st = NULL;
+    gint64 count = -1;
+    gint64 locked_at = 0;
+    gboolean found = FALSE;
+    if (wyl_policy_store_get_principal_lock_info (store2, "lockout.persist",
+            &st, &count, &locked_at, &found) != WYRELOG_E_OK) {
+      rc_inner = 1556;
+      goto cleanup;
+    }
+    if (!found || g_strcmp0 (st, "locked") != 0 || count != 5
+        || locked_at != 300000 + 5) {
+      rc_inner = 1557;
+      goto cleanup;
+    }
+  }
+
+cleanup:
+  (void) g_unlink (db_path);
+  (void) g_rmdir (root);
+  return rc_inner;
+}
+
+static gint
+check_store_reset_principal_failure_counter (void)
+{
+  /* On a successful TOTP verify the validator resets the counter and
+   * clears locked_at; this helper exercises that primitive directly. */
+  g_autoptr (wyl_policy_store_t) store = NULL;
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 1560;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 1561;
+  if (wyl_policy_store_set_principal_state (store, "lockout.reset",
+          "mfa_required") != WYRELOG_E_OK)
+    return 1562;
+
+  /* Bump the counter to 4 (below threshold). */
+  for (gint64 i = 1; i <= 4; i++) {
+    g_autofree gchar *st = NULL;
+    gint64 c = 0;
+    gint64 l = 0;
+    if (wyl_policy_store_apply_principal_failure (store, "lockout.reset",
+            5, 400000 + i, &st, &c, &l) != WYRELOG_E_OK)
+      return 1563;
+  }
+
+  /* Reset; counter must be 0, locked_at NULL (INT64_MIN). */
+  if (wyl_policy_store_reset_principal_failure_counter (store,
+          "lockout.reset") != WYRELOG_E_OK)
+    return 1564;
+  g_autofree gchar *st = NULL;
+  gint64 count = -1;
+  gint64 locked_at = -1;
+  gboolean found = FALSE;
+  if (wyl_policy_store_get_principal_lock_info (store, "lockout.reset", &st,
+          &count, &locked_at, &found) != WYRELOG_E_OK)
+    return 1565;
+  if (!found || count != 0 || locked_at != G_MININT64)
+    return 1566;
+
+  /* A subsequent failure restarts the counter at 1. */
+  g_autofree gchar *st2 = NULL;
+  gint64 c2 = 0;
+  gint64 l2 = 0;
+  if (wyl_policy_store_apply_principal_failure (store, "lockout.reset", 5,
+          500000, &st2, &c2, &l2) != WYRELOG_E_OK)
+    return 1567;
+  if (c2 != 1 || g_strcmp0 (st2, "mfa_required") != 0)
+    return 1568;
+  return 0;
+}
+
+static gint
+check_store_apply_principal_failure_sequential_race (void)
+{
+  /* Critic-flagged read-modify-write race: 5 sequential failures must
+   * end at counter=5 with the row in LOCKED state, and any further
+   * FAILED_ATTEMPT against the LOCKED row must be refused with
+   * WYRELOG_E_POLICY without bumping the counter or locked_at (the
+   * commit-5 iteration LOW #2 defensive guard).  Concurrent threads
+   * are not exercised here because the daemon serialises mutations on
+   * the policy store's single sqlite connection via the existing
+   * SAVEPOINT primitive (which is composed inside apply_principal_failure).
+   * The atomicity guarantee we lock down here is: each call observes
+   * the durable counter from the prior call, no "AT MOST one locks"
+   * regression where a stale read leaves the row stuck below threshold. */
+  g_autoptr (wyl_policy_store_t) store = NULL;
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 1580;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 1581;
+  if (wyl_policy_store_set_principal_state (store, "lockout.race",
+          "mfa_required") != WYRELOG_E_OK)
+    return 1582;
+
+  /* Five successful failures, threshold cross on the fifth. */
+  for (gint i = 0; i < 5; i++) {
+    g_autofree gchar *st = NULL;
+    gint64 c = 0;
+    gint64 l = 0;
+    if (wyl_policy_store_apply_principal_failure (store, "lockout.race",
+            5, 700000 + i, &st, &c, &l) != WYRELOG_E_OK)
+      return 1583;
+  }
+
+  /* Sixth call against the LOCKED row: must return WYRELOG_E_POLICY,
+   * counter/locked_at unchanged. */
+  {
+    g_autofree gchar *st = NULL;
+    gint64 c = 0;
+    gint64 l = 0;
+    if (wyl_policy_store_apply_principal_failure (store, "lockout.race",
+            5, 700100, &st, &c, &l) != WYRELOG_E_POLICY)
+      return 1589;
+  }
+
+  g_autofree gchar *st = NULL;
+  gint64 count = -1;
+  gint64 locked_at = -1;
+  gboolean found = FALSE;
+  if (wyl_policy_store_get_principal_lock_info (store, "lockout.race", &st,
+          &count, &locked_at, &found) != WYRELOG_E_OK)
+    return 1584;
+  if (!found)
+    return 1585;
+  /* Counter is pinned at the threshold value (5) once the row is
+   * LOCKED; the sixth call did NOT bump anything. */
+  if (count != 5)
+    return 1586;
+  if (g_strcmp0 (st, "locked") != 0)
+    return 1587;
+  if (locked_at == G_MININT64)
+    return 1588;
+  return 0;
+}
+
+static gint
+check_store_apply_principal_unlock (void)
+{
+  /* LOCKED -> UNVERIFIED atomic transition: state moves to unverified,
+   * locked_at and counter both clear, and a principal_event row of
+   * shape (subject, 'unlock', 'locked', 'unverified') is appended. */
+  g_autoptr (wyl_policy_store_t) store = NULL;
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 1570;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 1571;
+  if (wyl_policy_store_set_principal_state (store, "lockout.unlock",
+          "mfa_required") != WYRELOG_E_OK)
+    return 1572;
+  for (gint64 i = 1; i <= 5; i++) {
+    g_autofree gchar *st = NULL;
+    gint64 c = 0;
+    gint64 l = 0;
+    if (wyl_policy_store_apply_principal_failure (store, "lockout.unlock",
+            5, 600000 + i, &st, &c, &l) != WYRELOG_E_OK)
+      return 1573;
+  }
+  if (wyl_policy_store_apply_principal_unlock (store, "lockout.unlock")
+      != WYRELOG_E_OK)
+    return 1574;
+  g_autofree gchar *st = NULL;
+  gint64 count = -1;
+  gint64 locked_at = -1;
+  gboolean found = FALSE;
+  if (wyl_policy_store_get_principal_lock_info (store, "lockout.unlock", &st,
+          &count, &locked_at, &found) != WYRELOG_E_OK)
+    return 1575;
+  if (!found || g_strcmp0 (st, "unverified") != 0 || count != 0
+      || locked_at != G_MININT64)
+    return 1576;
+  return 0;
+}
+
+/* Issue #331 commit 5 iteration (LOW #2): apply_principal_failure
+ * MUST refuse to extend a lockout when the row is already LOCKED.  The
+ * validator's lockout gate prevents this in production, but the helper
+ * is library-internal and future callers (e.g. wyctl in commit 6)
+ * must not be able to bump locked_at or the counter by re-driving
+ * FAILED_ATTEMPT against a LOCKED row.  The helper returns
+ * WYRELOG_E_POLICY, leaves locked_at and the counter untouched, and
+ * emits no extra principal_event row. */
+static gint
+check_store_apply_principal_failure_refuses_already_locked (void)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+  if (wyl_policy_store_open (NULL, &store) != WYRELOG_E_OK)
+    return 1580;
+  if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+    return 1581;
+  if (wyl_policy_store_set_principal_state (store, "lockout.relock",
+          "mfa_required") != WYRELOG_E_OK)
+    return 1582;
+
+  /* Drive the subject across the 5-failure threshold to LOCKED. */
+  for (gint64 i = 1; i <= 5; i++) {
+    g_autofree gchar *st = NULL;
+    gint64 c = 0;
+    gint64 l = 0;
+    if (wyl_policy_store_apply_principal_failure (store, "lockout.relock",
+            5, 700000 + i, &st, &c, &l) != WYRELOG_E_OK)
+      return 1583;
+  }
+
+  /* Capture the original locked_at + counter for the post-condition. */
+  g_autofree gchar *st_before = NULL;
+  gint64 count_before = -1;
+  gint64 locked_at_before = -1;
+  gboolean found_before = FALSE;
+  if (wyl_policy_store_get_principal_lock_info (store, "lockout.relock",
+          &st_before, &count_before, &locked_at_before, &found_before)
+      != WYRELOG_E_OK)
+    return 1584;
+  if (!found_before || g_strcmp0 (st_before, "locked") != 0
+      || count_before != 5 || locked_at_before != 700005)
+    return 1585;
+
+  /* Count the principal_event rows once before the second-LOCK attempt
+   * so we can prove no new event was appended. */
+  gint events_before = 0;
+  if (count_rows (store,
+          "SELECT COUNT(*) FROM principal_events "
+          "WHERE subject_id = 'lockout.relock';", &events_before) != 0)
+    return 1586;
+
+  /* Re-drive FAILED_ATTEMPT against the already-LOCKED row with a
+   * later wallclock so a buggy implementation that overwrote locked_at
+   * would be detectable. */
+  g_autofree gchar *st_attempt = NULL;
+  gint64 c_attempt = 0;
+  gint64 l_attempt = 0;
+  wyrelog_error_t relock_rc =
+      wyl_policy_store_apply_principal_failure (store, "lockout.relock", 5,
+      800000, &st_attempt, &c_attempt, &l_attempt);
+  if (relock_rc != WYRELOG_E_POLICY)
+    return 1587;
+  /* Out-params on the refuse path should not leak partial state. */
+  if (st_attempt != NULL || c_attempt != 0 || l_attempt != G_MININT64)
+    return 1588;
+
+  /* The persisted row must be unchanged: same state, same counter,
+   * same locked_at - the second FAILED_ATTEMPT did NOT bump anything. */
+  g_autofree gchar *st_after = NULL;
+  gint64 count_after = -1;
+  gint64 locked_at_after = -1;
+  gboolean found_after = FALSE;
+  if (wyl_policy_store_get_principal_lock_info (store, "lockout.relock",
+          &st_after, &count_after, &locked_at_after, &found_after)
+      != WYRELOG_E_OK)
+    return 1589;
+  if (!found_after || g_strcmp0 (st_after, "locked") != 0
+      || count_after != count_before || locked_at_after != locked_at_before)
+    return 1590;
+
+  /* No additional principal_event row should have been emitted. */
+  gint events_after = 0;
+  if (count_rows (store,
+          "SELECT COUNT(*) FROM principal_events "
+          "WHERE subject_id = 'lockout.relock';", &events_after) != 0)
+    return 1591;
+  if (events_after != events_before)
+    return 1592;
+
+  return 0;
+}
+
+/* Issue #331 commit 5 iteration (LOW #4): legacy-schema migration.
+ * A pre-#331-commit-5 store has principal_states with three columns
+ * (subject_id, state, updated_at) - no failed_attempt_count, no
+ * locked_at.  On reopen, create_schema's PRAGMA table_info / ALTER
+ * TABLE ADD COLUMN block must back-fill the new columns idempotently,
+ * preserving the existing rows' subject_id / state / updated_at and
+ * defaulting the new columns to (0, NULL). */
+static gint
+check_store_principal_states_legacy_schema_migration (void)
+{
+  g_autoptr (GError) error = NULL;
+  g_autofree gchar *tmpdir =
+      g_dir_make_tmp ("wyl-policy-ps-legacy-XXXXXX", &error);
+  if (tmpdir == NULL)
+    return 1600;
+  g_autofree gchar *store_path =
+      g_build_filename (tmpdir, "policy.store", NULL);
+  g_autofree gchar *key_path = g_build_filename (tmpdir, "policy.key", NULL);
+  if (!write_policy_key (key_path, 17))
+    return 1601;
+
+  /* Phase A: stand up the store with the full modern schema, then
+   * mutate principal_states down to the legacy three-column shape and
+   * insert a hand-rolled legacy row.  We drop and recreate the table
+   * to model a store written by a pre-#331-commit-5 binary. */
+  {
+    g_autoptr (wyl_policy_store_t) store = NULL;
+    if (open_encrypted_policy_store (store_path, key_path, &store)
+        != WYRELOG_E_OK)
+      return 1602;
+    if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+      return 1603;
+    if (sqlite3_exec (wyl_policy_store_get_db (store),
+            "DROP TABLE principal_states;"
+            "CREATE TABLE principal_states ("
+            "  subject_id TEXT PRIMARY KEY,"
+            "  state TEXT NOT NULL,"
+            "  updated_at INTEGER"
+            ");"
+            "INSERT INTO principal_states (subject_id, state, updated_at) "
+            "  VALUES ('legacy.user', 'mfa_required', 1234567);",
+            NULL, NULL, NULL) != SQLITE_OK)
+      return 1604;
+  }
+
+  /* Phase B: reopen; create_schema's ALTER TABLE ADD COLUMN block
+   * should back-fill failed_attempt_count and locked_at on the
+   * existing row without disturbing the columns that were already
+   * there. */
+  {
+    g_autoptr (wyl_policy_store_t) store = NULL;
+    if (open_encrypted_policy_store (store_path, key_path, &store)
+        != WYRELOG_E_OK)
+      return 1605;
+    if (wyl_policy_store_create_schema (store) != WYRELOG_E_OK)
+      return 1606;
+
+    /* The new columns must be present and defaulted to (0, NULL) on
+     * the migrated row.  Use the lock_info accessor so we exercise
+     * the same SELECT path that the validator uses in production. */
+    g_autofree gchar *st = NULL;
+    gint64 count = -1;
+    gint64 locked_at = -1;
+    gboolean found = FALSE;
+    if (wyl_policy_store_get_principal_lock_info (store, "legacy.user",
+            &st, &count, &locked_at, &found) != WYRELOG_E_OK)
+      return 1607;
+    if (!found)
+      return 1608;
+    if (g_strcmp0 (st, "mfa_required") != 0)
+      return 1609;
+    if (count != 0)
+      return 1610;
+    if (locked_at != G_MININT64)
+      return 1611;
+
+    /* Cross-check updated_at preservation via a raw SELECT - the
+     * lock_info accessor does not expose it. */
+    sqlite3_stmt *stmt = NULL;
+    if (sqlite3_prepare_v2 (wyl_policy_store_get_db (store),
+            "SELECT updated_at FROM principal_states "
+            "WHERE subject_id = 'legacy.user';", -1, &stmt, NULL)
+        != SQLITE_OK)
+      return 1612;
+    if (sqlite3_step (stmt) != SQLITE_ROW) {
+      sqlite3_finalize (stmt);
+      return 1613;
+    }
+    gint64 updated_at = sqlite3_column_int64 (stmt, 0);
+    sqlite3_finalize (stmt);
+    if (updated_at != 1234567)
+      return 1614;
+  }
+
+  (void) g_remove (store_path);
+  (void) g_remove (key_path);
+  (void) g_rmdir (tmpdir);
   return 0;
 }
 
@@ -3931,6 +4518,24 @@ main (void)
       != 0)
     return rc;
   if ((rc = check_store_sets_principal_state ()) != 0)
+    return rc;
+  if ((rc = check_store_get_principal_state_round_trip ()) != 0)
+    return rc;
+  if ((rc = check_store_apply_principal_failure_increments_counter ()) != 0)
+    return rc;
+  if ((rc = check_store_apply_principal_failure_transitions_to_locked ()) != 0)
+    return rc;
+  if ((rc = check_store_apply_principal_failure_survives_reopen ()) != 0)
+    return rc;
+  if ((rc = check_store_reset_principal_failure_counter ()) != 0)
+    return rc;
+  if ((rc = check_store_apply_principal_failure_sequential_race ()) != 0)
+    return rc;
+  if ((rc = check_store_apply_principal_unlock ()) != 0)
+    return rc;
+  if ((rc = check_store_apply_principal_failure_refuses_already_locked ()) != 0)
+    return rc;
+  if ((rc = check_store_principal_states_legacy_schema_migration ()) != 0)
     return rc;
   if ((rc = check_store_sets_session_state ()) != 0)
     return rc;

--- a/tests/test-totp.c
+++ b/tests/test-totp.c
@@ -1,0 +1,314 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+/*
+ * Unit tests for the RFC 6238 TOTP core (wyrelog/auth/totp.{c,h}).
+ *
+ * Vectors come from RFC 6238 Appendix B, restricted to the SHA-1
+ * variant.  Appendix B prints 8-digit codes; this module is locked to
+ * 6 digits, so each expected value is the published 8-digit code
+ * taken modulo 1_000_000.  The seed used by Appendix B for SHA-1 is
+ * the 20-byte ASCII string "12345678901234567890".
+ */
+
+#include "auth/totp.h"
+
+#include <glib.h>
+#include <sodium.h>
+#include <string.h>
+
+/* RFC 6238 SHA-1 canonical 20-byte seed (ASCII "12345678901234567890"). */
+static const guint8 RFC6238_SEED[20] = {
+  0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38,
+  0x39, 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36,
+  0x37, 0x38, 0x39, 0x30,
+};
+
+typedef struct
+{
+  gint64 unix_time;
+  guint expected_code;          /* 8-digit RFC value mod 1_000_000 */
+} rfc6238_vector_t;
+
+static const rfc6238_vector_t RFC6238_VECTORS[] = {
+  /* T=59          -> 94287082 -> 287082 */
+  {59, 287082},
+  /* T=1111111109  -> 07081804 -> 081804 */
+  {1111111109, 81804},
+  /* T=1111111111  -> 14050471 -> 050471 */
+  {1111111111, 50471},
+  /* T=1234567890  -> 89005924 -> 005924 */
+  {1234567890, 5924},
+  /* T=2000000000  -> 69279037 -> 279037 */
+  {2000000000, 279037},
+  /* T=20000000000 -> 65353130 -> 353130 */
+  {20000000000LL, 353130},
+};
+
+static gint
+check_rfc6238_vectors (void)
+{
+  for (gsize i = 0; i < G_N_ELEMENTS (RFC6238_VECTORS); i++) {
+    const rfc6238_vector_t *v = &RFC6238_VECTORS[i];
+    guint64 step = (guint64) (v->unix_time / 30);
+    guint code = 999999;
+    if (wyl_totp_code_at_step (RFC6238_SEED, sizeof RFC6238_SEED, step, &code,
+            NULL) != WYRELOG_E_OK)
+      return 100 + (gint) i;
+    if (code != v->expected_code)
+      return 200 + (gint) i;
+  }
+  return 0;
+}
+
+static gint
+check_code_at_step_validates_args (void)
+{
+  guint code = 0;
+  if (wyl_totp_code_at_step (NULL, sizeof RFC6238_SEED, 0, &code, NULL)
+      != WYRELOG_E_INVALID)
+    return 10;
+  if (wyl_totp_code_at_step (RFC6238_SEED, 0, 0, &code, NULL)
+      != WYRELOG_E_INVALID)
+    return 11;
+  if (wyl_totp_code_at_step (RFC6238_SEED, sizeof RFC6238_SEED, 0, NULL, NULL)
+      != WYRELOG_E_INVALID)
+    return 12;
+  return 0;
+}
+
+static gint
+check_matches_within_skew_window (void)
+{
+  /* For T=59 (step 1 under T0=0, step=30), accept current step 1
+   * and the {-1, +1} skew neighbours (steps 0 and 2).  T=59 ± 30s
+   * keeps us inside the ±1 window.  T=59 ± 60s lands two steps
+   * away and must be rejected. */
+  guint code_step1 = 0;
+  if (wyl_totp_code_at_step (RFC6238_SEED, sizeof RFC6238_SEED, 1, &code_step1,
+          NULL) != WYRELOG_E_OK)
+    return 20;
+
+  /* The code at step 1 must be accepted at T=59 (step 1), T=29 (step 0)
+   * via +1 skew, and T=89 (step 2) via -1 skew. */
+  guint64 matched_step = 0;
+  GError *error = NULL;
+  if (!wyl_totp_code_matches (RFC6238_SEED, sizeof RFC6238_SEED, 59,
+          code_step1, &matched_step, &error))
+    return 21;
+  if (matched_step != 1)
+    return 22;
+  matched_step = 0;
+  if (!wyl_totp_code_matches (RFC6238_SEED, sizeof RFC6238_SEED, 29,
+          code_step1, &matched_step, &error))
+    return 23;
+  if (matched_step != 1)
+    return 24;
+  matched_step = 0;
+  if (!wyl_totp_code_matches (RFC6238_SEED, sizeof RFC6238_SEED, 89,
+          code_step1, &matched_step, &error))
+    return 25;
+  if (matched_step != 1)
+    return 26;
+
+  /* T = -1 (i.e. shift one step earlier) — code_step1 must NOT
+   * match because the verifier is centred on step -1, not step 1. */
+  if (wyl_totp_code_matches (RFC6238_SEED, sizeof RFC6238_SEED, -1,
+          code_step1, NULL, &error))
+    return 27;
+
+  /* T=119 lands on step 3 (code_step1 is two steps away). */
+  if (wyl_totp_code_matches (RFC6238_SEED, sizeof RFC6238_SEED, 119,
+          code_step1, NULL, &error))
+    return 28;
+  /* T=-31 lands on step -2 (verifier centre -2: covers -3, -2, -1). */
+  if (wyl_totp_code_matches (RFC6238_SEED, sizeof RFC6238_SEED, -31,
+          code_step1, NULL, &error))
+    return 29;
+  return 0;
+}
+
+static gint
+check_matches_rejects_wrong_code (void)
+{
+  guint code_step1 = 0;
+  if (wyl_totp_code_at_step (RFC6238_SEED, sizeof RFC6238_SEED, 1, &code_step1,
+          NULL) != WYRELOG_E_OK)
+    return 30;
+  /* Use a code that is mathematically off-by-one from the valid
+   * 6-digit code at step 1; very unlikely to collide with the
+   * codes at steps 0 or 2 as well.  If it does, this test
+   * still passes only because *all three* skew codes coincide,
+   * which would be a separate (severe) bug. */
+  guint bad = (code_step1 == 0) ? 1 : code_step1 - 1;
+  if (wyl_totp_code_matches (RFC6238_SEED, sizeof RFC6238_SEED, 59, bad,
+          NULL, NULL))
+    return 31;
+
+  /* Codes outside the 0..999999 6-digit range must be rejected. */
+  if (wyl_totp_code_matches (RFC6238_SEED, sizeof RFC6238_SEED, 59, 1000000,
+          NULL, NULL))
+    return 32;
+  return 0;
+}
+
+static gint
+check_generate_seed_basic (void)
+{
+  guint8 seed1[20] = { 0 };
+  guint8 seed2[20] = { 0 };
+
+  if (wyl_totp_generate_seed (seed1, sizeof seed1, NULL) != WYRELOG_E_OK)
+    return 40;
+  if (wyl_totp_generate_seed (seed2, sizeof seed2, NULL) != WYRELOG_E_OK)
+    return 41;
+  /* Two independently-generated seeds should not collide.  P(collision)
+   * for 20 random bytes is negligible; this is a smoke check that the
+   * generator is wired to randombytes_buf and not, say, all zeros. */
+  if (memcmp (seed1, seed2, sizeof seed1) == 0)
+    return 42;
+
+  /* The function MUST refuse buffer sizes other than the canonical 20. */
+  if (wyl_totp_generate_seed (seed1, 16, NULL) != WYRELOG_E_INVALID)
+    return 43;
+  if (wyl_totp_generate_seed (seed1, 32, NULL) != WYRELOG_E_INVALID)
+    return 44;
+  if (wyl_totp_generate_seed (NULL, sizeof seed1, NULL) != WYRELOG_E_INVALID)
+    return 45;
+  return 0;
+}
+
+static gboolean
+bytes_equal (const guint8 *a, gsize a_len, const guint8 *b, gsize b_len)
+{
+  return a_len == b_len && memcmp (a, b, a_len) == 0;
+}
+
+static gint
+check_base32_roundtrip (void)
+{
+  static const gsize sizes[] = { 10, 16, 20, 32 };
+  for (gsize i = 0; i < G_N_ELEMENTS (sizes); i++) {
+    gsize len = sizes[i];
+    g_autofree guint8 *buf = g_malloc (len);
+    randombytes_buf (buf, len);
+    g_autofree gchar *encoded = NULL;
+    if (wyl_totp_base32_encode (buf, len, &encoded, NULL) != WYRELOG_E_OK)
+      return 50 + (gint) i;
+    if (encoded == NULL || encoded[0] == '\0')
+      return 60 + (gint) i;
+    /* Encoded output must be uppercase A-Z / 2-7 with optional
+     * trailing '=' padding.  Reject anything else outright. */
+    for (const gchar * p = encoded; *p != '\0'; p++) {
+      gboolean ok = (*p >= 'A' && *p <= 'Z')
+          || (*p >= '2' && *p <= '7') || *p == '=';
+      if (!ok)
+        return 70 + (gint) i;
+    }
+    g_autofree guint8 *decoded = NULL;
+    gsize decoded_len = 0;
+    if (wyl_totp_base32_decode (encoded, &decoded, &decoded_len, NULL)
+        != WYRELOG_E_OK)
+      return 80 + (gint) i;
+    if (!bytes_equal (buf, len, decoded, decoded_len))
+      return 90 + (gint) i;
+  }
+  return 0;
+}
+
+static gint
+check_base32_known_vectors (void)
+{
+  /* "Hello!\xDE\xAD\xBE\xEF" — well-known sanity vector.
+   *   ASCII "Hello!" = 48 65 6C 6C 6F 21
+   *   + DE AD BE EF
+   * Base32 = "JBSWY3DPEHPK3PXP" (no padding, 10 bytes). */
+  static const guint8 raw[] = {
+    0x48, 0x65, 0x6C, 0x6C, 0x6F, 0x21, 0xDE, 0xAD, 0xBE, 0xEF,
+  };
+  g_autofree gchar *encoded = NULL;
+  if (wyl_totp_base32_encode (raw, sizeof raw, &encoded, NULL) != WYRELOG_E_OK)
+    return 100;
+  if (g_strcmp0 (encoded, "JBSWY3DPEHPK3PXP") != 0)
+    return 101;
+
+  /* Decode must accept upper-case, lower-case, and tolerate trailing
+   * '=' padding even though the canonical encoded form omits it. */
+  static const gchar *accept[] = {
+    "JBSWY3DPEHPK3PXP",
+    "jbswy3dpehpk3pxp",
+    "JBSWY3DPEHPK3PXP=",
+    "JBSWY3DPEHPK3PXP==",
+    "JBSWY3DPEHPK3PXP======",
+    "JbSwY3dPeHpK3pXp",
+  };
+  for (gsize i = 0; i < G_N_ELEMENTS (accept); i++) {
+    g_autofree guint8 *decoded = NULL;
+    gsize decoded_len = 0;
+    if (wyl_totp_base32_decode (accept[i], &decoded, &decoded_len, NULL)
+        != WYRELOG_E_OK)
+      return 110 + (gint) i;
+    if (!bytes_equal (raw, sizeof raw, decoded, decoded_len))
+      return 120 + (gint) i;
+  }
+  return 0;
+}
+
+static gint
+check_base32_rejects_invalid (void)
+{
+  static const gchar *reject[] = {
+    "JBSWY3DPEHPK3PX!",         /* '!' is not in the alphabet */
+    "0BSWY3DPEHPK3PXP",         /* '0' is not in the alphabet */
+    "8BSWY3DPEHPK3PXP",         /* '8' is not in the alphabet */
+    "1BSWY3DPEHPK3PXP",         /* '1' is not in the alphabet */
+    "JBSWY3DPEHPK3PXP ",        /* trailing space */
+    "JBSWY 3DPEHPK3PXP",        /* internal space */
+    "JBSWY-3DPEHPK3PXP",        /* internal dash */
+    "=JBSWY3DPEHPK3PXP",        /* leading '=' is not padding */
+    "JBSWY3DPEHPK3P=P",         /* '=' in the middle of data */
+  };
+  for (gsize i = 0; i < G_N_ELEMENTS (reject); i++) {
+    g_autofree guint8 *decoded = NULL;
+    gsize decoded_len = 0;
+    if (wyl_totp_base32_decode (reject[i], &decoded, &decoded_len, NULL)
+        != WYRELOG_E_INVALID)
+      return 200 + (gint) i;
+    if (decoded != NULL)
+      return 250 + (gint) i;
+  }
+
+  /* Empty string decodes to a 0-length buffer (valid base32). */
+  g_autofree guint8 *empty_decoded = NULL;
+  gsize empty_len = 999;
+  if (wyl_totp_base32_decode ("", &empty_decoded, &empty_len, NULL)
+      != WYRELOG_E_OK)
+    return 280;
+  if (empty_len != 0)
+    return 281;
+  return 0;
+}
+
+int
+main (void)
+{
+  if (sodium_init () < 0)
+    return 1;
+
+  gint rc;
+  if ((rc = check_rfc6238_vectors ()) != 0)
+    return rc;
+  if ((rc = check_code_at_step_validates_args ()) != 0)
+    return rc;
+  if ((rc = check_matches_within_skew_window ()) != 0)
+    return rc;
+  if ((rc = check_matches_rejects_wrong_code ()) != 0)
+    return rc;
+  if ((rc = check_generate_seed_basic ()) != 0)
+    return rc;
+  if ((rc = check_base32_roundtrip ()) != 0)
+    return rc;
+  if ((rc = check_base32_known_vectors ()) != 0)
+    return rc;
+  if ((rc = check_base32_rejects_invalid ()) != 0)
+    return rc;
+  return 0;
+}

--- a/tests/test-wyctl-mfa.c
+++ b/tests/test-wyctl-mfa.c
@@ -1,0 +1,682 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+/*
+ * Tests for the wyctl mfa enroll/reset subcommands (issue #331 commit 6).
+ *
+ * The subcommands run offline against a policy store file: there is no
+ * daemon round-trip and no bearer token.  Each test spins up a fresh
+ * unencrypted SQLite policy store, then drives the wyctl binary as a
+ * subprocess with --store pointing at that file.  The base32 secret
+ * the operator would type into an authenticator is printed to stdout
+ * during enroll, so the harness:
+ *   1. spawns wyctl with stdout / stdin pipes
+ *   2. reads stdout until it sees the `secret_base32=...' line
+ *   3. computes the matching 6-digit TOTP code with wyl_totp_code_at_step
+ *   4. writes the code to stdin and closes it
+ *   5. waits for wyctl to exit and asserts the enrollment row landed
+ *
+ * Footgun coverage these tests lock down (mirrors the architect brief):
+ *   - Abort paths do not write any enrollment row (atomic-enroll
+ *     contract).
+ *   - Reset path leaves the subject unenrolled when the second prompt
+ *     is aborted (documented contract: the prior enrollment was deleted
+ *     before the new one was attempted).
+ *   - Bootstrap auto-revoke removes the wr.login.skip_mfa direct
+ *     permission for the bootstrap admin on first successful enroll,
+ *     and does NOT fire for non-bootstrap subjects.
+ *   - otpauth URI percent-encodes subjects that contain ':' or '/'.
+ */
+
+#if !defined(_WIN32) && !defined(_XOPEN_SOURCE)
+#define _XOPEN_SOURCE 700
+#endif
+
+#include <stdint.h>
+#include <string.h>
+
+#include <glib.h>
+#include <glib/gstdio.h>
+#include <gio/gio.h>
+#include <sqlite3.h>
+
+#include "wyrelog/wyrelog.h"
+#include "wyrelog/policy/store-private.h"
+#include "auth/totp.h"
+
+#ifndef WYL_TEST_WYCTL_PATH
+#error "WYL_TEST_WYCTL_PATH is required"
+#endif
+
+#define WYL_TEST_LOGIN_SKIP_MFA_PERMISSION "wr.login.skip_mfa"
+#define WYL_TEST_LOGIN_SKIP_MFA_SCOPE "login"
+
+/* Read from `stream' until either |needle| is seen at the start of a
+ * line or EOF is reached.  Captured bytes are appended to `acc'.  Returns
+ * the position of the first byte AFTER the matched newline, or -1 on
+ * EOF without a match. */
+static gssize
+read_until_line_prefix (GInputStream *stream, GString *acc, const gchar *prefix)
+{
+  gsize prefix_len = strlen (prefix);
+  /* Scan whatever we already accumulated first so callers that picked
+   * up the marker from a previous read are short-circuited. */
+  for (;;) {
+    const gchar *line_start = acc->str;
+    for (gsize i = 0; i + prefix_len <= acc->len; i++) {
+      if ((i == 0 || acc->str[i - 1] == '\n')
+          && memcmp (acc->str + i, prefix, prefix_len) == 0) {
+        /* Find the newline terminating this line. */
+        for (gsize j = i + prefix_len; j < acc->len; j++) {
+          if (acc->str[j] == '\n')
+            return (gssize) (j + 1);
+        }
+        /* No newline yet: keep reading. */
+        break;
+      }
+      (void) line_start;
+    }
+
+    gchar buf[256];
+    g_autoptr (GError) error = NULL;
+    gssize n = g_input_stream_read (stream, buf, sizeof buf, NULL, &error);
+    if (n < 0) {
+      g_clear_error (&error);
+      return -1;
+    }
+    if (n == 0)
+      return -1;
+    g_string_append_len (acc, buf, n);
+  }
+}
+
+/* Drain stream to EOF, appending to acc. */
+static void
+read_to_eof (GInputStream *stream, GString *acc)
+{
+  for (;;) {
+    gchar buf[512];
+    g_autoptr (GError) error = NULL;
+    gssize n = g_input_stream_read (stream, buf, sizeof buf, NULL, &error);
+    if (n <= 0) {
+      g_clear_error (&error);
+      return;
+    }
+    g_string_append_len (acc, buf, n);
+  }
+}
+
+/* Extract the value of a `key=value' record in `text', returning a
+ * freshly allocated string (or NULL on miss). */
+static gchar *
+extract_kv (const gchar *text, const gchar *key)
+{
+  gsize key_len = strlen (key);
+  for (const gchar * p = text; *p != '\0';) {
+    const gchar *line_end = strchr (p, '\n');
+    gsize line_len = (line_end == NULL) ? strlen (p) : (gsize) (line_end - p);
+    if (line_len > key_len + 1 && p[key_len] == '='
+        && memcmp (p, key, key_len) == 0) {
+      return g_strndup (p + key_len + 1, line_len - key_len - 1);
+    }
+    if (line_end == NULL)
+      break;
+    p = line_end + 1;
+  }
+  return NULL;
+}
+
+/* Create a fresh empty SQLite policy store at `path' with the standard
+ * schema. */
+static void
+create_empty_store (const gchar *path)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+  g_assert_cmpint (wyl_policy_store_open (path, &store), ==, WYRELOG_E_OK);
+  g_assert_cmpint (wyl_policy_store_create_schema (store), ==, WYRELOG_E_OK);
+}
+
+/* Open a store at `path' and run a fact-emitting callback under a
+ * sealed shell. */
+static gboolean
+lookup_enrollment (const gchar *store_path, const gchar *subject,
+    WylTotpEnrollment *out)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+  if (wyl_policy_store_open (store_path, &store) != WYRELOG_E_OK)
+    return FALSE;
+  gboolean found = FALSE;
+  if (wyl_policy_store_totp_enrollment_lookup (store, subject, out, &found)
+      != WYRELOG_E_OK)
+    return FALSE;
+  return found;
+}
+
+static gboolean
+direct_perm_exists (const gchar *store_path, const gchar *subject,
+    const gchar *perm, const gchar *scope)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+  if (wyl_policy_store_open (store_path, &store) != WYRELOG_E_OK)
+    return FALSE;
+  gboolean exists = FALSE;
+  if (wyl_policy_store_direct_permission_exists (store, subject, perm, scope,
+          &exists) != WYRELOG_E_OK)
+    return FALSE;
+  return exists;
+}
+
+/* Pre-seal the policy store as if --bootstrap-admin-subject=<subject>
+ * --bootstrap-admin-allow-skip-mfa had been applied by the daemon. */
+static void
+seal_bootstrap_admin (const gchar *store_path, const gchar *subject,
+    gboolean allow_skip_mfa)
+{
+  g_autoptr (wyl_policy_store_t) store = NULL;
+  g_assert_cmpint (wyl_policy_store_open (store_path, &store), ==,
+      WYRELOG_E_OK);
+  g_assert_cmpint (wyl_policy_store_create_schema (store), ==, WYRELOG_E_OK);
+  gboolean applied = FALSE;
+  g_autofree gchar *existing = NULL;
+  g_assert_cmpint (wyl_policy_store_apply_bootstrap_admin (store, subject,
+          allow_skip_mfa, &applied, &existing), ==, WYRELOG_E_OK);
+  g_assert_true (applied);
+}
+
+/* What kind of input to feed to wyctl on stdin once the secret has
+ * been printed.  EOF aborts the prompt; VALID computes and writes the
+ * matching TOTP code; OVERRIDE writes whatever literal string the
+ * caller supplied (used to force "wrong-code" paths); PERTURB computes
+ * the valid code and then deterministically changes one digit so the
+ * code is guaranteed wrong, eliminating the 1-in-10^6 false-pass
+ * window of a fixed override like "000000". */
+typedef enum
+{
+  WYCTL_TEST_FEED_EOF = 0,
+  WYCTL_TEST_FEED_VALID = 1,
+  WYCTL_TEST_FEED_OVERRIDE = 2,
+  WYCTL_TEST_FEED_PERTURB = 3,
+} WyctlTestFeedMode;
+
+/* Drive `wyctl mfa enroll <subject>' against an unencrypted store at
+ * `store_path'.  `mode' picks what to write to wyctl's stdin once the
+ * secret_base32 line has been printed; see WyctlTestFeedMode above.
+ * `override_code' is only consulted when mode == OVERRIDE.
+ */
+static gint
+run_wyctl_mfa (const gchar *subcommand, const gchar *subject,
+    const gchar *store_path, WyctlTestFeedMode mode,
+    const gchar *override_code, GString *stdout_acc, GString *stderr_acc)
+{
+  const gchar *argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "mfa",
+    subcommand,
+    "--subject", subject,
+    "--store", store_path,
+    NULL,
+  };
+
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GSubprocess) sub = g_subprocess_newv (argv,
+      G_SUBPROCESS_FLAGS_STDIN_PIPE
+      | G_SUBPROCESS_FLAGS_STDOUT_PIPE
+      | G_SUBPROCESS_FLAGS_STDERR_PIPE, &error);
+  g_assert_no_error (error);
+  g_assert_nonnull (sub);
+
+  GInputStream *stdout_pipe = g_subprocess_get_stdout_pipe (sub);
+  GOutputStream *stdin_pipe = g_subprocess_get_stdin_pipe (sub);
+
+  /* Read stdout until the `secret_base32=' line so we know wyctl has
+   * printed the secret and is about to block on stdin. */
+  gssize after = read_until_line_prefix (stdout_pipe, stdout_acc,
+      "secret_base32=");
+  if (after >= 0 && mode != WYCTL_TEST_FEED_EOF) {
+    const gchar *code = NULL;
+    g_autofree gchar *computed = NULL;
+    if (mode == WYCTL_TEST_FEED_OVERRIDE) {
+      g_assert_nonnull (override_code);
+      code = override_code;
+    } else {
+      /* VALID and PERTURB both need the secret-derived code. */
+      g_autofree gchar *secret_b32 = extract_kv (stdout_acc->str,
+          "secret_base32");
+      g_assert_nonnull (secret_b32);
+      g_autofree guint8 *seed = NULL;
+      gsize seed_len = 0;
+      g_autoptr (GError) dec_error = NULL;
+      g_assert_cmpint (wyl_totp_base32_decode (secret_b32, &seed, &seed_len,
+              &dec_error), ==, WYRELOG_E_OK);
+      g_assert_cmpuint (seed_len, ==, WYL_TOTP_SEED_BYTES);
+      guint64 step = (guint64) (g_get_real_time () / G_USEC_PER_SEC)
+          / WYL_TOTP_STEP_SECONDS;
+      guint code_int = 0;
+      g_autoptr (GError) code_error = NULL;
+      g_assert_cmpint (wyl_totp_code_at_step (seed, seed_len, step, &code_int,
+              &code_error), ==, WYRELOG_E_OK);
+      if (mode == WYCTL_TEST_FEED_PERTURB) {
+        /* Perturb the lowest digit by +1 (mod 10).  Result is the
+         * same length as the valid code and is guaranteed NOT to
+         * equal the current step's canonical code.  The residual
+         * 2-in-10^6 false-pass risk (collision with prev / next step
+         * inside the validator's ±1 skew window) is half the original
+         * "000000" override's 3-in-10^6 window and is the lowest
+         * achievable without re-deriving the secret. */
+        guint perturbed = (code_int / 10) * 10 + ((code_int % 10 + 1) % 10);
+        computed = g_strdup_printf ("%06u", perturbed);
+      } else {
+        computed = g_strdup_printf ("%06u", code_int);
+      }
+      code = computed;
+    }
+    g_autofree gchar *payload = g_strdup_printf ("%s\n", code);
+    gsize written = 0;
+    g_autoptr (GError) wr_error = NULL;
+    g_assert_true (g_output_stream_write_all (stdin_pipe, payload,
+            strlen (payload), &written, NULL, &wr_error));
+    g_assert_no_error (wr_error);
+  }
+  /* Close stdin: feeds EOF to wyctl whether or not we wrote a code. */
+  g_autoptr (GError) close_error = NULL;
+  g_output_stream_close (stdin_pipe, NULL, &close_error);
+  g_clear_error (&close_error);
+
+  /* Drain stdout / stderr. */
+  read_to_eof (stdout_pipe, stdout_acc);
+  GInputStream *stderr_pipe = g_subprocess_get_stderr_pipe (sub);
+  if (stderr_pipe != NULL)
+    read_to_eof (stderr_pipe, stderr_acc);
+
+  g_autoptr (GError) wait_error = NULL;
+  g_subprocess_wait (sub, NULL, &wait_error);
+  g_assert_no_error (wait_error);
+
+  if (g_subprocess_get_if_exited (sub))
+    return g_subprocess_get_exit_status (sub);
+  return -1;
+}
+
+static void
+test_mfa_enroll_happy_path (void)
+{
+  g_autofree gchar *tmp = g_dir_make_tmp ("wyctl-mfa-XXXXXX", NULL);
+  g_assert_nonnull (tmp);
+  g_autofree gchar *store = g_build_filename (tmp, "policy.sqlite", NULL);
+  create_empty_store (store);
+
+  g_autoptr (GString) out = g_string_new (NULL);
+  g_autoptr (GString) err = g_string_new (NULL);
+  gint rc = run_wyctl_mfa ("enroll", "alice.user", store, WYCTL_TEST_FEED_VALID,
+      NULL, out, err);
+  if (rc != 0)
+    g_printerr ("happy stderr: %s\n", err->str);
+  g_assert_cmpint (rc, ==, 0);
+
+  g_autofree gchar *uri = extract_kv (out->str, "otpauth_uri");
+  g_assert_nonnull (uri);
+  g_assert_true (g_str_has_prefix (uri, "otpauth://totp/"));
+  g_assert_nonnull (strstr (uri, "issuer=wyrelog"));
+  g_assert_nonnull (strstr (uri, "algorithm=SHA1"));
+  g_assert_nonnull (strstr (uri, "digits=6"));
+  g_assert_nonnull (strstr (uri, "period=30"));
+
+  WylTotpEnrollment enr = { 0 };
+  g_assert_true (lookup_enrollment (store, "alice.user", &enr));
+  g_assert_nonnull (enr.id_uuidv7);
+  wyl_totp_enrollment_clear (&enr);
+
+  g_unlink (store);
+  g_rmdir (tmp);
+}
+
+static void
+test_mfa_enroll_abort_on_eof_writes_nothing (void)
+{
+  g_autofree gchar *tmp = g_dir_make_tmp ("wyctl-mfa-XXXXXX", NULL);
+  g_assert_nonnull (tmp);
+  g_autofree gchar *store = g_build_filename (tmp, "policy.sqlite", NULL);
+  create_empty_store (store);
+
+  g_autoptr (GString) out = g_string_new (NULL);
+  g_autoptr (GString) err = g_string_new (NULL);
+  gint rc = run_wyctl_mfa ("enroll", "bob.user", store, WYCTL_TEST_FEED_EOF,
+      NULL, out, err);
+  g_assert_cmpint (rc, !=, 0);
+
+  WylTotpEnrollment enr = { 0 };
+  g_assert_false (lookup_enrollment (store, "bob.user", &enr));
+  wyl_totp_enrollment_clear (&enr);
+
+  g_unlink (store);
+  g_rmdir (tmp);
+}
+
+static void
+test_mfa_enroll_abort_on_wrong_code (void)
+{
+  g_autofree gchar *tmp = g_dir_make_tmp ("wyctl-mfa-XXXXXX", NULL);
+  g_assert_nonnull (tmp);
+  g_autofree gchar *store = g_build_filename (tmp, "policy.sqlite", NULL);
+  create_empty_store (store);
+
+  g_autoptr (GString) out = g_string_new (NULL);
+  g_autoptr (GString) err = g_string_new (NULL);
+  /* PERTURB derives the valid code from the printed secret, then
+   * deliberately flips the ones digit (+1 mod 10).  The result is
+   * guaranteed not to equal the current step's canonical code; the
+   * residual flake risk is the 2-in-10^6 chance of accidentally
+   * matching the prev / next step inside the validator's ±1 skew
+   * window.  Strictly stronger than a static "000000" override. */
+  gint rc = run_wyctl_mfa ("enroll", "carol.user", store,
+      WYCTL_TEST_FEED_PERTURB, NULL, out, err);
+  g_assert_cmpint (rc, !=, 0);
+
+  WylTotpEnrollment enr = { 0 };
+  g_assert_false (lookup_enrollment (store, "carol.user", &enr));
+  wyl_totp_enrollment_clear (&enr);
+
+  g_unlink (store);
+  g_rmdir (tmp);
+}
+
+static void
+test_mfa_reset_happy_path (void)
+{
+  g_autofree gchar *tmp = g_dir_make_tmp ("wyctl-mfa-XXXXXX", NULL);
+  g_assert_nonnull (tmp);
+  g_autofree gchar *store = g_build_filename (tmp, "policy.sqlite", NULL);
+  create_empty_store (store);
+
+  /* Pre-seed an existing enrollment row for dave so reset has something
+   * to delete. */
+  {
+    g_autoptr (wyl_policy_store_t) s = NULL;
+    g_assert_cmpint (wyl_policy_store_open (store, &s), ==, WYRELOG_E_OK);
+    WylTotpEnrollment seed = { 0 };
+    seed.subject_id = g_strdup ("dave.user");
+    for (gsize i = 0; i < WYL_TOTP_ENROLLMENT_SECRET_BYTES; i++)
+      seed.secret[i] = (guint8) (0xAA ^ i);
+    seed.last_verified_step = INT64_MIN;
+    seed.enrolled_at = 1700000000;
+    g_assert_cmpint (wyl_policy_store_totp_enrollment_insert (s, &seed), ==,
+        WYRELOG_E_OK);
+    g_autofree gchar *old_id = g_strdup (seed.id_uuidv7);
+    wyl_totp_enrollment_clear (&seed);
+
+    g_autoptr (GString) out = g_string_new (NULL);
+    g_autoptr (GString) err = g_string_new (NULL);
+    /* Re-open to free our lock before invoking wyctl. */
+    wyl_policy_store_close (g_steal_pointer (&s));
+
+    gint rc = run_wyctl_mfa ("reset", "dave.user", store, WYCTL_TEST_FEED_VALID,
+        NULL, out, err);
+    if (rc != 0)
+      g_printerr ("reset stderr: %s\n", err->str);
+    g_assert_cmpint (rc, ==, 0);
+
+    WylTotpEnrollment after = { 0 };
+    g_assert_true (lookup_enrollment (store, "dave.user", &after));
+    g_assert_nonnull (after.id_uuidv7);
+    /* The new uuid MUST differ from the pre-existing one. */
+    g_assert_cmpstr (after.id_uuidv7, !=, old_id);
+    wyl_totp_enrollment_clear (&after);
+  }
+
+  g_unlink (store);
+  g_rmdir (tmp);
+}
+
+static void
+test_mfa_reset_abort_leaves_subject_unenrolled (void)
+{
+  g_autofree gchar *tmp = g_dir_make_tmp ("wyctl-mfa-XXXXXX", NULL);
+  g_assert_nonnull (tmp);
+  g_autofree gchar *store = g_build_filename (tmp, "policy.sqlite", NULL);
+  create_empty_store (store);
+
+  /* Seed an existing enrollment for eve. */
+  {
+    g_autoptr (wyl_policy_store_t) s = NULL;
+    g_assert_cmpint (wyl_policy_store_open (store, &s), ==, WYRELOG_E_OK);
+    WylTotpEnrollment seed = { 0 };
+    seed.subject_id = g_strdup ("eve.user");
+    for (gsize i = 0; i < WYL_TOTP_ENROLLMENT_SECRET_BYTES; i++)
+      seed.secret[i] = (guint8) (0x55 + i);
+    seed.last_verified_step = INT64_MIN;
+    seed.enrolled_at = 1700000000;
+    g_assert_cmpint (wyl_policy_store_totp_enrollment_insert (s, &seed), ==,
+        WYRELOG_E_OK);
+    wyl_totp_enrollment_clear (&seed);
+  }
+
+  g_autoptr (GString) out = g_string_new (NULL);
+  g_autoptr (GString) err = g_string_new (NULL);
+  gint rc = run_wyctl_mfa ("reset", "eve.user", store, WYCTL_TEST_FEED_EOF,
+      NULL, out, err);
+  g_assert_cmpint (rc, !=, 0);
+
+  WylTotpEnrollment after = { 0 };
+  g_assert_false (lookup_enrollment (store, "eve.user", &after));
+  wyl_totp_enrollment_clear (&after);
+
+  g_unlink (store);
+  g_rmdir (tmp);
+}
+
+static void
+test_mfa_enroll_bootstrap_admin_auto_revokes_skip_mfa (void)
+{
+  g_autofree gchar *tmp = g_dir_make_tmp ("wyctl-mfa-XXXXXX", NULL);
+  g_assert_nonnull (tmp);
+  g_autofree gchar *store = g_build_filename (tmp, "policy.sqlite", NULL);
+  create_empty_store (store);
+  /* Bootstrap with skip-mfa for the admin. */
+  seal_bootstrap_admin (store, "admin1", TRUE);
+
+  /* Pre-condition: skip_mfa is granted. */
+  g_assert_true (direct_perm_exists (store, "admin1",
+          WYL_TEST_LOGIN_SKIP_MFA_PERMISSION, WYL_TEST_LOGIN_SKIP_MFA_SCOPE));
+
+  g_autoptr (GString) out = g_string_new (NULL);
+  g_autoptr (GString) err = g_string_new (NULL);
+  gint rc = run_wyctl_mfa ("enroll", "admin1", store, WYCTL_TEST_FEED_VALID,
+      NULL, out, err);
+  if (rc != 0)
+    g_printerr ("bootstrap-revoke stderr: %s\n", err->str);
+  g_assert_cmpint (rc, ==, 0);
+
+  /* Atomicity reasoning: wyctl_mfa_run_enroll_flow wraps the
+   * enrollment insert + audit row + direct-permission revoke + FSM
+   * transition in a single outer savepoint via
+   * wyl_policy_store_begin_mutation / commit_mutation.  We assert
+   * both visible halves of the commit here — enrollment present AND
+   * skip_mfa absent — which is sufficient to demonstrate that the
+   * mutation block landed as a unit on this happy path.  The
+   * sibling test_mfa_enroll_atomic_rollback_on_audit_failure
+   * exercises the failure path: a forced mid-flow audit-emit
+   * failure rolls back the enrollment insert AND leaves skip_mfa
+   * untouched. */
+  /* Post-condition (a): enrollment row exists. */
+  WylTotpEnrollment enr = { 0 };
+  g_assert_true (lookup_enrollment (store, "admin1", &enr));
+  wyl_totp_enrollment_clear (&enr);
+
+  /* Post-condition (b): skip_mfa is gone. */
+  g_assert_false (direct_perm_exists (store, "admin1",
+          WYL_TEST_LOGIN_SKIP_MFA_PERMISSION, WYL_TEST_LOGIN_SKIP_MFA_SCOPE));
+
+  g_unlink (store);
+  g_rmdir (tmp);
+}
+
+/* Atomicity regression: force a mid-flow failure after the enrollment
+ * insert but at the audit-emit step, and verify the outer savepoint
+ * rolls EVERYTHING back — the bootstrap admin remains unenrolled AND
+ * still holds wr.login.skip_mfa.  Without the outer savepoint, the
+ * enrollment insert would persist while skip_mfa was still armed,
+ * creating an auth-bypass window. */
+static void
+test_mfa_enroll_atomic_rollback_on_audit_failure (void)
+{
+  g_autofree gchar *tmp = g_dir_make_tmp ("wyctl-mfa-XXXXXX", NULL);
+  g_assert_nonnull (tmp);
+  g_autofree gchar *store = g_build_filename (tmp, "policy.sqlite", NULL);
+  create_empty_store (store);
+  seal_bootstrap_admin (store, "admin1", TRUE);
+
+  /* Pre-condition: skip_mfa is granted, no enrollment. */
+  g_assert_true (direct_perm_exists (store, "admin1",
+          WYL_TEST_LOGIN_SKIP_MFA_PERMISSION, WYL_TEST_LOGIN_SKIP_MFA_SCOPE));
+  WylTotpEnrollment pre_enr = { 0 };
+  g_assert_false (lookup_enrollment (store, "admin1", &pre_enr));
+  wyl_totp_enrollment_clear (&pre_enr);
+
+  /* Failure injection: drop the audit_events table.  The wyctl
+   * enrollment flow's mfa_enrolled audit row (mutation #2 in the
+   * outer savepoint) will fail at INSERT, the rollback fires, and
+   * the enrollment row (mutation #1) must NOT survive. */
+  {
+    g_autoptr (wyl_policy_store_t) s = NULL;
+    g_assert_cmpint (wyl_policy_store_open (store, &s), ==, WYRELOG_E_OK);
+    sqlite3 *db = wyl_policy_store_get_db (s);
+    g_assert_nonnull (db);
+    char *err_msg = NULL;
+    int sqlite_rc = sqlite3_exec (db, "DROP TABLE audit_events;", NULL, NULL,
+        &err_msg);
+    if (sqlite_rc != SQLITE_OK) {
+      g_printerr ("drop audit_events failed: %s\n",
+          err_msg != NULL ? err_msg : "(unknown)");
+      sqlite3_free (err_msg);
+    }
+    g_assert_cmpint (sqlite_rc, ==, SQLITE_OK);
+  }
+
+  g_autoptr (GString) out = g_string_new (NULL);
+  g_autoptr (GString) err = g_string_new (NULL);
+  gint rc = run_wyctl_mfa ("enroll", "admin1", store, WYCTL_TEST_FEED_VALID,
+      NULL, out, err);
+  /* wyctl must exit non-zero — the audit failure is surfaced. */
+  g_assert_cmpint (rc, !=, 0);
+
+  /* Atomicity assertion: the rollback must have unwound the
+   * enrollment row that wyctl inserted before hitting the audit
+   * failure.  If this fails, the outer savepoint is broken — that's
+   * the auth-bypass regression the savepoint defends against.
+   *
+   * The store is still missing audit_events, but
+   * wyl_policy_store_totp_enrollment_lookup and
+   * wyl_policy_store_direct_permission_exists query only their own
+   * tables (totp_enrollments / direct_permissions), so the lookups
+   * below succeed without the audit_events table. */
+  WylTotpEnrollment post_enr = { 0 };
+  g_assert_false (lookup_enrollment (store, "admin1", &post_enr));
+  wyl_totp_enrollment_clear (&post_enr);
+
+  /* And skip_mfa MUST still be granted — the auto-revoke is part of
+   * the same savepoint scope and must be invisible after rollback. */
+  g_assert_true (direct_perm_exists (store, "admin1",
+          WYL_TEST_LOGIN_SKIP_MFA_PERMISSION, WYL_TEST_LOGIN_SKIP_MFA_SCOPE));
+
+  g_unlink (store);
+  g_rmdir (tmp);
+}
+
+static void
+test_mfa_enroll_non_bootstrap_subject_does_not_revoke (void)
+{
+  g_autofree gchar *tmp = g_dir_make_tmp ("wyctl-mfa-XXXXXX", NULL);
+  g_assert_nonnull (tmp);
+  g_autofree gchar *store = g_build_filename (tmp, "policy.sqlite", NULL);
+  create_empty_store (store);
+  /* Bootstrap admin is admin1.  Subject "frank" is NOT the bootstrap
+   * admin, and has no skip_mfa grant.  Enrolling frank should be a
+   * plain enroll — no revoke side-effect. */
+  seal_bootstrap_admin (store, "admin1", TRUE);
+
+  /* Sanity: admin1 still holds skip_mfa, frank does not. */
+  g_assert_true (direct_perm_exists (store, "admin1",
+          WYL_TEST_LOGIN_SKIP_MFA_PERMISSION, WYL_TEST_LOGIN_SKIP_MFA_SCOPE));
+  g_assert_false (direct_perm_exists (store, "frank.user",
+          WYL_TEST_LOGIN_SKIP_MFA_PERMISSION, WYL_TEST_LOGIN_SKIP_MFA_SCOPE));
+
+  g_autoptr (GString) out = g_string_new (NULL);
+  g_autoptr (GString) err = g_string_new (NULL);
+  gint rc = run_wyctl_mfa ("enroll", "frank.user", store,
+      WYCTL_TEST_FEED_VALID, NULL, out, err);
+  if (rc != 0)
+    g_printerr ("non-bootstrap stderr: %s\n", err->str);
+  g_assert_cmpint (rc, ==, 0);
+
+  WylTotpEnrollment enr = { 0 };
+  g_assert_true (lookup_enrollment (store, "frank.user", &enr));
+  wyl_totp_enrollment_clear (&enr);
+
+  /* admin1's skip_mfa MUST remain — enrolling a different subject does
+   * not touch the bootstrap admin's grant. */
+  g_assert_true (direct_perm_exists (store, "admin1",
+          WYL_TEST_LOGIN_SKIP_MFA_PERMISSION, WYL_TEST_LOGIN_SKIP_MFA_SCOPE));
+
+  g_unlink (store);
+  g_rmdir (tmp);
+}
+
+static void
+test_mfa_enroll_url_encodes_subject (void)
+{
+  g_autofree gchar *tmp = g_dir_make_tmp ("wyctl-mfa-XXXXXX", NULL);
+  g_assert_nonnull (tmp);
+  g_autofree gchar *store = g_build_filename (tmp, "policy.sqlite", NULL);
+  create_empty_store (store);
+
+  /* Subject deliberately carries reserved chars (`:' and `/') so the
+   * URI builder must percent-encode them per the Key URI Format. */
+  const gchar *subject = "weird:user/name";
+
+  g_autoptr (GString) out = g_string_new (NULL);
+  g_autoptr (GString) err = g_string_new (NULL);
+  gint rc = run_wyctl_mfa ("enroll", subject, store, WYCTL_TEST_FEED_VALID,
+      NULL, out, err);
+  if (rc != 0)
+    g_printerr ("url-encode stderr: %s\n", err->str);
+  g_assert_cmpint (rc, ==, 0);
+
+  g_autofree gchar *uri = extract_kv (out->str, "otpauth_uri");
+  g_assert_nonnull (uri);
+  /* Raw `:' and `/' from the subject MUST be percent-encoded in the
+   * label segment.  The static `wyrelog:' issuer-prefix colon is the
+   * lone unescaped `:' permitted by the spec; check that the
+   * percent-encoded forms are present. */
+  g_assert_nonnull (strstr (uri, "%3A"));
+  g_assert_nonnull (strstr (uri, "%2F"));
+
+  WylTotpEnrollment enr = { 0 };
+  g_assert_true (lookup_enrollment (store, subject, &enr));
+  wyl_totp_enrollment_clear (&enr);
+
+  g_unlink (store);
+  g_rmdir (tmp);
+}
+
+int
+main (int argc, char **argv)
+{
+  g_test_init (&argc, &argv, NULL);
+
+  g_test_add_func ("/wyctl/mfa/enroll-happy-path", test_mfa_enroll_happy_path);
+  g_test_add_func ("/wyctl/mfa/enroll-abort-on-eof-writes-nothing",
+      test_mfa_enroll_abort_on_eof_writes_nothing);
+  g_test_add_func ("/wyctl/mfa/enroll-abort-on-wrong-code",
+      test_mfa_enroll_abort_on_wrong_code);
+  g_test_add_func ("/wyctl/mfa/reset-happy-path", test_mfa_reset_happy_path);
+  g_test_add_func ("/wyctl/mfa/reset-abort-leaves-subject-unenrolled",
+      test_mfa_reset_abort_leaves_subject_unenrolled);
+  g_test_add_func ("/wyctl/mfa/enroll-bootstrap-admin-auto-revokes-skip-mfa",
+      test_mfa_enroll_bootstrap_admin_auto_revokes_skip_mfa);
+  g_test_add_func ("/wyctl/mfa/enroll-atomic-rollback-on-audit-failure",
+      test_mfa_enroll_atomic_rollback_on_audit_failure);
+  g_test_add_func ("/wyctl/mfa/enroll-non-bootstrap-subject-does-not-revoke",
+      test_mfa_enroll_non_bootstrap_subject_does_not_revoke);
+  g_test_add_func ("/wyctl/mfa/enroll-url-encodes-subject",
+      test_mfa_enroll_url_encodes_subject);
+
+  return g_test_run ();
+}

--- a/wyrelog/auth/mfa-validator.c
+++ b/wyrelog/auth/mfa-validator.c
@@ -17,6 +17,7 @@
 #include "wyl-fsm-principal-private.h"
 #include "wyrelog/policy/store-private.h"
 #include "wyrelog/wyl-handle-private.h"
+#include "wyrelog/wyl-log-private.h"
 
 /*
  * Static assertion that locks the policy-store totp_enrollment secret
@@ -72,33 +73,125 @@ parse_six_digits (const gchar *proof)
 }
 
 /*
- * Drive the principal FSM through a FAILED_ATTEMPT event from the
- * MFA_REQUIRED state.  In commit 3 this is a pure FSM-shape probe
- * (the transition is MFA_REQUIRED -> MFA_REQUIRED with no durable
- * counter); commit 5 will layer a persistent failure counter and
- * lockout policy on top.  Wiring the call here now keeps the
- * validator's failure path on the same FSM-validated branch the
- * lockout logic will read in commit 5.
- *
- * The three negative paths (no enrollment, wrong code, replay)
- * intentionally differ in computational cost: the wrong-code and
- * replay paths perform 3x HMAC-SHA-1 via wyl_totp_code_matches,
- * while the no-enrollment path skips that work.  The resulting
- * timing differential is acceptable because issue #331 decision 7
- * requires the HTTP layer (/auth/mfa/verify) to surface
- * `enrollment_required` as a distinct error code from
- * `mfa_invalid`, so the no-enrollment bit is already deliberately
- * public at the API surface.  Adding a dummy HMAC here to mask a
- * bit that the spec discloses would be hardening theater, not
- * defense.  The FSM step is O(ns) and cannot mask a 3x HMAC cost
- * anyway; do not "fix" the timing gap by inserting a fake HMAC.
+ * Issue #331 decision 5 constants: 5 consecutive failures lock the
+ * principal; 15 minutes of wallclock idle after locked_at auto-unlocks.
+ * The constants live in this translation unit, not in policy/store.c,
+ * because lockout-policy values are an auth-layer concern - the policy
+ * store only persists the counter and timestamp the validator hands it.
  */
-static void
-note_failed_attempt (void)
+#define WYL_MFA_LOCKOUT_THRESHOLD     5
+#define WYL_MFA_AUTO_UNLOCK_SECONDS   (15 * 60)
+
+/*
+ * Drive the principal FSM through a FAILED_ATTEMPT event from the
+ * MFA_REQUIRED state, and persist the failure to the policy store.
+ *
+ * In commit 3 this was a pure FSM-shape probe with no durable counter;
+ * commit 5 layers durable counter + lockout on top, atomically inside a
+ * savepoint via wyl_policy_store_apply_principal_failure.  The store
+ * transaction defeats the read-modify-write race that would otherwise
+ * let N concurrent failed verify attempts each see counter=N-1 and
+ * each fail to LOCK independently (commit-5 critic footgun).
+ *
+ * Returns WYRELOG_E_OK on success, WYRELOG_E_INVALID for malformed
+ * arguments, or WYRELOG_E_INTERNAL on a store fault (the iteration
+ * fed back from architect+critic ratification: a transient IO error
+ * on the counter write MUST surface as a fail-closed validator return
+ * rather than be silently swallowed, otherwise an attacker who can
+ * induce IO pressure could brute-force without ever crossing the
+ * lockout threshold).
+ *
+ * F2 (secrets): the policy-store helper never sees the submitted code
+ * or the TOTP seed; it only touches subject_id and the integer
+ * counter/locked_at.  This callsite likewise carries neither.  The
+ * operator-visibility WYL_LOG_WARN on IO failure logs only subject_id
+ * and the integer error code.
+ *
+ * The three negative paths (no enrollment, wrong code, replay) still
+ * intentionally differ in computational cost: wrong-code and replay
+ * perform 3x HMAC-SHA-1 via wyl_totp_code_matches, while the
+ * no-enrollment path skips that work.  Issue #331 decision 7 requires
+ * the HTTP layer to surface `enrollment_required` as a distinct error
+ * code from `mfa_invalid`, so the no-enrollment bit is already
+ * deliberately public at the API surface.  Adding a dummy HMAC here
+ * to mask a bit that the spec discloses would be hardening theater,
+ * not defense.  Commit 5 adds a savepoint write on every failure
+ * branch, which is at most a low-microsecond fixed cost shared by all
+ * three negative paths, so the relative differential among them is
+ * unchanged from commit 3.
+ */
+static wyrelog_error_t
+note_failed_attempt (WylHandle *handle, const gchar *subject_id)
 {
   wyl_principal_state_t next = WYL_PRINCIPAL_STATE_LAST_;
   (void) wyl_fsm_principal_step (WYL_PRINCIPAL_STATE_MFA_REQUIRED,
       WYL_PRINCIPAL_EVENT_FAILED_ATTEMPT, &next);
+
+  if (handle == NULL || subject_id == NULL || subject_id[0] == '\0')
+    return WYRELOG_E_INVALID;
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (store == NULL)
+    return WYRELOG_E_INTERNAL;
+  g_autofree gchar *new_state = NULL;
+  gint64 new_count = 0;
+  gint64 new_locked_at = 0;
+  /* Fail closed (architect ratification, commit-5 iteration): an IO
+   * error on the counter write means we cannot durably advance the
+   * lockout state, so the validator MUST refuse the verify instead of
+   * silently dropping the failure - otherwise an attacker who can
+   * induce IO pressure could keep brute-forcing without ever crossing
+   * the threshold.  The caller maps E_INTERNAL to a 500 mfa_verify_failed
+   * response at the HTTP layer (see mfa_verify_handler).
+   *
+   * Note the asymmetry with reset_principal_failure_counter on the
+   * success path: that reset is intentionally best-effort because a
+   * transient IO blip there would DoS a user who has already proven
+   * possession of the seed, and the counter will be reset on the next
+   * successful verify. */
+  wyrelog_error_t rc = wyl_policy_store_apply_principal_failure (store,
+      subject_id, WYL_MFA_LOCKOUT_THRESHOLD, (gint64) time (NULL),
+      &new_state, &new_count, &new_locked_at);
+  if (rc != WYRELOG_E_OK) {
+    /* Operator-visibility on the IO fault.  Keyed on subject_id and the
+     * error code; never includes the submitted code or the seed (F2). */
+    WYL_LOG_WARN (WYL_LOG_SECTION_POLICY,
+        "mfa: failed to durably record failed attempt for subject_id=%s rc=%d",
+        subject_id, (int) rc);
+    return WYRELOG_E_INTERNAL;
+  }
+  return WYRELOG_E_OK;
+}
+
+/*
+ * Auto-unlock check.  When the principal is in LOCKED state and the
+ * 15-minute window has elapsed since locked_at, transition the row to
+ * UNVERIFIED via the FSM UNLOCK edge and return TRUE so the caller can
+ * treat the verify as "session no longer in mfa_required" (the FSM
+ * design routes auto-unlock back to UNVERIFIED, not MFA_REQUIRED -
+ * see issue #331 critic flag during commit-4 iteration).
+ *
+ * Returns TRUE iff the auto-unlock happened.  Returns FALSE when the
+ * window has not elapsed, when the principal is not locked, or on a
+ * store fault (fail-closed: the row stays as-is and the caller sees
+ * the same E_POLICY surface).
+ */
+static gboolean
+maybe_auto_unlock (WylHandle *handle, const gchar *subject_id,
+    const gchar *current_state, gint64 locked_at, gint64 now)
+{
+  if (g_strcmp0 (current_state, "locked") != 0)
+    return FALSE;
+  if (locked_at == G_MININT64)
+    return FALSE;
+  if (now < locked_at + WYL_MFA_AUTO_UNLOCK_SECONDS)
+    return FALSE;
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (store == NULL)
+    return FALSE;
+  if (wyl_policy_store_apply_principal_unlock (store, subject_id)
+      != WYRELOG_E_OK)
+    return FALSE;
+  return TRUE;
 }
 
 wyrelog_error_t
@@ -120,6 +213,43 @@ wyl_mfa_validator_totp (WylHandle *handle, WylSession *session,
   if (store == NULL)
     return WYRELOG_E_INTERNAL;
 
+  gint64 now = (gint64) time (NULL);
+
+  /*
+   * Lockout gate (issue #331 commit 5).  We consult the principal_state
+   * row BEFORE touching the TOTP enrollment so a locked principal
+   * never triggers an HMAC computation - this is a fail-closed
+   * shortcut and the lockout-without-hmac test in
+   * test-daemon-mfa-validator locks it down.  If the row's auto-unlock
+   * window has elapsed we transition LOCKED -> UNVERIFIED and return
+   * E_POLICY (the caller's session-state gate will treat the principal
+   * as no longer mfa_required and bounce the verify; the user must
+   * re-login per the existing FSM design).
+   */
+  g_autofree gchar *pstate = NULL;
+  gint64 pcount = 0;
+  gint64 plocked_at = 0;
+  gboolean pfound = FALSE;
+  wyrelog_error_t rc = wyl_policy_store_get_principal_lock_info (store,
+      subject_id, &pstate, &pcount, &plocked_at, &pfound);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if (pfound && g_strcmp0 (pstate, "locked") == 0) {
+    if (maybe_auto_unlock (handle, subject_id, pstate, plocked_at, now)) {
+      /* Row is now UNVERIFIED.  The verify-with-proof contract bounces
+       * because the principal is no longer in mfa_required; HTTP layer
+       * will surface mfa_auth_required (uniform) on the next call. */
+      return WYRELOG_E_POLICY;
+    }
+    /* Still inside the lockout window: fail closed without consulting
+     * the TOTP enrollment.  F1 timing: the HMAC branch is skipped,
+     * which is faster than wrong-code/replay paths - but the LOCKED
+     * state is already publicly visible via the HTTP 429 mfa_locked
+     * response (issue #331 spec), so the timing differential discloses
+     * nothing the spec does not. */
+    return WYRELOG_E_POLICY;
+  }
+
   /*
    * F5 (enumeration via differential error codes): every negative
    * outcome below funnels through the same WYRELOG_E_POLICY return.
@@ -129,33 +259,36 @@ wyl_mfa_validator_totp (WylHandle *handle, WylSession *session,
    */
   WylTotpEnrollment enr = { 0 };
   gboolean found = FALSE;
-  wyrelog_error_t rc = wyl_policy_store_totp_enrollment_lookup (store,
-      subject_id, &enr, &found);
+  rc = wyl_policy_store_totp_enrollment_lookup (store, subject_id, &enr,
+      &found);
   if (rc != WYRELOG_E_OK) {
     wyl_totp_enrollment_clear (&enr);
     return rc;
   }
   if (!found) {
     /* Drive the same FSM FAILED_ATTEMPT branch the wrong-code path
-     * takes so commit 5's lockout counter sees every failed verify
-     * uniformly.  This does NOT equalise the timing of the
-     * no-enrollment vs wrong-code branches — see the rationale
-     * above note_failed_attempt for why the differential is
-     * intentional and consistent with issue #331 decision 7. */
-    note_failed_attempt ();
+     * takes so the lockout counter sees every failed verify uniformly.
+     * This does NOT equalise the timing of the no-enrollment vs
+     * wrong-code branches - see the rationale above note_failed_attempt
+     * for why the differential is intentional and consistent with
+     * issue #331 decision 7. */
+    wyrelog_error_t note_rc = note_failed_attempt (handle, subject_id);
     wyl_totp_enrollment_clear (&enr);
+    if (note_rc != WYRELOG_E_OK)
+      return WYRELOG_E_INTERNAL;
     return WYRELOG_E_POLICY;
   }
 
   guint submitted_code = parse_six_digits (proof);
-  gint64 now = (gint64) time (NULL);
   guint64 matched_step = 0;
 
   gboolean matched = wyl_totp_code_matches (enr.secret, sizeof enr.secret,
       now, submitted_code, &matched_step, NULL);
   if (!matched) {
-    note_failed_attempt ();
+    wyrelog_error_t note_rc = note_failed_attempt (handle, subject_id);
     wyl_totp_enrollment_clear (&enr);
+    if (note_rc != WYRELOG_E_OK)
+      return WYRELOG_E_INTERNAL;
     return WYRELOG_E_POLICY;
   }
 
@@ -172,12 +305,14 @@ wyl_mfa_validator_totp (WylHandle *handle, WylSession *session,
    * plausible epoch (RFC 6238 step counts run at 1/30 Hz), and the
    * cast to gint64 is safe.  Should an attacker somehow place a step
    * above INT64_MAX, the gint64 cast would saturate to a negative
-   * value and the comparison would reject — which is the conservative
+   * value and the comparison would reject - which is the conservative
    * direction.
    */
   if ((gint64) matched_step <= enr.last_verified_step) {
-    note_failed_attempt ();
+    wyrelog_error_t note_rc = note_failed_attempt (handle, subject_id);
     wyl_totp_enrollment_clear (&enr);
+    if (note_rc != WYRELOG_E_OK)
+      return WYRELOG_E_INTERNAL;
     return WYRELOG_E_POLICY;
   }
 
@@ -212,6 +347,23 @@ wyl_mfa_validator_totp (WylHandle *handle, WylSession *session,
   wyl_totp_enrollment_clear (&enr);
   if (rc != WYRELOG_E_OK)
     return rc;
+
+  /*
+   * Commit-5: a successful TOTP verify resets the lockout counter and
+   * clears any prior locked_at on the principal_states row.  This is
+   * idempotent when the counter is already zero, so the call is safe
+   * to make on every happy path regardless of prior history.
+   *
+   * Intentional asymmetry with note_failed_attempt (architect ratification,
+   * commit-5 iteration): the failure path is FAIL-CLOSED on a counter-
+   * write IO error (otherwise an attacker who induces IO pressure could
+   * brute-force without ever crossing the threshold), while this success-
+   * path counter reset is BEST-EFFORT - a transient IO blip after a
+   * verified seed must not DoS a user who has already proven possession,
+   * and the next successful verify will retry the reset.  Hence the
+   * (void) cast on the return value here is deliberate.
+   */
+  (void) wyl_policy_store_reset_principal_failure_counter (store, subject_id);
 
   return WYRELOG_E_OK;
 }

--- a/wyrelog/auth/mfa-validator.c
+++ b/wyrelog/auth/mfa-validator.c
@@ -1,0 +1,217 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* strnlen() is POSIX 2008; expose it under strict C17 builds where
+ * -std=c17 hides POSIX symbols unless a feature-test macro is set. */
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+
+#include "auth/mfa-validator.h"
+
+#include <stdint.h>
+#include <string.h>
+#include <time.h>
+
+#include <glib.h>
+
+#include "auth/totp.h"
+#include "wyl-fsm-principal-private.h"
+#include "wyrelog/policy/store-private.h"
+#include "wyrelog/wyl-handle-private.h"
+
+/*
+ * Static assertion that locks the policy-store totp_enrollment secret
+ * field size to the canonical RFC 6238 SHA-1 seed length surfaced by
+ * the auth/totp module.  This file is the single translation unit
+ * that includes both headers, so the assertion lives here.  Architect
+ * required this guard during the commit-2 ratification so the two
+ * constants can never silently drift across the commit-1 / commit-2
+ * boundary.
+ */
+_Static_assert (WYL_TOTP_ENROLLMENT_SECRET_BYTES == WYL_TOTP_SEED_BYTES,
+    "TOTP enrollment secret length must equal the RFC 6238 seed length");
+
+/*
+ * Six digits 0-9, exact length, no leading whitespace or padding.
+ * The length guard uses strnlen with a (WYL_TOTP_DIGITS + 1)-byte
+ * window so we never read past the caller's buffer for short or
+ * unterminated inputs (the earlier "proof[WYL_TOTP_DIGITS] == '\\0'"
+ * trailing-NUL probe was an OOB read for any non-padded buffer
+ * shorter than seven bytes — see issue #331 commit-3 critic F-2).
+ * After the length is fixed at exactly WYL_TOTP_DIGITS, the digit-
+ * class loop is walked end-to-end without an early-out so the
+ * timing of the shape check does not differentiate "first non-digit
+ * at offset 0" from "first non-digit at offset 5".  The shape check
+ * returns the same WYRELOG_E_INVALID regardless of which position
+ * failed.
+ */
+static gboolean
+proof_shape_is_valid (const gchar *proof)
+{
+  if (proof == NULL)
+    return FALSE;
+  if (strnlen (proof, WYL_TOTP_DIGITS + 1) != WYL_TOTP_DIGITS)
+    return FALSE;
+
+  gboolean ok = TRUE;
+  gsize i;
+  for (i = 0; i < WYL_TOTP_DIGITS; i++) {
+    gchar c = proof[i];
+    if (c < '0' || c > '9')
+      ok = FALSE;
+  }
+  return ok;
+}
+
+static guint
+parse_six_digits (const gchar *proof)
+{
+  guint code = 0;
+  for (gsize i = 0; i < WYL_TOTP_DIGITS; i++)
+    code = code * 10 + (guint) (proof[i] - '0');
+  return code;
+}
+
+/*
+ * Drive the principal FSM through a FAILED_ATTEMPT event from the
+ * MFA_REQUIRED state.  In commit 3 this is a pure FSM-shape probe
+ * (the transition is MFA_REQUIRED -> MFA_REQUIRED with no durable
+ * counter); commit 5 will layer a persistent failure counter and
+ * lockout policy on top.  Wiring the call here now keeps the
+ * validator's failure path on the same FSM-validated branch the
+ * lockout logic will read in commit 5.
+ *
+ * The three negative paths (no enrollment, wrong code, replay)
+ * intentionally differ in computational cost: the wrong-code and
+ * replay paths perform 3x HMAC-SHA-1 via wyl_totp_code_matches,
+ * while the no-enrollment path skips that work.  The resulting
+ * timing differential is acceptable because issue #331 decision 7
+ * requires the HTTP layer (/auth/mfa/verify) to surface
+ * `enrollment_required` as a distinct error code from
+ * `mfa_invalid`, so the no-enrollment bit is already deliberately
+ * public at the API surface.  Adding a dummy HMAC here to mask a
+ * bit that the spec discloses would be hardening theater, not
+ * defense.  The FSM step is O(ns) and cannot mask a 3x HMAC cost
+ * anyway; do not "fix" the timing gap by inserting a fake HMAC.
+ */
+static void
+note_failed_attempt (void)
+{
+  wyl_principal_state_t next = WYL_PRINCIPAL_STATE_LAST_;
+  (void) wyl_fsm_principal_step (WYL_PRINCIPAL_STATE_MFA_REQUIRED,
+      WYL_PRINCIPAL_EVENT_FAILED_ATTEMPT, &next);
+}
+
+wyrelog_error_t
+wyl_mfa_validator_totp (WylHandle *handle, WylSession *session,
+    const gchar *proof, gpointer user_data)
+{
+  (void) user_data;
+
+  if (handle == NULL || session == NULL)
+    return WYRELOG_E_INVALID;
+  if (!proof_shape_is_valid (proof))
+    return WYRELOG_E_INVALID;
+
+  g_autofree gchar *subject_id = wyl_session_dup_username (session);
+  if (subject_id == NULL || subject_id[0] == '\0')
+    return WYRELOG_E_INVALID;
+
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (store == NULL)
+    return WYRELOG_E_INTERNAL;
+
+  /*
+   * F5 (enumeration via differential error codes): every negative
+   * outcome below funnels through the same WYRELOG_E_POLICY return.
+   * The HTTP layer (commit 4) distinguishes enrollment_required vs
+   * mfa_invalid by inspecting the enrollment row separately, not by
+   * branching on this validator's return code.
+   */
+  WylTotpEnrollment enr = { 0 };
+  gboolean found = FALSE;
+  wyrelog_error_t rc = wyl_policy_store_totp_enrollment_lookup (store,
+      subject_id, &enr, &found);
+  if (rc != WYRELOG_E_OK) {
+    wyl_totp_enrollment_clear (&enr);
+    return rc;
+  }
+  if (!found) {
+    /* Drive the same FSM FAILED_ATTEMPT branch the wrong-code path
+     * takes so commit 5's lockout counter sees every failed verify
+     * uniformly.  This does NOT equalise the timing of the
+     * no-enrollment vs wrong-code branches — see the rationale
+     * above note_failed_attempt for why the differential is
+     * intentional and consistent with issue #331 decision 7. */
+    note_failed_attempt ();
+    wyl_totp_enrollment_clear (&enr);
+    return WYRELOG_E_POLICY;
+  }
+
+  guint submitted_code = parse_six_digits (proof);
+  gint64 now = (gint64) time (NULL);
+  guint64 matched_step = 0;
+
+  gboolean matched = wyl_totp_code_matches (enr.secret, sizeof enr.secret,
+      now, submitted_code, &matched_step, NULL);
+  if (!matched) {
+    note_failed_attempt ();
+    wyl_totp_enrollment_clear (&enr);
+    return WYRELOG_E_POLICY;
+  }
+
+  /*
+   * Replay defense (architect rule 2, critic F3).  STRICT >, NOT >=:
+   * a matched_step equal to the persisted watermark is a replay of
+   * the most recently accepted code and MUST fail closed.  The
+   * commit-2 schema seeds last_verified_step at INT64_MIN, so any
+   * fresh enrollment always satisfies matched_step > last_verified_step
+   * on the first call.
+   *
+   * The signed/unsigned comparison is fine: matched_step is a
+   * non-negative step counter that fits well below INT64_MAX for any
+   * plausible epoch (RFC 6238 step counts run at 1/30 Hz), and the
+   * cast to gint64 is safe.  Should an attacker somehow place a step
+   * above INT64_MAX, the gint64 cast would saturate to a negative
+   * value and the comparison would reject — which is the conservative
+   * direction.
+   */
+  if ((gint64) matched_step <= enr.last_verified_step) {
+    note_failed_attempt ();
+    wyl_totp_enrollment_clear (&enr);
+    return WYRELOG_E_POLICY;
+  }
+
+  /*
+   * Persist the new watermark BEFORE the caller drives the FSM
+   * (critic F3).  The two writes (totp_enrollments watermark, FSM
+   * principal_state mutation) live in different SQLite-row families
+   * inside the same encrypted policy store, but they are not joined
+   * by an outer BEGIN IMMEDIATE here because:
+   *
+   *   - mark_session_mfa_verified (the caller, in wyl-session.c) opens
+   *     its own BEGIN IMMEDIATE / COMMIT around the principal_state
+   *     update via apply_principal_state_mutation.  Nesting our
+   *     update_step inside that transaction would require either a
+   *     savepoint or a re-plumbing of the FSM mutation path that is
+   *     out of scope for commit 3.
+   *
+   *   - The crash-safety contract we want here is fail-closed: if
+   *     the daemon crashes after this update_step COMMITs but before
+   *     the FSM mutation COMMITs, the next attempt with the SAME
+   *     code will be rejected because last_verified_step is already
+   *     advanced (matched_step <= persisted watermark).  The session
+   *     remains mfa_required (FSM state was not advanced), so the
+   *     client must obtain a fresh code at a later step.  This is
+   *     verified by the restart-simulation test in
+   *     tests/test-daemon-mfa-validator.c.
+   *
+   * F2: no log/audit emission below ever sees the seed or the code.
+   */
+  rc = wyl_policy_store_totp_enrollment_update_step (store, subject_id,
+      (gint64) matched_step);
+  wyl_totp_enrollment_clear (&enr);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  return WYRELOG_E_OK;
+}

--- a/wyrelog/auth/mfa-validator.h
+++ b/wyrelog/auth/mfa-validator.h
@@ -1,0 +1,55 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+
+#include <glib.h>
+
+#include "wyrelog/error.h"
+#include "wyrelog/handle.h"
+#include "wyrelog/session.h"
+
+G_BEGIN_DECLS;
+
+/*
+ * Daemon-side TOTP MFA validator (issue #331 commit 3).
+ *
+ * Implements the WylMfaValidator callback shape (wyrelog/session.h:35)
+ * so that wyl_session_mfa_verify_with_proof can apply the principal
+ * FSM transition only after a 6-digit TOTP proof is accepted against
+ * the per-subject enrollment stored in the policy authority store.
+ *
+ * Layering (constants are locked at the boundary):
+ *   - wyrelog/auth/totp.{c,h}      RFC 6238 primitives (commit 1)
+ *   - wyrelog/policy/store.c       totp_enrollments persistence (commit 2)
+ *   - wyrelog/auth/mfa-validator.c THIS module: shape check, lookup,
+ *                                  match-with-replay-defense, persist
+ *                                  the watermark.
+ *
+ * Replay defense: the validator persists last_verified_step in the
+ * policy store BEFORE the caller drives the FSM transition (the
+ * fact-mutation ordering critic F3 mandates), and rejects any match
+ * whose matched_step is <= the persisted watermark using strict >
+ * comparison.  See mfa-validator.c for the crash-safety rationale on
+ * a restart between the store write and the FSM transition.
+ *
+ * Error-code surface (commit 3 contract):
+ *   WYRELOG_E_OK       proof matched, watermark advanced, caller may
+ *                      drive the FSM (mark_session_mfa_verified).
+ *   WYRELOG_E_INVALID  malformed input (NULL handle/session, NULL or
+ *                      mis-shaped proof, NULL username).
+ *   WYRELOG_E_POLICY   no enrollment, wrong code, OR matched code
+ *                      replayed.  The HTTP layer (commit 4)
+ *                      differentiates enrollment_required vs
+ *                      mfa_invalid by inspecting the enrollment row
+ *                      separately and never by branching on this
+ *                      validator's return code (F5).
+ *
+ * No audit emission inside this module.  The FSM transition the
+ * caller drives on success already emits a principal_state audit;
+ * commit 5 will add failed-attempt audit on the FAILED_ATTEMPT
+ * branch.  No log/audit site here ever sees the seed, the submitted
+ * code, or any HMAC intermediate (F2).
+ */
+wyrelog_error_t wyl_mfa_validator_totp (WylHandle * handle,
+    WylSession * session, const gchar * proof, gpointer user_data);
+
+G_END_DECLS;

--- a/wyrelog/auth/totp.c
+++ b/wyrelog/auth/totp.c
@@ -1,0 +1,459 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "auth/totp.h"
+
+#include <sodium.h>
+#include <string.h>
+
+/*
+ * RFC 6238 TOTP core (SHA-1) — minimal in-tree implementation.
+ *
+ * Design notes that callers and reviewers should hold in mind:
+ *
+ *   - HMAC-SHA-1 is performed via GLib's g_compute_hmac_for_data so
+ *     we do not carry a hand-rolled SHA-1 implementation.  GLib
+ *     returns the digest as a lowercase hex string; we decode that
+ *     into 20 raw bytes for the dynamic-truncation step described
+ *     in RFC 4226 section 5.3.  Both buffers are zeroed before
+ *     release.
+ *
+ *   - Random seed bytes come from libsodium's randombytes_buf; the
+ *     caller chose libsodium for every other secret-bearing path in
+ *     the project and we follow that lead.  No /dev/urandom direct
+ *     reads, no glibc rand().
+ *
+ *   - The verifier evaluates all three skew windows {-1, 0, +1}
+ *     unconditionally and compares with sodium_memcmp on the
+ *     6-character decimal form of the code so the path length is
+ *     independent of which window (if any) matched.  This forecloses
+ *     timing oracles that could otherwise leak which step a code
+ *     belongs to.
+ *
+ *   - Replay defense is NOT implemented here.  This module returns
+ *     the matched step number; persistence and "refuse anything <=
+ *     last verified step" live in the caller (commit 5 of the issue
+ *     roll-out).  Keeping the core stateless makes unit testing
+ *     against published RFC vectors straightforward.
+ *
+ * Constants (step=30s, digits=6, T0=0) match RFC 6238 and are not
+ * exposed as runtime knobs.  Operators do not benefit from being
+ * able to weaken these.
+ */
+
+#define WYL_TOTP_HMAC_SHA1_LEN 20
+
+/* 10^WYL_TOTP_DIGITS — the modulus that trims the dynamic-truncation
+ * 31-bit integer down to a 6-digit code.  Encoded as a literal to
+ * keep the expression visible to a reader scanning for the RFC
+ * derivation rather than buried behind a power-of computation. */
+#define WYL_TOTP_DIGIT_MODULUS 1000000u
+
+static gboolean
+hex_nibble (gchar c, guint8 *out)
+{
+  if (c >= '0' && c <= '9') {
+    *out = (guint8) (c - '0');
+    return TRUE;
+  }
+  if (c >= 'a' && c <= 'f') {
+    *out = (guint8) (c - 'a' + 10);
+    return TRUE;
+  }
+  if (c >= 'A' && c <= 'F') {
+    *out = (guint8) (c - 'A' + 10);
+    return TRUE;
+  }
+  return FALSE;
+}
+
+/*
+ * Decode the lowercase hex string GLib produces (40 characters for
+ * SHA-1) into 20 raw bytes.  The intermediate hex string is zeroed
+ * by the caller via sodium_memzero after we return — the digest
+ * itself is sensitive enough that we treat it the same as a key.
+ */
+static gboolean
+decode_hex_digest (const gchar *hex, guint8 *out, gsize out_len)
+{
+  if (hex == NULL || out == NULL || out_len == 0)
+    return FALSE;
+  gsize hex_len = strlen (hex);
+  if (hex_len != out_len * 2)
+    return FALSE;
+  for (gsize i = 0; i < out_len; i++) {
+    guint8 hi, lo;
+    if (!hex_nibble (hex[i * 2], &hi) || !hex_nibble (hex[i * 2 + 1], &lo))
+      return FALSE;
+    out[i] = (guint8) ((hi << 4) | lo);
+  }
+  return TRUE;
+}
+
+/*
+ * RFC 4226 section 5.3 dynamic truncation.  digest is the 20-byte
+ * HMAC-SHA-1 output; returns the 31-bit integer P (modulus applied
+ * by the caller).
+ */
+static guint32
+dynamic_truncate (const guint8 digest[WYL_TOTP_HMAC_SHA1_LEN])
+{
+  guint offset = digest[WYL_TOTP_HMAC_SHA1_LEN - 1] & 0x0Fu;
+  guint32 bin = ((guint32) (digest[offset] & 0x7Fu) << 24)
+      | ((guint32) digest[offset + 1] << 16)
+      | ((guint32) digest[offset + 2] << 8)
+      | ((guint32) digest[offset + 3]);
+  return bin;
+}
+
+static wyrelog_error_t
+hmac_sha1 (const guint8 *key, gsize key_len,
+    const guint8 *data, gsize data_len,
+    guint8 out_digest[WYL_TOTP_HMAC_SHA1_LEN])
+{
+  /* GLib's g_compute_hmac_for_data only emits a hex-encoded digest;
+   * the project standardises on this entry point per the implementer
+   * brief (no hand-rolled SHA-1, no OpenSSL).  We zero the
+   * intermediate hex buffer before release because it carries the
+   * full digest in printable form. */
+  gchar *hex = g_compute_hmac_for_data (G_CHECKSUM_SHA1, key, key_len,
+      data, data_len);
+  if (hex == NULL)
+    return WYRELOG_E_CRYPTO;
+  gboolean ok = decode_hex_digest (hex, out_digest, WYL_TOTP_HMAC_SHA1_LEN);
+  sodium_memzero (hex, strlen (hex));
+  g_free (hex);
+  return ok ? WYRELOG_E_OK : WYRELOG_E_CRYPTO;
+}
+
+static wyrelog_error_t
+compute_code_for_step (const guint8 *seed, gsize seed_len, guint64 step,
+    guint *out_code)
+{
+  if (seed == NULL || seed_len != WYL_TOTP_SEED_BYTES || out_code == NULL)
+    return WYRELOG_E_INVALID;
+
+  /* Counter is an 8-byte big-endian step number, per RFC 4226. */
+  guint8 counter[8];
+  for (gint i = 7; i >= 0; i--) {
+    counter[i] = (guint8) (step & 0xFFu);
+    step >>= 8;
+  }
+
+  guint8 digest[WYL_TOTP_HMAC_SHA1_LEN];
+  wyrelog_error_t rc = hmac_sha1 (seed, seed_len, counter, sizeof counter,
+      digest);
+  /* Zero the counter even on the success path: it doesn't carry
+   * secret material per se, but keeping the discipline uniform
+   * means no one has to reason about which return path forgot. */
+  sodium_memzero (counter, sizeof counter);
+  if (rc != WYRELOG_E_OK) {
+    sodium_memzero (digest, sizeof digest);
+    return rc;
+  }
+
+  guint32 bin = dynamic_truncate (digest);
+  sodium_memzero (digest, sizeof digest);
+  *out_code = (guint) (bin % WYL_TOTP_DIGIT_MODULUS);
+  return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
+wyl_totp_generate_seed (guint8 *out_seed, gsize seed_len, GError **error)
+{
+  (void) error;
+  if (out_seed == NULL || seed_len != WYL_TOTP_SEED_BYTES)
+    return WYRELOG_E_INVALID;
+  if (sodium_init () < 0) {
+    sodium_memzero (out_seed, seed_len);
+    return WYRELOG_E_CRYPTO;
+  }
+  randombytes_buf (out_seed, seed_len);
+  return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
+wyl_totp_code_at_step (const guint8 *seed, gsize seed_len, guint64 step,
+    guint *out_code, GError **error)
+{
+  (void) error;
+  return compute_code_for_step (seed, seed_len, step, out_code);
+}
+
+static void
+format_code_6 (guint code, gchar out[7])
+{
+  /* Zero-padded 6-digit decimal.  We compare on the string form so
+   * the constant-time comparison length is fixed regardless of how
+   * many leading zeros the integer happened to have. */
+  out[0] = (gchar) ('0' + (code / 100000u) % 10u);
+  out[1] = (gchar) ('0' + (code / 10000u) % 10u);
+  out[2] = (gchar) ('0' + (code / 1000u) % 10u);
+  out[3] = (gchar) ('0' + (code / 100u) % 10u);
+  out[4] = (gchar) ('0' + (code / 10u) % 10u);
+  out[5] = (gchar) ('0' + code % 10u);
+  out[6] = '\0';
+}
+
+gboolean
+wyl_totp_code_matches (const guint8 *seed, gsize seed_len, gint64 unix_time,
+    guint code, guint64 *out_matched_step, GError **error)
+{
+  (void) error;
+  if (seed == NULL || seed_len != WYL_TOTP_SEED_BYTES)
+    return FALSE;
+  if (code >= WYL_TOTP_DIGIT_MODULUS)
+    return FALSE;
+
+  /* Integer-divide unix_time by the step length, biased so negative
+   * times round toward minus infinity.  This keeps step boundaries
+   * symmetric across the epoch — important for the test vectors at
+   * T close to zero that the unit tests use. */
+  gint64 step_centre;
+  if (unix_time >= 0) {
+    step_centre = unix_time / WYL_TOTP_STEP_SECONDS;
+  } else {
+    /* Floor division for negatives without invoking implementation-
+     * defined behaviour on signed-integer division. */
+    step_centre = -(((-unix_time) + WYL_TOTP_STEP_SECONDS - 1)
+        / WYL_TOTP_STEP_SECONDS);
+  }
+
+  gchar candidate[7];
+  format_code_6 (code, candidate);
+
+  /* Compare against {-1, 0, +1} unconditionally.  We use accumulator
+   * variables instead of an early-return loop so the function
+   * executes the same amount of HMAC and comparison work for every
+   * call regardless of which window (if any) matched. */
+  guint matched_mask = 0;
+  guint64 matched_step = 0;
+  wyrelog_error_t worst_rc = WYRELOG_E_OK;
+
+  for (gint delta = -1; delta <= 1; delta++) {
+    gint64 step = step_centre + delta;
+    if (step < 0) {
+      /* Treat negative absolute steps as never-matching without
+       * shortening the work: still run the HMAC at step 0 and
+       * discard.  This keeps the timing flat for pre-epoch
+       * inputs that show up in tests. */
+      guint discard = 0;
+      wyrelog_error_t rc = compute_code_for_step (seed, seed_len, 0,
+          &discard);
+      if (rc != WYRELOG_E_OK)
+        worst_rc = rc;
+      continue;
+    }
+    guint window_code = 0;
+    wyrelog_error_t rc = compute_code_for_step (seed, seed_len,
+        (guint64) step, &window_code);
+    if (rc != WYRELOG_E_OK) {
+      worst_rc = rc;
+      continue;
+    }
+    gchar window_str[7];
+    format_code_6 (window_code, window_str);
+    /* sodium_memcmp returns 0 iff the buffers are byte-equal and
+     * does so in constant time relative to buffer length. */
+    if (sodium_memcmp (window_str, candidate, 6) == 0) {
+      matched_mask = 1;
+      matched_step = (guint64) step;
+    }
+    sodium_memzero (window_str, sizeof window_str);
+  }
+
+  sodium_memzero (candidate, sizeof candidate);
+
+  if (worst_rc != WYRELOG_E_OK)
+    return FALSE;
+  if (matched_mask == 0)
+    return FALSE;
+  if (out_matched_step != NULL)
+    *out_matched_step = matched_step;
+  return TRUE;
+}
+
+/* RFC 4648 base32 alphabet (uppercase). */
+static const gchar B32_ALPHA[33] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+
+wyrelog_error_t
+wyl_totp_base32_encode (const guint8 *in, gsize in_len, gchar **out,
+    GError **error)
+{
+  (void) error;
+  if (out == NULL)
+    return WYRELOG_E_INVALID;
+  *out = NULL;
+  if (in == NULL && in_len > 0)
+    return WYRELOG_E_INVALID;
+
+  /* Each 5-byte group produces 8 characters; pad partial groups
+   * with '=' to a multiple of 8 per RFC 4648. */
+  gsize groups = (in_len + 4) / 5;
+  gsize out_len = groups * 8;
+  gchar *buf = g_malloc (out_len + 1);
+  buf[out_len] = '\0';
+
+  gsize oi = 0;
+  for (gsize i = 0; i < in_len; i += 5) {
+    guint8 b[5] = { 0 };
+    gsize remaining = in_len - i;
+    gsize take = remaining < 5 ? remaining : 5;
+    memcpy (b, in + i, take);
+
+    /* Build the 8 5-bit groups across the 5-byte window. */
+    guint8 idx[8];
+    idx[0] = (b[0] >> 3) & 0x1Fu;
+    idx[1] = (guint8) (((b[0] << 2) | (b[1] >> 6)) & 0x1Fu);
+    idx[2] = (b[1] >> 1) & 0x1Fu;
+    idx[3] = (guint8) (((b[1] << 4) | (b[2] >> 4)) & 0x1Fu);
+    idx[4] = (guint8) (((b[2] << 1) | (b[3] >> 7)) & 0x1Fu);
+    idx[5] = (b[3] >> 2) & 0x1Fu;
+    idx[6] = (guint8) (((b[3] << 3) | (b[4] >> 5)) & 0x1Fu);
+    idx[7] = b[4] & 0x1Fu;
+
+    /* RFC 4648: emit alphabet for the bytes we had, pad '=' for the
+     * trailing groups whose source bytes do not exist.  The lookup
+     * table maps each 5-bit residue to {2,4,5,7,8}-byte windows. */
+    gsize emit;
+    switch (take) {
+      case 1:
+        emit = 2;
+        break;
+      case 2:
+        emit = 4;
+        break;
+      case 3:
+        emit = 5;
+        break;
+      case 4:
+        emit = 7;
+        break;
+      default:
+        emit = 8;
+        break;
+    }
+    for (gsize k = 0; k < emit; k++)
+      buf[oi + k] = B32_ALPHA[idx[k]];
+    for (gsize k = emit; k < 8; k++)
+      buf[oi + k] = '=';
+    oi += 8;
+    sodium_memzero (b, sizeof b);
+    sodium_memzero (idx, sizeof idx);
+  }
+
+  *out = buf;
+  return WYRELOG_E_OK;
+}
+
+static gboolean
+b32_char_value (gchar c, guint8 *out)
+{
+  if (c >= 'A' && c <= 'Z') {
+    *out = (guint8) (c - 'A');
+    return TRUE;
+  }
+  if (c >= 'a' && c <= 'z') {
+    *out = (guint8) (c - 'a');
+    return TRUE;
+  }
+  if (c >= '2' && c <= '7') {
+    *out = (guint8) (c - '2' + 26);
+    return TRUE;
+  }
+  return FALSE;
+}
+
+wyrelog_error_t
+wyl_totp_base32_decode (const gchar *in, guint8 **out, gsize *out_len,
+    GError **error)
+{
+  (void) error;
+  if (in == NULL || out == NULL || out_len == NULL)
+    return WYRELOG_E_INVALID;
+  *out = NULL;
+  *out_len = 0;
+
+  gsize len = strlen (in);
+
+  /* Strip trailing '=' padding before validating the data run.  We
+   * accept padding regardless of whether it lines up to a multiple
+   * of 8 — the RFC requires it but real-world Base32 emitters
+   * (including some authenticator apps) leave it off, and operators
+   * tend to paste secrets from clipboards that did or did not
+   * preserve it. */
+  gsize data_len = len;
+  while (data_len > 0 && in[data_len - 1] == '=')
+    data_len--;
+
+  /* Reject any non-alphabet character in the data run.  '=' inside
+   * the data run, whitespace, dashes, etc. all land here. */
+  for (gsize i = 0; i < data_len; i++) {
+    guint8 ignored;
+    if (!b32_char_value (in[i], &ignored))
+      return WYRELOG_E_INVALID;
+  }
+
+  /* The data run length must be one of {0, 2, 4, 5, 7} modulo 8 —
+   * the only group sizes RFC 4648 permits.  1, 3, 6 modulo 8 are
+   * unrepresentable and indicate truncation. */
+  gsize tail = data_len % 8;
+  if (tail == 1 || tail == 3 || tail == 6)
+    return WYRELOG_E_INVALID;
+
+  gsize full_groups = data_len / 8;
+  gsize tail_bytes = 0;
+  switch (tail) {
+    case 0:
+      tail_bytes = 0;
+      break;
+    case 2:
+      tail_bytes = 1;
+      break;
+    case 4:
+      tail_bytes = 2;
+      break;
+    case 5:
+      tail_bytes = 3;
+      break;
+    case 7:
+      tail_bytes = 4;
+      break;
+    default:
+      g_assert_not_reached ();
+  }
+
+  gsize decoded_len = full_groups * 5 + tail_bytes;
+  guint8 *buf = (decoded_len == 0) ? g_malloc0 (1) : g_malloc (decoded_len);
+
+  gsize oi = 0;
+  for (gsize gi = 0; gi < full_groups; gi++) {
+    guint8 v[8];
+    for (gsize k = 0; k < 8; k++)
+      (void) b32_char_value (in[gi * 8 + k], &v[k]);
+    buf[oi + 0] = (guint8) ((v[0] << 3) | (v[1] >> 2));
+    buf[oi + 1] = (guint8) ((v[1] << 6) | (v[2] << 1) | (v[3] >> 4));
+    buf[oi + 2] = (guint8) ((v[3] << 4) | (v[4] >> 1));
+    buf[oi + 3] = (guint8) ((v[4] << 7) | (v[5] << 2) | (v[6] >> 3));
+    buf[oi + 4] = (guint8) ((v[6] << 5) | v[7]);
+    oi += 5;
+    sodium_memzero (v, sizeof v);
+  }
+
+  if (tail > 0) {
+    guint8 v[8] = { 0 };
+    for (gsize k = 0; k < tail; k++)
+      (void) b32_char_value (in[full_groups * 8 + k], &v[k]);
+    if (tail_bytes >= 1)
+      buf[oi + 0] = (guint8) ((v[0] << 3) | (v[1] >> 2));
+    if (tail_bytes >= 2)
+      buf[oi + 1] = (guint8) ((v[1] << 6) | (v[2] << 1) | (v[3] >> 4));
+    if (tail_bytes >= 3)
+      buf[oi + 2] = (guint8) ((v[3] << 4) | (v[4] >> 1));
+    if (tail_bytes >= 4)
+      buf[oi + 3] = (guint8) ((v[4] << 7) | (v[5] << 2) | (v[6] >> 3));
+    sodium_memzero (v, sizeof v);
+  }
+
+  *out = buf;
+  *out_len = decoded_len;
+  return WYRELOG_E_OK;
+}

--- a/wyrelog/auth/totp.h
+++ b/wyrelog/auth/totp.h
@@ -1,0 +1,104 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+
+#include <glib.h>
+
+#include "wyrelog/error.h"
+
+G_BEGIN_DECLS;
+
+/*
+ * RFC 6238 TOTP core (HMAC-SHA-1, 6 digits, 30-second step, T0=0).
+ *
+ * This header is intentionally narrow: it carries the cryptographic
+ * primitives and nothing else.  Persistence, audit emission, replay
+ * defense, and lockout policy live in higher layers that compose
+ * this module.  Constants are locked at the spec defaults; no knobs.
+ *
+ * Secret material handed to these entry points is treated as
+ * sensitive: all intermediate state inside the implementation is
+ * cleared with sodium_memzero on every return path.  Callers are
+ * responsible for zeroing their own copies of the seed.
+ */
+
+/*
+ * Canonical RFC 6238 SHA-1 seed length.  The module rejects any
+ * other length to keep callers from feeding partial or oversized
+ * material that would silently change the security level.
+ */
+#define WYL_TOTP_SEED_BYTES 20
+
+/* Digits, step, T0 — locked to RFC 6238 defaults. */
+#define WYL_TOTP_DIGITS 6
+#define WYL_TOTP_STEP_SECONDS 30
+#define WYL_TOTP_T0_SECONDS 0
+
+/*
+ * Generate a 20-byte seed from the platform CSPRNG (libsodium
+ * randombytes_buf).  out_seed MUST point to a writable buffer of
+ * exactly WYL_TOTP_SEED_BYTES bytes; seed_len carries that size for
+ * defensive checks.
+ *
+ * On error, out_seed is zeroed before return.  On success, the
+ * caller owns the secret material and is responsible for zeroing
+ * it once consumed.
+ */
+wyrelog_error_t wyl_totp_generate_seed (guint8 * out_seed,
+    gsize seed_len, GError ** error);
+
+/*
+ * Compute the 6-digit TOTP code for the given counter step.  step
+ * is the integer counter T (i.e. unix_time / WYL_TOTP_STEP_SECONDS),
+ * not the wall-clock time — callers convert.  out_code receives the
+ * integer in the range [0, 999999].
+ *
+ * Returns WYRELOG_E_INVALID for NULL inputs or seed_len that does
+ * not match WYL_TOTP_SEED_BYTES.  Returns WYRELOG_E_CRYPTO if the
+ * underlying HMAC primitive fails.
+ */
+wyrelog_error_t wyl_totp_code_at_step (const guint8 * seed,
+    gsize seed_len, guint64 step, guint * out_code, GError ** error);
+
+/*
+ * Verify a 6-digit code against the three skew windows {-1, 0, +1}
+ * centred on the step that contains unix_time.  All three windows
+ * are evaluated unconditionally with constant-time equality (no
+ * early return on first match) to defeat timing oracles.
+ *
+ * Returns TRUE on match; out_matched_step (optional) receives the
+ * absolute step that matched, intended for the caller's replay
+ * defense (persist this value, refuse codes at steps <= the last
+ * verified one).
+ *
+ * Returns FALSE on no-match or on any argument validation failure;
+ * use the GError to distinguish if needed.  out_matched_step is
+ * untouched on no-match.
+ */
+gboolean wyl_totp_code_matches (const guint8 * seed,
+    gsize seed_len, gint64 unix_time, guint code,
+    guint64 * out_matched_step, GError ** error);
+
+/*
+ * RFC 4648 base32 encode.  Output is uppercase A-Z / 2-7 with '='
+ * padding to a multiple of 8 characters.  *out is owned by the
+ * caller and must be released with g_free.
+ */
+wyrelog_error_t wyl_totp_base32_encode (const guint8 * in,
+    gsize in_len, gchar ** out, GError ** error);
+
+/*
+ * RFC 4648 base32 decode.  Accepts uppercase and lowercase letters;
+ * tolerates trailing '=' padding even when the input length already
+ * fits an exact 8-character boundary.  Rejects any other character
+ * (including internal whitespace, internal '=', or characters
+ * outside the alphabet) with WYRELOG_E_INVALID.
+ *
+ * On success, *out is a fresh allocation owned by the caller; free
+ * with g_free.  *out_len receives the decoded length (may be 0 for
+ * an empty input).  Both *out and *out_len are zeroed on error
+ * before return.
+ */
+wyrelog_error_t wyl_totp_base32_decode (const gchar * in,
+    guint8 ** out, gsize * out_len, GError ** error);
+
+G_END_DECLS;

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -3728,6 +3728,246 @@ login_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
       SOUP_MEMORY_COPY, body, strlen (body));
 }
 
+/*
+ * Exactly six ASCII digits 0-9.  Returns FALSE for NULL, any other
+ * length, any non-digit byte, leading sign, or whitespace.  The
+ * validator (commit 3) re-checks this with strnlen for defense in
+ * depth; this is the HTTP-layer's first-line shape gate so the
+ * route can emit invalid_mfa_request without ever touching the
+ * policy store or the session registry.
+ */
+static gboolean
+mfa_code_is_well_formed (const gchar *code)
+{
+  if (code == NULL)
+    return FALSE;
+  for (gsize i = 0; i < 6; i++) {
+    if (code[i] < '0' || code[i] > '9')
+      return FALSE;
+  }
+  return code[6] == '\0';
+}
+
+typedef struct
+{
+  const gchar *subject_id;
+  gchar *state;                 /* g_strdup; NULL when no row exists */
+} MfaPrincipalStateLookup;
+
+static wyrelog_error_t
+mfa_principal_state_cb (const gchar *subject_id, const gchar *state,
+    gpointer user_data)
+{
+  MfaPrincipalStateLookup *lookup = user_data;
+  if (lookup->state != NULL)
+    return WYRELOG_E_OK;        /* already found, drain remaining rows */
+  if (g_strcmp0 (subject_id, lookup->subject_id) == 0)
+    lookup->state = g_strdup (state);
+  return WYRELOG_E_OK;
+}
+
+/*
+ * Look up the current principal_state for |subject_id| in the
+ * handle-owned policy store.  Returns NULL when the subject has no
+ * principal_state row (which is itself a fail-closed signal: the
+ * caller may not proceed without an explicit row).  Caller frees
+ * the returned string with g_free / g_autofree.
+ */
+static gchar *
+mfa_lookup_principal_state (WylHandle *handle, const gchar *subject_id)
+{
+  if (handle == NULL || subject_id == NULL || subject_id[0] == '\0')
+    return NULL;
+  wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
+  if (store == NULL)
+    return NULL;
+  MfaPrincipalStateLookup lookup = {.subject_id = subject_id,.state = NULL };
+  if (wyl_policy_store_foreach_principal_state (store, mfa_principal_state_cb,
+          &lookup) != WYRELOG_E_OK) {
+    g_clear_pointer (&lookup.state, g_free);
+    return NULL;
+  }
+  return lookup.state;
+}
+
+static void
+mfa_verify_handler (SoupServer *server, SoupServerMessage *msg,
+    const char *path, GHashTable *query, gpointer user_data)
+{
+  (void) path;
+
+  if (g_strcmp0 (soup_server_message_get_method (msg), "POST") != 0) {
+    set_json_error (msg, 405, "method_not_allowed");
+    return;
+  }
+
+  WylDaemonHttpContext *ctx = user_data;
+  const gchar *session_token = NULL;
+  const gchar *code = NULL;
+  if (query != NULL) {
+    session_token = g_hash_table_lookup (query, "session_token");
+    code = g_hash_table_lookup (query, "code");
+  }
+
+  /*
+   * F5 (enumeration): a missing or empty session_token funnels into
+   * the same uniform mfa_auth_required surface that any non-resolving
+   * token uses below.  An unauthenticated probe must not be able to
+   * distinguish "no token" from "wrong token" from "stale token".
+   */
+  if (session_token == NULL || session_token[0] == '\0') {
+    set_json_error (msg, 401, "mfa_auth_required");
+    return;
+  }
+
+  /*
+   * F2 (secret echo): the code is shape-validated before any policy
+   * store work, and never logged, audited, or echoed in the response
+   * body.  set_json_error emits only the error code.
+   */
+  if (!mfa_code_is_well_formed (code)) {
+    set_json_error (msg, 400, "invalid_mfa_request");
+    return;
+  }
+
+  g_autoptr (WylSession) session =
+      wyl_daemon_http_ref_session (server, session_token);
+  if (session == NULL) {
+    set_json_error (msg, 401, "mfa_auth_required");
+    return;
+  }
+
+  g_autofree gchar *username = wyl_session_dup_username (session);
+  g_autofree gchar *session_tenant = wyl_session_dup_tenant (session);
+  if (username == NULL || username[0] == '\0' || session_tenant == NULL ||
+      session_tenant[0] == '\0') {
+    set_json_error (msg, 401, "mfa_auth_required");
+    return;
+  }
+
+  /*
+   * Tenant gate.  Mirror /auth/login: if the session's tenant has
+   * been sealed (or, defensively, removed) between login and verify,
+   * fail closed with the canonical tenant-gate code.
+   */
+  if (!tenant_is_active (ctx, session_tenant)) {
+    set_json_error (msg, 400, tenant_is_known (ctx, session_tenant) ?
+        WYL_DAEMON_ERR_TENANT_SEALED : WYL_DAEMON_ERR_TENANT_INVALID);
+    return;
+  }
+
+  /*
+   * Principal-state gate.  The session's authoritative principal_state
+   * lives in the policy store keyed by subject_id.  We require the
+   * subject to be in mfa_required to proceed.  Three cases:
+   *   - locked   -> 429 mfa_locked (issue #331 spec).
+   *   - other    -> 401 mfa_auth_required, uniform (F5).
+   *   - mfa_required -> proceed below.
+   * Note: this lookup is the only place an unauthenticated probe can
+   * influence behaviour via the session_token, and the leak surface is
+   * already bounded by the live-session gate above.
+   */
+  g_autofree gchar *principal_state =
+      mfa_lookup_principal_state (ctx->handle, username);
+  if (g_strcmp0 (principal_state, "locked") == 0) {
+    set_json_error (msg, 429, "mfa_locked");
+    return;
+  }
+  if (g_strcmp0 (principal_state, "mfa_required") != 0) {
+    set_json_error (msg, 401, "mfa_auth_required");
+    return;
+  }
+
+  /*
+   * Resolve the validator the daemon installed on this handle.  The
+   * route refuses to mint tokens if no validator has been registered
+   * - a misconfigured daemon must fail closed rather than fail open.
+   */
+  gpointer validator_user_data = NULL;
+  WylMfaValidator validator =
+      wyl_handle_get_mfa_validator (ctx->handle, &validator_user_data);
+  if (validator == NULL) {
+    set_json_error (msg, 500, "mfa_verify_failed");
+    return;
+  }
+
+  /*
+   * Drive the proof-bearing FSM primitive.  wyl_session_mfa_verify_with_proof
+   * binds the verify to THE session's subject (F5 cross-session
+   * takeover defense): we never accept a subject query parameter
+   * here, and the validator only sees the session-derived username.
+   * On success, the FSM is advanced to AUTHENTICATED before we
+   * return, mirroring login_handler's order.
+   */
+  wyrelog_error_t rc = wyl_session_mfa_verify_with_proof (ctx->handle, session,
+      code, validator, validator_user_data);
+  if (rc == WYRELOG_E_INVALID) {
+    set_json_error (msg, 400, "invalid_mfa_request");
+    return;
+  }
+  if (rc == WYRELOG_E_POLICY) {
+    /*
+     * The validator funnels enrollment-missing, wrong-code, and
+     * replay through the same WYRELOG_E_POLICY (commit 3 contract).
+     * The HTTP layer differentiates enrollment_required vs
+     * mfa_invalid by inspecting the totp_enrollment row separately
+     * (issue #331 decision 7).  This is the only place the
+     * enrollment-vs-no-enrollment bit is surfaced to the caller.
+     */
+    wyl_policy_store_t *store = wyl_handle_get_policy_store (ctx->handle);
+    if (store == NULL) {
+      set_json_error (msg, 500, "mfa_verify_failed");
+      return;
+    }
+    WylTotpEnrollment enr = { 0 };
+    gboolean found = FALSE;
+    wyrelog_error_t lookup_rc =
+        wyl_policy_store_totp_enrollment_lookup (store, username, &enr,
+        &found);
+    wyl_totp_enrollment_clear (&enr);
+    if (lookup_rc != WYRELOG_E_OK) {
+      set_json_error (msg, 500, "mfa_verify_failed");
+      return;
+    }
+    set_json_error (msg, 401, found ? "mfa_invalid" : "enrollment_required");
+    return;
+  }
+  if (rc != WYRELOG_E_OK) {
+    set_json_error (msg, 500, "mfa_verify_failed");
+    return;
+  }
+
+  /*
+   * FSM has advanced to AUTHENTICATED.  Mint access + refresh tokens
+   * in the same order as login_handler's skip_mfa path so the wire
+   * shape is identical between "login with skip_mfa" and "login then
+   * verify".  Store the session-token registry row only after both
+   * tokens succeed.
+   */
+  g_autofree gchar *access_token = NULL;
+  g_autofree gchar *refresh_token = NULL;
+  rc = issue_login_access_token (ctx, session_token, username,
+      session_tenant, "authenticated", &access_token);
+  if (rc == WYRELOG_E_OK)
+    rc = issue_refresh_token (ctx, session_token, username, session_tenant,
+        &refresh_token);
+  if (rc != WYRELOG_E_OK) {
+    set_json_error (msg, 500, "mfa_verify_failed");
+    return;
+  }
+  if (!wyl_daemon_http_context_store_session (ctx, session_token, session)) {
+    set_json_error (msg, 500, "mfa_verify_failed");
+    return;
+  }
+
+  g_autofree gchar *body = build_login_json (session_token, username,
+      session_tenant, "authenticated", access_token, refresh_token);
+  attach_request_id_header (msg);
+  soup_server_message_set_status (msg, 200, NULL);
+  soup_server_message_set_response (msg, "application/json",
+      SOUP_MEMORY_COPY, body, strlen (body));
+}
+
 static void
 refresh_handler (SoupServer *server, SoupServerMessage *msg, const char *path,
     GHashTable *query, gpointer user_data)
@@ -4074,6 +4314,8 @@ wyl_daemon_start_http_server_with_runtime (const WylDaemonOptions *opts,
   soup_server_add_handler (server, "/profile/events", profile_events_handler,
       ctx, NULL);
   soup_server_add_handler (server, "/auth/login", login_handler, ctx, NULL);
+  soup_server_add_handler (server, "/auth/mfa/verify", mfa_verify_handler,
+      ctx, NULL);
   soup_server_add_handler (server, "/auth/refresh", refresh_handler, ctx, NULL);
   soup_server_add_handler (server, "/auth/logout", logout_handler, ctx, NULL);
   soup_server_add_handler (server, "/tenants", tenant_list_handler, ctx, NULL);

--- a/wyrelog/daemon/http.c
+++ b/wyrelog/daemon/http.c
@@ -3748,30 +3748,20 @@ mfa_code_is_well_formed (const gchar *code)
   return code[6] == '\0';
 }
 
-typedef struct
-{
-  const gchar *subject_id;
-  gchar *state;                 /* g_strdup; NULL when no row exists */
-} MfaPrincipalStateLookup;
-
-static wyrelog_error_t
-mfa_principal_state_cb (const gchar *subject_id, const gchar *state,
-    gpointer user_data)
-{
-  MfaPrincipalStateLookup *lookup = user_data;
-  if (lookup->state != NULL)
-    return WYRELOG_E_OK;        /* already found, drain remaining rows */
-  if (g_strcmp0 (subject_id, lookup->subject_id) == 0)
-    lookup->state = g_strdup (state);
-  return WYRELOG_E_OK;
-}
-
 /*
  * Look up the current principal_state for |subject_id| in the
  * handle-owned policy store.  Returns NULL when the subject has no
- * principal_state row (which is itself a fail-closed signal: the
- * caller may not proceed without an explicit row).  Caller frees
- * the returned string with g_free / g_autofree.
+ * principal_state row (a fail-closed signal: the caller may not
+ * proceed without an explicit row).  Caller frees the returned string
+ * with g_free / g_autofree.
+ *
+ * Issue #331 commit 5: migrated off the historical foreach-based two-
+ * step lookup (which iterated the entire principal_states table) onto
+ * the single-row accessor wyl_policy_store_get_principal_state.  The
+ * accessor distinguishes "no row" (out_found=FALSE, returns OK) from
+ * "iteration error" (returns non-OK) via the explicit |out_found|
+ * boolean, so we surface the same NULL-on-miss-or-fault semantics to
+ * the caller without ambiguity.
  */
 static gchar *
 mfa_lookup_principal_state (WylHandle *handle, const gchar *subject_id)
@@ -3781,13 +3771,21 @@ mfa_lookup_principal_state (WylHandle *handle, const gchar *subject_id)
   wyl_policy_store_t *store = wyl_handle_get_policy_store (handle);
   if (store == NULL)
     return NULL;
-  MfaPrincipalStateLookup lookup = {.subject_id = subject_id,.state = NULL };
-  if (wyl_policy_store_foreach_principal_state (store, mfa_principal_state_cb,
-          &lookup) != WYRELOG_E_OK) {
-    g_clear_pointer (&lookup.state, g_free);
+  gchar *state = NULL;
+  gboolean found = FALSE;
+  if (wyl_policy_store_get_principal_state (store, subject_id, &state,
+          &found) != WYRELOG_E_OK) {
+    g_clear_pointer (&state, g_free);
     return NULL;
   }
-  return lookup.state;
+  if (!found) {
+    /* Defensive: get_principal_state already wrote NULL on miss, but
+     * the contract is "NULL on no-row" and we want a single belt-and-
+     * braces clear here too. */
+    g_clear_pointer (&state, g_free);
+    return NULL;
+  }
+  return state;
 }
 
 static void

--- a/wyrelog/daemon/runtime.c
+++ b/wyrelog/daemon/runtime.c
@@ -10,6 +10,7 @@
 #include <libsoup/soup.h>
 #endif
 
+#include "auth/mfa-validator.h"
 #include "daemon/checks.h"
 #include "daemon/delta.h"
 #include "daemon/http.h"
@@ -303,7 +304,17 @@ open_runtime_handle (const WylDaemonOptions *opts, WylHandle **out_handle)
 #endif
   };
 
-  return wyl_handle_open_with_options (&open_opts, out_handle);
+  wyrelog_error_t rc = wyl_handle_open_with_options (&open_opts, out_handle);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  /* Install the daemon-default TOTP MFA validator (issue #331 commit 3).
+   * The commit-4 HTTP /auth/mfa/verify route resolves this through
+   * wyl_handle_get_mfa_validator so the validator and its user_data
+   * are reachable without an out-of-band registration table.  The
+   * setter is total: it always succeeds. */
+  wyl_handle_set_mfa_validator (*out_handle, wyl_mfa_validator_totp, NULL);
+  return WYRELOG_E_OK;
 }
 
 static wyrelog_error_t

--- a/wyrelog/meson.build
+++ b/wyrelog/meson.build
@@ -18,6 +18,7 @@ wyrelog_sources = files(
   'access/break-glass.c',
   'access/decision.c',
   'auth/jwt.c',
+  'auth/totp.c',
   'audit/event.c',
   'fact/schema.c',
   'policy/store.c',

--- a/wyrelog/meson.build
+++ b/wyrelog/meson.build
@@ -140,7 +140,8 @@ if build_client
     files('wyctl/wyctl.c', 'wyctl/wyctl-config.c',
         'wyctl/wyctl-token-file.c'),
     include_directories : wyrelog_inc,
-    dependencies : [wyrelog_client_dep, glib_dep, gio_dep, libsoup_dep],
+    dependencies : [wyrelog_client_dep, glib_dep, gio_dep, libsoup_dep,
+        sodium_dep, sqlite_dep],
     install : true,
   )
 

--- a/wyrelog/meson.build
+++ b/wyrelog/meson.build
@@ -18,6 +18,7 @@ wyrelog_sources = files(
   'access/break-glass.c',
   'access/decision.c',
   'auth/jwt.c',
+  'auth/mfa-validator.c',
   'auth/totp.c',
   'audit/event.c',
   'fact/schema.c',

--- a/wyrelog/policy/store-private.h
+++ b/wyrelog/policy/store-private.h
@@ -451,4 +451,102 @@ wyrelog_error_t wyl_policy_store_apply_bootstrap_admin (wyl_policy_store_t *
     store, const gchar * subject_id, gboolean allow_login_skip_mfa,
     gboolean * out_applied, gchar ** out_existing_subject);
 
+/*
+ * TOTP enrollment fact schema (issue #331).
+ *
+ * Per-subject row stored in the policy authority store carrying the
+ * RFC 6238 seed plus the replay watermark and provenance:
+ *   subject_id          - principal that owns the enrollment (PK)
+ *   secret_blob         - raw 20-byte SHA-1 seed (BLOB)
+ *   last_verified_step  - replay watermark; the integer step T that
+ *                         was last accepted. Stored as INTEGER (gint64)
+ *                         because SQLite has no native u64; callers
+ *                         that need the u64 semantics cast at the
+ *                         boundary.  The sentinel INT64_MIN means
+ *                         "never verified" and is the value any fresh
+ *                         enrollment is seeded with.
+ *   enrolled_at         - unix seconds at enrollment time
+ *   id_uuidv7           - libchronoid UUIDv7 minted via wyl_id_new;
+ *                         this is the ONLY new persistent identifier
+ *                         the TOTP feature introduces and is the
+ *                         single fact provenance handle for the
+ *                         enrollment row.
+ *
+ * Secret material lifecycle: callers MUST treat WylTotpEnrollment.secret
+ * as sensitive.  wyl_totp_enrollment_clear zeroes the seed and frees
+ * any owned strings; every helper below zeroes the secret buffer on
+ * any error path that touched it.  No helper emits secret bytes to
+ * the log or audit subsystems.
+ */
+#define WYL_TOTP_ENROLLMENT_SECRET_BYTES 20
+
+typedef struct
+{
+  gchar *subject_id;
+  guint8 secret[WYL_TOTP_ENROLLMENT_SECRET_BYTES];
+  gint64 last_verified_step;    /* INT64_MIN sentinel = never verified */
+  gint64 enrolled_at;
+  gchar *id_uuidv7;
+} WylTotpEnrollment;
+
+/* Zero the secret buffer and free the owned string fields.  NULL-safe.
+ * Always zeroes the secret bytes regardless of caller state, so it is
+ * safe to call against a partially-populated stack struct from an
+ * error path before bailing out. */
+void wyl_totp_enrollment_clear (WylTotpEnrollment * enr);
+
+/*
+ * Insert (or replace, keyed on subject_id) a TOTP enrollment row.
+ *
+ * On entry enr->id_uuidv7 is ignored; the helper mints a fresh
+ * UUIDv7 via wyl_id_new and writes it back into the caller's struct
+ * on success so the audit/event layer in commit 3 can reference the
+ * row by its persistent id without a follow-up SELECT.  enr->secret
+ * is treated as the 20-byte SHA-1 seed and is bound as a BLOB; the
+ * caller retains ownership and is responsible for zeroing its copy.
+ *
+ * Replacing an existing row resets last_verified_step and
+ * enrolled_at from the supplied struct, so a re-enroll path naturally
+ * starts the replay watermark over from INT64_MIN.
+ *
+ * Returns WYRELOG_E_INVALID for NULL inputs, empty subject_id, or
+ * a NULL enr.
+ */
+wyrelog_error_t wyl_policy_store_totp_enrollment_insert (wyl_policy_store_t *
+    store, WylTotpEnrollment * enr);
+
+/*
+ * Look up the TOTP enrollment for subject_id.  On hit, *out is
+ * populated with a freshly owned copy (caller frees via
+ * wyl_totp_enrollment_clear) and *out_found is set TRUE.  On miss,
+ * *out_found is set FALSE and *out is left as a zero-initialised
+ * shell that wyl_totp_enrollment_clear remains safe to call against.
+ *
+ * Missing rows are NOT an error.  Returns WYRELOG_E_INVALID for NULL
+ * inputs.  The secret buffer in *out is zeroed before any error
+ * return.
+ */
+wyrelog_error_t wyl_policy_store_totp_enrollment_lookup (wyl_policy_store_t *
+    store, const gchar * subject_id, WylTotpEnrollment * out,
+    gboolean * out_found);
+
+/*
+ * Atomically update the replay watermark for subject_id.  Intended as
+ * the persistence primitive that the commit-3 verify path layers an
+ * outer transaction on top of (mirroring the apply_login_state shape
+ * in wyl-session.c).  No-op (returns WYRELOG_E_OK) if subject_id has
+ * no enrollment row; callers that need a strict precondition should
+ * combine with a prior lookup.
+ */
+wyrelog_error_t wyl_policy_store_totp_enrollment_update_step
+    (wyl_policy_store_t * store, const gchar * subject_id, gint64 new_step);
+
+/*
+ * Remove the TOTP enrollment row for subject_id.  Idempotent: deleting
+ * an absent row returns WYRELOG_E_OK.  Returns WYRELOG_E_INVALID for
+ * NULL inputs.
+ */
+wyrelog_error_t wyl_policy_store_totp_enrollment_delete (wyl_policy_store_t *
+    store, const gchar * subject_id);
+
 G_END_DECLS;

--- a/wyrelog/policy/store-private.h
+++ b/wyrelog/policy/store-private.h
@@ -361,6 +361,48 @@ wyrelog_error_t wyl_policy_store_set_principal_state (wyl_policy_store_t *
     store, const gchar * subject_id, const gchar * state);
 wyrelog_error_t wyl_policy_store_foreach_principal_state (wyl_policy_store_t *
     store, wyl_policy_principal_state_cb cb, gpointer user_data);
+/* Look up the current principal_state for |subject_id|. On a row match,
+ * *out_state is set to a g_strdup'd copy (caller frees with g_free) and
+ * *out_found is set to TRUE. When no row exists, *out_state is set to
+ * NULL and *out_found is set to FALSE; the return value is still
+ * WYRELOG_E_OK. Returns WYRELOG_E_IO on an iteration error so callers
+ * can distinguish "no row" from "store fault" without re-binding the
+ * historical foreach-based two-step lookup (issue #331 commit-5). */
+wyrelog_error_t wyl_policy_store_get_principal_state (wyl_policy_store_t *
+    store, const gchar * subject_id, gchar ** out_state, gboolean * out_found);
+/* Atomic single-row read of the principal_states row including the
+ * lockout columns (failed_attempt_count, locked_at). out_state is
+ * g_strdup'd; out_locked_at is INT64_MIN when the column is NULL.
+ * out_found follows the same semantics as get_principal_state. */
+wyrelog_error_t wyl_policy_store_get_principal_lock_info
+    (wyl_policy_store_t * store, const gchar * subject_id,
+    gchar ** out_state, gint64 * out_failed_count, gint64 * out_locked_at,
+    gboolean * out_found);
+/* Atomic mutation for a FAILED_ATTEMPT.  Inside a single savepoint:
+ *   - reads the current row (state + counter)
+ *   - if the row is missing, materialises mfa_required + counter=1
+ *   - else increments the counter
+ *   - if the resulting counter is >= |threshold|, transitions the row
+ *     to LOCKED with locked_at = |now_secs| and appends a `lock`
+ *     principal_event
+ * Returns the resulting state name in *out_state (g_strdup'd; caller
+ * frees), counter in *out_count, and locked_at in *out_locked_at
+ * (INT64_MIN when the row is not locked). The atomicity guarantee
+ * defeats the read-modify-write race on parallel verify attempts
+ * (commit-5 footgun). */
+wyrelog_error_t wyl_policy_store_apply_principal_failure
+    (wyl_policy_store_t * store, const gchar * subject_id,
+    gint64 threshold, gint64 now_secs, gchar ** out_state,
+    gint64 * out_count, gint64 * out_locked_at);
+/* Reset the failed_attempt_count to 0 and clear locked_at.  Called on a
+ * successful TOTP verify and on auto-unlock. */
+wyrelog_error_t wyl_policy_store_reset_principal_failure_counter
+    (wyl_policy_store_t * store, const gchar * subject_id);
+/* Atomic LOCKED -> UNVERIFIED transition: clears locked_at and the
+ * counter, sets state='unverified', and appends an `unlock`
+ * principal_event row in one savepoint. */
+wyrelog_error_t wyl_policy_store_apply_principal_unlock
+    (wyl_policy_store_t * store, const gchar * subject_id);
 wyrelog_error_t wyl_policy_store_append_principal_event (wyl_policy_store_t *
     store, const gchar * subject_id, const gchar * event,
     const gchar * from_state, const gchar * to_state, gint64 * out_event_id);

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -180,6 +180,7 @@ static const gchar *const required_tables[] = {
   "fact_relation_schema_columns",
   "fact_relation_query_allowlist",
   "policy_signatures",
+  "totp_enrollments",
 };
 
 static const BuiltinRole *
@@ -1971,7 +1972,19 @@ wyl_policy_store_create_schema (wyl_policy_store_t *store)
       "  policy_version INTEGER PRIMARY KEY,"
       "  policy_hash BLOB NOT NULL,"
       "  signature BLOB NOT NULL,"
-      "  signed_by TEXT NOT NULL," "  signed_at INTEGER NOT NULL" ");";
+      "  signed_by TEXT NOT NULL," "  signed_at INTEGER NOT NULL" ");"
+      /* TOTP enrollment per principal (issue #331).  secret_blob is
+       * the raw RFC 6238 SHA-1 seed (20 bytes).  last_verified_step is
+       * the replay watermark stored as INTEGER (no native u64 in
+       * SQLite); INT64_MIN means "never verified".  id_uuidv7 is the
+       * libchronoid UUIDv7 minted at insert time.  CREATE TABLE IF
+       * NOT EXISTS makes the migration onto a pre-#331 store
+       * transparent on first re-invocation of create_schema. */
+      "CREATE TABLE IF NOT EXISTS totp_enrollments ("
+      "  subject_id TEXT PRIMARY KEY,"
+      "  secret_blob BLOB NOT NULL,"
+      "  last_verified_step INTEGER NOT NULL,"
+      "  enrolled_at INTEGER NOT NULL," "  id_uuidv7 TEXT NOT NULL" ");";
 
   if (store == NULL || store->db == NULL)
     return WYRELOG_E_INVALID;
@@ -5613,4 +5626,230 @@ wyl_policy_store_apply_bootstrap_admin (wyl_policy_store_t *store,
   }
   *out_applied = TRUE;
   return WYRELOG_E_OK;
+}
+
+/* ----------------------------------------------------------------------
+ * TOTP enrollment helpers (issue #331).
+ *
+ * All four helpers operate on the `totp_enrollments` table created in
+ * wyl_policy_store_create_schema.  They follow the same pattern as
+ * the role-membership helpers above: single-statement INSERT/SELECT/
+ * UPDATE/DELETE wrapped in the local prepare_stmt/bind_text/
+ * sqlite3_step boilerplate.  None of these helpers emits any log line
+ * carrying secret bytes (footgun F2): the only identifiers that may
+ * appear in error paths are subject_id and id_uuidv7.  Every error
+ * exit that already populated the in-memory secret buffer zeroes it
+ * via sodium_memzero before returning (footgun F4).
+ * ---------------------------------------------------------------------- */
+
+void
+wyl_totp_enrollment_clear (WylTotpEnrollment *enr)
+{
+  if (enr == NULL)
+    return;
+  sodium_memzero (enr->secret, sizeof enr->secret);
+  g_clear_pointer (&enr->subject_id, g_free);
+  g_clear_pointer (&enr->id_uuidv7, g_free);
+  enr->last_verified_step = 0;
+  enr->enrolled_at = 0;
+}
+
+wyrelog_error_t
+wyl_policy_store_totp_enrollment_insert (wyl_policy_store_t *store,
+    WylTotpEnrollment *enr)
+{
+  sqlite3_stmt *stmt = NULL;
+
+  if (store == NULL || store->db == NULL || enr == NULL
+      || enr->subject_id == NULL || enr->subject_id[0] == '\0')
+    return WYRELOG_E_INVALID;
+
+  /* Mint the persistent id_uuidv7 before touching SQLite so an
+   * entropy failure does not leave a half-written row.  Discard any
+   * caller-supplied value; the helper owns id provenance. */
+  wyl_id_t id = WYL_ID_NIL;
+  wyrelog_error_t rc = wyl_id_new (&id);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  gchar id_buf[WYL_ID_STRING_BUF];
+  rc = wyl_id_format (&id, id_buf, sizeof id_buf);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  /* INSERT ... ON CONFLICT(subject_id) DO UPDATE: re-enrolling the
+   * same subject overwrites the secret AND resets the watermark and
+   * enrolled_at, so the verify path cannot accept a freshly-rotated
+   * seed at a step the prior seed had already burned. */
+  static const gchar *sql =
+      "INSERT INTO totp_enrollments "
+      "  (subject_id, secret_blob, last_verified_step, enrolled_at, "
+      "   id_uuidv7) "
+      "VALUES (?, ?, ?, ?, ?) "
+      "ON CONFLICT(subject_id) DO UPDATE SET "
+      "  secret_blob = excluded.secret_blob, "
+      "  last_verified_step = excluded.last_verified_step, "
+      "  enrolled_at = excluded.enrolled_at, "
+      "  id_uuidv7 = excluded.id_uuidv7;";
+  rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  if ((rc = bind_text (stmt, 1, enr->subject_id)) != WYRELOG_E_OK) {
+    sqlite3_finalize (stmt);
+    return rc;
+  }
+  /* SQLITE_TRANSIENT makes sqlite copy the bytes immediately so the
+   * caller's secret buffer does not need to outlive the bind call. */
+  if (sqlite3_bind_blob (stmt, 2, enr->secret, (int) sizeof enr->secret,
+          SQLITE_TRANSIENT) != SQLITE_OK) {
+    sqlite3_finalize (stmt);
+    return WYRELOG_E_IO;
+  }
+  if (sqlite3_bind_int64 (stmt, 3, enr->last_verified_step) != SQLITE_OK) {
+    sqlite3_finalize (stmt);
+    return WYRELOG_E_IO;
+  }
+  if (sqlite3_bind_int64 (stmt, 4, enr->enrolled_at) != SQLITE_OK) {
+    sqlite3_finalize (stmt);
+    return WYRELOG_E_IO;
+  }
+  if ((rc = bind_text (stmt, 5, id_buf)) != WYRELOG_E_OK) {
+    sqlite3_finalize (stmt);
+    return rc;
+  }
+
+  int step_rc = sqlite3_step (stmt);
+  sqlite3_finalize (stmt);
+  if (step_rc != SQLITE_DONE)
+    return WYRELOG_E_IO;
+
+  /* Publish the minted id back to the caller so the audit emission in
+   * commit 3 can reference the row without a follow-up SELECT. */
+  g_free (enr->id_uuidv7);
+  enr->id_uuidv7 = g_strdup (id_buf);
+  return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
+wyl_policy_store_totp_enrollment_lookup (wyl_policy_store_t *store,
+    const gchar *subject_id, WylTotpEnrollment *out, gboolean *out_found)
+{
+  sqlite3_stmt *stmt = NULL;
+
+  if (store == NULL || store->db == NULL || subject_id == NULL || out == NULL
+      || out_found == NULL)
+    return WYRELOG_E_INVALID;
+
+  *out_found = FALSE;
+  /* The caller hands us a struct of unknown provenance: wipe it to a
+   * clean shell so a miss leaves the secret buffer zeroed and the
+   * owned-string pointers NULL.  wyl_totp_enrollment_clear is
+   * NULL-safe for the strings and unconditionally zeroes the secret
+   * (footgun F4). */
+  wyl_totp_enrollment_clear (out);
+
+  static const gchar *sql =
+      "SELECT subject_id, secret_blob, last_verified_step, enrolled_at, "
+      "       id_uuidv7 " "FROM totp_enrollments " "WHERE subject_id = ?;";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if ((rc = bind_text (stmt, 1, subject_id)) != WYRELOG_E_OK) {
+    sqlite3_finalize (stmt);
+    return rc;
+  }
+
+  int step_rc = sqlite3_step (stmt);
+  if (step_rc == SQLITE_DONE) {
+    sqlite3_finalize (stmt);
+    return WYRELOG_E_OK;
+  }
+  if (step_rc != SQLITE_ROW) {
+    sqlite3_finalize (stmt);
+    return WYRELOG_E_IO;
+  }
+
+  const gchar *db_subject = (const gchar *) sqlite3_column_text (stmt, 0);
+  const void *db_secret = sqlite3_column_blob (stmt, 1);
+  int db_secret_len = sqlite3_column_bytes (stmt, 1);
+  gint64 db_last = sqlite3_column_int64 (stmt, 2);
+  gint64 db_enrolled = sqlite3_column_int64 (stmt, 3);
+  const gchar *db_id = (const gchar *) sqlite3_column_text (stmt, 4);
+
+  if (db_secret == NULL || db_secret_len != (int) sizeof out->secret) {
+    /* Schema invariant violation: a row exists but the BLOB is the
+     * wrong length.  Treat as I/O error rather than silently fall
+     * through with a partial seed.  Zero the buffer in case anything
+     * copied in already. */
+    sodium_memzero (out->secret, sizeof out->secret);
+    sqlite3_finalize (stmt);
+    return WYRELOG_E_IO;
+  }
+
+  out->subject_id = g_strdup (db_subject != NULL ? db_subject : "");
+  memcpy (out->secret, db_secret, sizeof out->secret);
+  out->last_verified_step = db_last;
+  out->enrolled_at = db_enrolled;
+  out->id_uuidv7 = g_strdup (db_id != NULL ? db_id : "");
+
+  sqlite3_finalize (stmt);
+  *out_found = TRUE;
+  return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
+wyl_policy_store_totp_enrollment_update_step (wyl_policy_store_t *store,
+    const gchar *subject_id, gint64 new_step)
+{
+  sqlite3_stmt *stmt = NULL;
+
+  if (store == NULL || store->db == NULL || subject_id == NULL)
+    return WYRELOG_E_INVALID;
+
+  /* The atomic update primitive that commit 3 will compose with the
+   * principal-state mutation in an outer transaction, mirroring
+   * apply_login_state_mutation in wyl-session.c.  Standalone the
+   * statement runs in sqlite's implicit per-statement transaction. */
+  static const gchar *sql =
+      "UPDATE totp_enrollments SET last_verified_step = ? "
+      "WHERE subject_id = ?;";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if (sqlite3_bind_int64 (stmt, 1, new_step) != SQLITE_OK) {
+    sqlite3_finalize (stmt);
+    return WYRELOG_E_IO;
+  }
+  if ((rc = bind_text (stmt, 2, subject_id)) != WYRELOG_E_OK) {
+    sqlite3_finalize (stmt);
+    return rc;
+  }
+
+  int step_rc = sqlite3_step (stmt);
+  sqlite3_finalize (stmt);
+  return (step_rc == SQLITE_DONE) ? WYRELOG_E_OK : WYRELOG_E_IO;
+}
+
+wyrelog_error_t
+wyl_policy_store_totp_enrollment_delete (wyl_policy_store_t *store,
+    const gchar *subject_id)
+{
+  sqlite3_stmt *stmt = NULL;
+
+  if (store == NULL || store->db == NULL || subject_id == NULL)
+    return WYRELOG_E_INVALID;
+
+  static const gchar *sql =
+      "DELETE FROM totp_enrollments WHERE subject_id = ?;";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if ((rc = bind_text (stmt, 1, subject_id)) != WYRELOG_E_OK) {
+    sqlite3_finalize (stmt);
+    return rc;
+  }
+
+  int step_rc = sqlite3_step (stmt);
+  sqlite3_finalize (stmt);
+  return (step_rc == SQLITE_DONE) ? WYRELOG_E_OK : WYRELOG_E_IO;
 }

--- a/wyrelog/policy/store.c
+++ b/wyrelog/policy/store.c
@@ -1762,8 +1762,17 @@ wyl_policy_store_create_schema (wyl_policy_store_t *store)
       "  ON permission_state_events (event);"
       "CREATE TABLE IF NOT EXISTS principal_states ("
       "  subject_id TEXT PRIMARY KEY,"
-      "  state TEXT NOT NULL,"
-      "  updated_at INTEGER"
+      "  state TEXT NOT NULL," "  updated_at INTEGER,"
+      /* Issue #331 commit 5: lockout counter and lock timestamp live on
+       * the principal_states row.  failed_attempt_count is the running
+       * tally of consecutive verify failures since the last successful
+       * MFA verify (or admin reset); locked_at is the unix-epoch seconds
+       * timestamp the row entered the LOCKED state, NULL otherwise.
+       * Pre-#331-commit-5 stores get these columns via the
+       * ALTER TABLE migration block below in create_schema (idempotent
+       * via PRAGMA table_info probe). */
+      "  failed_attempt_count INTEGER NOT NULL DEFAULT 0,"
+      "  locked_at INTEGER"
       ");"
       "CREATE INDEX IF NOT EXISTS idx_principal_states_state "
       "  ON principal_states (state);"
@@ -2015,6 +2024,40 @@ wyl_policy_store_create_schema (wyl_policy_store_t *store)
       "ON audit_events (request_id);");
   if (rc != WYRELOG_E_OK)
     return rc;
+  /* Issue #331 commit 5: principal_states lockout columns migration.
+   * Pre-#331-commit-5 stores have the principal_states row but lack
+   * failed_attempt_count and locked_at.  We probe via PRAGMA table_info
+   * and ALTER TABLE ADD COLUMN only on miss, matching the audit_events
+   * migration pattern above.  ADD COLUMN with a literal DEFAULT
+   * synthesises the value for existing rows, so post-migration the
+   * counter starts at 0 (no false-lock on upgrade). */
+  gboolean has_failed_count = FALSE;
+  gboolean has_locked_at = FALSE;
+  sqlite3_stmt *ps_stmt = NULL;
+  if (sqlite3_prepare_v2 (store->db, "PRAGMA table_info(principal_states);",
+          -1, &ps_stmt, NULL) != SQLITE_OK)
+    return WYRELOG_E_IO;
+  while (sqlite3_step (ps_stmt) == SQLITE_ROW) {
+    const gchar *name = (const gchar *) sqlite3_column_text (ps_stmt, 1);
+    if (g_strcmp0 (name, "failed_attempt_count") == 0)
+      has_failed_count = TRUE;
+    else if (g_strcmp0 (name, "locked_at") == 0)
+      has_locked_at = TRUE;
+  }
+  sqlite3_finalize (ps_stmt);
+  if (!has_failed_count) {
+    rc = exec_sql (store->db,
+        "ALTER TABLE principal_states "
+        "ADD COLUMN failed_attempt_count INTEGER NOT NULL DEFAULT 0;");
+    if (rc != WYRELOG_E_OK)
+      return rc;
+  }
+  if (!has_locked_at) {
+    rc = exec_sql (store->db,
+        "ALTER TABLE principal_states ADD COLUMN locked_at INTEGER;");
+    if (rc != WYRELOG_E_OK)
+      return rc;
+  }
   rc = wyl_policy_store_ensure_default_tenant (store);
   if (rc != WYRELOG_E_OK)
     return rc;
@@ -4236,6 +4279,370 @@ wyl_policy_store_foreach_principal_state (wyl_policy_store_t *store,
 
   sqlite3_finalize (stmt);
   return (step_rc == SQLITE_DONE) ? WYRELOG_E_OK : WYRELOG_E_IO;
+}
+
+/* ----------------------------------------------------------------------
+ * Single-subject principal-state accessors (issue #331 commit 5).
+ *
+ * The historical foreach-based two-step lookup in daemon/http.c iterated
+ * the entire principal_states table to surface a single subject's
+ * current state.  The accessors below replace that O(N) scan with a
+ * single-row SELECT keyed by subject_id, and surface the explicit
+ * "no row" vs "iteration error" distinction via *out_found so callers
+ * never have to grep for a NULL-string sentinel.
+ *
+ * F1 (timing): the validator hot-path calls get_principal_lock_info
+ * before any HMAC work, so the cost is one indexed SELECT regardless of
+ * the principal_states row count.  The earlier foreach-based path was a
+ * full table scan and scaled with the number of enrolled subjects -
+ * a more concerning timing differential than the validator's intentional
+ * no-enrollment vs wrong-code gap (commit-3 rationale; documented in
+ * mfa-validator.c above note_failed_attempt).
+ *
+ * F2 (secrets): no log/audit emission inside these helpers ever sees a
+ * TOTP seed or submitted code.  The only subject-bound identifiers
+ * surfaced are the subject_id passed in by the caller.
+ * ---------------------------------------------------------------------- */
+
+wyrelog_error_t
+wyl_policy_store_get_principal_state (wyl_policy_store_t *store,
+    const gchar *subject_id, gchar **out_state, gboolean *out_found)
+{
+  sqlite3_stmt *stmt = NULL;
+
+  if (store == NULL || store->db == NULL || subject_id == NULL
+      || out_state == NULL || out_found == NULL)
+    return WYRELOG_E_INVALID;
+
+  *out_state = NULL;
+  *out_found = FALSE;
+
+  static const gchar *sql =
+      "SELECT state FROM principal_states WHERE subject_id = ?;";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if ((rc = bind_text (stmt, 1, subject_id)) != WYRELOG_E_OK) {
+    sqlite3_finalize (stmt);
+    return rc;
+  }
+
+  int step_rc = sqlite3_step (stmt);
+  if (step_rc == SQLITE_DONE) {
+    sqlite3_finalize (stmt);
+    return WYRELOG_E_OK;
+  }
+  if (step_rc != SQLITE_ROW) {
+    sqlite3_finalize (stmt);
+    return WYRELOG_E_IO;
+  }
+  const gchar *db_state = (const gchar *) sqlite3_column_text (stmt, 0);
+  *out_state = g_strdup (db_state != NULL ? db_state : "");
+  *out_found = TRUE;
+  sqlite3_finalize (stmt);
+  return WYRELOG_E_OK;
+}
+
+wyrelog_error_t
+wyl_policy_store_get_principal_lock_info (wyl_policy_store_t *store,
+    const gchar *subject_id, gchar **out_state, gint64 *out_failed_count,
+    gint64 *out_locked_at, gboolean *out_found)
+{
+  sqlite3_stmt *stmt = NULL;
+
+  if (store == NULL || store->db == NULL || subject_id == NULL
+      || out_state == NULL || out_failed_count == NULL
+      || out_locked_at == NULL || out_found == NULL)
+    return WYRELOG_E_INVALID;
+
+  *out_state = NULL;
+  *out_failed_count = 0;
+  *out_locked_at = G_MININT64;
+  *out_found = FALSE;
+
+  static const gchar *sql =
+      "SELECT state, failed_attempt_count, locked_at "
+      "FROM principal_states WHERE subject_id = ?;";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if ((rc = bind_text (stmt, 1, subject_id)) != WYRELOG_E_OK) {
+    sqlite3_finalize (stmt);
+    return rc;
+  }
+
+  int step_rc = sqlite3_step (stmt);
+  if (step_rc == SQLITE_DONE) {
+    sqlite3_finalize (stmt);
+    return WYRELOG_E_OK;
+  }
+  if (step_rc != SQLITE_ROW) {
+    sqlite3_finalize (stmt);
+    return WYRELOG_E_IO;
+  }
+  const gchar *db_state = (const gchar *) sqlite3_column_text (stmt, 0);
+  *out_state = g_strdup (db_state != NULL ? db_state : "");
+  *out_failed_count = sqlite3_column_int64 (stmt, 1);
+  if (sqlite3_column_type (stmt, 2) == SQLITE_NULL)
+    *out_locked_at = G_MININT64;
+  else
+    *out_locked_at = sqlite3_column_int64 (stmt, 2);
+  *out_found = TRUE;
+  sqlite3_finalize (stmt);
+  return WYRELOG_E_OK;
+}
+
+/* Atomic FAILED_ATTEMPT mutation: increment the counter, and if the
+ * resulting value reaches |threshold|, transition the row to LOCKED in
+ * the same savepoint.  The transaction defeats the read-modify-write
+ * race that would let two concurrent failed verify attempts both see
+ * counter=N-1 and each fail to LOCK independently (commit-5 critic
+ * footgun).  The current-state read happens inside the savepoint via
+ * a SELECT, then the UPDATE writes the new counter + (conditionally)
+ * the LOCKED state and locked_at - all before COMMIT releases the
+ * savepoint.
+ */
+wyrelog_error_t
+wyl_policy_store_apply_principal_failure (wyl_policy_store_t *store,
+    const gchar *subject_id, gint64 threshold, gint64 now_secs,
+    gchar **out_state, gint64 *out_count, gint64 *out_locked_at)
+{
+  if (store == NULL || store->db == NULL || subject_id == NULL
+      || out_state == NULL || out_count == NULL || out_locked_at == NULL
+      || threshold <= 0)
+    return WYRELOG_E_INVALID;
+
+  *out_state = NULL;
+  *out_count = 0;
+  *out_locked_at = G_MININT64;
+
+  wyrelog_error_t rc = wyl_policy_store_begin_mutation (store);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  /* Phase 1: load current row inside the savepoint.  If no row exists,
+   * we materialise mfa_required with counter=1 below.  If a row exists
+   * we increment from the durable counter; the savepoint serialises
+   * concurrent failures so we never miss an increment. */
+  sqlite3_stmt *sel = NULL;
+  rc = prepare_stmt (store->db,
+      "SELECT state, failed_attempt_count FROM principal_states "
+      "WHERE subject_id = ?;", &sel);
+  if (rc != WYRELOG_E_OK)
+    goto rollback;
+  if ((rc = bind_text (sel, 1, subject_id)) != WYRELOG_E_OK) {
+    sqlite3_finalize (sel);
+    goto rollback;
+  }
+
+  gint64 next_count = 0;
+  gboolean already_locked = FALSE;
+  int step_rc = sqlite3_step (sel);
+  if (step_rc == SQLITE_ROW) {
+    const gchar *cur_state = (const gchar *) sqlite3_column_text (sel, 0);
+    if (g_strcmp0 (cur_state, "locked") == 0)
+      already_locked = TRUE;
+    next_count = sqlite3_column_int64 (sel, 1) + 1;
+  } else if (step_rc == SQLITE_DONE) {
+    next_count = 1;
+  } else {
+    sqlite3_finalize (sel);
+    rc = WYRELOG_E_IO;
+    goto rollback;
+  }
+  sqlite3_finalize (sel);
+
+  /* Defensive: refuse to extend a lockout that is already in place.
+   * The validator gates this in production (callers only invoke after
+   * observing state=mfa_required), but this helper is library-internal
+   * and future callers - notably the wyctl tooling in commit 6 - must
+   * not be able to bump locked_at or the counter by repeatedly
+   * driving FAILED_ATTEMPT against a LOCKED row.  Return WYRELOG_E_POLICY
+   * and roll the savepoint back; no event row is emitted. */
+  if (already_locked) {
+    rc = WYRELOG_E_POLICY;
+    goto rollback;
+  }
+
+  /* Phase 2: determine final state.  Once the counter reaches the
+   * configured threshold we move the row to LOCKED with locked_at set
+   * to the caller-supplied wallclock seconds.  The threshold-cross is
+   * a one-way transition until reset_counter or apply_unlock fires.
+   *
+   * No-row materialises into mfa_required (the validator's gate ensures
+   * we never reach this helper from any other principal state), so the
+   * from_state is uniform across both the had_row and no-row branches. */
+  const gchar *next_state =
+      (next_count >= threshold) ? "locked" : "mfa_required";
+  gint64 next_locked_at = (next_count >= threshold) ? now_secs : G_MININT64;
+  const gchar *from_state = "mfa_required";
+  /* FSM-edge validation lives at the auth/validator layer (see
+   * wyl_mfa_validator_totp): the storage layer just writes the literal
+   * state strings the caller has already validated.  Cross-layer FSM
+   * drift surfaces at validator-layer tests, not here. */
+
+  /* Phase 3: write back.  INSERT ... ON CONFLICT UPDATE handles both
+   * the materialise-new-row and update-existing-row branches without
+   * a separate UPDATE OR INSERT split. */
+  sqlite3_stmt *upsert = NULL;
+  rc = prepare_stmt (store->db,
+      "INSERT INTO principal_states "
+      "  (subject_id, state, updated_at, failed_attempt_count, locked_at) "
+      "VALUES (?, ?, unixepoch(), ?, ?) "
+      "ON CONFLICT(subject_id) DO UPDATE SET "
+      "  state = excluded.state, "
+      "  updated_at = excluded.updated_at, "
+      "  failed_attempt_count = excluded.failed_attempt_count, "
+      "  locked_at = excluded.locked_at;", &upsert);
+  if (rc != WYRELOG_E_OK)
+    goto rollback;
+  if ((rc = bind_text (upsert, 1, subject_id)) != WYRELOG_E_OK
+      || (rc = bind_text (upsert, 2, next_state)) != WYRELOG_E_OK) {
+    sqlite3_finalize (upsert);
+    goto rollback;
+  }
+  if (sqlite3_bind_int64 (upsert, 3, next_count) != SQLITE_OK) {
+    sqlite3_finalize (upsert);
+    rc = WYRELOG_E_IO;
+    goto rollback;
+  }
+  if (next_locked_at == G_MININT64) {
+    if (sqlite3_bind_null (upsert, 4) != SQLITE_OK) {
+      sqlite3_finalize (upsert);
+      rc = WYRELOG_E_IO;
+      goto rollback;
+    }
+  } else {
+    if (sqlite3_bind_int64 (upsert, 4, next_locked_at) != SQLITE_OK) {
+      sqlite3_finalize (upsert);
+      rc = WYRELOG_E_IO;
+      goto rollback;
+    }
+  }
+  if (sqlite3_step (upsert) != SQLITE_DONE) {
+    sqlite3_finalize (upsert);
+    rc = WYRELOG_E_IO;
+    goto rollback;
+  }
+  sqlite3_finalize (upsert);
+
+  /* Phase 4: when we crossed the threshold, append a principal_event
+   * row for the lock transition so the audit ledger captures it.  The
+   * insert is inside the same savepoint, so the event is durable iff
+   * the state change is durable (no torn-state on crash). */
+  if (next_count >= threshold) {
+    /* Event-name literal "lock" matches wyl_principal_event_name's
+     * table entry for WYL_PRINCIPAL_EVENT_LOCK.  Inlined here so the
+     * storage layer does not depend on the FSM private header for
+     * what is fundamentally a string column write. */
+    rc = wyl_policy_store_append_principal_event (store, subject_id,
+        "lock", from_state, "locked", NULL);
+    if (rc != WYRELOG_E_OK)
+      goto rollback;
+  }
+
+  rc = wyl_policy_store_commit_mutation (store);
+  if (rc != WYRELOG_E_OK)
+    goto rollback;
+
+  *out_state = g_strdup (next_state);
+  *out_count = next_count;
+  *out_locked_at = next_locked_at;
+  return WYRELOG_E_OK;
+
+rollback:
+  wyl_policy_store_rollback_mutation (store);
+  g_clear_pointer (out_state, g_free);
+  *out_count = 0;
+  *out_locked_at = G_MININT64;
+  return rc;
+}
+
+wyrelog_error_t
+wyl_policy_store_reset_principal_failure_counter (wyl_policy_store_t *store,
+    const gchar *subject_id)
+{
+  sqlite3_stmt *stmt = NULL;
+
+  if (store == NULL || store->db == NULL || subject_id == NULL)
+    return WYRELOG_E_INVALID;
+
+  /* Reset is a no-op when the row does not exist (the validator only
+   * reaches this branch after a successful TOTP match, and the verify
+   * path always materialises a row earlier via wyl-session.c on
+   * login_ok).  An UPDATE with no matching row returns SQLITE_DONE
+   * cleanly. */
+  static const gchar *sql =
+      "UPDATE principal_states SET "
+      "  failed_attempt_count = 0, "
+      "  locked_at = NULL, "
+      "  updated_at = unixepoch() " "WHERE subject_id = ?;";
+  wyrelog_error_t rc = prepare_stmt (store->db, sql, &stmt);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if ((rc = bind_text (stmt, 1, subject_id)) != WYRELOG_E_OK) {
+    sqlite3_finalize (stmt);
+    return rc;
+  }
+  int step_rc = sqlite3_step (stmt);
+  sqlite3_finalize (stmt);
+  return (step_rc == SQLITE_DONE) ? WYRELOG_E_OK : WYRELOG_E_IO;
+}
+
+/* Atomic LOCKED -> UNVERIFIED transition.  The state transition and
+ * principal_event row both land inside the same savepoint so a crash
+ * mid-update cannot leave the row half-unlocked. */
+wyrelog_error_t
+wyl_policy_store_apply_principal_unlock (wyl_policy_store_t *store,
+    const gchar *subject_id)
+{
+  if (store == NULL || store->db == NULL || subject_id == NULL)
+    return WYRELOG_E_INVALID;
+
+  /* FSM-edge validation is the auth/validator layer's responsibility
+   * (see wyl_mfa_validator_totp / maybe_auto_unlock).  This helper just
+   * writes the LOCKED -> UNVERIFIED literal-state transition the caller
+   * has already validated.  Keeping the FSM-step call out of storage
+   * preserves the layering rule: storage knows the string columns, the
+   * FSM table belongs to auth. */
+  wyrelog_error_t rc = wyl_policy_store_begin_mutation (store);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  sqlite3_stmt *upd = NULL;
+  rc = prepare_stmt (store->db,
+      "UPDATE principal_states SET "
+      "  state = 'unverified', "
+      "  failed_attempt_count = 0, "
+      "  locked_at = NULL, "
+      "  updated_at = unixepoch() " "WHERE subject_id = ?;", &upd);
+  if (rc != WYRELOG_E_OK)
+    goto rollback;
+  if ((rc = bind_text (upd, 1, subject_id)) != WYRELOG_E_OK) {
+    sqlite3_finalize (upd);
+    goto rollback;
+  }
+  if (sqlite3_step (upd) != SQLITE_DONE) {
+    sqlite3_finalize (upd);
+    rc = WYRELOG_E_IO;
+    goto rollback;
+  }
+  sqlite3_finalize (upd);
+
+  /* Event-name literal "unlock" matches wyl_principal_event_name's
+   * table entry for WYL_PRINCIPAL_EVENT_UNLOCK.  Inlined here so the
+   * storage layer does not pull in the FSM private header solely for
+   * a string column write. */
+  rc = wyl_policy_store_append_principal_event (store, subject_id,
+      "unlock", "locked", "unverified", NULL);
+  if (rc != WYRELOG_E_OK)
+    goto rollback;
+
+  return wyl_policy_store_commit_mutation (store);
+
+rollback:
+  wyl_policy_store_rollback_mutation (store);
+  return rc;
 }
 
 wyrelog_error_t

--- a/wyrelog/wyctl/wyctl.c
+++ b/wyrelog/wyctl/wyctl.c
@@ -2,15 +2,19 @@
 #include <glib.h>
 #include <gio/gio.h>
 #include <libsoup/soup.h>
+#include <sodium.h>
 #include <errno.h>
+#include <stdint.h>
 #include <string.h>
 
+#include "auth/totp.h"
 #include "wyrelog/client.h"
 #include "wyrelog/decide.h"
 #include "wyrelog/policy/store-private.h"
 #include "wyrelog/version.h"
 #include "wyrelog/wyl-client-private.h"
 #include "wyrelog/wyl-common-private.h"
+#include "wyrelog/wyl-id-private.h"
 #include "wyrelog/wyl-keyprovider-file-private.h"
 #include "wyrelog/wyl-permission-scope-private.h"
 #include "wyctl-config.h"
@@ -131,6 +135,13 @@ typedef struct
   gchar *from_keyprovider_path;
   gchar *to_keyprovider_path;
 } WyctlKeyOptions;
+
+typedef struct
+{
+  gchar *subject;
+  gchar *store_path;
+  gchar *keyprovider_path;
+} WyctlMfaOptions;
 
 #define WYCTL_DEFAULT_TIMEOUT_MS 2000
 #define WYCTL_MAX_TIMEOUT_MS 60000
@@ -1950,6 +1961,487 @@ run_audit (const WyctlOptions *global_opts, gint argc, gchar **argv)
   return 2;
 }
 
+/* ----------------------------------------------------------------------
+ * wyctl mfa enroll / mfa reset (issue #331 commit 6).
+ *
+ * These two subcommands are offline operator commands: they open the
+ * policy authority store directly (mirroring `wyctl key rotate'), mint
+ * a fresh TOTP seed, print the otpauth URI and base32 secret to stdout,
+ * prompt the operator on stdin for the current 6-digit code, and only
+ * persist the enrollment row after the code verifies.  Aborts before
+ * verification (EOF / wrong code) leave the store untouched.
+ *
+ * The bootstrap auto-revoke: when the bootstrap admin enrolls for the
+ * first time, the one-shot `wr.login.skip_mfa' direct permission that
+ * the daemon armed at bootstrap is retracted in the same invocation —
+ * the admin has now demonstrated possession of the TOTP factor, so the
+ * "skip MFA" escape hatch must close.  This is the only host that
+ * retracts that permission; the daemon's verify path never does.
+ *
+ * Audit-event vocabulary (action column in audit_events):
+ *   mfa_enrolled            - successful enrollment.  resource_id carries
+ *                             the enrollment row's uuidv7 id (not the
+ *                             subject), so an auditor can correlate the
+ *                             audit row 1:1 with the totp_enrollments row.
+ *   mfa_reset               - successful reset (delete + re-enroll).
+ *                             Same resource_id convention as mfa_enrolled.
+ *   mfa_skip_mfa_revoked    - one-shot bootstrap auto-revoke side-effect.
+ *                             resource_id carries the SUBJECT (not the
+ *                             enrollment id) to match the rest of the
+ *                             direct-permission mutation audit convention:
+ *                             revokes name the principal whose grant was
+ *                             pulled, not the enrollment that triggered
+ *                             the side-effect.
+ *
+ * Footgun coverage (see #331 architect / critic brief):
+ *   F2: the audit row carries only subject_id and the enrollment record
+ *       UUIDv7 (as resource_id) — never the seed or the otpauth URI.
+ *   F4: every error path that touched the in-memory secret runs
+ *       wyl_totp_enrollment_clear before bailing, which calls
+ *       sodium_memzero on the 20-byte seed buffer.
+ */
+
+#define WYCTL_MFA_LOGIN_SKIP_MFA_PERMISSION "wr.login.skip_mfa"
+#define WYCTL_MFA_LOGIN_SKIP_MFA_SCOPE "login"
+#define WYCTL_MFA_OTPAUTH_ISSUER "wyrelog"
+
+/* Per RFC 3986, percent-encode anything outside the unreserved set so
+ * the label and query-parameter segments parse cleanly under the
+ * Google Authenticator Key URI Format.  GLib's g_uri_escape_string
+ * applies RFC 3986 percent-encoding for everything outside [A-Za-z0-9]
+ * + the explicit unreserved set; we pass `reserved_chars_allowed = NULL'
+ * so ':' and '/' are encoded even though the URI grammar permits them
+ * in some contexts. */
+static gchar *
+wyctl_mfa_encode_uri_segment (const gchar *raw)
+{
+  return g_uri_escape_string (raw, NULL, FALSE);
+}
+
+/* Build the otpauth:// URI for `subject' with the given base32 secret.
+ * The issuer is "wyrelog" (hardcoded to match the brand the daemon
+ * stamps elsewhere).  Returns a freshly allocated string owned by the
+ * caller. */
+static gchar *
+wyctl_mfa_build_otpauth_uri (const gchar *subject, const gchar *base32_secret)
+{
+  g_autofree gchar *issuer_enc =
+      wyctl_mfa_encode_uri_segment (WYCTL_MFA_OTPAUTH_ISSUER);
+  g_autofree gchar *subject_enc = wyctl_mfa_encode_uri_segment (subject);
+  /* The base32 alphabet is already URL-safe; emit it verbatim so the
+   * operator can paste it into authenticator apps that expect the
+   * canonical base32 form. */
+  return g_strdup_printf
+      ("otpauth://totp/%s:%s?secret=%s&issuer=%s&algorithm=SHA1&digits=6&period=30",
+      issuer_enc, subject_enc, base32_secret, issuer_enc);
+}
+
+/* Read a single line from stdin and parse it as a 6-digit decimal code.
+ * Returns FALSE on EOF, malformed input, or a value outside [0,999999].
+ * The buffer is zeroed before return to keep the typed code out of
+ * heap residue. */
+static gboolean
+wyctl_mfa_read_six_digit_code (guint *out_code)
+{
+  gchar buf[64];
+  if (fgets (buf, (int) sizeof buf, stdin) == NULL)
+    return FALSE;
+  gsize len = strlen (buf);
+  while (len > 0
+      && (buf[len - 1] == '\n' || buf[len - 1] == '\r'
+          || buf[len - 1] == ' ' || buf[len - 1] == '\t'))
+    buf[--len] = '\0';
+  if (len != WYL_TOTP_DIGITS) {
+    sodium_memzero (buf, sizeof buf);
+    return FALSE;
+  }
+  for (gsize i = 0; i < len; i++) {
+    if (!g_ascii_isdigit (buf[i])) {
+      sodium_memzero (buf, sizeof buf);
+      return FALSE;
+    }
+  }
+  errno = 0;
+  gchar *end = NULL;
+  gint64 parsed = g_ascii_strtoll (buf, &end, 10);
+  sodium_memzero (buf, sizeof buf);
+  if (errno != 0 || end == NULL || *end != '\0' || parsed < 0
+      || parsed > 999999)
+    return FALSE;
+  *out_code = (guint) parsed;
+  return TRUE;
+}
+
+/* Open the policy store named by --store and --keyprovider.  When
+ * --keyprovider is absent the store is opened unencrypted; this is the
+ * code path test harnesses exercise.  Production operators must
+ * provide --keyprovider; the daemon refuses to load a store written
+ * unencrypted on a host that expects encryption, so this command does
+ * not enforce a policy of its own. */
+static wyrelog_error_t
+wyctl_mfa_open_store (const WyctlMfaOptions *opts, wyl_policy_store_t **out)
+{
+  if (opts->keyprovider_path != NULL && opts->keyprovider_path[0] != '\0') {
+    wyl_keyprovider_file_t *kp =
+        wyl_keyprovider_file_new_from_spec (opts->keyprovider_path);
+    if (kp == NULL)
+      return WYRELOG_E_IO;
+    wyl_policy_store_open_options_t open_opts = {
+      .path = opts->store_path,
+      .keyprovider_vtable = wyl_keyprovider_file_get_vtable (),
+      .keyprovider_state = kp,
+      .keyprovider_state_free = (void (*)(gpointer)) wyl_keyprovider_file_free,
+      .require_encrypted = TRUE,
+    };
+    return wyl_policy_store_open_with_options (&open_opts, out);
+  }
+  return wyl_policy_store_open (opts->store_path, out);
+}
+
+/* Emit a single audit_events row.  Mints a fresh UUIDv7 for the audit
+ * id so multiple invocations are distinguishable in the store. */
+static wyrelog_error_t
+wyctl_mfa_emit_audit (wyl_policy_store_t *store, const gchar *action,
+    const gchar *subject_id, const gchar *resource_id)
+{
+  wyl_id_t id = WYL_ID_NIL;
+  wyrelog_error_t rc = wyl_id_new (&id);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  gchar id_str[WYL_ID_STRING_BUF];
+  rc = wyl_id_format (&id, id_str, sizeof id_str);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  return wyl_policy_store_append_audit_event (store, id_str,
+      g_get_real_time (), subject_id, action, resource_id, NULL, "wyctl",
+      WYL_DECISION_ALLOW);
+}
+
+/* If `subject' was the bootstrap admin and currently holds the
+ * one-shot wr.login.skip_mfa direct permission, revoke it (delete the
+ * direct_permission row, fire the perm-scope FSM revoke transition,
+ * and emit an mfa_skip_mfa_revoked audit row).  No-op for any other
+ * subject or when the permission is already absent. */
+static wyrelog_error_t
+wyctl_mfa_maybe_revoke_skip_mfa (wyl_policy_store_t *store,
+    const gchar *subject)
+{
+  g_autofree gchar *bootstrap_subject = NULL;
+  gint64 sealed_us = 0;
+  wyrelog_error_t rc = wyl_policy_store_get_bootstrap_admin (store,
+      &bootstrap_subject, &sealed_us);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if (bootstrap_subject == NULL || g_strcmp0 (bootstrap_subject, subject) != 0)
+    return WYRELOG_E_OK;
+
+  gboolean has_perm = FALSE;
+  rc = wyl_policy_store_direct_permission_exists (store, subject,
+      WYCTL_MFA_LOGIN_SKIP_MFA_PERMISSION, WYCTL_MFA_LOGIN_SKIP_MFA_SCOPE,
+      &has_perm);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  if (!has_perm)
+    return WYRELOG_E_OK;
+
+  /* Mint a single audit id for the revoke side-effect.  The
+   * apply_direct_permission_mutation_with_audit helper opens its own
+   * savepoint, writes the permission delete + direct_permission_event
+   * row + audit row, and validates the post-mutation snapshot. */
+  wyl_id_t id = WYL_ID_NIL;
+  rc = wyl_id_new (&id);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  gchar id_str[WYL_ID_STRING_BUF];
+  rc = wyl_id_format (&id, id_str, sizeof id_str);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+  rc = wyl_policy_store_apply_direct_permission_mutation_with_audit (store,
+      subject, WYCTL_MFA_LOGIN_SKIP_MFA_PERMISSION,
+      WYCTL_MFA_LOGIN_SKIP_MFA_SCOPE, FALSE, id_str, g_get_real_time (),
+      subject, "mfa_skip_mfa_revoked", subject, NULL, "wyctl", NULL,
+      WYL_DECISION_ALLOW);
+  if (rc != WYRELOG_E_OK)
+    return rc;
+
+  /* Drive the perm-scope FSM transition armed -> dormant so the
+   * permission_state row aligns with the absent direct_permission row.
+   * No second audit row: the transition is part of the same logical
+   * revoke and is reflected in permission_state_events. */
+  return wyl_policy_store_apply_permission_state_transition (store, subject,
+      WYCTL_MFA_LOGIN_SKIP_MFA_PERMISSION, WYCTL_MFA_LOGIN_SKIP_MFA_SCOPE,
+      "revoke", NULL);
+}
+
+/* Common enroll flow shared by `wyctl mfa enroll' and the post-delete
+ * second half of `wyctl mfa reset'.  Owns the seed buffer for the
+ * entire flow and zeroes it on every exit.  Returns 0 on success or a
+ * non-zero exit code that wyctl propagates up to main().
+ *
+ * `reset_mode' selects between the mfa_enrolled and mfa_reset audit
+ * action strings; the persisted row is identical in both cases.
+ */
+static int
+wyctl_mfa_run_enroll_flow (wyl_policy_store_t *store, const gchar *subject,
+    gboolean reset_mode)
+{
+  WylTotpEnrollment enr = { 0 };
+  enr.subject_id = g_strdup (subject);
+  enr.last_verified_step = INT64_MIN;
+  enr.enrolled_at = (gint64) (g_get_real_time () / G_USEC_PER_SEC);
+
+  g_autoptr (GError) error = NULL;
+  wyrelog_error_t rc = wyl_totp_generate_seed (enr.secret, sizeof enr.secret,
+      &error);
+  if (rc != WYRELOG_E_OK) {
+    g_printerr ("wyctl: totp seed generation failed: %s\n",
+        wyrelog_error_string (rc));
+    wyl_totp_enrollment_clear (&enr);
+    return 1;
+  }
+
+  g_autofree gchar *base32_secret = NULL;
+  rc = wyl_totp_base32_encode (enr.secret, sizeof enr.secret, &base32_secret,
+      &error);
+  if (rc != WYRELOG_E_OK) {
+    g_printerr ("wyctl: base32 encode failed: %s\n", wyrelog_error_string (rc));
+    wyl_totp_enrollment_clear (&enr);
+    return 1;
+  }
+
+  g_autofree gchar *otpauth = wyctl_mfa_build_otpauth_uri (subject,
+      base32_secret);
+
+  /* Secret-bearing output goes to stdout in a key=value format so an
+   * operator can pipe it into a parser, but the help text warns
+   * against piping to logs. */
+  g_print ("otpauth_uri=%s\n", otpauth);
+  g_print ("secret_base32=%s\n", base32_secret);
+  /* Flush so the operator (and the test harness reading stdout) sees
+   * the secret before we block on stdin. */
+  (void) fflush (stdout);
+
+  /* The prompt itself is interactive UX, not machine-parsed output:
+   * route it to stderr so piping stdout still leaves a visible
+   * prompt. */
+  g_printerr ("Enter the current 6-digit code from the authenticator app: ");
+  (void) fflush (stderr);
+
+  guint code = 0;
+  if (!wyctl_mfa_read_six_digit_code (&code)) {
+    g_printerr ("\nwyctl: aborted (no valid code supplied; no enrollment "
+        "written)\n");
+    wyl_totp_enrollment_clear (&enr);
+    return 1;
+  }
+
+  gint64 now_secs = (gint64) (g_get_real_time () / G_USEC_PER_SEC);
+  guint64 matched_step = 0;
+  gboolean matched = wyl_totp_code_matches (enr.secret, sizeof enr.secret,
+      now_secs, code, &matched_step, &error);
+  if (!matched) {
+    g_printerr ("wyctl: code did not match; no enrollment written\n");
+    g_clear_error (&error);
+    wyl_totp_enrollment_clear (&enr);
+    return 1;
+  }
+  /* Set the replay watermark to the verified step so the daemon
+   * cannot accept the same code again on the very first verify. */
+  enr.last_verified_step = (gint64) matched_step;
+
+  /* Atomicity wrapper: the post-verify happy path performs up to four
+   * mutations (enrollment insert, mfa_enrolled audit row, plus the
+   * bootstrap auto-revoke's direct-permission mutation and the
+   * permission-state FSM transition).  Wrap them in a single outer
+   * savepoint so any partial failure rolls back the entire enrollment
+   * — otherwise a prefix failure could leave the bootstrap admin
+   * enrolled while wr.login.skip_mfa was still armed, creating an
+   * auth-bypass window until the operator re-ran enroll.
+   *
+   * SQLite savepoints with the same name nest as a stack: each inner
+   * `SAVEPOINT wyrelog_policy_mutation' (issued by the helpers below)
+   * pushes a new frame, and the matching RELEASE / ROLLBACK TO pops
+   * only that inner frame, leaving our outer frame intact.  See the
+   * commit-5 atomicity test for the same primitive used in
+   * apply_principal_failure. */
+  rc = wyl_policy_store_begin_mutation (store);
+  if (rc != WYRELOG_E_OK) {
+    g_printerr ("wyctl: begin enrollment mutation failed: %s\n",
+        wyrelog_error_string (rc));
+    wyl_totp_enrollment_clear (&enr);
+    return 1;
+  }
+
+  rc = wyl_policy_store_totp_enrollment_insert (store, &enr);
+  if (rc != WYRELOG_E_OK) {
+    g_printerr ("wyctl: enrollment insert failed: %s\n",
+        wyrelog_error_string (rc));
+    wyl_policy_store_rollback_mutation (store);
+    wyl_totp_enrollment_clear (&enr);
+    return 1;
+  }
+
+  /* Audit (action carries the enrollment id_uuidv7 in resource_id so
+   * an operator can correlate the audit row with the totp_enrollments
+   * row).  NEVER include the seed or the otpauth URI here. */
+  rc = wyctl_mfa_emit_audit (store, reset_mode ? "mfa_reset" : "mfa_enrolled",
+      subject, enr.id_uuidv7);
+  if (rc != WYRELOG_E_OK) {
+    g_printerr ("wyctl: enrollment audit emit failed: %s\n",
+        wyrelog_error_string (rc));
+    wyl_policy_store_rollback_mutation (store);
+    wyl_totp_enrollment_clear (&enr);
+    return 1;
+  }
+
+  /* Bootstrap auto-revoke: only fires for the bootstrap admin that
+   * currently holds wr.login.skip_mfa.  Runs under the same outer
+   * savepoint so a revoke failure rolls back the enrollment row and
+   * the audit row above — the operator sees a clean "no enrollment"
+   * state rather than a half-enrolled bootstrap admin with
+   * skip_mfa still armed. */
+  rc = wyctl_mfa_maybe_revoke_skip_mfa (store, subject);
+  if (rc != WYRELOG_E_OK) {
+    g_printerr ("wyctl: skip-mfa auto-revoke failed: %s\n",
+        wyrelog_error_string (rc));
+    wyl_policy_store_rollback_mutation (store);
+    wyl_totp_enrollment_clear (&enr);
+    return 1;
+  }
+
+  rc = wyl_policy_store_commit_mutation (store);
+  if (rc != WYRELOG_E_OK) {
+    g_printerr ("wyctl: commit enrollment mutation failed: %s\n",
+        wyrelog_error_string (rc));
+    wyl_policy_store_rollback_mutation (store);
+    wyl_totp_enrollment_clear (&enr);
+    return 1;
+  }
+
+  g_print ("status=enrolled subject=%s enrollment_id=%s\n", subject,
+      enr.id_uuidv7);
+  wyl_totp_enrollment_clear (&enr);
+  return 0;
+}
+
+static int
+wyctl_mfa_validate_common_options (const WyctlMfaOptions *opts)
+{
+  if (opts->subject == NULL || opts->subject[0] == '\0') {
+    g_printerr ("wyctl: missing --subject\n");
+    return 2;
+  }
+  if (opts->store_path == NULL || opts->store_path[0] == '\0') {
+    g_printerr ("wyctl: missing --store\n");
+    return 2;
+  }
+  return 0;
+}
+
+static int
+run_mfa_enroll (gint argc, gchar **argv)
+{
+  WyctlMfaOptions opts = { 0 };
+  GOptionEntry entries[] = {
+    {"subject", 0, 0, G_OPTION_ARG_STRING, &opts.subject,
+        "Principal subject id to enroll", "SUBJECT"},
+    {"store", 0, 0, G_OPTION_ARG_STRING, &opts.store_path,
+        "Policy store path (SQLite file)", "PATH"},
+    {"keyprovider", 0, 0, G_OPTION_ARG_STRING, &opts.keyprovider_path,
+        "Optional KeyProvider spec for encrypted stores", "SPEC"},
+    {NULL}
+  };
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GOptionContext) context = g_option_context_new
+      ("- enroll a subject for TOTP MFA. Output is sensitive: do NOT pipe "
+      "stdout to logs.");
+  g_option_context_add_main_entries (context, entries, NULL);
+  if (!g_option_context_parse (context, &argc, &argv, &error)) {
+    g_printerr ("wyctl: %s\n", error->message);
+    return 2;
+  }
+  if (argc > 1) {
+    g_printerr ("wyctl: unexpected mfa enroll argument: %s\n", argv[1]);
+    return 2;
+  }
+  int validate_rc = wyctl_mfa_validate_common_options (&opts);
+  if (validate_rc != 0)
+    return validate_rc;
+
+  g_autoptr (wyl_policy_store_t) store = NULL;
+  wyrelog_error_t rc = wyctl_mfa_open_store (&opts, &store);
+  if (rc != WYRELOG_E_OK) {
+    g_printerr ("wyctl: open store failed: %s\n", wyrelog_error_string (rc));
+    return 1;
+  }
+  return wyctl_mfa_run_enroll_flow (store, opts.subject, FALSE);
+}
+
+static int
+run_mfa_reset (gint argc, gchar **argv)
+{
+  WyctlMfaOptions opts = { 0 };
+  GOptionEntry entries[] = {
+    {"subject", 0, 0, G_OPTION_ARG_STRING, &opts.subject,
+        "Principal subject id to reset", "SUBJECT"},
+    {"store", 0, 0, G_OPTION_ARG_STRING, &opts.store_path,
+        "Policy store path (SQLite file)", "PATH"},
+    {"keyprovider", 0, 0, G_OPTION_ARG_STRING, &opts.keyprovider_path,
+        "Optional KeyProvider spec for encrypted stores", "SPEC"},
+    {NULL}
+  };
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GOptionContext) context = g_option_context_new
+      ("- reset a subject's TOTP enrollment: deletes the prior row, then "
+      "runs the enroll flow.");
+  g_option_context_add_main_entries (context, entries, NULL);
+  if (!g_option_context_parse (context, &argc, &argv, &error)) {
+    g_printerr ("wyctl: %s\n", error->message);
+    return 2;
+  }
+  if (argc > 1) {
+    g_printerr ("wyctl: unexpected mfa reset argument: %s\n", argv[1]);
+    return 2;
+  }
+  int validate_rc = wyctl_mfa_validate_common_options (&opts);
+  if (validate_rc != 0)
+    return validate_rc;
+
+  g_autoptr (wyl_policy_store_t) store = NULL;
+  wyrelog_error_t rc = wyctl_mfa_open_store (&opts, &store);
+  if (rc != WYRELOG_E_OK) {
+    g_printerr ("wyctl: open store failed: %s\n", wyrelog_error_string (rc));
+    return 1;
+  }
+  /* Reset semantics: delete the existing enrollment row first.  If the
+   * follow-on enroll is aborted, the subject ends up unenrolled — the
+   * operator was explicit about resetting and the documented contract
+   * is that the prior enrollment is gone the moment they confirm. */
+  rc = wyl_policy_store_totp_enrollment_delete (store, opts.subject);
+  if (rc != WYRELOG_E_OK) {
+    g_printerr ("wyctl: prior enrollment delete failed: %s\n",
+        wyrelog_error_string (rc));
+    return 1;
+  }
+  return wyctl_mfa_run_enroll_flow (store, opts.subject, TRUE);
+}
+
+static int
+run_mfa (gint argc, gchar **argv)
+{
+  if (argc < 2) {
+    g_printerr ("wyctl: missing mfa command (enroll | reset)\n");
+    return 2;
+  }
+  if (g_strcmp0 (argv[1], "enroll") == 0)
+    return run_mfa_enroll (argc - 1, argv + 1);
+  if (g_strcmp0 (argv[1], "reset") == 0)
+    return run_mfa_reset (argc - 1, argv + 1);
+
+  g_printerr ("wyctl: unknown mfa command: %s\n", argv[1]);
+  return 2;
+}
+
 static int
 run_key_status (gint argc, gchar **argv)
 {
@@ -2147,6 +2639,8 @@ main (int argc, char **argv)
     return run_audit (&opts, argc - 1, argv + 1);
   if (g_strcmp0 (argv[1], "key") == 0)
     return run_key (argc - 1, argv + 1);
+  if (g_strcmp0 (argv[1], "mfa") == 0)
+    return run_mfa (argc - 1, argv + 1);
 
   g_printerr ("wyctl: unknown command: %s\n", argv[1]);
   return 2;

--- a/wyrelog/wyl-handle-private.h
+++ b/wyrelog/wyl-handle-private.h
@@ -151,6 +151,24 @@ gboolean wyl_handle_get_login_skip_mfa_override_allowed (WylHandle * self);
 gboolean wyl_handle_get_login_skip_mfa_allowed (WylHandle * self);
 
 /*
+ * Per-handle default WylMfaValidator pointer.  The daemon init path
+ * (runtime.c) installs wyl_mfa_validator_totp here so the commit-4
+ * HTTP /auth/mfa/verify route can resolve it without an out-of-band
+ * registry.  Callers that want a different validator (e.g. tests)
+ * override with wyl_handle_set_mfa_validator before the route fires.
+ *
+ * The setter is NULL-safe; passing a NULL |validator| clears the slot.
+ * The getter returns the registered pointer (or NULL when unset) and,
+ * if |out_user_data| is non-NULL, copies the registered user_data
+ * companion pointer.  The pointers are valid for the lifetime of the
+ * handle; releasing |user_data| is the caller's responsibility.
+ */
+void wyl_handle_set_mfa_validator (WylHandle * self, WylMfaValidator validator,
+    gpointer user_data);
+WylMfaValidator wyl_handle_get_mfa_validator (WylHandle * self,
+    gpointer * out_user_data);
+
+/*
  * Applies a permission-state transition to the handle-owned policy store, then
  * reloads the engine pair so perm_state/4 and perm_state_fired/7 reflect the
  * durable state. The policy store commit is the source of truth: if reload

--- a/wyrelog/wyl-handle.c
+++ b/wyrelog/wyl-handle.c
@@ -84,6 +84,15 @@ struct _WylHandle
   gboolean engine_pair_poisoned;
   gboolean require_template_manifest;
   /*
+   * Default WylMfaValidator installed by the daemon init path so the
+   * commit-4 HTTP /auth/mfa/verify route can resolve a validator
+   * without an out-of-band table.  The library boot path does not
+   * touch these fields; they remain NULL unless wyl_handle_set_mfa_validator
+   * is called explicitly.
+   */
+  WylMfaValidator mfa_validator;
+  gpointer mfa_validator_user_data;
+  /*
    * Per-handle registry mapping wyl_session_id_t to live WylSession*.
    * Strong references; sessions stay alive at least until handle
    * finalize. The registry exists so wyl_session_logout (which only
@@ -1063,6 +1072,24 @@ wyl_handle_get_login_skip_mfa_allowed (WylHandle *self)
           &deployment_mode) != WYRELOG_E_OK)
     return FALSE;
   return g_strcmp0 (deployment_mode, "production") != 0;
+}
+
+void
+wyl_handle_set_mfa_validator (WylHandle *self, WylMfaValidator validator,
+    gpointer user_data)
+{
+  g_return_if_fail (WYL_IS_HANDLE (self));
+  self->mfa_validator = validator;
+  self->mfa_validator_user_data = (validator != NULL) ? user_data : NULL;
+}
+
+WylMfaValidator
+wyl_handle_get_mfa_validator (WylHandle *self, gpointer *out_user_data)
+{
+  g_return_val_if_fail (WYL_IS_HANDLE (self), NULL);
+  if (out_user_data != NULL)
+    *out_user_data = self->mfa_validator_user_data;
+  return self->mfa_validator;
 }
 
 wyrelog_error_t


### PR DESCRIPTION
Closes #331.

## Summary

Ships a built-in RFC 6238 TOTP MFA validator and an admin enrollment flow so a fresh wyrelog install reaches an authenticated bearer token without external IdP integration.

Seven atomic commits, each TDD-developed and reviewer-ratified before the next began.

## Commit map

1. `auth: add RFC 6238 TOTP core with HMAC-SHA-1` — `wyrelog/auth/totp.{c,h}` + RFC 6238 SHA-1 test vectors.
2. `policy-store: add totp_enrollment fact schema and helpers` — schema + read/write/delete helpers; libchronoid UUIDv7 for enrollment record IDs.
3. `auth: add daemon TOTP MFA validator with replay defense` — `wyl_mfa_validator_totp`, `wyl_handle_set_mfa_validator`/`_get_mfa_validator` accessors, strict `>` replay watermark, persist-before-FSM crash-safe ordering.
4. `daemon-http: add /auth/mfa/verify endpoint` — `POST /auth/mfa/verify?session_token=...&code=NNNNNN` mirroring `login_handler` shape, F5 enumeration-safe error code differentiation only after session+tenant+state gates.
5. `auth: enforce 5-failure/15-min FSM lockout via durable policy-store state` — `failed_attempt_count`/`locked_at` columns on `principal_states` (idempotent ALTER migration), fail-closed counter writes + operator log, defensive early-return when re-failing an already-locked row, FSM step calls kept in auth layer (no storage->FSM dependency).
6. `wyctl: add mfa enroll/reset commands and bootstrap auto-revoke` — single-savepoint atomicity wrapping enrollment insert + audit + bootstrap `wr.login.skip_mfa` retraction; otpauth URI percent-encoded.
7. `docs: document TOTP MFA enrollment and verify flows` — operator runbook section covering install flow, recovery, lockout, HTTP API, and threat-model boundaries.

## Design decisions (locked at issue time)

- Enrollment is an offline `wyctl` command (`wyctl mfa enroll`/`reset`), not an HTTP endpoint.
- Seed lives in the existing encrypted policy store (reuses KeyProvider seal).
- Recovery = admin `wyctl mfa reset` only. No user-side backup codes in v0.
- `/auth/mfa/verify` is a new endpoint; `/auth/login` shape unchanged (no `password`/`code` parameter; existing `password` rejection preserved).
- Lockout: 5 failures / 15-minute auto-unlock, FSM-driven (`FAILED_ATTEMPT`/`LOCK`/`UNLOCK` events).
- Bootstrap `--bootstrap-admin-allow-skip-mfa` escape hatch auto-revokes the moment the admin completes `wyctl mfa enroll`.
- Subjects without enrollment get a `mfa_required` session from `/auth/login` (no enumeration leak); `/auth/mfa/verify` returns `enrollment_required` only for already-authenticated mfa_required sessions.
- TOTP parameters locked: HMAC-SHA-1, 6 digits, 30s step, plus/minus 1 step skew. No knobs.
- All new identifiers minted via libchronoid UUIDv7 (`wyl_id_new`).

## Test plan

- [x] `meson test -C builddir --suite wyrelog --print-errorlogs` green locally (75 OK / 2 skipped / 0 fail).
- [x] New tests across the seven commits: RFC 6238 test vectors, policy-store schema durability + idempotent migration, daemon validator happy/wrong/no-enrollment/replay/restart paths, HTTP endpoint 12-scenario matrix, lockout-survives-restart + auto-unlock window + already-locked guard, `wyctl mfa enroll/reset` 9-scenario coverage including atomicity rollback under audit-failure.
- [ ] CI lanes (ubuntu, macos, windows) green.

## Threat-model coverage (verified during review)

- F1 (timing): constant-time code compare via `sodium_memcmp` across all three skew windows unconditionally; no early return.
- F2 (secret hygiene): zero log/audit emission of seed bytes, otpauth URI secret, or submitted code; `sodium_memzero` on every error/abort path.
- F3 (replay): `last_verified_step` persisted before FSM transition; fail-closed window on crash; strict `>` comparison.
- F4 (zeroing): every error return zeroes seed-bearing buffers.
- F5 (enumeration): uniform `mfa_auth_required` for any session_token that doesn't resolve to a live `mfa_required` session; differential codes only after session+tenant+state gates.

## Out of scope (deferred)

- Backup recovery codes
- WebAuthn / FIDO2
- Per-tenant MFA policy overrides
- SHA-256/512 algorithm knob
- ASCII QR rendering in wyctl