### PR TITLE
feat(wyctl): gsettings fallback for mfa --store/--keyprovider

### DIFF
--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -311,6 +311,34 @@ The subject must already exist as a principal in the policy store
 (typically through `wyctl policy role-grant`). Enrollment does not
 create principals — it only attaches a TOTP factor to one.
 
+### Setting defaults via GSettings
+
+Operators who enroll multiple subjects against the same policy store and
+KeyProvider can stop repeating `--store` and `--keyprovider` on every
+invocation by setting the two GSettings keys once:
+
+```sh
+gsettings set org.wyrelog.wyctl default-policy-store /var/lib/wyrelog/policy.sqlite
+gsettings set org.wyrelog.wyctl default-keyprovider systemd-creds:wyrelog-policy
+```
+
+After this, `sudo wyctl mfa enroll --subject alice` (no `--store`, no
+`--keyprovider`) resolves both paths from GSettings. `--subject` is
+**not** a GSettings-backed key — it is always passed explicitly per
+enrollment, because every enrollment targets exactly one principal.
+
+Precedence is **CLI > GSettings > error**: an explicit `--store` or
+`--keyprovider` on the command line still wins over the GSettings value,
+and if neither is set the existing per-flag missing diagnostic fires.
+The existing kill switch `WYCTL_DISABLE_GSETTINGS=1` (the literal
+string `1`) disables the GSettings fallback uniformly across all wyctl
+subcommands, including the mfa subcommands, restoring the pre-GSettings
+"CLI-or-nothing" behaviour for incident-response or CI runs.
+
+See the *wyctl Configuration and Token-File Safety* section below for
+the full key reference and the surrounding precedence/kill-switch
+machinery.
+
 ### Recovery and Reset
 
 There are no user-side backup codes in v0. The only recovery path is
@@ -928,7 +956,12 @@ not need to be repeated on every invocation, while bearer-token bytes are
 loaded only from a protected on-disk token file. Explicit CLI flags always
 override GSettings. The GSettings store records only the *path* to the
 token file; the bytes themselves never live in dconf, the keyfile backend,
-or any other GSettings backing store.
+or any other GSettings backing store. The same path-only / spec-only
+discipline applies to the MFA defaults: `default-policy-store` records
+the policy-store path, and `default-keyprovider` records the KeyProvider
+*spec string* (e.g. `file:/etc/wyrelog/policy.key`,
+`systemd-creds:wyrelog-policy`). The KeyProvider key material, the TOTP
+seed bytes, and the policy-store contents never live in GSettings.
 
 Daemon defaults live in `/etc/wyrelog/wyrelogd.conf` (see the previous
 section) — wyctl and wyrelogd intentionally do **not** share a single
@@ -962,6 +995,8 @@ honest about which surface acted.
 | `default-guard-loc-class` | `s` | `""` | Location class used when `--guard-loc-class` is omitted. |
 | `default-guard-risk` | `i` | `-1` | Risk score (0..100) used when `--guard-risk` is omitted. `-1` is the "unset" sentinel because `0` is a real risk score. |
 | `default-guard-timestamp-mode` | `s` | `"none"` | Strategy for filling `--guard-timestamp` when omitted. `"none"` preserves the historical "must be supplied" behaviour; `"now"` is reserved for a future commit that fills the current wall-clock time. |
+| `default-policy-store` | `s` | `""` | Backs `--store` for `wyctl mfa enroll|reset`. Policy-store path (SQLite file). Empty = "no default; CLI must supply." |
+| `default-keyprovider` | `s` | `""` | Backs `--keyprovider` for `wyctl mfa enroll|reset`. KeyProvider spec (e.g. `file:/etc/wyrelog/policy.key`). Empty = "no default; CLI must supply." |
 
 Example: configure the operator workstation once and let every wyctl
 invocation pick up the defaults.
@@ -987,6 +1022,13 @@ of:
    default URL or tenant from those.
 3. **Unset** — the existing per-flag "missing" diagnostic fires
    (`wyctl: missing daemon URL`, `wyctl: missing --tenant`, etc.).
+
+The `wyctl mfa enroll` and `wyctl mfa reset` subcommands participate in
+the same resolver pipeline: `--store` falls back to `default-policy-store`
+and `--keyprovider` falls back to `default-keyprovider` under the same
+precedence rule (CLI > GSettings > missing-flag diagnostic). The
+`WYCTL_DISABLE_GSETTINGS=1` kill switch documented below disables the
+fallback uniformly across all wyctl subcommands, mfa included.
 
 ### Kill Switch: `WYCTL_DISABLE_GSETTINGS`
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -312,8 +312,14 @@ if build_client and host_machine.system() != 'windows'
     dependencies : [wyrelog_dep, glib_dep, gio_dep, sqlite_dep, sodium_dep],
   )
 
+  # The MFA harness now exercises the GSettings fallback for --store /
+  # --keyprovider (issue #333), so it needs the compiled schema on
+  # GSETTINGS_SCHEMA_DIR and the memory backend, just like the
+  # wyctl-config / wyctl-basic tests.  Per-test XDG-keyfile fixtures
+  # then layer a real GSettings keyfile on top of that schema dir.
   test('wyctl-mfa', test_wyctl_mfa,
-    depends : [wyctl_exe],
+    depends : [wyctl_exe, wyctl_gschemas_compiled],
+    env : wyctl_gsettings_test_env,
     timeout : 60,
   )
 

--- a/tests/test-wyctl-config.c
+++ b/tests/test-wyctl-config.c
@@ -20,6 +20,8 @@ fresh_settings (void)
     "default-guard-loc-class",
     "default-guard-risk",
     "default-guard-timestamp-mode",
+    "default-policy-store",
+    "default-keyprovider",
   };
   for (gsize i = 0; i < G_N_ELEMENTS (keys); i++)
     g_settings_reset (settings, keys[i]);
@@ -126,6 +128,79 @@ test_resolve_uint_no_settings_returns_null (void)
 }
 
 static void
+test_resolve_string_policy_store_cli_wins (void)
+{
+  g_autoptr (GSettings) settings = fresh_settings ();
+  g_settings_set_string (settings, "default-policy-store",
+      "/var/lib/wyrelog/from-gsettings.sqlite");
+
+  g_autofree gchar *resolved =
+      wyctl_resolve_string_option ("/tmp/from-cli.sqlite", settings,
+      "default-policy-store");
+  g_assert_cmpstr (resolved, ==, "/tmp/from-cli.sqlite");
+}
+
+static void
+test_resolve_string_policy_store_falls_back_to_settings (void)
+{
+  g_autoptr (GSettings) settings = fresh_settings ();
+  g_settings_set_string (settings, "default-policy-store",
+      "/var/lib/wyrelog/from-gsettings.sqlite");
+
+  g_autofree gchar *resolved = wyctl_resolve_string_option (NULL, settings,
+      "default-policy-store");
+  g_assert_cmpstr (resolved, ==, "/var/lib/wyrelog/from-gsettings.sqlite");
+}
+
+static void
+test_resolve_string_policy_store_empty_settings_is_unset (void)
+{
+  g_autoptr (GSettings) settings = fresh_settings ();
+  /* Schema default is the empty string. Symmetry with daemon-url:
+     no CLI value + empty-string in GSettings must surface as NULL so
+     the caller's "missing --store" diagnostic fires unchanged. */
+  g_autofree gchar *resolved = wyctl_resolve_string_option (NULL, settings,
+      "default-policy-store");
+  g_assert_null (resolved);
+}
+
+static void
+test_resolve_string_keyprovider_cli_wins (void)
+{
+  g_autoptr (GSettings) settings = fresh_settings ();
+  g_settings_set_string (settings, "default-keyprovider",
+      "systemd-creds:wyrelog-policy-from-gsettings");
+
+  g_autofree gchar *resolved =
+      wyctl_resolve_string_option ("file:/etc/wyrelog/keyprovider.key",
+      settings, "default-keyprovider");
+  g_assert_cmpstr (resolved, ==, "file:/etc/wyrelog/keyprovider.key");
+}
+
+static void
+test_resolve_string_keyprovider_falls_back_to_settings (void)
+{
+  g_autoptr (GSettings) settings = fresh_settings ();
+  g_settings_set_string (settings, "default-keyprovider",
+      "systemd-creds:wyrelog-policy");
+
+  g_autofree gchar *resolved = wyctl_resolve_string_option (NULL, settings,
+      "default-keyprovider");
+  g_assert_cmpstr (resolved, ==, "systemd-creds:wyrelog-policy");
+}
+
+static void
+test_resolve_string_keyprovider_empty_settings_is_unset (void)
+{
+  g_autoptr (GSettings) settings = fresh_settings ();
+  /* Empty-string symmetry: matches the daemon-url test at line ~78
+     and the policy-store equivalent above. */
+  g_autofree gchar *resolved = wyctl_resolve_string_option (NULL, settings,
+      "default-keyprovider");
+  g_assert_null (resolved);
+}
+
+static void
 test_open_settings_respects_kill_switch (void)
 {
   /* WYCTL_DISABLE_GSETTINGS=1 must short-circuit before any schema
@@ -187,6 +262,22 @@ main (int argc, char **argv)
       test_resolve_uint_renders_settings_value);
   g_test_add_func ("/wyctl/config/resolve-uint/no-settings-returns-null",
       test_resolve_uint_no_settings_returns_null);
+  g_test_add_func ("/wyctl/config/resolve-string/policy-store-cli-wins",
+      test_resolve_string_policy_store_cli_wins);
+  g_test_add_func
+      ("/wyctl/config/resolve-string/policy-store-falls-back-to-settings",
+      test_resolve_string_policy_store_falls_back_to_settings);
+  g_test_add_func
+      ("/wyctl/config/resolve-string/policy-store-empty-settings-is-unset",
+      test_resolve_string_policy_store_empty_settings_is_unset);
+  g_test_add_func ("/wyctl/config/resolve-string/keyprovider-cli-wins",
+      test_resolve_string_keyprovider_cli_wins);
+  g_test_add_func
+      ("/wyctl/config/resolve-string/keyprovider-falls-back-to-settings",
+      test_resolve_string_keyprovider_falls_back_to_settings);
+  g_test_add_func
+      ("/wyctl/config/resolve-string/keyprovider-empty-settings-is-unset",
+      test_resolve_string_keyprovider_empty_settings_is_unset);
   g_test_add_func ("/wyctl/config/open/respects-kill-switch",
       test_open_settings_respects_kill_switch);
   g_test_add_func ("/wyctl/config/open/handle-when-schema-present",

--- a/tests/test-wyctl-gschema.c
+++ b/tests/test-wyctl-gschema.c
@@ -38,6 +38,8 @@ test_schema_keys_and_types (void)
     {"default-guard-loc-class", G_VARIANT_TYPE_STRING},
     {"default-guard-risk", G_VARIANT_TYPE_INT32},
     {"default-guard-timestamp-mode", G_VARIANT_TYPE_STRING},
+    {"default-policy-store", G_VARIANT_TYPE_STRING},
+    {"default-keyprovider", G_VARIANT_TYPE_STRING},
   };
 
   for (gsize i = 0; i < G_N_ELEMENTS (expected); i++) {
@@ -89,6 +91,8 @@ test_schema_defaults_safe (void)
     "default-graph",
     "access-token-file",
     "default-guard-loc-class",
+    "default-policy-store",
+    "default-keyprovider",
   };
 
   for (gsize i = 0; i < G_N_ELEMENTS (string_keys); i++) {

--- a/tests/test-wyctl-mfa.c
+++ b/tests/test-wyctl-mfa.c
@@ -196,30 +196,25 @@ typedef enum
   WYCTL_TEST_FEED_PERTURB = 3,
 } WyctlTestFeedMode;
 
-/* Drive `wyctl mfa enroll <subject>' against an unencrypted store at
- * `store_path'.  `mode' picks what to write to wyctl's stdin once the
- * secret_base32 line has been printed; see WyctlTestFeedMode above.
- * `override_code' is only consulted when mode == OVERRIDE.
- */
+/* Spawn `wyctl' with the supplied argv (already including the wyctl
+ * path as argv[0]) and `envp' (NULL to inherit) and drive the TOTP
+ * stdin handshake using `mode'.  Factored out of `run_wyctl_mfa' so
+ * the GSettings-fallback tests in this file can build their own argv
+ * (with no `--store') and pass a custom envp that points GSettings at
+ * a keyfile fixture. */
 static gint
-run_wyctl_mfa (const gchar *subcommand, const gchar *subject,
-    const gchar *store_path, WyctlTestFeedMode mode,
-    const gchar *override_code, GString *stdout_acc, GString *stderr_acc)
+run_wyctl_mfa_argv_env (const gchar *const *argv, gchar **envp,
+    WyctlTestFeedMode mode, const gchar *override_code,
+    GString *stdout_acc, GString *stderr_acc)
 {
-  const gchar *argv[] = {
-    WYL_TEST_WYCTL_PATH,
-    "mfa",
-    subcommand,
-    "--subject", subject,
-    "--store", store_path,
-    NULL,
-  };
-
   g_autoptr (GError) error = NULL;
-  g_autoptr (GSubprocess) sub = g_subprocess_newv (argv,
-      G_SUBPROCESS_FLAGS_STDIN_PIPE
-      | G_SUBPROCESS_FLAGS_STDOUT_PIPE
-      | G_SUBPROCESS_FLAGS_STDERR_PIPE, &error);
+  g_autoptr (GSubprocessLauncher) launcher =
+      g_subprocess_launcher_new (G_SUBPROCESS_FLAGS_STDIN_PIPE
+      | G_SUBPROCESS_FLAGS_STDOUT_PIPE | G_SUBPROCESS_FLAGS_STDERR_PIPE);
+  if (envp != NULL)
+    g_subprocess_launcher_set_environ (launcher, envp);
+  g_autoptr (GSubprocess) sub =
+      g_subprocess_launcher_spawnv (launcher, argv, &error);
   g_assert_no_error (error);
   g_assert_nonnull (sub);
 
@@ -293,6 +288,26 @@ run_wyctl_mfa (const gchar *subcommand, const gchar *subject,
   if (g_subprocess_get_if_exited (sub))
     return g_subprocess_get_exit_status (sub);
   return -1;
+}
+
+/* Thin wrapper preserving the original `run_wyctl_mfa' contract used
+ * by the issue #331 tests: build `--subject SUBJECT --store STORE_PATH'
+ * argv with no extra envp and drive the handshake. */
+static gint
+run_wyctl_mfa (const gchar *subcommand, const gchar *subject,
+    const gchar *store_path, WyctlTestFeedMode mode,
+    const gchar *override_code, GString *stdout_acc, GString *stderr_acc)
+{
+  const gchar *argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "mfa",
+    subcommand,
+    "--subject", subject,
+    "--store", store_path,
+    NULL,
+  };
+  return run_wyctl_mfa_argv_env (argv, NULL, mode, override_code, stdout_acc,
+      stderr_acc);
 }
 
 static void
@@ -656,6 +671,488 @@ test_mfa_enroll_url_encodes_subject (void)
   g_rmdir (tmp);
 }
 
+/* ------------------------------------------------------------------
+ * Issue #333 — GSettings fallback for `--store' / `--keyprovider'.
+ *
+ * The tests below drive `wyctl mfa enroll' as a subprocess with a
+ * GSettings keyfile fixture that supplies `default-policy-store' (and,
+ * for symmetry, `default-keyprovider').  Same memory backend invariant
+ * the unit tests at tests/test-wyctl-config.c rely on, except this
+ * file goes one layer further out and exercises the wyctl binary so
+ * the resolver call site inside `run_mfa_enroll' is the thing actually
+ * under test.
+ *
+ * The tests intentionally do NOT cover --keyprovider against a real
+ * encrypted store: the harness uses unencrypted stores throughout,
+ * matching the rest of this file.  Coverage of the keyprovider key is
+ * therefore the unit-level symmetry tests in test-wyctl-config.c plus
+ * a single subprocess test below that asserts the resolver consumes
+ * the keyprovider key when --keyprovider is omitted (we route through
+ * a clearly invalid spec so the failure mode is keyprovider-rejected,
+ * not store-open-failed, proving the value flowed through the
+ * resolver call site).
+ * ------------------------------------------------------------------ */
+
+static gchar *
+make_keyfile_xdg_dir_mfa (const gchar *const *keys, const gchar *const *values)
+{
+  g_autoptr (GError) error = NULL;
+  gchar *xdg = g_dir_make_tmp ("wyctl-mfa-xdg-XXXXXX", &error);
+  g_assert_no_error (error);
+
+  g_autofree gchar *settings_dir = g_build_filename (xdg, "glib-2.0",
+      "settings", NULL);
+  g_assert_cmpint (g_mkdir_with_parents (settings_dir, 0700), ==, 0);
+
+  g_autofree gchar *keyfile_path = g_build_filename (settings_dir, "keyfile",
+      NULL);
+  g_autoptr (GKeyFile) keyfile = g_key_file_new ();
+  for (gsize i = 0; keys != NULL && keys[i] != NULL; i++) {
+    g_assert_nonnull (values[i]);
+    g_key_file_set_string (keyfile, "org/wyrelog/wyctl", keys[i], values[i]);
+  }
+  g_assert_true (g_key_file_save_to_file (keyfile, keyfile_path, &error));
+  g_assert_no_error (error);
+  return xdg;
+}
+
+static gchar *
+gvariant_literal_for_string_mfa (const gchar *value)
+{
+  g_autoptr (GVariant) variant = g_variant_new_string (value);
+  return g_variant_print (variant, FALSE);
+}
+
+static void
+remove_dir_recursive_mfa (const gchar *path)
+{
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GFile) file = g_file_new_for_path (path);
+  g_autoptr (GFileEnumerator) en = g_file_enumerate_children (file,
+      G_FILE_ATTRIBUTE_STANDARD_NAME ","
+      G_FILE_ATTRIBUTE_STANDARD_TYPE, G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,
+      NULL, &error);
+  if (en != NULL) {
+    while (TRUE) {
+      g_autoptr (GFileInfo) info = g_file_enumerator_next_file (en, NULL,
+          &error);
+      if (info == NULL)
+        break;
+      g_autofree gchar *child = g_build_filename (path,
+          g_file_info_get_name (info), NULL);
+      if (g_file_info_get_file_type (info) == G_FILE_TYPE_DIRECTORY)
+        remove_dir_recursive_mfa (child);
+      else
+        g_unlink (child);
+    }
+  }
+  g_clear_error (&error);
+  g_rmdir (path);
+}
+
+/* Build an envp anchored at the parent process's env, with
+ * XDG_CONFIG_HOME pointed at `xdg_dir' and the GSettings keyfile
+ * backend selected.  When `disable_gsettings' is TRUE, also set
+ * WYCTL_DISABLE_GSETTINGS=1 so the fallback is suppressed.  Caller
+ * frees with g_strfreev. */
+static gchar **
+build_mfa_gsettings_envp (const gchar *xdg_dir, gboolean disable_gsettings)
+{
+  gchar **envp = g_get_environ ();
+  envp = g_environ_setenv (envp, "XDG_CONFIG_HOME", xdg_dir, TRUE);
+  envp = g_environ_setenv (envp, "GSETTINGS_BACKEND", "keyfile", TRUE);
+  if (disable_gsettings)
+    envp = g_environ_setenv (envp, "WYCTL_DISABLE_GSETTINGS", "1", TRUE);
+  else
+    envp = g_environ_unsetenv (envp, "WYCTL_DISABLE_GSETTINGS");
+  return envp;
+}
+
+/* (1) CLI value wins over GSettings: both set, CLI is explicit, the
+ *     row must land in the CLI-named store and the GSettings-named
+ *     store must remain empty. */
+static void
+test_mfa_enroll_cli_store_wins_over_gsettings (void)
+{
+  g_autofree gchar *tmp = g_dir_make_tmp ("wyctl-mfa-XXXXXX", NULL);
+  g_assert_nonnull (tmp);
+  g_autofree gchar *cli_store = g_build_filename (tmp, "cli.sqlite", NULL);
+  g_autofree gchar *gs_store = g_build_filename (tmp, "gs.sqlite", NULL);
+  create_empty_store (cli_store);
+  create_empty_store (gs_store);
+
+  g_autofree gchar *literal = gvariant_literal_for_string_mfa (gs_store);
+  const gchar *keys[] = { "default-policy-store", NULL };
+  const gchar *values[] = { literal, NULL };
+  g_autofree gchar *xdg = make_keyfile_xdg_dir_mfa (keys, values);
+  g_auto (GStrv) envp = build_mfa_gsettings_envp (xdg, FALSE);
+
+  const gchar *argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "mfa", "enroll",
+    "--subject", "alice.cli",
+    "--store", cli_store,
+    NULL,
+  };
+  g_autoptr (GString) out = g_string_new (NULL);
+  g_autoptr (GString) err = g_string_new (NULL);
+  gint rc = run_wyctl_mfa_argv_env (argv, envp, WYCTL_TEST_FEED_VALID, NULL,
+      out, err);
+  remove_dir_recursive_mfa (xdg);
+  if (rc != 0)
+    g_printerr ("cli-wins stderr: %s\n", err->str);
+  g_assert_cmpint (rc, ==, 0);
+
+  WylTotpEnrollment cli_enr = { 0 };
+  g_assert_true (lookup_enrollment (cli_store, "alice.cli", &cli_enr));
+  wyl_totp_enrollment_clear (&cli_enr);
+
+  WylTotpEnrollment gs_enr = { 0 };
+  g_assert_false (lookup_enrollment (gs_store, "alice.cli", &gs_enr));
+  wyl_totp_enrollment_clear (&gs_enr);
+
+  g_unlink (cli_store);
+  g_unlink (gs_store);
+  g_rmdir (tmp);
+}
+
+/* (2) Populated GSettings + missing CLI --store: resolver supplies the
+ *     path and the row lands in the GSettings-named store. */
+static void
+test_mfa_enroll_gsettings_supplies_store (void)
+{
+  g_autofree gchar *tmp = g_dir_make_tmp ("wyctl-mfa-XXXXXX", NULL);
+  g_assert_nonnull (tmp);
+  g_autofree gchar *gs_store = g_build_filename (tmp, "gs.sqlite", NULL);
+  create_empty_store (gs_store);
+
+  g_autofree gchar *literal = gvariant_literal_for_string_mfa (gs_store);
+  const gchar *keys[] = { "default-policy-store", NULL };
+  const gchar *values[] = { literal, NULL };
+  g_autofree gchar *xdg = make_keyfile_xdg_dir_mfa (keys, values);
+  g_auto (GStrv) envp = build_mfa_gsettings_envp (xdg, FALSE);
+
+  const gchar *argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "mfa", "enroll",
+    "--subject", "alice.gs",
+    NULL,
+  };
+  g_autoptr (GString) out = g_string_new (NULL);
+  g_autoptr (GString) err = g_string_new (NULL);
+  gint rc = run_wyctl_mfa_argv_env (argv, envp, WYCTL_TEST_FEED_VALID, NULL,
+      out, err);
+  if (rc != 0)
+    g_printerr ("gs-supplies stderr: %s\n", err->str);
+  g_assert_cmpint (rc, ==, 0);
+
+  WylTotpEnrollment enr = { 0 };
+  g_assert_true (lookup_enrollment (gs_store, "alice.gs", &enr));
+  wyl_totp_enrollment_clear (&enr);
+
+  remove_dir_recursive_mfa (xdg);
+  g_unlink (gs_store);
+  g_rmdir (tmp);
+}
+
+/* (3) Both unset (empty GSettings + no CLI): existing
+ *     "missing --store" diagnostic must surface. */
+static void
+test_mfa_enroll_both_unset_surfaces_missing_flag (void)
+{
+  /* Empty keyfile (no keys at all); the schema default for
+   * default-policy-store is the empty string and the resolver maps
+   * that to "unset". */
+  g_autofree gchar *xdg = make_keyfile_xdg_dir_mfa (NULL, NULL);
+  g_auto (GStrv) envp = build_mfa_gsettings_envp (xdg, FALSE);
+
+  const gchar *argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "mfa", "enroll",
+    "--subject", "alice.none",
+    NULL,
+  };
+  g_autoptr (GString) out = g_string_new (NULL);
+  g_autoptr (GString) err = g_string_new (NULL);
+  /* Feed EOF: we never reach the secret prompt because the missing-
+   * flag diagnostic fires before any store is opened. */
+  gint rc = run_wyctl_mfa_argv_env (argv, envp, WYCTL_TEST_FEED_EOF, NULL,
+      out, err);
+  remove_dir_recursive_mfa (xdg);
+
+  g_assert_cmpint (rc, !=, 0);
+  g_assert_nonnull (g_strstr_len (err->str, -1, "wyctl: missing --store"));
+}
+
+/* (4) WYCTL_DISABLE_GSETTINGS=1 + populated GSettings + no CLI:
+ *     the kill switch suppresses the fallback and the missing-flag
+ *     diagnostic surfaces. */
+static void
+test_mfa_enroll_kill_switch_disables_fallback (void)
+{
+  g_autofree gchar *tmp = g_dir_make_tmp ("wyctl-mfa-XXXXXX", NULL);
+  g_assert_nonnull (tmp);
+  g_autofree gchar *gs_store = g_build_filename (tmp, "gs.sqlite", NULL);
+  create_empty_store (gs_store);
+
+  g_autofree gchar *literal = gvariant_literal_for_string_mfa (gs_store);
+  const gchar *keys[] = { "default-policy-store", NULL };
+  const gchar *values[] = { literal, NULL };
+  g_autofree gchar *xdg = make_keyfile_xdg_dir_mfa (keys, values);
+  g_auto (GStrv) envp = build_mfa_gsettings_envp (xdg, TRUE);
+
+  const gchar *argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "mfa", "enroll",
+    "--subject", "alice.kill",
+    NULL,
+  };
+  g_autoptr (GString) out = g_string_new (NULL);
+  g_autoptr (GString) err = g_string_new (NULL);
+  gint rc = run_wyctl_mfa_argv_env (argv, envp, WYCTL_TEST_FEED_EOF, NULL,
+      out, err);
+  remove_dir_recursive_mfa (xdg);
+
+  g_assert_cmpint (rc, !=, 0);
+  g_assert_nonnull (g_strstr_len (err->str, -1, "wyctl: missing --store"));
+
+  /* Sanity: the GSettings-named store stayed empty even though it was
+   * fully populated in the keyfile.  Proves the kill switch beat the
+   * resolver, not that the resolver got confused. */
+  WylTotpEnrollment enr = { 0 };
+  g_assert_false (lookup_enrollment (gs_store, "alice.kill", &enr));
+  wyl_totp_enrollment_clear (&enr);
+
+  g_unlink (gs_store);
+  g_rmdir (tmp);
+}
+
+/* (5) Defense-in-depth: after a successful fully-GSettings-resolved
+ *     enrollment, the operator-supplied keyfile MUST contain only the
+ *     store path (and any other operator-set keys).  No seed bytes,
+ *     no otpauth URI, no verification code, no UUIDv7.  This pins the
+ *     invariant that the wyctl GSettings keys are operator-config
+ *     only, never the destination of any enrollment artifact.
+ *
+ *     We can't introspect dconf in a test sandbox, but the keyfile
+ *     backend writes to a single file under XDG_CONFIG_HOME so a
+ *     byte-level scan against the captured enrollment artifacts is
+ *     equivalent: any leak would mean the wyctl code path or the
+ *     resolver wrote into the GSettings backend, which would show up
+ *     in this file. */
+static void
+test_mfa_enroll_gsettings_backing_store_has_no_secrets (void)
+{
+  g_autofree gchar *tmp = g_dir_make_tmp ("wyctl-mfa-XXXXXX", NULL);
+  g_assert_nonnull (tmp);
+  g_autofree gchar *gs_store = g_build_filename (tmp, "gs.sqlite", NULL);
+  create_empty_store (gs_store);
+
+  g_autofree gchar *literal = gvariant_literal_for_string_mfa (gs_store);
+  const gchar *keys[] = { "default-policy-store", NULL };
+  const gchar *values[] = { literal, NULL };
+  g_autofree gchar *xdg = make_keyfile_xdg_dir_mfa (keys, values);
+  g_auto (GStrv) envp = build_mfa_gsettings_envp (xdg, FALSE);
+
+  const gchar *argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "mfa", "enroll",
+    "--subject", "alice.scan",
+    NULL,
+  };
+  g_autoptr (GString) out = g_string_new (NULL);
+  g_autoptr (GString) err = g_string_new (NULL);
+  gint rc = run_wyctl_mfa_argv_env (argv, envp, WYCTL_TEST_FEED_VALID, NULL,
+      out, err);
+  if (rc != 0)
+    g_printerr ("scan stderr: %s\n", err->str);
+  g_assert_cmpint (rc, ==, 0);
+
+  /* Capture the secrets the enrollment produced before scanning. */
+  g_autofree gchar *secret_b32 = extract_kv (out->str, "secret_base32");
+  g_autofree gchar *otpauth_uri = extract_kv (out->str, "otpauth_uri");
+  WylTotpEnrollment enr = { 0 };
+  g_assert_true (lookup_enrollment (gs_store, "alice.scan", &enr));
+  g_autofree gchar *enrollment_id = g_strdup (enr.id_uuidv7);
+  wyl_totp_enrollment_clear (&enr);
+  g_assert_nonnull (secret_b32);
+  g_assert_nonnull (otpauth_uri);
+  g_assert_nonnull (enrollment_id);
+
+  /* Read the keyfile back from disk and scan it for any of those
+   * artifacts.  The keyfile is the entire GSettings backing store for
+   * this test (XDG_CONFIG_HOME points only at the temp xdg dir). */
+  g_autofree gchar *keyfile_path = g_build_filename (xdg, "glib-2.0",
+      "settings", "keyfile", NULL);
+  g_autofree gchar *keyfile_bytes = NULL;
+  gsize keyfile_len = 0;
+  g_autoptr (GError) read_error = NULL;
+  g_assert_true (g_file_get_contents (keyfile_path, &keyfile_bytes,
+          &keyfile_len, &read_error));
+  g_assert_no_error (read_error);
+
+  /* The path the operator wrote to GSettings IS expected to be
+   * present; nothing else may be. */
+  g_assert_nonnull (g_strstr_len (keyfile_bytes, keyfile_len, gs_store));
+  g_assert_null (g_strstr_len (keyfile_bytes, keyfile_len, secret_b32));
+  g_assert_null (g_strstr_len (keyfile_bytes, keyfile_len, otpauth_uri));
+  g_assert_null (g_strstr_len (keyfile_bytes, keyfile_len, enrollment_id));
+
+  /* And the subject we just enrolled must not have been written into
+   * the GSettings keyfile either: defense-in-depth against a future
+   * change that accidentally persists `default-subject'.  See the
+   * issue #333 brief: --subject is per-invocation, never a default. */
+  g_assert_null (g_strstr_len (keyfile_bytes, keyfile_len, "alice.scan"));
+
+  remove_dir_recursive_mfa (xdg);
+  g_unlink (gs_store);
+  g_rmdir (tmp);
+}
+
+/* (6) Empty-string GSettings is treated as unset.  Mirrors the unit
+ *     test test_resolve_string_empty_settings_is_unset.  Forces the
+ *     keyfile to contain `default-policy-store=''' explicitly so the
+ *     code path that reads the value (rather than absent-key default)
+ *     is exercised. */
+static void
+test_mfa_enroll_empty_gsettings_string_is_unset (void)
+{
+  g_autofree gchar *literal = gvariant_literal_for_string_mfa ("");
+  const gchar *keys[] = { "default-policy-store", NULL };
+  const gchar *values[] = { literal, NULL };
+  g_autofree gchar *xdg = make_keyfile_xdg_dir_mfa (keys, values);
+  g_auto (GStrv) envp = build_mfa_gsettings_envp (xdg, FALSE);
+
+  const gchar *argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "mfa", "enroll",
+    "--subject", "alice.empty",
+    NULL,
+  };
+  g_autoptr (GString) out = g_string_new (NULL);
+  g_autoptr (GString) err = g_string_new (NULL);
+  gint rc = run_wyctl_mfa_argv_env (argv, envp, WYCTL_TEST_FEED_EOF, NULL,
+      out, err);
+  remove_dir_recursive_mfa (xdg);
+
+  g_assert_cmpint (rc, !=, 0);
+  g_assert_nonnull (g_strstr_len (err->str, -1, "wyctl: missing --store"));
+}
+
+/* (7) The same matrix for `mfa reset': populated GSettings, no CLI,
+ *     reset path must consume the GSettings value.  Seeds an existing
+ *     enrollment row first so the delete-then-enroll path actually
+ *     has something to delete. */
+static void
+test_mfa_reset_gsettings_supplies_store (void)
+{
+  g_autofree gchar *tmp = g_dir_make_tmp ("wyctl-mfa-XXXXXX", NULL);
+  g_assert_nonnull (tmp);
+  g_autofree gchar *gs_store = g_build_filename (tmp, "gs.sqlite", NULL);
+  create_empty_store (gs_store);
+
+  {
+    g_autoptr (wyl_policy_store_t) s = NULL;
+    g_assert_cmpint (wyl_policy_store_open (gs_store, &s), ==, WYRELOG_E_OK);
+    WylTotpEnrollment seed = { 0 };
+    seed.subject_id = g_strdup ("alice.reset");
+    for (gsize i = 0; i < WYL_TOTP_ENROLLMENT_SECRET_BYTES; i++)
+      seed.secret[i] = (guint8) (0x33 ^ i);
+    seed.last_verified_step = INT64_MIN;
+    seed.enrolled_at = 1700000000;
+    g_assert_cmpint (wyl_policy_store_totp_enrollment_insert (s, &seed), ==,
+        WYRELOG_E_OK);
+    wyl_totp_enrollment_clear (&seed);
+  }
+
+  g_autofree gchar *literal = gvariant_literal_for_string_mfa (gs_store);
+  const gchar *keys[] = { "default-policy-store", NULL };
+  const gchar *values[] = { literal, NULL };
+  g_autofree gchar *xdg = make_keyfile_xdg_dir_mfa (keys, values);
+  g_auto (GStrv) envp = build_mfa_gsettings_envp (xdg, FALSE);
+
+  const gchar *argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "mfa", "reset",
+    "--subject", "alice.reset",
+    NULL,
+  };
+  g_autoptr (GString) out = g_string_new (NULL);
+  g_autoptr (GString) err = g_string_new (NULL);
+  gint rc = run_wyctl_mfa_argv_env (argv, envp, WYCTL_TEST_FEED_VALID, NULL,
+      out, err);
+  remove_dir_recursive_mfa (xdg);
+  if (rc != 0)
+    g_printerr ("reset-gs stderr: %s\n", err->str);
+  g_assert_cmpint (rc, ==, 0);
+
+  WylTotpEnrollment after = { 0 };
+  g_assert_true (lookup_enrollment (gs_store, "alice.reset", &after));
+  wyl_totp_enrollment_clear (&after);
+
+  g_unlink (gs_store);
+  g_rmdir (tmp);
+}
+
+/* (8) Subprocess coverage for the `default-keyprovider' resolver call
+ *     site: with --keyprovider omitted but GSettings populated, wyctl
+ *     must consume the GSettings value.  We point GSettings at a
+ *     deliberately-unreadable keyprovider spec so the failure mode is
+ *     `keyprovider unreadable' / `open store failed', not "missing
+ *     --keyprovider".  That proves the resolver fed the spec into
+ *     wyctl_mfa_open_store rather than the value being silently
+ *     dropped. */
+static void
+test_mfa_enroll_gsettings_supplies_keyprovider (void)
+{
+  g_autofree gchar *tmp = g_dir_make_tmp ("wyctl-mfa-XXXXXX", NULL);
+  g_assert_nonnull (tmp);
+  g_autofree gchar *gs_store = g_build_filename (tmp, "gs.sqlite", NULL);
+  create_empty_store (gs_store);
+
+  /* Keyprovider spec that is syntactically a `file:' spec but refers
+   * to a path that does not exist.  wyl_keyprovider_file_new_from_spec
+   * returns NULL, wyctl_mfa_open_store returns WYRELOG_E_IO, and wyctl
+   * exits non-zero with "open store failed".  We never reach the
+   * stdin prompt. */
+  g_autofree gchar *bogus_kp = g_build_filename (tmp, "no-such-keyprovider",
+      NULL);
+  g_autofree gchar *kp_spec = g_strdup_printf ("file:%s", bogus_kp);
+
+  g_autofree gchar *store_lit = gvariant_literal_for_string_mfa (gs_store);
+  g_autofree gchar *kp_lit = gvariant_literal_for_string_mfa (kp_spec);
+  const gchar *keys[] = {
+    "default-policy-store",
+    "default-keyprovider",
+    NULL,
+  };
+  const gchar *values[] = { store_lit, kp_lit, NULL };
+  g_autofree gchar *xdg = make_keyfile_xdg_dir_mfa (keys, values);
+  g_auto (GStrv) envp = build_mfa_gsettings_envp (xdg, FALSE);
+
+  const gchar *argv[] = {
+    WYL_TEST_WYCTL_PATH,
+    "mfa", "enroll",
+    "--subject", "alice.kp",
+    NULL,
+  };
+  g_autoptr (GString) out = g_string_new (NULL);
+  g_autoptr (GString) err = g_string_new (NULL);
+  gint rc = run_wyctl_mfa_argv_env (argv, envp, WYCTL_TEST_FEED_EOF, NULL,
+      out, err);
+  remove_dir_recursive_mfa (xdg);
+
+  g_assert_cmpint (rc, !=, 0);
+  /* The resolver consumed --keyprovider from GSettings.  The expected
+   * failure mode is the keyprovider-rejected path, NOT "missing
+   * --keyprovider" (which would prove the value never flowed). */
+  g_assert_null (g_strstr_len (err->str, -1, "wyctl: missing --keyprovider"));
+  g_assert_nonnull (g_strstr_len (err->str, -1, "wyctl: open store failed"));
+
+  g_unlink (gs_store);
+  g_rmdir (tmp);
+}
+
 int
 main (int argc, char **argv)
 {
@@ -677,6 +1174,24 @@ main (int argc, char **argv)
       test_mfa_enroll_non_bootstrap_subject_does_not_revoke);
   g_test_add_func ("/wyctl/mfa/enroll-url-encodes-subject",
       test_mfa_enroll_url_encodes_subject);
+
+  /* Issue #333: GSettings fallback for --store / --keyprovider. */
+  g_test_add_func ("/wyctl/mfa/enroll-cli-store-wins-over-gsettings",
+      test_mfa_enroll_cli_store_wins_over_gsettings);
+  g_test_add_func ("/wyctl/mfa/enroll-gsettings-supplies-store",
+      test_mfa_enroll_gsettings_supplies_store);
+  g_test_add_func ("/wyctl/mfa/enroll-both-unset-surfaces-missing-flag",
+      test_mfa_enroll_both_unset_surfaces_missing_flag);
+  g_test_add_func ("/wyctl/mfa/enroll-kill-switch-disables-fallback",
+      test_mfa_enroll_kill_switch_disables_fallback);
+  g_test_add_func ("/wyctl/mfa/enroll-gsettings-backing-store-has-no-secrets",
+      test_mfa_enroll_gsettings_backing_store_has_no_secrets);
+  g_test_add_func ("/wyctl/mfa/enroll-empty-gsettings-string-is-unset",
+      test_mfa_enroll_empty_gsettings_string_is_unset);
+  g_test_add_func ("/wyctl/mfa/reset-gsettings-supplies-store",
+      test_mfa_reset_gsettings_supplies_store);
+  g_test_add_func ("/wyctl/mfa/enroll-gsettings-supplies-keyprovider",
+      test_mfa_enroll_gsettings_supplies_keyprovider);
 
   return g_test_run ();
 }

--- a/wyrelog/wyctl/org.wyrelog.wyctl.gschema.xml
+++ b/wyrelog/wyctl/org.wyrelog.wyctl.gschema.xml
@@ -87,5 +87,32 @@
         would replay the same timestamp across invocations.
       </description>
     </key>
+
+    <key name="default-policy-store" type="s">
+      <default>""</default>
+      <summary>Default policy store path for offline subcommands</summary>
+      <description>
+        Filesystem path used when --store is omitted by an offline
+        wyctl subcommand (currently `mfa enroll` / `mfa reset`).
+        Empty string means "no default; the CLI flag must be
+        provided." The key is named `default-policy-store` rather
+        than `default-store` so the schema is unambiguous about
+        which kind of store the path refers to — wyctl's offline
+        subcommands operate on policy stores, never the fact store
+        or any other store wyrelog persists.
+      </description>
+    </key>
+
+    <key name="default-keyprovider" type="s">
+      <default>""</default>
+      <summary>Default KeyProvider spec for encrypted policy stores</summary>
+      <description>
+        KeyProvider spec used when --keyprovider is omitted by an
+        offline wyctl subcommand. Accepts the same `systemd-creds:NAME`
+        and `file:PATH` forms the CLI flag does. Empty string means
+        "no default; the CLI flag must be provided." The schema stores
+        only the spec string, never key material.
+      </description>
+    </key>
   </schema>
 </schemalist>

--- a/wyrelog/wyctl/wyctl.c
+++ b/wyrelog/wyctl/wyctl.c
@@ -2365,10 +2365,14 @@ run_mfa_enroll (const WyctlOptions *global_opts, gint argc, gchar **argv)
     return 2;
   }
 
-  /* Resolve --store and --keyprovider against GSettings defaults.  The
-   * resolver returns an owned copy or NULL; the original opts.* slots
-   * stay owned by GOptionContext, so we keep the resolved values in
-   * g_autofree locals and rebind opts.* to them before validation. */
+  /* Resolve --store and --keyprovider from CLI / GSettings (CLI wins;
+   * empty falls back to the default-policy-store / default-keyprovider
+   * keys). The resolved values live in the g_autofree locals; we
+   * overwrite opts.store_path / opts.keyprovider_path so downstream
+   * validation/open sees the resolved value. The original
+   * GOptionContext-owned strings in those slots are dropped (small
+   * one-shot leak absorbed at CLI tear-down — same pattern as
+   * elsewhere in wyctl). */
   g_autofree gchar *store_path = wyctl_resolve_string_option (opts.store_path,
       global_opts->settings, "default-policy-store");
   g_autofree gchar *keyprovider_path =
@@ -2417,7 +2421,14 @@ run_mfa_reset (const WyctlOptions *global_opts, gint argc, gchar **argv)
     return 2;
   }
 
-  /* Mirror the resolver/ownership pattern from run_mfa_enroll. */
+  /* Resolve --store and --keyprovider from CLI / GSettings (CLI wins;
+   * empty falls back to the default-policy-store / default-keyprovider
+   * keys). The resolved values live in the g_autofree locals; we
+   * overwrite opts.store_path / opts.keyprovider_path so downstream
+   * validation/open sees the resolved value. The original
+   * GOptionContext-owned strings in those slots are dropped (small
+   * one-shot leak absorbed at CLI tear-down — same pattern as
+   * elsewhere in wyctl). */
   g_autofree gchar *store_path = wyctl_resolve_string_option (opts.store_path,
       global_opts->settings, "default-policy-store");
   g_autofree gchar *keyprovider_path =

--- a/wyrelog/wyctl/wyctl.c
+++ b/wyrelog/wyctl/wyctl.c
@@ -2339,7 +2339,7 @@ wyctl_mfa_validate_common_options (const WyctlMfaOptions *opts)
 }
 
 static int
-run_mfa_enroll (gint argc, gchar **argv)
+run_mfa_enroll (const WyctlOptions *global_opts, gint argc, gchar **argv)
 {
   WyctlMfaOptions opts = { 0 };
   GOptionEntry entries[] = {
@@ -2364,6 +2364,19 @@ run_mfa_enroll (gint argc, gchar **argv)
     g_printerr ("wyctl: unexpected mfa enroll argument: %s\n", argv[1]);
     return 2;
   }
+
+  /* Resolve --store and --keyprovider against GSettings defaults.  The
+   * resolver returns an owned copy or NULL; the original opts.* slots
+   * stay owned by GOptionContext, so we keep the resolved values in
+   * g_autofree locals and rebind opts.* to them before validation. */
+  g_autofree gchar *store_path = wyctl_resolve_string_option (opts.store_path,
+      global_opts->settings, "default-policy-store");
+  g_autofree gchar *keyprovider_path =
+      wyctl_resolve_string_option (opts.keyprovider_path,
+      global_opts->settings, "default-keyprovider");
+  opts.store_path = store_path;
+  opts.keyprovider_path = keyprovider_path;
+
   int validate_rc = wyctl_mfa_validate_common_options (&opts);
   if (validate_rc != 0)
     return validate_rc;
@@ -2378,7 +2391,7 @@ run_mfa_enroll (gint argc, gchar **argv)
 }
 
 static int
-run_mfa_reset (gint argc, gchar **argv)
+run_mfa_reset (const WyctlOptions *global_opts, gint argc, gchar **argv)
 {
   WyctlMfaOptions opts = { 0 };
   GOptionEntry entries[] = {
@@ -2403,6 +2416,16 @@ run_mfa_reset (gint argc, gchar **argv)
     g_printerr ("wyctl: unexpected mfa reset argument: %s\n", argv[1]);
     return 2;
   }
+
+  /* Mirror the resolver/ownership pattern from run_mfa_enroll. */
+  g_autofree gchar *store_path = wyctl_resolve_string_option (opts.store_path,
+      global_opts->settings, "default-policy-store");
+  g_autofree gchar *keyprovider_path =
+      wyctl_resolve_string_option (opts.keyprovider_path,
+      global_opts->settings, "default-keyprovider");
+  opts.store_path = store_path;
+  opts.keyprovider_path = keyprovider_path;
+
   int validate_rc = wyctl_mfa_validate_common_options (&opts);
   if (validate_rc != 0)
     return validate_rc;
@@ -2427,16 +2450,16 @@ run_mfa_reset (gint argc, gchar **argv)
 }
 
 static int
-run_mfa (gint argc, gchar **argv)
+run_mfa (const WyctlOptions *global_opts, gint argc, gchar **argv)
 {
   if (argc < 2) {
     g_printerr ("wyctl: missing mfa command (enroll | reset)\n");
     return 2;
   }
   if (g_strcmp0 (argv[1], "enroll") == 0)
-    return run_mfa_enroll (argc - 1, argv + 1);
+    return run_mfa_enroll (global_opts, argc - 1, argv + 1);
   if (g_strcmp0 (argv[1], "reset") == 0)
-    return run_mfa_reset (argc - 1, argv + 1);
+    return run_mfa_reset (global_opts, argc - 1, argv + 1);
 
   g_printerr ("wyctl: unknown mfa command: %s\n", argv[1]);
   return 2;
@@ -2640,7 +2663,7 @@ main (int argc, char **argv)
   if (g_strcmp0 (argv[1], "key") == 0)
     return run_key (argc - 1, argv + 1);
   if (g_strcmp0 (argv[1], "mfa") == 0)
-    return run_mfa (argc - 1, argv + 1);
+    return run_mfa (&opts, argc - 1, argv + 1);
 
   g_printerr ("wyctl: unknown command: %s\n", argv[1]);
   return 2;


### PR DESCRIPTION
Closes #333. Follow-up to PR #332.

## Summary

Wires `wyctl mfa enroll`/`reset` into the existing `wyctl_resolve_string_option` GSettings pipeline so operators can set policy-store path and keyprovider spec once and stop retyping them. Two atomic commits, both reviewer-ratified.

## Commit map

1. `wyctl: read default-policy-store and default-keyprovider GSettings keys for mfa subcommands` — adds two `s` keys (default `""`) to `org.wyrelog.wyctl.gschema.xml`; threads `WyctlOptions *global_opts` through `run_mfa` and into both subcommands; calls the existing resolver before `wyctl_mfa_validate_common_options`; +14 subtests (6 unit + 8 subprocess incl. defense-in-depth no-secrets-in-keyfile scan).
2. `docs: document gsettings fallback for wyctl mfa subcommands` — operator-runbook MFA section gets `Setting defaults via GSettings`; key table extended; "paths/specs only, never secrets" policy statement extended to cover the new keys; pin backfill in `tests/test-wyctl-gschema.c`; corrected an inaccurate ownership-pattern comment in `wyctl.c` that claimed run_status-style mirroring (run_status does not rebind `opts`, the mfa subcommands do).

## Design (locked)

- Two new keys: `default-policy-store` (backs `--store`), `default-keyprovider` (backs `--keyprovider`). Both `s`, default `""`.
- Precedence: CLI > GSettings > missing-flag diagnostic. Unchanged from existing wyctl subcommands.
- `--subject` deliberately NOT GSettings-backed — every enrollment targets a different principal.
- `WYCTL_DISABLE_GSETTINGS=1` covers mfa uniformly with the rest of wyctl.
- No daemon-side GSettings (intentional, per existing `operator-runbook.md:903-922` rationale).

## Test plan

- [x] `meson test -C builddir --suite wyrelog` green locally (75 OK / 2 skipped / 0 fail).
- [x] Unit: CLI wins, GSettings fills, both empty surfaces error, empty-string-as-unset symmetry, kill-switch disables fallback — for both keys.
- [x] Subprocess: end-to-end enroll succeeds with both CLI args, both from GSettings, mixed, and the kill-switch path.
- [x] Defense-in-depth: after a GSettings-backed enrollment, the dconf keyfile contains the operator-supplied path/spec but NOT the seed bytes, otpauth URI, or enrollment UUIDv7.
- [ ] CI lanes (ubuntu, macos, windows) green.

## Threat model

- `default-policy-store` and `default-keyprovider` store only paths and spec strings. The KeyProvider key material, the TOTP seed bytes, and policy-store contents never live in GSettings — verified by the defense-in-depth test and documented in the runbook policy section.
- The operator-UID assumption (dconf is operator-writable; a compromised operator session is already game-over) applies uniformly. Adding these two keys does not enlarge the attack surface beyond what the existing `access-token-file` key already accepts.

## Out of scope (unchanged from issue)

- `--subject` as a GSettings default
- New env var override layers beyond `WYCTL_DISABLE_GSETTINGS`
- Daemon-side GSettings
- Validating store-path / keyprovider-spec contents at flag-resolution time