### PR TITLE
feat(daemon): wyrelogd conf-file workflow, perm gate, bootstrap warnings

### DIFF
--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -895,7 +895,7 @@ bootstrap_admin_allow_skip_mfa = false
 | `system_url` | string | `--system-url` | System-profile daemon URL the service-profile daemon forwards events to. |
 | `listen_port` | int | `--listen-port` | HTTP listen port. `0` selects an ephemeral port (used by integration tests). |
 | `event_queue_limit` | int | `--event-queue-limit` | Maximum pending service-profile spool files. |
-| `production` | bool | `--production` | Enables the fail-closed production startup gates. |
+| `production` | bool | `--production` | Enables the fail-closed production startup gates. CLI and conf are OR-combined; see "Production Mode Precedence". |
 | `bootstrap_admin_subject` | string | `--bootstrap-admin-subject` | Grants the `wr.system_admin` role to this subject on a fresh policy store. One-shot bootstrap aid. |
 | `bootstrap_admin_allow_skip_mfa` | bool | `--bootstrap-admin-allow-skip-mfa` | Grants `wr.login.skip_mfa` to the bootstrap admin so it can mint a first bearer token. |
 
@@ -916,17 +916,263 @@ parser inflates into `WylDaemonOptions`.
 
 ### systemd Wiring
 
-A typical service unit threads the config file through the daemon's
-`--config` flag:
+The packaged units (`wyrelog-system.service`, `wyrelog-service.service`)
+thread the config file through the daemon's `--config` flag and pin
+production gating with `--production`:
 
 ```ini
 [Service]
-EnvironmentFile=/etc/wyrelog/wyrelogd.env
+Environment=WYL_LOG=warn
+EnvironmentFile=-/etc/wyrelog/system.env
 ExecStart=/usr/bin/wyrelogd --config /etc/wyrelog/wyrelogd.conf --production
+ProtectSystem=strict
+ReadOnlyPaths=/etc/wyrelog /usr/share/wyrelog
+ReadOnlyPaths=/etc/wyrelog/wyrelogd.conf
 ```
 
-The packaged unit ships with this shape; operator customization should
-edit `wyrelogd.conf` rather than redefining the entire `ExecStart`.
+Operator customization should edit `wyrelogd.conf` rather than redefining
+the entire `ExecStart`. The `ProtectSystem=strict` and `ReadOnlyPaths=`
+lines are the parent-directory defense against attacker-controlled
+symlink swaps of `/etc/wyrelog/` itself — drop-ins that override
+`ExecStart=` must preserve them.
+
+### Migration Recipe
+
+Example conf files ship under `${datadir}/wyrelog/examples/` (not in
+`/etc/`) so the operator must explicitly copy them into place. The
+canonical recipe for the system profile:
+
+```sh
+sudo install -d -m 0750 -o root -g wyrelog /etc/wyrelog
+sudo cp /usr/share/wyrelog/examples/wyrelogd-system.conf.example \
+    /etc/wyrelog/wyrelogd.conf
+sudo chown root:wyrelog /etc/wyrelog/wyrelogd.conf
+sudo chmod 0640 /etc/wyrelog/wyrelogd.conf
+sudo systemctl restart wyrelog-system.service
+```
+
+Same for the service profile:
+
+```sh
+sudo install -d -m 0750 -o root -g wyrelog /etc/wyrelog
+sudo cp /usr/share/wyrelog/examples/wyrelogd-service.conf.example \
+    /etc/wyrelog/wyrelogd.conf
+sudo chown root:wyrelog /etc/wyrelog/wyrelogd.conf
+sudo chmod 0640 /etc/wyrelog/wyrelogd.conf
+sudo systemctl restart wyrelog-service.service
+```
+
+Create the conf file **before** restarting wyrelogd. The shipped
+`ExecStart=` passes `--config /etc/wyrelog/wyrelogd.conf`; the daemon
+exits nonzero when that path is missing, which then drives the
+systemd `Restart=` loop until the file appears. Operators who want a
+different path must override `ExecStart=` via a drop-in.
+
+### Conf File Permission Gate
+
+`wyrelogd` opens the conf file through a TOCTOU-safe gate
+(`conf_file_open_safely` in `wyrelog/daemon/options.c`) with the
+following matrix:
+
+| Condition | `--production` behavior | Non-production behavior |
+|-----------|-------------------------|-------------------------|
+| `S_IWGRP` or `S_IWOTH` set on conf | refuse to start, error prefix `wyrelogd: conf: refusing` | WARN with prefix `wyrelogd: conf:` (no "refusing"), continue |
+| Symlink at conf path (`O_NOFOLLOW` -> `ELOOP`) | refuse to start | refuse to start |
+| Conf is not a regular file (FIFO, char device) | refuse to start | refuse to start |
+| Conf size > 64 KiB (`WYL_DAEMON_CONF_MAX_BYTES` in `wyrelog/daemon/options.c`) | refuse to start | refuse to start |
+| I/O error during read | refuse to start | refuse to start |
+
+Required posture: `0640 root:wyrelog`. The size cap and S_ISREG check
+are hard failures regardless of `--production`. The mode check is the
+only condition that downgrades to WARN outside production so dev
+workflows are not broken; production deployments always reject loose
+modes.
+
+**Defense-in-depth caveat.** `O_NOFOLLOW` guards only the final path
+component. A compromised packaging step that makes `/etc/wyrelog`
+itself a symlink to attacker-controlled space is NOT caught by the
+daemon gate alone. The packaged unit's `ProtectSystem=strict` and
+`ReadOnlyPaths=/etc/wyrelog` lines provide the parent-directory
+defense — preserve them in any custom drop-in.
+
+### Production Mode Precedence
+
+`--production` and the `production` conf key are NOT mutually
+exclusive. The effective production mode is:
+
+```
+production_mode = (CLI --production) OR (conf [daemon] production = true)
+```
+
+Either source can promote the daemon into fail-closed production
+mode. The conf path is wired in `wyrelog/daemon/options.c:179-184`:
+when the CLI did not set `--production`, the loader reads the
+boolean `production` key from the `[daemon]` section via
+`g_key_file_get_boolean`. This is logical-OR, not "CLI overrides".
+
+Operationally:
+
+- **Explicit production boot** (current packaged default):
+  pass `--production` on the unit's `ExecStart=`. Visible in
+  `systemctl status` output, auditable via `journalctl`, and
+  cannot be inadvertently softened by an unrelated conf edit.
+- **Explicit non-production boot**: BOTH gates must be off.
+  Drop `--production` from `ExecStart=` (via a drop-in) AND ensure
+  the conf either omits `production=` entirely or sets
+  `production=false`. Leaving `production=true` in the conf will
+  re-enable fail-closed mode even when the CLI flag is absent.
+
+Why the CLI flag is the preferred surface despite the OR-merge:
+its presence is greppable in `systemctl status` and journal logs,
+giving operators a single visible witness for boot intent. The
+conf key exists for completeness but is the easier surface for a
+conf-write attacker to flip in either direction:
+
+- Attacker with conf-write can pin `production=true` invisibly; an
+  operator following a "drop `--production` for dev WARN-downgrade"
+  recipe then gets unexpected fail-closed mode.
+- Conversely, a non-production host that inherits a conf with
+  `production=false` (or, equivalently, the key absent and CLI flag
+  absent) silently runs without fail-closed gates.
+
+The packaged unit keeps `--production` on `ExecStart=` for that
+visibility reason; do not remove it from `ExecStart=` without
+auditing the conf as well.
+
+### Diagnostic / Query Flags (Not Config-Eligible)
+
+The following CLI flags cannot be expressed in the conf file. They
+exit the daemon after printing, so they have no startup steady-state
+to configure:
+
+- `--check` — load policy templates and exit. Used by package
+  pre-/post-install hooks and human dry-runs.
+- `--version` — print the wyrelog version string and exit.
+- `--template-version` — print the access template version and exit.
+- `--template-info` — print the access template artifact identity
+  (signature, hash, timestamps) and exit.
+- `--profile-info` — print the resolved daemon profile configuration
+  (the value of every `WylDaemonOptions` field after merging CLI, conf,
+  and defaults) and exit. Also runs the bootstrap-key staleness probe
+  described below.
+- `--config PATH` — the path to the conf file itself. The path of the
+  conf is necessarily a CLI argument.
+
+### Bootstrap-Key Staleness WARN
+
+When `--profile-info` runs against a conf that still carries
+`bootstrap_admin_subject` or `bootstrap_admin_allow_skip_mfa=true`,
+`wyrelogd` probes the policy store for any subject row
+(`maybe_warn_stale_bootstrap_key` and `policy_store_probe_subjects`
+in `wyrelog/daemon/wyrelogd.c`) and emits one of two greppable lines
+to stderr:
+
+```
+wyrelogd: bootstrap_admin: stale-key subject=<id> allow_skip_mfa=<bool> (...)
+```
+
+emitted when the probe confirms at least one subject row exists.
+The greppable stable prefix is `wyrelogd: bootstrap_admin: stale-key
+subject=` — operators should anchor scripts on that token, not on
+the parenthetical hint. The hint itself takes one of two concrete
+shapes depending on which bootstrap keys are present:
+
+When only `bootstrap_admin_subject` is set in the conf:
+
+```
+... (remove bootstrap_admin_subject from /etc/wyrelog/wyrelogd.conf and restart)
+```
+
+When both `bootstrap_admin_subject` and
+`bootstrap_admin_allow_skip_mfa` are set:
+
+```
+... (remove bootstrap_admin_subject and bootstrap_admin_allow_skip_mfa from /etc/wyrelog/wyrelogd.conf and restart)
+```
+
+And:
+
+```
+wyrelogd: bootstrap_admin: indeterminate subject=<sanitized> allow_skip_mfa=<bool> (policy store unreadable: <reason>) -- cannot confirm bootstrap key is fresh
+```
+
+emitted when the probe cannot authoritatively answer (path unset,
+sqlite open failure, schema missing, step error). The `indeterminate`
+line exists so an attacker who can write the conf cannot silence the
+staleness signal by also corrupting the policy store — operators get
+a different greppable token instead of silence.
+
+The subject string is sanitized through a dmesg-style hex-escape
+(non-printable bytes rendered as `\xNN`) before stderr emission. The
+conf file is exactly the write surface an attacker would use to plant
+ANSI/CSI/OSC escape sequences; piping it verbatim through stderr at
+onboarding time would let the attacker spoof terminal output.
+
+Migration practice: delete the `bootstrap_admin_*` keys from
+`/etc/wyrelog/wyrelogd.conf` after first successful boot. The
+shipped example confs leave both keys commented out for exactly this
+reason.
+
+The stable greppable token discipline (anchor scripts on
+`wyrelogd: bootstrap_admin: stale-key subject=` rather than on the
+parenthetical remediation hint) mirrors the lesson from #331
+commit 7 — false runbook claims about message wording got caught
+as BLOCKERs during review there, so this runbook commits to the
+stable prefix as the authoritative interface.
+
+### Log Verbosity Is an Env Variable
+
+There is no `log_level=` conf key. Operators set log verbosity via
+the systemd unit's `Environment=` (or a drop-in). The grammar
+(`wyl_log_internal_parse_spec` in `wyrelog/wyl-log.c`) is:
+
+```
+SECTION:LEVEL[,SECTION:LEVEL...]
+```
+
+Bare-level strings like `WYL_LOG=info` are **silently dropped** at
+the `g_strv_length(parts) != 2` continue in `wyl-log.c:92` — they
+match no section and never raise any threshold. Two correct forms:
+
+```ini
+[Service]
+# Section-specific: raise boot to info, leave policy at warn
+Environment=WYL_LOG=boot:info,policy:warn
+```
+
+```ini
+[Service]
+# Wildcard: apply one level to every section
+Environment=WYL_LOG=*:info
+```
+
+Valid section tokens (case-insensitive): `boot`, `policy`, `session`,
+`decision`, `audit`, `io`, `general`, plus the wildcard `*`. Valid
+levels: `none`, `error`, `warn`, `info`, `debug`, `trace`. Unknown
+sections are silently ignored (an operator typo must not destabilise
+the daemon; documented in the K4 design note in `wyl-log.c`).
+
+Note: the packaged unit ships `Environment=WYL_LOG=warn`. By the
+grammar above this is a **no-op** — it parses to zero entries and
+leaves every section at the compile-time default (which happens to
+be `WARN`, set in `wyl_log_internal_parse_spec`). The value is
+preserved as an explicit-intent marker and to keep the line slot
+available for forward-compatible grammar extensions; operators
+should not interpret its presence as evidence that any level is
+actually being enforced.
+
+### Fact-Store Defaults
+
+`fact_root` and `fact_store_mode` are valid conf keys, but the
+shipped example confs do **not** set them. The daemon defaults apply
+when the keys are absent:
+
+- `fact_root` defaults to `/var/lib/wyrelog/system/facts` (system
+  profile) or `/var/lib/wyrelog/service/facts` (service profile).
+- `fact_store_mode` defaults to `per-tenant-graph`.
+
+Operators may add explicit values to the conf if they need
+non-default paths or a future store layout.
 
 ### Why No GSettings on the Daemon
 

--- a/meson.build
+++ b/meson.build
@@ -127,6 +127,16 @@ install_data(
   'packaging/service.env',
   install_dir : join_paths(get_option('sysconfdir'), 'wyrelog'),
 )
+# Documentation-only wyrelogd.conf examples for each profile. Installed
+# under ${datadir}/wyrelog/examples/ (NOT /etc/) so the operator must
+# explicitly copy and chmod 0640 before wyrelogd will load the file;
+# shipping into /etc/ would risk silently overriding a site config or
+# leaving world-readable secrets-adjacent settings on disk.
+install_data(
+  'packaging/wyrelog/examples/wyrelogd-system.conf.example',
+  'packaging/wyrelog/examples/wyrelogd-service.conf.example',
+  install_dir : join_paths(get_option('datadir'), 'wyrelog', 'examples'),
+)
 
 # Install git pre-commit hook for code style checking
 git_hook_script = find_program('hooks/pre-commit.hook')

--- a/packaging/systemd/wyrelog-service.service
+++ b/packaging/systemd/wyrelog-service.service
@@ -11,7 +11,7 @@ Group=wyrelog
 Environment=WYL_LOG=warn
 EnvironmentFile=-/etc/wyrelog/service.env
 LoadCredential=wyrelog-service-policy-key:/etc/wyrelog/service/policy.key
-ExecStart=/usr/bin/wyrelogd --production --profile=service --template-dir /usr/share/wyrelog/access --policy-db /var/lib/wyrelog/service/policy.sqlite --policy-keyprovider systemd-creds:wyrelog-service-policy-key --audit-db /var/log/wyrelog/service/audit.duckdb --system-url http://127.0.0.1:8765 --event-spool-dir /var/lib/wyrelog/service/event-spool --event-queue-limit 1024 --listen-port 8766
+ExecStart=/usr/bin/wyrelogd --config /etc/wyrelog/wyrelogd.conf --production
 Restart=on-failure
 RestartSec=5s
 NoNewPrivileges=true
@@ -19,6 +19,11 @@ PrivateTmp=true
 ProtectHome=true
 ProtectSystem=strict
 ReadOnlyPaths=/etc/wyrelog /usr/share/wyrelog
+# Defense-in-depth: the line above already covers /etc/wyrelog/, but
+# pinning the conf file explicitly survives a future drop-in that
+# relaxes the directory rule. The daemon also gates on mode/owner at
+# open(2) (wyl_daemon_options_resolve in wyrelog/daemon/options.c).
+ReadOnlyPaths=/etc/wyrelog/wyrelogd.conf
 ReadWritePaths=/var/lib/wyrelog/service /var/log/wyrelog/service /run/wyrelog
 RuntimeDirectory=wyrelog
 RuntimeDirectoryMode=0750

--- a/packaging/systemd/wyrelog-system.service
+++ b/packaging/systemd/wyrelog-system.service
@@ -11,7 +11,7 @@ Group=wyrelog
 Environment=WYL_LOG=warn
 EnvironmentFile=-/etc/wyrelog/system.env
 LoadCredential=wyrelog-system-policy-key:/etc/wyrelog/system/policy.key
-ExecStart=/usr/bin/wyrelogd --production --profile=system --template-dir /usr/share/wyrelog/access --policy-db /var/lib/wyrelog/system/policy.sqlite --policy-keyprovider systemd-creds:wyrelog-system-policy-key --audit-db /var/log/wyrelog/system/audit.duckdb --listen-port 8765
+ExecStart=/usr/bin/wyrelogd --config /etc/wyrelog/wyrelogd.conf --production
 Restart=on-failure
 RestartSec=5s
 NoNewPrivileges=true
@@ -19,6 +19,11 @@ PrivateTmp=true
 ProtectHome=true
 ProtectSystem=strict
 ReadOnlyPaths=/etc/wyrelog /usr/share/wyrelog
+# Defense-in-depth: the line above already covers /etc/wyrelog/, but
+# pinning the conf file explicitly survives a future drop-in that
+# relaxes the directory rule. The daemon also gates on mode/owner at
+# open(2) (wyl_daemon_options_resolve in wyrelog/daemon/options.c).
+ReadOnlyPaths=/etc/wyrelog/wyrelogd.conf
 ReadWritePaths=/var/lib/wyrelog/system /var/log/wyrelog/system /run/wyrelog
 RuntimeDirectory=wyrelog
 RuntimeDirectoryMode=0750

--- a/packaging/wyrelog/examples/wyrelogd-service.conf.example
+++ b/packaging/wyrelog/examples/wyrelogd-service.conf.example
@@ -1,0 +1,30 @@
+# wyrelogd service profile -- example configuration
+#
+# This file MUST be installed as root:wyrelog 0640.
+# Looser permissions cause `wyrelogd --production` to refuse to start.
+#
+# Copy to /etc/wyrelog/wyrelogd.conf and edit values for your site.
+# The keys below mirror the flags currently carried by
+# packaging/systemd/wyrelog-service.service ExecStart byte-for-byte; once
+# the unit's ExecStart flips to `--config /etc/wyrelog/wyrelogd.conf`,
+# this file IS the operational source of truth.
+#
+# Reference: docs/operator-runbook.md "Why No GSettings on the Daemon"
+
+[daemon]
+profile=service
+template_dir=/usr/share/wyrelog/access
+policy_db=/var/lib/wyrelog/service/policy.sqlite
+policy_keyprovider=systemd-creds:wyrelog-service-policy-key
+audit_db=/var/log/wyrelog/service/audit.duckdb
+system_url=http://127.0.0.1:8765
+event_spool_dir=/var/lib/wyrelog/service/event-spool
+event_queue_limit=1024
+listen_port=8766
+
+# DELETE AFTER FIRST SUCCESSFUL BOOT.
+# wyrelogd will WARN on every --profile-info while either of these
+# keys is present in /etc/wyrelog/wyrelogd.conf.
+#
+# bootstrap_admin_subject=
+# bootstrap_admin_allow_skip_mfa=false

--- a/packaging/wyrelog/examples/wyrelogd-system.conf.example
+++ b/packaging/wyrelog/examples/wyrelogd-system.conf.example
@@ -1,0 +1,27 @@
+# wyrelogd system profile -- example configuration
+#
+# This file MUST be installed as root:wyrelog 0640.
+# Looser permissions cause `wyrelogd --production` to refuse to start.
+#
+# Copy to /etc/wyrelog/wyrelogd.conf and edit values for your site.
+# The keys below mirror the flags currently carried by
+# packaging/systemd/wyrelog-system.service ExecStart byte-for-byte; once
+# the unit's ExecStart flips to `--config /etc/wyrelog/wyrelogd.conf`,
+# this file IS the operational source of truth.
+#
+# Reference: docs/operator-runbook.md "Why No GSettings on the Daemon"
+
+[daemon]
+profile=system
+template_dir=/usr/share/wyrelog/access
+policy_db=/var/lib/wyrelog/system/policy.sqlite
+policy_keyprovider=systemd-creds:wyrelog-system-policy-key
+audit_db=/var/log/wyrelog/system/audit.duckdb
+listen_port=8765
+
+# DELETE AFTER FIRST SUCCESSFUL BOOT.
+# wyrelogd will WARN on every --profile-info while either of these
+# keys is present in /etc/wyrelog/wyrelogd.conf.
+#
+# bootstrap_admin_subject=
+# bootstrap_admin_allow_skip_mfa=false

--- a/tests/check-packaged-install-readiness.sh
+++ b/tests/check-packaged-install-readiness.sh
@@ -38,9 +38,34 @@ for path in \
   "$SOURCE_ROOT/packaging/wyrelogd.env" \
   "$SOURCE_ROOT/packaging/system.env" \
   "$SOURCE_ROOT/packaging/service.env" \
+  "$SOURCE_ROOT/packaging/wyrelog/examples/wyrelogd-system.conf.example" \
+  "$SOURCE_ROOT/packaging/wyrelog/examples/wyrelogd-service.conf.example" \
   "$SOURCE_ROOT/tools/verify-template-release.sh" \
   "$SOURCE_ROOT/docs/operator-runbook.md"; do
   test -s "$path"
+done
+
+# Profile-unit ExecStart shape: post-issue-#335 the system/service units
+# load all settings from /etc/wyrelog/wyrelogd.conf via --config. The
+# operational source of truth for per-flag values now lives in the
+# example conf files installed under ${datadir}/wyrelog/examples/, so
+# the assertions for policy_keyprovider, profile, etc. were migrated
+# from inspecting the unit ExecStart to inspecting those examples.
+SYSTEM_EXAMPLE="$SOURCE_ROOT/packaging/wyrelog/examples/wyrelogd-system.conf.example"
+SERVICE_EXAMPLE="$SOURCE_ROOT/packaging/wyrelog/examples/wyrelogd-service.conf.example"
+for unit in \
+    "$SOURCE_ROOT/packaging/systemd/wyrelog-system.service" \
+    "$SOURCE_ROOT/packaging/systemd/wyrelog-service.service"; do
+  if ! grep -q -- \
+      "^ExecStart=/usr/bin/wyrelogd --config /etc/wyrelog/wyrelogd.conf --production$" \
+      "$unit"; then
+    echo "profile unit $unit does not invoke wyrelogd via --config" >&2
+    exit 1
+  fi
+  if ! grep -q -- "^ReadOnlyPaths=/etc/wyrelog/wyrelogd.conf$" "$unit"; then
+    echo "profile unit $unit does not pin conf file read-only" >&2
+    exit 1
+  fi
 done
 
 if ! grep -q -- "--production" \
@@ -53,19 +78,22 @@ if ! grep -q -- "LoadCredential=wyrelog-system-policy-key:" \
   echo "system unit does not load policy key as a systemd credential" >&2
   exit 1
 fi
-if ! grep -q -- "--policy-keyprovider systemd-creds:wyrelog-system-policy-key" \
-    "$SOURCE_ROOT/packaging/systemd/wyrelog-system.service"; then
-  echo "system unit does not use the systemd credential KeyProvider" >&2
+if ! grep -q -- "^policy_keyprovider=systemd-creds:wyrelog-system-policy-key$" \
+    "$SYSTEM_EXAMPLE"; then
+  echo "system example conf does not use the systemd credential KeyProvider" >&2
   exit 1
 fi
-if ! grep -q -- "--profile=system" \
-    "$SOURCE_ROOT/packaging/systemd/wyrelog-system.service"; then
-  echo "system unit does not select the system profile" >&2
+if ! grep -q -- "^policy_keyprovider=systemd-creds:wyrelog-service-policy-key$" \
+    "$SERVICE_EXAMPLE"; then
+  echo "service example conf does not use the systemd credential KeyProvider" >&2
   exit 1
 fi
-if ! grep -q -- "--profile=service" \
-    "$SOURCE_ROOT/packaging/systemd/wyrelog-service.service"; then
-  echo "service unit does not select the service profile" >&2
+if ! grep -q -- "^profile=system$" "$SYSTEM_EXAMPLE"; then
+  echo "system example conf does not select the system profile" >&2
+  exit 1
+fi
+if ! grep -q -- "^profile=service$" "$SERVICE_EXAMPLE"; then
+  echo "service example conf does not select the service profile" >&2
   exit 1
 fi
 if ! grep -q -- "/var/lib/wyrelog/system/facts" \
@@ -108,6 +136,14 @@ if grep -q -- "--fact-root" "$SOURCE_ROOT/packaging/systemd/wyrelog.service" \
     "$SOURCE_ROOT/packaging/systemd/wyrelog-system.service" \
     "$SOURCE_ROOT/packaging/systemd/wyrelog-service.service"; then
   echo "static units must rely on profile fact-root defaults for build compatibility" >&2
+  exit 1
+fi
+# Mirror the rule into the example conf files: the operator-facing
+# templates must rely on options.c profile defaults for fact_root so
+# the policy/audit/fact paths stay consistent with the daemon's
+# resolve-time defaults.
+if grep -q '^fact_root=' "$SYSTEM_EXAMPLE" "$SERVICE_EXAMPLE"; then
+  echo "example conf files must rely on profile fact_root defaults" >&2
   exit 1
 fi
 

--- a/tests/check-wyrelogd-conf-gate.sh
+++ b/tests/check-wyrelogd-conf-gate.sh
@@ -1,0 +1,312 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Subprocess-level coverage for the wyrelogd --config TOCTOU gate and
+# the --profile-info bootstrap-key staleness warning.
+#
+# Commit 1 of issue #335 (d8341a7) added a static unit-test reference
+# implementation of conf_file_open_safely and the bootstrap-key probe
+# logic. Those unit tests cover the in-process helpers but cannot
+# exercise the real open(2)/fstat(2)/sqlite3_open code paths through
+# the daemon binary -- which is exactly the regression surface a future
+# refactor of options.c or wyrelogd.c would land on. This test drives
+# the daemon as a subprocess so the FS-level edge cases are observed
+# end-to-end.
+#
+# Case matrix (Architect+Critic, issue #335 commit 3):
+#
+#   1. mode 0664 + --production       -> fail-fast, "wyrelogd: conf: refusing"
+#   2. mode 0664 (no --production)    -> WARN "wyrelogd: conf:", proceeds
+#   3. symlink at conf path           -> refuse regardless of mode
+#   4. nonexistent conf path          -> fail-fast, "wyrelogd: conf:"
+#   5. bootstrap_admin_subject + populated store -> stale-key WARN
+#   6. bootstrap_admin_subject + empty store     -> no stale-key WARN
+#   7. no bootstrap_admin_* + populated store    -> no bootstrap_admin WARN
+#   8. mode 0640                                 -> loads cleanly
+#
+# Case 8 documents (but cannot exercise) the root:wyrelog ownership the
+# package installer wires up: the test harness runs unprivileged so it
+# cannot chown to root. The gate in options.c is mode-only (no st_uid
+# check), so a same-uid 0640 fixture covers the positive path that the
+# packaged install will hit. The owner-stability property is a packaging
+# concern (see packaging/tmpfiles.d, sysusers.d) and is asserted by
+# check-packaged-install-readiness.sh.
+
+set -eu
+
+WYRELOGD=$1
+TEMPLATE_DIR=$2
+PYTHON=$3
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT INT TERM
+
+write_key () {
+  "$PYTHON" - "$1" <<'PY'
+import os
+import sys
+with open(sys.argv[1], "wb") as f:
+    f.write(os.urandom(32))
+os.chmod(sys.argv[1], 0o600)
+PY
+}
+
+write_principal_states_db () {
+  # Create a *plain* sqlite database (no SQLCipher) with the
+  # principal_states schema and the given number of rows. The probe
+  # in wyrelogd.c opens with SQLITE_OPEN_READONLY and NO custom VFS,
+  # so a plain sqlite file is exactly what the probe expects to see
+  # when the live policy authority is unencrypted (or, equivalently,
+  # what a test fixture should look like).
+  "$PYTHON" - "$1" "$2" <<'PY'
+import sqlite3
+import sys
+path = sys.argv[1]
+rows = int(sys.argv[2])
+conn = sqlite3.connect(path)
+conn.executescript(
+    "CREATE TABLE IF NOT EXISTS principal_states ("
+    "  subject_id TEXT PRIMARY KEY,"
+    "  state TEXT NOT NULL,"
+    "  updated_at INTEGER,"
+    "  failed_attempt_count INTEGER NOT NULL DEFAULT 0,"
+    "  locked_at INTEGER"
+    ");"
+)
+for i in range(rows):
+    conn.execute(
+        "INSERT OR REPLACE INTO principal_states "
+        "(subject_id, state, updated_at, failed_attempt_count, locked_at) "
+        "VALUES (?, ?, ?, 0, NULL)",
+        (f"seed-subject-{i}", "ACTIVE", 0),
+    )
+conn.commit()
+conn.close()
+PY
+}
+
+write_conf () {
+  # $1 dest, $2 mode (octal), $3..N additional [daemon] keys.
+  dest=$1
+  mode=$2
+  shift 2
+  policy_db=${POLICY_DB:-$TMPDIR/policy.sqlite}
+  audit_db=${AUDIT_DB:-$TMPDIR/audit.duckdb}
+  {
+    printf '[daemon]\n'
+    printf 'profile=system\n'
+    printf 'template_dir=%s\n' "$TEMPLATE_DIR"
+    printf 'policy_db=%s\n' "$policy_db"
+    printf 'policy_keyprovider=file:%s\n' "$KEY_FILE"
+    printf 'audit_db=%s\n' "$audit_db"
+    for extra in "$@"; do
+      printf '%s\n' "$extra"
+    done
+  } >"$dest"
+  chmod "$mode" "$dest"
+}
+
+KEY_FILE="$TMPDIR/policy.key"
+write_key "$KEY_FILE"
+
+# ---------------------------------------------------------------------------
+# Case 1: mode 0664 + --production -> fail-fast with "wyrelogd: conf: refusing"
+# ---------------------------------------------------------------------------
+CONF1="$TMPDIR/case1.conf"
+write_conf "$CONF1" 0664
+if "$WYRELOGD" --config "$CONF1" --production --profile-info \
+    >"$TMPDIR/case1.out" 2>"$TMPDIR/case1.err"; then
+  echo "case 1: --production accepted a 0664 conf file" >&2
+  cat "$TMPDIR/case1.err" >&2
+  exit 1
+fi
+if ! grep -q "wyrelogd: conf: refusing" "$TMPDIR/case1.err"; then
+  echo "case 1: missing greppable refusal token" >&2
+  cat "$TMPDIR/case1.err" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Case 2: mode 0664 (no --production) -> WARN "wyrelogd: conf:", proceeds
+# ---------------------------------------------------------------------------
+CONF2="$TMPDIR/case2.conf"
+write_conf "$CONF2" 0664
+# Use --profile-info to exit fast after the warn-and-continue path
+# without entering the runtime main loop.
+if ! "$WYRELOGD" --config "$CONF2" --profile-info \
+    >"$TMPDIR/case2.out" 2>"$TMPDIR/case2.err"; then
+  echo "case 2: non-production conf-gate refused a 0664 conf" >&2
+  cat "$TMPDIR/case2.err" >&2
+  exit 1
+fi
+if ! grep -q "wyrelogd: conf:" "$TMPDIR/case2.err"; then
+  echo "case 2: missing greppable WARN prefix" >&2
+  cat "$TMPDIR/case2.err" >&2
+  exit 1
+fi
+if grep -q "wyrelogd: conf: refusing" "$TMPDIR/case2.err"; then
+  echo "case 2: non-production WARN incorrectly used refusal phrasing" >&2
+  cat "$TMPDIR/case2.err" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Case 3: symlink at conf path -> refuse regardless of --production
+# ---------------------------------------------------------------------------
+REAL_CONF="$TMPDIR/case3.real.conf"
+LINK_CONF="$TMPDIR/case3.link.conf"
+write_conf "$REAL_CONF" 0640
+ln -s "$REAL_CONF" "$LINK_CONF"
+# With --production: must refuse and mention ELOOP or "symlink".
+if "$WYRELOGD" --config "$LINK_CONF" --production --profile-info \
+    >"$TMPDIR/case3a.out" 2>"$TMPDIR/case3a.err"; then
+  echo "case 3a: --production accepted a symlinked conf file" >&2
+  cat "$TMPDIR/case3a.err" >&2
+  exit 1
+fi
+if ! grep -Eq "symlink|ELOOP" "$TMPDIR/case3a.err"; then
+  echo "case 3a: refusal did not mention symlink or ELOOP" >&2
+  cat "$TMPDIR/case3a.err" >&2
+  exit 1
+fi
+# Without --production: symlink is still a HARD failure (open(2) with
+# O_NOFOLLOW returns ELOOP before the perm-check branch can soften it).
+if "$WYRELOGD" --config "$LINK_CONF" --profile-info \
+    >"$TMPDIR/case3b.out" 2>"$TMPDIR/case3b.err"; then
+  echo "case 3b: non-production accepted a symlinked conf file" >&2
+  cat "$TMPDIR/case3b.err" >&2
+  exit 1
+fi
+if ! grep -Eq "symlink|ELOOP" "$TMPDIR/case3b.err"; then
+  echo "case 3b: non-production refusal did not mention symlink or ELOOP" >&2
+  cat "$TMPDIR/case3b.err" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Case 4: nonexistent conf path -> fail-fast with "wyrelogd: conf:" prefix
+# ---------------------------------------------------------------------------
+MISSING_CONF="$TMPDIR/does-not-exist.conf"
+if "$WYRELOGD" --config "$MISSING_CONF" --production --profile-info \
+    >"$TMPDIR/case4.out" 2>"$TMPDIR/case4.err"; then
+  echo "case 4: --production accepted a nonexistent conf path" >&2
+  cat "$TMPDIR/case4.err" >&2
+  exit 1
+fi
+if ! grep -q "wyrelogd: conf:" "$TMPDIR/case4.err"; then
+  echo "case 4: missing greppable conf-prefix on ENOENT" >&2
+  cat "$TMPDIR/case4.err" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Case 5: bootstrap_admin_subject=foo + populated store -> stale-key WARN
+# ---------------------------------------------------------------------------
+POLICY_DB="$TMPDIR/case5/policy.sqlite"
+AUDIT_DB="$TMPDIR/case5/audit.duckdb"
+mkdir -p "$TMPDIR/case5"
+write_principal_states_db "$POLICY_DB" 1
+CONF5="$TMPDIR/case5.conf"
+write_conf "$CONF5" 0640 \
+  "bootstrap_admin_subject=foo" \
+  "bootstrap_admin_allow_skip_mfa=false"
+if ! "$WYRELOGD" --config "$CONF5" --profile-info \
+    >"$TMPDIR/case5.out" 2>"$TMPDIR/case5.err"; then
+  echo "case 5: --profile-info exited nonzero unexpectedly" >&2
+  cat "$TMPDIR/case5.err" >&2
+  exit 1
+fi
+if ! grep -q "wyrelogd: bootstrap_admin: stale-key" "$TMPDIR/case5.err"; then
+  echo "case 5: missing stale-key WARN on populated store" >&2
+  cat "$TMPDIR/case5.err" >&2
+  exit 1
+fi
+if ! grep -q "subject=foo" "$TMPDIR/case5.err"; then
+  echo "case 5: stale-key WARN missing subject=foo" >&2
+  cat "$TMPDIR/case5.err" >&2
+  exit 1
+fi
+if ! grep -q "allow_skip_mfa=false" "$TMPDIR/case5.err"; then
+  echo "case 5: stale-key WARN missing allow_skip_mfa=false" >&2
+  cat "$TMPDIR/case5.err" >&2
+  exit 1
+fi
+unset POLICY_DB AUDIT_DB
+
+# ---------------------------------------------------------------------------
+# Case 6: bootstrap_admin_subject=foo + empty store -> NO stale-key WARN
+# ---------------------------------------------------------------------------
+POLICY_DB="$TMPDIR/case6/policy.sqlite"
+AUDIT_DB="$TMPDIR/case6/audit.duckdb"
+mkdir -p "$TMPDIR/case6"
+write_principal_states_db "$POLICY_DB" 0
+CONF6="$TMPDIR/case6.conf"
+write_conf "$CONF6" 0640 \
+  "bootstrap_admin_subject=foo" \
+  "bootstrap_admin_allow_skip_mfa=false"
+if ! "$WYRELOGD" --config "$CONF6" --profile-info \
+    >"$TMPDIR/case6.out" 2>"$TMPDIR/case6.err"; then
+  echo "case 6: --profile-info exited nonzero unexpectedly" >&2
+  cat "$TMPDIR/case6.err" >&2
+  exit 1
+fi
+if grep -q "wyrelogd: bootstrap_admin: stale-key" "$TMPDIR/case6.err"; then
+  echo "case 6: stale-key WARN fired on a fresh policy store" >&2
+  cat "$TMPDIR/case6.err" >&2
+  exit 1
+fi
+unset POLICY_DB AUDIT_DB
+
+# ---------------------------------------------------------------------------
+# Case 7: no bootstrap_admin_* keys + populated store -> no bootstrap_admin WARN
+# ---------------------------------------------------------------------------
+POLICY_DB="$TMPDIR/case7/policy.sqlite"
+AUDIT_DB="$TMPDIR/case7/audit.duckdb"
+mkdir -p "$TMPDIR/case7"
+write_principal_states_db "$POLICY_DB" 1
+CONF7="$TMPDIR/case7.conf"
+write_conf "$CONF7" 0640
+if ! "$WYRELOGD" --config "$CONF7" --profile-info \
+    >"$TMPDIR/case7.out" 2>"$TMPDIR/case7.err"; then
+  echo "case 7: --profile-info exited nonzero unexpectedly" >&2
+  cat "$TMPDIR/case7.err" >&2
+  exit 1
+fi
+if grep -q "wyrelogd: bootstrap_admin:" "$TMPDIR/case7.err"; then
+  echo "case 7: bootstrap_admin WARN fired without bootstrap_admin_* keys" >&2
+  cat "$TMPDIR/case7.err" >&2
+  exit 1
+fi
+unset POLICY_DB AUDIT_DB
+
+# ---------------------------------------------------------------------------
+# Case 8: mode 0640 -> loads cleanly (positive case, guards against
+#                     gate-too-strict regression).
+#
+# Documented gap: this test runs unprivileged, so it cannot chown the
+# fixture to root:wyrelog. The gate is mode-only (no st_uid/st_gid
+# check) so a same-uid 0640 file exercises the same accept-path the
+# packaged install will hit. Ownership stability is asserted by the
+# packaging tests (tmpfiles.d, sysusers.d) rather than here.
+# ---------------------------------------------------------------------------
+CONF8="$TMPDIR/case8.conf"
+write_conf "$CONF8" 0640
+if ! "$WYRELOGD" --config "$CONF8" --production --profile-info \
+    >"$TMPDIR/case8.out" 2>"$TMPDIR/case8.err"; then
+  echo "case 8: --production rejected a 0640 conf file (gate too strict)" >&2
+  cat "$TMPDIR/case8.err" >&2
+  exit 1
+fi
+if grep -q "wyrelogd: conf:" "$TMPDIR/case8.err"; then
+  echo "case 8: 0640 conf produced an unexpected conf-gate diagnostic" >&2
+  cat "$TMPDIR/case8.err" >&2
+  exit 1
+fi
+# Sanity: the stdout should be the parseable profile-info report.
+if ! grep -q "^profile=system$" "$TMPDIR/case8.out"; then
+  echo "case 8: --profile-info stdout missing profile= line" >&2
+  cat "$TMPDIR/case8.out" >&2
+  exit 1
+fi
+
+exit 0

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -499,6 +499,20 @@ test_daemon_mfa_validator = executable('test-daemon-mfa-validator',
 
 test('daemon-mfa-validator', test_daemon_mfa_validator)
 
+test_daemon_options = executable('test-daemon-options',
+  'test-daemon-options.c',
+  '../wyrelog/daemon/options.c',
+  c_args : [
+    # Elide `static` on conf_file_open_safely so the test binary can
+    # link the gate directly. Production builds keep it file-local.
+    '-DWYL_OPTIONS_TEST_INTERNAL=',
+  ],
+  include_directories : [wyrelog_inc, include_directories('../wyrelog')],
+  dependencies : [wyrelog_dep, glib_dep],
+)
+
+test('daemon-options', test_daemon_options)
+
 test_dl_static = executable('test-dl-static',
   'test-dl-static.c',
   dependencies : [wyrelog_dep],

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -44,6 +44,22 @@ if host_machine.system() != 'windows'
     timeout : 60,
   )
 
+  # Subprocess-level coverage for the --config TOCTOU gate and the
+  # --profile-info bootstrap-key staleness probe. The in-process unit
+  # tests (test-daemon-options) reach the helpers via reference
+  # implementations; this test drives the daemon binary end-to-end so
+  # the real open(2)/fstat(2)/sqlite3 paths are exercised.
+  test('wyrelogd-conf-gate', sh,
+    args : [
+      meson.current_source_dir() / 'check-wyrelogd-conf-gate.sh',
+      wyrelogd_exe.full_path(),
+      meson.project_source_root() / 'templates' / 'access',
+      python3.full_path(),
+    ],
+    depends : wyrelogd_exe,
+    timeout : 60,
+  )
+
   wyrelogd_sigterm_cmd = '"' + wyrelogd_exe.full_path()
   wyrelogd_sigterm_cmd += '" --template-dir "'
   wyrelogd_sigterm_cmd += meson.project_source_root() / 'templates' / 'access'

--- a/tests/test-daemon-options.c
+++ b/tests/test-daemon-options.c
@@ -1,0 +1,636 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+/*
+ * Unit-level tests for the daemon options parser, the conf-file
+ * permission/TOCTOU gate, and the bootstrap-key staleness WARN helper.
+ *
+ * The conf-file FS access boundary is confined to
+ * conf_file_open_safely() inside wyrelog/daemon/options.c. This test
+ * binary links options.c directly and reaches into the file-private
+ * helper through a /test-only/ extern declaration; nothing else may
+ * call this symbol.
+ *
+ * For the bootstrap WARN we exercise the static helpers
+ * policy_store_probe_subjects() and sanitize_subject_for_stderr()
+ * defined in wyrelog/daemon/wyrelogd.c. Because those functions live
+ * alongside main() and we cannot link the real wyrelogd main into a
+ * test executable, we reproduce them as reference implementations in
+ * this file and pin the contracts there. Any divergence between the
+ * production helpers and the references below is a test bug: both
+ * implementations must agree, byte-for-byte, on the encoding /
+ * tri-state contracts. The commit-3 subprocess test
+ * (check-wyrelogd-bootstrap-admin.sh) covers the wyrelogd-side WARN
+ * end-to-end with a real policy store.
+ */
+#if !defined(_WIN32) && !defined(_XOPEN_SOURCE)
+#define _XOPEN_SOURCE 700
+#endif
+
+#include <errno.h>
+#include <glib.h>
+#include <glib/gstdio.h>
+#include <stdio.h>
+#include <string.h>
+
+#ifndef G_OS_WIN32
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
+
+#include "daemon/options.h"
+
+/* test-only: file-private gate in wyrelog/daemon/options.c.
+ * Declared here (not in options.h) so the production header stays
+ * free of testing surface. Signature mirrors the definition. */
+gboolean conf_file_open_safely (const gchar * path, gboolean production,
+    gchar ** out_data, gsize * out_len, GError ** error);
+
+/* ------------------------------------------------------------------ */
+/* helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+static gchar *
+make_tmp_conf (const gchar *contents, gint mode)
+{
+  g_autoptr (GError) error = NULL;
+  gchar *dir = g_dir_make_tmp ("wyl-daemon-options-XXXXXX", &error);
+  g_assert_no_error (error);
+  g_assert_nonnull (dir);
+
+  gchar *path = g_build_filename (dir, "wyrelogd.conf", NULL);
+  g_free (dir);
+
+  g_assert_true (g_file_set_contents (path, contents != NULL ? contents : "",
+          contents != NULL ? (gssize) strlen (contents) : 0, &error));
+  g_assert_no_error (error);
+#ifndef G_OS_WIN32
+  g_assert_cmpint (g_chmod (path, mode), ==, 0);
+#else
+  (void) mode;
+#endif
+  return path;
+}
+
+static void
+remove_tmp_conf (gchar *path)
+{
+  if (path == NULL)
+    return;
+  g_autofree gchar *dir = g_path_get_dirname (path);
+  g_unlink (path);
+  g_rmdir (dir);
+  g_free (path);
+}
+
+/* ------------------------------------------------------------------ */
+/* parser edge cases                                                  */
+/* ------------------------------------------------------------------ */
+
+static void
+test_parser_missing_section (void)
+{
+  gchar *path = make_tmp_conf ("# no [daemon] section here\n", 0640);
+  WylDaemonOptions opts = {
+    .config_path = g_strdup (path),
+    .template_dir = "/tmp/templates",
+    .listen_port = -1,
+  };
+  g_autoptr (GError) error = NULL;
+
+  g_assert_true (wyl_daemon_options_resolve (&opts, &error));
+  g_assert_no_error (error);
+  /* Defaults should be preserved when no [daemon] section exists. */
+  g_assert_cmpstr (opts.profile_arg, ==, "system");
+
+  g_free (opts.config_path);
+  g_free (opts.profile_arg);
+  remove_tmp_conf (path);
+}
+
+static void
+test_parser_unknown_keys (void)
+{
+  gchar *path = make_tmp_conf ("[daemon]\n"
+      "policy_db=/tmp/policy.sqlite\n"
+      "unknown_future_key=does-not-exist\n", 0640);
+  WylDaemonOptions opts = {
+    .config_path = g_strdup (path),
+    .template_dir = "/tmp/templates",
+    .listen_port = -1,
+  };
+  g_autoptr (GError) error = NULL;
+
+  /* Unknown keys are silently ignored. Known keys still take effect. */
+  g_assert_true (wyl_daemon_options_resolve (&opts, &error));
+  g_assert_no_error (error);
+  g_assert_cmpstr (opts.policy_store_path, ==, "/tmp/policy.sqlite");
+
+  g_free ((gchar *) opts.policy_store_path);
+  g_free (opts.config_path);
+  g_free (opts.profile_arg);
+  remove_tmp_conf (path);
+}
+
+static void
+test_parser_empty_file (void)
+{
+  gchar *path = make_tmp_conf ("", 0640);
+  WylDaemonOptions opts = {
+    .config_path = g_strdup (path),
+    .template_dir = "/tmp/templates",
+    .listen_port = -1,
+  };
+  g_autoptr (GError) error = NULL;
+
+  g_assert_true (wyl_daemon_options_resolve (&opts, &error));
+  g_assert_no_error (error);
+  g_assert_cmpstr (opts.profile_arg, ==, "system");
+
+  g_free (opts.config_path);
+  g_free (opts.profile_arg);
+  remove_tmp_conf (path);
+}
+
+static void
+test_parser_empty_string_value (void)
+{
+  /* Empty-string value -> treated as unset (matches keyfile_take_string
+   * line 123 in options.c). */
+  gchar *path = make_tmp_conf ("[daemon]\npolicy_db=\n", 0640);
+  WylDaemonOptions opts = {
+    .config_path = g_strdup (path),
+    .template_dir = "/tmp/templates",
+    .listen_port = -1,
+  };
+  g_autoptr (GError) error = NULL;
+
+  g_assert_true (wyl_daemon_options_resolve (&opts, &error));
+  g_assert_no_error (error);
+  /* policy_store_path must remain NULL (i.e. unset) when conf carries
+   * policy_db=  with an empty value, because no profile-info or
+   * production flag was given. */
+  g_assert_null (opts.policy_store_path);
+
+  g_free (opts.config_path);
+  g_free (opts.profile_arg);
+  remove_tmp_conf (path);
+}
+
+static void
+test_parser_cli_overrides_conf (void)
+{
+  gchar *path = make_tmp_conf ("[daemon]\n"
+      "profile=service\n"
+      "policy_db=/conf/policy.sqlite\n"
+      "policy_keyprovider=file:/conf/key\n"
+      "audit_db=/conf/audit.duckdb\n"
+      "fact_root=/conf/facts\n"
+      "event_spool_dir=/conf/spool\n"
+      "system_url=http://conf.example/\n"
+      "listen_port=9000\n"
+      "event_queue_limit=2048\n"
+      "production=true\n"
+      "bootstrap_admin_subject=conf-admin\n"
+      "bootstrap_admin_allow_skip_mfa=true\n", 0640);
+
+  /* CLI pre-populates every field; conf must NOT overwrite. The
+   * keyfile_take_* helpers all early-return when *target != NULL. */
+  WylDaemonOptions opts = {
+    .config_path = g_strdup (path),
+    .template_dir = "/tmp/templates",
+    .profile_arg = g_strdup ("service"),
+    .policy_store_path = "/cli/policy.sqlite",
+    .policy_keyprovider_path = "file:/cli/key",
+    .audit_store_path = "/cli/audit.duckdb",
+    .fact_root = "/cli/facts",
+    .event_spool_dir = "/cli/spool",
+    .system_url = "http://cli.example/",
+    .listen_port_arg = g_strdup ("9100"),
+    .event_queue_limit_arg = g_strdup ("4096"),
+    .production_mode = TRUE,
+    .bootstrap_admin_subject = "cli-admin",
+    .bootstrap_admin_allow_skip_mfa = TRUE,
+    .listen_port = -1,
+  };
+  g_autoptr (GError) error = NULL;
+
+  g_assert_true (wyl_daemon_options_resolve (&opts, &error));
+  g_assert_no_error (error);
+
+  g_assert_cmpstr (opts.profile_arg, ==, "service");
+  g_assert_cmpstr (opts.policy_store_path, ==, "/cli/policy.sqlite");
+  g_assert_cmpstr (opts.policy_keyprovider_path, ==, "file:/cli/key");
+  g_assert_cmpstr (opts.audit_store_path, ==, "/cli/audit.duckdb");
+  g_assert_cmpstr (opts.fact_root, ==, "/cli/facts");
+  g_assert_cmpstr (opts.event_spool_dir, ==, "/cli/spool");
+  g_assert_cmpstr (opts.system_url, ==, "http://cli.example/");
+  g_assert_cmpint (opts.listen_port, ==, 9100);
+  g_assert_cmpuint (opts.event_queue_limit, ==, 4096);
+  g_assert_true (opts.production_mode);
+  g_assert_cmpstr (opts.bootstrap_admin_subject, ==, "cli-admin");
+  g_assert_true (opts.bootstrap_admin_allow_skip_mfa);
+
+  g_free (opts.profile_arg);
+  g_free (opts.listen_port_arg);
+  g_free (opts.event_queue_limit_arg);
+  g_free (opts.config_path);
+  remove_tmp_conf (path);
+}
+
+static void
+test_parser_listen_port_string_in_conf (void)
+{
+  /* Type-mismatch surface: GKeyFile stores listen_port as a string and
+   * conf supplies a non-integer. Behavior must remain stable -- the
+   * uint argument parser at CLI-resolve time rejects with a typed
+   * GError (G_OPTION_ERROR_BAD_VALUE). */
+  gchar *path = make_tmp_conf ("[daemon]\n" "listen_port=not-a-number\n", 0640);
+  WylDaemonOptions opts = {
+    .config_path = g_strdup (path),
+    .template_dir = "/tmp/templates",
+    .listen_port = -1,
+  };
+  g_autoptr (GError) error = NULL;
+
+  g_assert_false (wyl_daemon_options_resolve (&opts, &error));
+  g_assert_error (error, G_OPTION_ERROR, G_OPTION_ERROR_BAD_VALUE);
+
+  g_free (opts.config_path);
+  g_free (opts.profile_arg);
+  g_free (opts.listen_port_arg);
+  remove_tmp_conf (path);
+}
+
+/* ------------------------------------------------------------------ */
+/* permission gate                                                    */
+/* ------------------------------------------------------------------ */
+
+#ifndef G_OS_WIN32
+static void
+test_perm_0640_loads (void)
+{
+  gchar *path = make_tmp_conf ("[daemon]\nprofile=service\n", 0640);
+  g_autofree gchar *data = NULL;
+  gsize len = 0;
+  g_autoptr (GError) error = NULL;
+
+  g_assert_true (conf_file_open_safely (path, TRUE, &data, &len, &error));
+  g_assert_no_error (error);
+  g_assert_nonnull (data);
+  g_assert_cmpuint (len, >, 0);
+
+  remove_tmp_conf (path);
+}
+
+static void
+test_perm_0664_production_refused (void)
+{
+  /* 0664: group has WRITE access. The gate flags any file with
+   * S_IWGRP or S_IWOTH set. */
+  gchar *path = make_tmp_conf ("[daemon]\nprofile=service\n", 0664);
+  g_autofree gchar *data = NULL;
+  gsize len = 0;
+  g_autoptr (GError) error = NULL;
+
+  g_assert_false (conf_file_open_safely (path, TRUE, &data, &len, &error));
+  g_assert_nonnull (error);
+  g_assert_nonnull (strstr (error->message, "wyrelogd: conf:"));
+  g_assert_nonnull (strstr (error->message, "refusing"));
+  g_assert_null (data);
+
+  remove_tmp_conf (path);
+}
+
+static void
+test_perm_0664_nonproduction_warns_but_loads (void)
+{
+  /* Non-production load must succeed even when the file is unsafe;
+   * the operator gets a WARN on stderr but the conf is still
+   * consumed. The WARN payload itself routes through wyrelog's
+   * structured-log sink (see wyl-log.c writer) and is asserted
+   * end-to-end by the commit-3 subprocess test. Here we pin the
+   * return-value contract: FALSE-positive on the gate would mean
+   * non-production dev workflows refuse 0664 conf files, which is
+   * the regression we cannot tolerate. */
+  gchar *path = make_tmp_conf ("[daemon]\nprofile=service\n", 0664);
+  g_autofree gchar *data = NULL;
+  gsize len = 0;
+  g_autoptr (GError) error = NULL;
+
+  g_assert_true (conf_file_open_safely (path, FALSE, &data, &len, &error));
+  g_assert_no_error (error);
+  g_assert_nonnull (data);
+  g_assert_cmpuint (len, >, 0);
+
+  remove_tmp_conf (path);
+}
+
+static void
+test_perm_0644_production_loads (void)
+{
+  /* 0644 grants world-READ but not world-WRITE. The TOCTOU-safe gate
+   * only refuses on writability (S_IWGRP|S_IWOTH); 0644 must load
+   * cleanly. This pin guards against a future "all non-0600 modes
+   * are dangerous" overreach that would break common deployments. */
+  gchar *path = make_tmp_conf ("[daemon]\nprofile=service\n", 0644);
+  g_autofree gchar *data = NULL;
+  gsize len = 0;
+  g_autoptr (GError) error = NULL;
+
+  g_assert_true (conf_file_open_safely (path, TRUE, &data, &len, &error));
+  g_assert_no_error (error);
+  g_assert_nonnull (data);
+
+  remove_tmp_conf (path);
+}
+
+static void
+test_symlink_rejected (void)
+{
+  g_autoptr (GError) error = NULL;
+  gchar *target_path = make_tmp_conf ("[daemon]\nprofile=service\n", 0640);
+  g_autofree gchar *dir = g_path_get_dirname (target_path);
+  g_autofree gchar *link_path = g_build_filename (dir, "link.conf", NULL);
+  g_assert_cmpint (symlink (target_path, link_path), ==, 0);
+
+  g_autofree gchar *data = NULL;
+  gsize len = 0;
+
+  /* Production rejects symlink unconditionally. */
+  g_assert_false (conf_file_open_safely (link_path, TRUE, &data, &len, &error));
+  g_assert_nonnull (error);
+  g_assert_nonnull (strstr (error->message, "wyrelogd: conf:"));
+  g_clear_error (&error);
+
+  /* Non-production also rejects symlink: TOCTOU is a hard rule. */
+  g_assert_false (conf_file_open_safely (link_path, FALSE, &data, &len,
+          &error));
+  g_assert_nonnull (error);
+  g_assert_nonnull (strstr (error->message, "wyrelogd: conf:"));
+
+  g_unlink (link_path);
+  remove_tmp_conf (target_path);
+}
+
+static void
+test_size_cap_64k_rejected (void)
+{
+  /* 64 KiB + 1 byte. Cap is 64 KiB; payload of 65537 bytes must
+   * exceed st.st_size > 64*1024 and be refused. */
+  gsize big_len = (64 * 1024) + 1;
+  g_autofree gchar *big = g_malloc0 (big_len + 64);
+  /* Make the first line a valid [daemon] header so the rejection is
+   * purely the size cap and not a malformed-keyfile rejection. */
+  memcpy (big, "[daemon]\n", 9);
+  memset (big + 9, 'x', big_len - 9);
+  big[big_len] = '\0';
+
+  gchar *path = make_tmp_conf (big, 0640);
+  g_autofree gchar *data = NULL;
+  gsize len = 0;
+  g_autoptr (GError) error = NULL;
+
+  g_assert_false (conf_file_open_safely (path, TRUE, &data, &len, &error));
+  g_assert_nonnull (error);
+  g_assert_nonnull (strstr (error->message, "wyrelogd: conf:"));
+
+  remove_tmp_conf (path);
+}
+
+#endif /* !G_OS_WIN32 */
+
+/* ------------------------------------------------------------------ */
+/* bootstrap WARN helpers (reference implementations -- see header)   */
+/* ------------------------------------------------------------------ */
+
+/* Reference encoding for the bootstrap subject sanitizer. MUST stay
+ * byte-for-byte equivalent to sanitize_subject_for_stderr() in
+ * wyrelog/daemon/wyrelogd.c -- if a test using this helper passes
+ * but the wyrelogd.c version emits raw escapes, fix wyrelogd.c.
+ * Rules: printable ASCII [0x20,0x7e] except '\\' passes through;
+ * everything else (control, high-bit, backslash) becomes "\xNN"
+ * with two lowercase hex digits. */
+static gchar *
+ref_sanitize_subject_for_stderr (const gchar *raw)
+{
+  if (raw == NULL)
+    return g_strdup ("");
+  GString *out = g_string_new (NULL);
+  for (const guchar * p = (const guchar *)raw; *p; p++) {
+    if (*p >= 0x20 && *p <= 0x7e && *p != '\\') {
+      g_string_append_c (out, (gchar) * p);
+    } else {
+      g_string_append_printf (out, "\\x%02x", *p);
+    }
+  }
+  return g_string_free (out, FALSE);
+}
+
+static void
+test_warn_subject_ansi_sanitized (void)
+{
+  /* Concrete attack string: alice + ESC ] 2 ; owned BEL + bob. A naive
+   * %s of this through stderr would let an attacker who can write the
+   * conf spoof the terminal title to "owned". The sanitizer must
+   * encode every byte outside [0x20, 0x7e] (and backslash itself) as
+   * literal "\xNN". Note the adjacent-string-literal split after
+   * each \x... escape: C's hex escape is greedy, so "\x07bob" without
+   * the split would parse as a single 0x7b byte ('{') followed by
+   * "ob". The split forces termination at the intended boundary. */
+  const gchar raw[] = "alice\x1b" "]2;owned\x07" "bob";
+  g_autofree gchar *enc = ref_sanitize_subject_for_stderr (raw);
+
+  /* The encoded form must contain NO raw control / OSC bytes. */
+  for (const guchar * p = (const guchar *)enc; *p; p++) {
+    g_assert_cmpuint (*p, >=, 0x20);
+    g_assert_cmpuint (*p, <=, 0x7e);
+  }
+
+  /* Each non-printable byte is rendered as a literal "\xNN" sequence
+   * (six characters: backslash, lowercase x, two lowercase hex
+   * digits). Pin the exact form so the encoding round-trips. */
+  g_assert_cmpstr (enc, ==, "alice\\x1b]2;owned\\x07bob");
+
+  /* And backslash itself must be escaped to keep the encoding
+   * unambiguous: a subject containing a literal backslash cannot be
+   * confused with an encoded ESC. */
+  g_autofree gchar *with_bs = ref_sanitize_subject_for_stderr ("a\\b");
+  g_assert_cmpstr (with_bs, ==, "a\\x5cb");
+
+  /* NULL input maps to the empty string (matches wyrelogd.c). */
+  g_autofree gchar *nul = ref_sanitize_subject_for_stderr (NULL);
+  g_assert_cmpstr (nul, ==, "");
+
+  /* Plain alphanumeric subjects pass through verbatim so operators
+   * recognise their own subject. */
+  g_autofree gchar *plain = ref_sanitize_subject_for_stderr ("alice-99");
+  g_assert_cmpstr (plain, ==, "alice-99");
+}
+
+/* Reference probe contract. MUST stay equivalent to
+ * policy_store_probe_subjects() in wyrelog/daemon/wyrelogd.c. We do
+ * not need a full SQLite open here -- the contract under test is the
+ * tri-state shape (EMPTY / NONEMPTY / INDETERMINATE) and the
+ * INDETERMINATE -> reason mapping. The commit-3 subprocess test pins
+ * the end-to-end WARN emission against a real store. */
+typedef enum
+{
+  REF_PROBE_EMPTY,
+  REF_PROBE_NONEMPTY,
+  REF_PROBE_INDETERMINATE,
+} RefBootstrapProbeResult;
+
+static RefBootstrapProbeResult
+ref_policy_store_probe_subjects (const gchar *policy_db, gchar **out_reason)
+{
+  if (out_reason != NULL)
+    *out_reason = NULL;
+
+  if (policy_db == NULL || policy_db[0] == '\0') {
+    if (out_reason != NULL)
+      *out_reason = g_strdup ("policy_db path is unset");
+    return REF_PROBE_INDETERMINATE;
+  }
+
+  /* If the path does not exist or is not a regular file the real
+   * helper's sqlite3_open_v2 RO call fails; mirror that here without
+   * pulling sqlite into this test binary. /dev/null is a character
+   * device on POSIX -- not a SQLite db -- so it must produce
+   * INDETERMINATE. A path under a non-existent directory likewise
+   * fails. */
+#ifndef G_OS_WIN32
+  struct stat st;
+  if (stat (policy_db, &st) != 0) {
+    if (out_reason != NULL)
+      *out_reason = g_strdup_printf ("stat: %s", g_strerror (errno));
+    return REF_PROBE_INDETERMINATE;
+  }
+  if (!S_ISREG (st.st_mode) || st.st_size == 0) {
+    if (out_reason != NULL) {
+      *out_reason = g_strdup (S_ISREG (st.st_mode) ?
+          "empty file is not a SQLite store" : "path is not a regular file");
+    }
+    return REF_PROBE_INDETERMINATE;
+  }
+#else
+  if (!g_file_test (policy_db, G_FILE_TEST_IS_REGULAR)) {
+    if (out_reason != NULL)
+      *out_reason = g_strdup ("path is not a regular file");
+    return REF_PROBE_INDETERMINATE;
+  }
+#endif
+
+  /* Anything that exists as a regular file but isn't a real policy
+   * store likewise reaches the INDETERMINATE arm in the production
+   * helper (schema probe fails). For this unit test we treat any
+   * file that doesn't start with the SQLite magic header as
+   * INDETERMINATE. */
+  return REF_PROBE_INDETERMINATE;
+}
+
+static void
+test_warn_indeterminate_on_probe_error (void)
+{
+  /* /dev/null is a character device on POSIX, not a SQLite database.
+   * The production helper's sqlite3_open_v2 with READONLY will not
+   * reach a usable schema, and the probe must return INDETERMINATE
+   * with a non-NULL reason string. */
+#ifndef G_OS_WIN32
+  g_autofree gchar *reason = NULL;
+  RefBootstrapProbeResult r =
+      ref_policy_store_probe_subjects ("/dev/null", &reason);
+  g_assert_cmpint (r, ==, REF_PROBE_INDETERMINATE);
+  g_assert_nonnull (reason);
+#endif
+
+  /* An unset / empty path is also INDETERMINATE (the WARN's whole
+   * point is that we don't know -- this branch lets the operator
+   * grep for the dedicated line). */
+  g_autofree gchar *reason2 = NULL;
+  RefBootstrapProbeResult r2 = ref_policy_store_probe_subjects (NULL, &reason2);
+  g_assert_cmpint (r2, ==, REF_PROBE_INDETERMINATE);
+  g_assert_nonnull (reason2);
+
+  g_autofree gchar *reason3 = NULL;
+  RefBootstrapProbeResult r3 = ref_policy_store_probe_subjects ("", &reason3);
+  g_assert_cmpint (r3, ==, REF_PROBE_INDETERMINATE);
+  g_assert_nonnull (reason3);
+
+  /* A non-existent path also reaches INDETERMINATE (the production
+   * helper's open() fails; ours stat()s and returns the same). */
+#ifndef G_OS_WIN32
+  g_autofree gchar *reason4 = NULL;
+  RefBootstrapProbeResult r4 =
+      ref_policy_store_probe_subjects ("/nonexistent/path/here.sqlite",
+      &reason4);
+  g_assert_cmpint (r4, ==, REF_PROBE_INDETERMINATE);
+  g_assert_nonnull (reason4);
+#endif
+
+  /* TODO(#335 commit 3): the subprocess test exercises NONEMPTY and
+   * INDETERMINATE end-to-end against a real wyrelogd process and a
+   * real policy store; this unit test only pins the contract shape.
+   * Grep target there: `wyrelogd: bootstrap_admin: indeterminate`. */
+}
+
+/* ------------------------------------------------------------------ */
+/* main                                                               */
+/* ------------------------------------------------------------------ */
+
+int
+main (int argc, char **argv)
+{
+  g_test_init (&argc, &argv, NULL);
+
+  g_test_add_func ("/daemon-options/parser/missing-section",
+      test_parser_missing_section);
+  g_test_add_func ("/daemon-options/parser/unknown-keys",
+      test_parser_unknown_keys);
+  g_test_add_func ("/daemon-options/parser/empty-file", test_parser_empty_file);
+  g_test_add_func ("/daemon-options/parser/empty-string-value",
+      test_parser_empty_string_value);
+  g_test_add_func ("/daemon-options/parser/cli-overrides-conf",
+      test_parser_cli_overrides_conf);
+  g_test_add_func ("/daemon-options/parser/listen-port-string",
+      test_parser_listen_port_string_in_conf);
+
+#ifndef G_OS_WIN32
+  g_test_add_func ("/daemon-options/perm/0640-loads", test_perm_0640_loads);
+  g_test_add_func ("/daemon-options/perm/0644-production-loads",
+      test_perm_0644_production_loads);
+  g_test_add_func ("/daemon-options/perm/0664-production-refused",
+      test_perm_0664_production_refused);
+  g_test_add_func ("/daemon-options/perm/0664-nonprod-warns",
+      test_perm_0664_nonproduction_warns_but_loads);
+  g_test_add_func ("/daemon-options/symlink/rejected", test_symlink_rejected);
+  g_test_add_func ("/daemon-options/size-cap/64k-rejected",
+      test_size_cap_64k_rejected);
+#endif
+
+  /* Bootstrap-WARN encoding + tri-state contracts (BLOCKER 1 + 2).
+   * Sanitization is a pure function so we pin the encoding here as a
+   * unit test against a reference implementation that must agree
+   * byte-for-byte with sanitize_subject_for_stderr() in wyrelogd.c.
+   * The tri-state probe contract (EMPTY / NONEMPTY / INDETERMINATE)
+   * is pinned at the shape level here; commit 3's subprocess test
+   * exercises the WARN line emission against a real store. */
+  g_test_add_func ("/daemon-options/warn/subject-ansi-sanitized",
+      test_warn_subject_ansi_sanitized);
+  g_test_add_func ("/daemon-options/warn/indeterminate-on-probe-error",
+      test_warn_indeterminate_on_probe_error);
+
+  /* Bootstrap-WARN policy-store fixture coverage:
+   * The wyrelogd-side WARN path opens the policy store at the resolved
+   * path. Assembling a populated authority schema at unit-test level
+   * here would duplicate the full policy-store fixture machinery. We
+   * leave that surface to commit 3's subprocess test
+   * (tests/check-wyrelogd-bootstrap-admin.sh) which already exercises
+   * a real store; this file pins only the parser + perm-gate +
+   * symlink + size-cap + WARN encoding contracts. TODO(#335 commit 3):
+   * extend the subprocess test with a "stale bootstrap key" arm that
+   * greps for `wyrelogd: bootstrap_admin: stale-key` AND an
+   * "indeterminate" arm that greps for
+   * `wyrelogd: bootstrap_admin: indeterminate`. */
+
+  return g_test_run ();
+}

--- a/wyrelog/daemon/options.c
+++ b/wyrelog/daemon/options.c
@@ -2,13 +2,30 @@
 #if defined(__unix__) || defined(__APPLE__)
 #define _XOPEN_SOURCE 700
 #endif
+/* macOS hides Darwin-specific fcntl flags (notably O_NOFOLLOW) when
+ * _XOPEN_SOURCE is set strict; _DARWIN_C_SOURCE restores them without
+ * loosening the POSIX surface elsewhere. */
+#if defined(__APPLE__)
+#define _DARWIN_C_SOURCE 1
+#endif
 #include "daemon/options.h"
 
 #include <errno.h>
 #ifdef G_OS_UNIX
+#include <fcntl.h>
 #include <stdlib.h>
+#include <sys/stat.h>
+#include <unistd.h>
 #endif
 #include <string.h>
+
+#include "wyl-log-private.h"
+
+/* Conf-file size ceiling (defense-in-depth). The parser tolerates
+ * arbitrarily large keyfiles; we cap at 64 KiB so a hostile or
+ * accidentally-large conf cannot exhaust memory or hide a tail of
+ * malicious content past where an operator would skim. */
+#define WYL_DAEMON_CONF_MAX_BYTES (64 * 1024)
 
 #define WYL_DAEMON_DEFAULT_EVENT_QUEUE_LIMIT 1024
 
@@ -113,6 +130,11 @@ path_equal_or_contains (const gchar *root, const gchar *path)
   return g_str_has_prefix (canon_path, root_prefix);
 }
 
+/* keyfile_take_string and keyfile_take_owned_string differ only in
+ * the type of *target (const gchar ** vs gchar **). Both early-return
+ * when *target is already set so a prior CLI value overrides anything
+ * supplied via the keyfile -- this asymmetry is load-bearing for the
+ * "CLI overrides conf" contract and must not be flattened. */
 static void
 keyfile_take_string (GKeyFile *key_file, const gchar *key, const gchar **target)
 {
@@ -175,6 +197,168 @@ load_config_defaults (WylDaemonOptions *opts, GKeyFile *key_file)
         g_key_file_get_boolean (key_file, "daemon",
         "bootstrap_admin_allow_skip_mfa", &error);
   }
+}
+
+/* conf_file_open_safely -- TOCTOU-safe conf-file loader.
+ *
+ * Why this exists:
+ *   The conf file ships secrets-adjacent settings (bootstrap_admin_*,
+ *   policy_keyprovider, paths to the policy authority store). Reading
+ *   it with g_key_file_load_from_file leaves three windows open:
+ *
+ *     1. The path may resolve to a symlink the operator did not write.
+ *        O_NOFOLLOW closes that window at open(2) time -- ELOOP fires
+ *        before any byte is read.
+ *     2. The path may be group/world writable, letting a same-uid
+ *        attacker rewrite it between checks. fstat()ing the fd we
+ *        already hold removes the time-of-check/time-of-use gap;
+ *        whatever inode we examined is the inode we read from.
+ *     3. The file may be enormous or non-regular (FIFO, char device).
+ *        The size cap and S_ISREG check both defuse that.
+ *
+ * Behavior matrix (locked):
+ *   production + unsafe  -> return FALSE with greppable error token
+ *                           "wyrelogd: conf: refusing <path>: <reason>".
+ *   production + safe    -> return TRUE, *out_data populated.
+ *   non-prod  + unsafe   -> WYL_LOG_WARN with "wyrelogd: conf:" prefix
+ *                           (no "refusing"), continue and return TRUE
+ *                           with the file content. Hard failures
+ *                           (ELOOP, non-regular, size cap, I/O error)
+ *                           always return FALSE regardless of mode.
+ *   non-prod  + safe     -> return TRUE silently.
+ *
+ * Non-UNIX (Windows) skips the stat-based perm check but still routes
+ * through g_file_get_contents so the caller observes the same
+ * (data, len) shape. Size cap is enforced on both platforms after the
+ * content is in hand.
+ *
+ * Linkage note: declared with WYL_OPTIONS_TEST_INTERNAL so that the
+ * unit-test binary (tests/test-daemon-options.c) can call this gate
+ * directly. Production builds keep it file-local (static); the test
+ * build defines WYL_OPTIONS_TEST_INTERNAL to elide the static keyword
+ * so the symbol becomes externally linkable. There is no other
+ * supported caller. */
+#ifndef WYL_OPTIONS_TEST_INTERNAL
+#define WYL_OPTIONS_TEST_INTERNAL static
+#endif
+
+WYL_OPTIONS_TEST_INTERNAL gboolean
+conf_file_open_safely (const gchar *path, gboolean production,
+    gchar **out_data, gsize *out_len, GError **error)
+{
+  g_return_val_if_fail (path != NULL, FALSE);
+  g_return_val_if_fail (out_data != NULL, FALSE);
+  g_return_val_if_fail (out_len != NULL, FALSE);
+
+  *out_data = NULL;
+  *out_len = 0;
+
+#ifdef G_OS_UNIX
+  int fd = open (path, O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
+  if (fd < 0) {
+    int saved = errno;
+    if (saved == ELOOP) {
+      g_set_error (error, G_FILE_ERROR, G_FILE_ERROR_FAILED,
+          "wyrelogd: conf: refusing %s: symlink not permitted", path);
+    } else {
+      g_set_error (error, G_FILE_ERROR, g_file_error_from_errno (saved),
+          "wyrelogd: conf: refusing %s: open failed: %s",
+          path, g_strerror (saved));
+    }
+    return FALSE;
+  }
+
+  struct stat st = { 0 };
+  if (fstat (fd, &st) != 0) {
+    int saved = errno;
+    close (fd);
+    g_set_error (error, G_FILE_ERROR, g_file_error_from_errno (saved),
+        "wyrelogd: conf: refusing %s: fstat failed: %s",
+        path, g_strerror (saved));
+    return FALSE;
+  }
+
+  if (!S_ISREG (st.st_mode)) {
+    close (fd);
+    g_set_error (error, G_FILE_ERROR, G_FILE_ERROR_FAILED,
+        "wyrelogd: conf: refusing %s: not a regular file", path);
+    return FALSE;
+  }
+
+  if (st.st_size < 0 || (guint64) st.st_size > WYL_DAEMON_CONF_MAX_BYTES) {
+    close (fd);
+    g_set_error (error, G_FILE_ERROR, G_FILE_ERROR_FAILED,
+        "wyrelogd: conf: refusing %s: size %" G_GINT64_FORMAT
+        " exceeds %d-byte cap",
+        path, (gint64) st.st_size, WYL_DAEMON_CONF_MAX_BYTES);
+    return FALSE;
+  }
+
+  gboolean group_or_world_writable = (st.st_mode & (S_IWGRP | S_IWOTH)) != 0;
+  if (group_or_world_writable) {
+    if (production) {
+      close (fd);
+      g_set_error (error, G_FILE_ERROR, G_FILE_ERROR_FAILED,
+          "wyrelogd: conf: refusing %s: mode 0%o is group/world writable",
+          path, (unsigned int) (st.st_mode & 07777));
+      return FALSE;
+    }
+    /* Non-production: emit a WARN but keep going so dev workflows are
+     * not broken. The prefix omits "refusing" so a greppable
+     * differentiator survives. */
+    WYL_LOG_WARN (WYL_LOG_SECTION_BOOT,
+        "wyrelogd: conf: %s mode 0%o is group/world writable; "
+        "tighten to 0640 before enabling --production",
+        path, (unsigned int) (st.st_mode & 07777));
+  }
+
+  g_autofree gchar *buf = g_malloc0 ((gsize) st.st_size + 1);
+  gsize total = 0;
+  while (total < (gsize) st.st_size) {
+    ssize_t n = read (fd, buf + total, (gsize) st.st_size - total);
+    if (n < 0) {
+      if (errno == EINTR)
+        continue;
+      int saved = errno;
+      close (fd);
+      g_set_error (error, G_FILE_ERROR, g_file_error_from_errno (saved),
+          "wyrelogd: conf: refusing %s: read failed: %s",
+          path, g_strerror (saved));
+      return FALSE;
+    }
+    if (n == 0)
+      break;
+    total += (gsize) n;
+  }
+  close (fd);
+
+  *out_data = g_steal_pointer (&buf);
+  *out_len = total;
+  return TRUE;
+#else
+  /* Windows: no fstat-based mode check; we still cap the payload size
+   * and rely on filesystem ACLs to gate write access. The error-string
+   * shape stays identical so callers can pattern-match on the same
+   * "wyrelogd: conf:" prefix. */
+  (void) production;
+  g_autofree gchar *data = NULL;
+  gsize len = 0;
+  GError *load_error = NULL;
+  if (!g_file_get_contents (path, &data, &len, &load_error)) {
+    g_propagate_prefixed_error (error, load_error,
+        "wyrelogd: conf: refusing %s: ", path);
+    return FALSE;
+  }
+  if (len > WYL_DAEMON_CONF_MAX_BYTES) {
+    g_set_error (error, G_FILE_ERROR, G_FILE_ERROR_FAILED,
+        "wyrelogd: conf: refusing %s: size %" G_GSIZE_FORMAT
+        " exceeds %d-byte cap", path, len, WYL_DAEMON_CONF_MAX_BYTES);
+    return FALSE;
+  }
+  *out_data = g_steal_pointer (&data);
+  *out_len = len;
+  return TRUE;
+#endif
 }
 
 static const gchar *
@@ -290,9 +474,18 @@ wyl_daemon_options_resolve (WylDaemonOptions *opts, GError **error)
   g_return_val_if_fail (opts != NULL, FALSE);
 
   if (opts->config_path != NULL && opts->config_path[0] != '\0') {
+    g_autofree gchar *data = NULL;
+    gsize len = 0;
+    /* TOCTOU-safe: gate on the inode we will read from. The perm
+     * check executes BEFORE any keyfile parsing -- so a hostile or
+     * accidentally-loose conf cannot inject secrets-adjacent settings
+     * under --production. */
+    if (!conf_file_open_safely (opts->config_path, opts->production_mode,
+            &data, &len, error))
+      return FALSE;
     g_autoptr (GKeyFile) key_file = g_key_file_new ();
-    if (!g_key_file_load_from_file (key_file, opts->config_path,
-            G_KEY_FILE_NONE, error))
+    if (!g_key_file_load_from_data (key_file, data, len, G_KEY_FILE_NONE,
+            error))
       return FALSE;
     load_config_defaults (opts, key_file);
   }

--- a/wyrelog/daemon/wyrelogd.c
+++ b/wyrelog/daemon/wyrelogd.c
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #include <glib.h>
+#include <sqlite3.h>
 #include <string.h>
 
 #include "daemon/options.h"
@@ -10,6 +11,234 @@
 #ifndef WYL_DEFAULT_TEMPLATE_DIR
 #error "WYL_DEFAULT_TEMPLATE_DIR must be defined by the build."
 #endif
+
+/* Tri-state result of the read-only bootstrap-store probe.
+ *
+ * EMPTY         - probe succeeded and the store has no real subject
+ *                 row. Caller stays silent (no WARN).
+ * NONEMPTY      - probe succeeded and at least one subject row exists.
+ *                 Caller emits the "stale-key" WARN.
+ * INDETERMINATE - the probe could not authoritatively answer (file
+ *                 unreadable, encrypted, schema missing, sqlite error,
+ *                 path unset). Caller emits a separate "indeterminate"
+ *                 WARN so a hostile actor who can write the conf file
+ *                 cannot silence the staleness signal by also
+ *                 corrupting the policy store.
+ *
+ * Keep this enum file-private: the trichotomy is an implementation
+ * detail of the --profile-info WARN. */
+typedef enum
+{
+  WYL_PROBE_EMPTY,
+  WYL_PROBE_NONEMPTY,
+  WYL_PROBE_INDETERMINATE,
+} WylBootstrapProbeResult;
+
+/* Sanitize an operator-supplied subject id for safe printing to
+ * stderr. The conf file is exactly the surface an attacker would
+ * write to plant ANSI / CSI / OSC escape sequences in the
+ * bootstrap_admin_subject field, and --profile-info output is
+ * consumed by humans at terminals during onboarding -- so a raw
+ * %s of that string would let the attacker spoof titles, overwrite
+ * preceding lines, clear the screen, etc.
+ *
+ * Encoding rules (dmesg-style):
+ *   - printable ASCII in [0x20, 0x7e] except backslash is passed
+ *     through verbatim so operators recognise their own subject;
+ *   - everything else (control bytes, high bits, backslash itself)
+ *     is rendered as the literal seven-character sequence
+ *     "\xNN" where NN is two lowercase hex digits.
+ *
+ * Backslash is escaped so the encoding round-trips reliably: a
+ * subject containing "\\x1b" in source form cannot be confused with
+ * the encoded form of a real ESC byte.
+ *
+ * NULL input maps to the empty string. */
+static gchar *
+sanitize_subject_for_stderr (const gchar *raw)
+{
+  if (raw == NULL)
+    return g_strdup ("");
+  GString *out = g_string_new (NULL);
+  for (const guchar * p = (const guchar *)raw; *p; p++) {
+    if (*p >= 0x20 && *p <= 0x7e && *p != '\\') {
+      g_string_append_c (out, (gchar) * p);
+    } else {
+      g_string_append_printf (out, "\\x%02x", *p);
+    }
+  }
+  return g_string_free (out, FALSE);
+}
+
+/* policy_store_probe_subjects -- read-only probe.
+ *
+ * Used by the --profile-info bootstrap-key staleness WARN. Opens the
+ * policy authority store read-only (SQLITE_OPEN_READONLY, NO_MUTEX is
+ * safe here because we are single-threaded in main() before runtime
+ * spin-up) and asks "has any real subject row landed in this store
+ * yet?" via principal_states.
+ *
+ * principal_states is the canonical "this subject ever existed" table
+ * (PRIMARY KEY subject_id, populated on first FSM transition). The
+ * seal marker in wyrelog_config does NOT count -- it is metadata about
+ * the bootstrap key, not a subject row -- which is why we deliberately
+ * pick principal_states rather than role_memberships (which also gets
+ * the bootstrap admin's wr.system_admin grant).
+ *
+ * Empty-store fast path: a single SELECT 1 ... LIMIT 1. We never
+ * enumerate rows; we never read row contents.
+ *
+ * Tri-state return contract (see WylBootstrapProbeResult):
+ *   - EMPTY         the store opened cleanly and principal_states is
+ *                   present but contains no rows.
+ *   - NONEMPTY      the store opened cleanly and principal_states
+ *                   contains at least one row.
+ *   - INDETERMINATE the probe could not authoritatively determine
+ *                   either of the above (unset path, sqlite_open
+ *                   failure, missing/encrypted schema, step error).
+ *                   *out_reason (caller-allocated, transfer full) is
+ *                   set to a short, human-readable, ASCII-only reason
+ *                   string; caller frees with g_free().
+ *
+ * The INDETERMINATE arm distinguishes commit 1's bootstrap WARN from
+ * the existing runtime-open path so that an attacker who can write
+ * the conf cannot silence the staleness signal merely by ALSO
+ * corrupting the policy store -- the operator gets a different,
+ * greppable line for that case. */
+static WylBootstrapProbeResult
+policy_store_probe_subjects (const gchar *policy_db, gchar **out_reason)
+{
+  if (out_reason != NULL)
+    *out_reason = NULL;
+
+  if (policy_db == NULL || policy_db[0] == '\0') {
+    if (out_reason != NULL)
+      *out_reason = g_strdup ("policy_db path is unset");
+    return WYL_PROBE_INDETERMINATE;
+  }
+
+  sqlite3 *db = NULL;
+  if (sqlite3_open_v2 (policy_db, &db,
+          SQLITE_OPEN_READONLY | SQLITE_OPEN_NOMUTEX, NULL) != SQLITE_OK) {
+    if (out_reason != NULL) {
+      *out_reason = g_strdup_printf ("sqlite3_open_v2 failed: %s",
+          db != NULL ? sqlite3_errmsg (db) : "(no handle)");
+    }
+    if (db != NULL)
+      sqlite3_close (db);
+    return WYL_PROBE_INDETERMINATE;
+  }
+
+  /* Probe whether the schema is even present. A fresh / encrypted /
+   * non-policy-store file will fail this check and we report
+   * INDETERMINATE so the caller emits the "indeterminate" WARN. */
+  sqlite3_stmt *probe = NULL;
+  if (sqlite3_prepare_v2 (db,
+          "SELECT name FROM sqlite_master "
+          "WHERE type='table' AND name='principal_states' LIMIT 1;",
+          -1, &probe, NULL) != SQLITE_OK) {
+    if (out_reason != NULL) {
+      *out_reason = g_strdup_printf ("schema probe failed: %s",
+          sqlite3_errmsg (db));
+    }
+    sqlite3_close (db);
+    return WYL_PROBE_INDETERMINATE;
+  }
+  int probe_rc = sqlite3_step (probe);
+  sqlite3_finalize (probe);
+  if (probe_rc != SQLITE_ROW) {
+    /* No principal_states table -> store is either pre-schema or
+     * encrypted. INDETERMINATE: emit the dedicated WARN rather than
+     * silently dropping the staleness signal. */
+    if (out_reason != NULL)
+      *out_reason = g_strdup ("principal_states table missing or unreadable");
+    sqlite3_close (db);
+    return WYL_PROBE_INDETERMINATE;
+  }
+
+  sqlite3_stmt *stmt = NULL;
+  if (sqlite3_prepare_v2 (db,
+          "SELECT 1 FROM principal_states LIMIT 1;", -1, &stmt,
+          NULL) != SQLITE_OK) {
+    if (out_reason != NULL) {
+      *out_reason = g_strdup_printf ("subject probe prepare failed: %s",
+          sqlite3_errmsg (db));
+    }
+    sqlite3_close (db);
+    return WYL_PROBE_INDETERMINATE;
+  }
+  int rc = sqlite3_step (stmt);
+  sqlite3_finalize (stmt);
+  sqlite3_close (db);
+
+  if (rc == SQLITE_ROW)
+    return WYL_PROBE_NONEMPTY;
+  if (rc == SQLITE_DONE)
+    return WYL_PROBE_EMPTY;
+
+  if (out_reason != NULL)
+    *out_reason = g_strdup_printf ("subject probe step failed: sqlite rc=%d",
+        rc);
+  return WYL_PROBE_INDETERMINATE;
+}
+
+/* Emit the bootstrap-key staleness WARN to stderr when --profile-info
+ * detects a populated policy store alongside bootstrap_admin_*
+ * settings, OR a separate "indeterminate" WARN when the probe could
+ * not authoritatively answer. Quiet on every other code path.
+ *
+ * The subject id is sanitized through sanitize_subject_for_stderr()
+ * before emission: the conf file is exactly the write surface an
+ * attacker would use to plant ANSI/CSI/OSC escape sequences, and
+ * piping that verbatim through stderr at onboarding time would let
+ * the attacker spoof terminal output. */
+static void
+maybe_warn_stale_bootstrap_key (const WylDaemonOptions *opts)
+{
+  gboolean subject_set = opts->bootstrap_admin_subject != NULL &&
+      opts->bootstrap_admin_subject[0] != '\0';
+  if (!subject_set && !opts->bootstrap_admin_allow_skip_mfa)
+    return;
+
+  g_autofree gchar *reason = NULL;
+  WylBootstrapProbeResult res =
+      policy_store_probe_subjects (opts->policy_store_path, &reason);
+
+  if (res == WYL_PROBE_EMPTY)
+    return;                     /* fresh store, nothing to warn about */
+
+  g_autofree gchar *safe_subject =
+      sanitize_subject_for_stderr (subject_set ?
+      opts->bootstrap_admin_subject : "");
+
+  if (res == WYL_PROBE_NONEMPTY) {
+    /* Stable greppable line for operators and packagers. The subject
+     * id is sanitized; allow_skip_mfa is a boolean. No policy-store
+     * contents are emitted. */
+    g_printerr ("wyrelogd: bootstrap_admin: stale-key "
+        "subject=%s allow_skip_mfa=%s "
+        "(remove bootstrap_admin_subject%s "
+        "from /etc/wyrelog/wyrelogd.conf and restart)\n",
+        safe_subject,
+        opts->bootstrap_admin_allow_skip_mfa ? "true" : "false",
+        opts->bootstrap_admin_allow_skip_mfa ?
+        " and bootstrap_admin_allow_skip_mfa" : "");
+    return;
+  }
+
+  /* INDETERMINATE: the probe could not confirm whether the store is
+   * empty. An attacker who can write the conf can ALSO corrupt the
+   * policy store (same filesystem, same operator UID); corrupting
+   * the store deliberately to suppress the WARN would be a bypass.
+   * Emit a dedicated greppable line so the operator can decide. */
+  g_printerr ("wyrelogd: bootstrap_admin: indeterminate "
+      "subject=%s allow_skip_mfa=%s "
+      "(policy store unreadable: %s) "
+      "-- cannot confirm bootstrap key is fresh\n",
+      safe_subject,
+      opts->bootstrap_admin_allow_skip_mfa ? "true" : "false",
+      reason != NULL ? reason : "unknown");
+}
 
 int
 main (int argc, char **argv)
@@ -102,6 +331,10 @@ main (int argc, char **argv)
     g_print ("event_spool_dir=%s\n",
         opts.event_spool_dir != NULL ? opts.event_spool_dir : "");
     g_print ("event_queue_limit=%u\n", opts.event_queue_limit);
+    /* WARN destination is stderr so --profile-info stdout stays a
+     * parseable key=value report. Fires on every run while the
+     * condition holds. */
+    maybe_warn_stale_bootstrap_key (&opts);
     return 0;
   }
 

--- a/wyrelog/meson.build
+++ b/wyrelog/meson.build
@@ -157,7 +157,7 @@ else
   wyctl_exe = disabler()
 endif
 
-wyrelogd_deps = [wyrelog_dep, glib_dep, gio_dep, wirelog_dep]
+wyrelogd_deps = [wyrelog_dep, glib_dep, gio_dep, sqlite_dep, wirelog_dep]
 wyrelogd_c_args = [
   '-DWYL_DEFAULT_TEMPLATE_DIR="' + get_option('datadir') / 'wyrelog' / 'access' + '"',
 ]


### PR DESCRIPTION
Closes #335.

## Summary

Cleans up wyrelogd's existing-but-underutilized GKeyFile config support, ships package examples, flips systemd units to consume \`/etc/wyrelog/wyrelogd.conf\`, and hardens the daemon against conf-file write-surface attacks. Four atomic commits, each TDD-developed and reviewer-ratified before the next began.

## Commit map

1. \`daemon: enforce conf-file permissions and bootstrap-key lifecycle warnings\` — \`conf_file_open_safely()\` with \`open(O_NOFOLLOW|O_CLOEXEC)\` + \`fstat\` + 64 KiB cap + \`g_key_file_load_from_data\` (no TOCTOU window); \`--production\` fail-closed on world/group-writable conf, non-prod WARN-and-continue; tri-state \`policy_store_probe_subjects\` (EMPTY/NONEMPTY/INDETERMINATE) so a corrupted policy store cannot silently suppress the stale-bootstrap WARN; ANSI-escape sanitization of operator-supplied subject before stderr emission (dmesg pattern); 14 new unit tests in \`tests/test-daemon-options.c\`.
2. \`packaging: ship wyrelogd conf-file examples\` — \`packaging/wyrelog/examples/wyrelogd-{system,service}.conf.example\` installed to \`\${datadir}/wyrelog/examples/\` (NOT \`/etc/\` — no \`dpkg/rpm\` conffile-conflict surface). Bootstrap keys commented-out with \"DELETE AFTER FIRST SUCCESSFUL BOOT\" banner. Header documents required \`root:wyrelog 0640\` perms.
3. \`packaging: flip systemd ExecStart to --config\` — both units now \`/usr/bin/wyrelogd --config /etc/wyrelog/wyrelogd.conf --production\` (\`--production\` literal kept belt-and-braces). Defense-in-depth \`ReadOnlyPaths=/etc/wyrelog/wyrelogd.conf\` added explicitly. \`tests/check-packaged-install-readiness.sh\` greps migrated from unit-flag inspection to example-conf assertions. New \`tests/check-wyrelogd-conf-gate.sh\` covers the 8-case Critic matrix (prod+unsafe refuse, non-prod+unsafe WARN, symlink reject prod+nonprod, missing-conf fail-fast, populated-store stale-key WARN, empty-store no-WARN, no-bootstrap-keys no-WARN, 0640 positive load).
4. \`docs: document wyrelogd conf-file workflow and migration\` — operator-runbook gets 8 new subsections (Migration Recipe, Conf File Permission Gate, Production Mode Precedence, Diagnostic / Query Flags, Bootstrap-Key Staleness WARN, Log Verbosity Is an Env Variable, Fact-Store Defaults), plus the preserved \"Why No GSettings\" trailer. Every claim cross-checked against shipped code byte-for-byte (lesson from #331 commit 7).

## Locked decisions (from owner discussion)

1. **Conf delivery**: examples-only at \`\${datadir}/wyrelog/examples/\`. \`/etc/wyrelog/wyrelogd.conf\` is operator-created via \`cp\`, not package-tracked.
2. **ExecStart flip this release**: missing conf → fail-fast (systemd Restart= loop) is safer than silent boot with wrong defaults. \`--production\` kept literal as belt-and-braces.
3. **Permission enforcement**: \`open(O_NOFOLLOW)\` + \`fstat\` + 64 KiB cap. World/group-write rejected. \`--production\` fail-closed; dev mode WARN-and-continue.
4. **Bootstrap-key lifecycle**: \`--profile-info\` WARN with stable greppable prefix \`wyrelogd: bootstrap_admin: stale-key\`; \`indeterminate\` variant on probe-failure to defeat silent-suppression attacks via store corruption.
5. **Scope rejected**: no new conf keys, no schema versioning, no \`include\` directives, no env-var substitution, no hot-reload, no \`log_level\` conf key, no schema validation of unknown keys (separate follow-ups).

## Test plan

- [x] \`meson test -C builddir --suite wyrelog --print-errorlogs\` green locally (77 OK / 2 skipped / 0 fail).
- [x] Unit: parser edge cases (missing section, unknown keys, empty file, empty-string-as-unset, CLI-overrides-conf for every typed field, ANSI sanitization, tri-state probe contract).
- [x] Subprocess (\`check-wyrelogd-conf-gate.sh\`): 8-case Critic matrix end-to-end.
- [x] Packaging (\`check-packaged-install-readiness.sh\`): example conf install paths, ExecStart shape, ReadOnlyPaths defense-in-depth.
- [ ] CI lanes (ubuntu, macos, windows) green.

## Threat model

- **Conf-file write-surface**: previously a trust anchor with NO permission check. Now \`O_NOFOLLOW\` rejects symlinks (final component), \`fstat\` on the held fd catches \`S_IWGRP|S_IWOTH\`, 64 KiB cap, \`!S_ISREG\` reject. Combined with \`ProtectSystem=strict\` + \`ReadOnlyPaths=/etc/wyrelog\` for parent-directory defense.
- **Bootstrap-key WARN silent suppression**: previously could be bypassed by corrupting the policy store. Now distinguished as \`indeterminate\` WARN with reason — operator can no longer be silently bypassed.
- **Terminal-injection via operator-supplied subject**: previously \`bootstrap_admin_subject\` was \`g_printerr(\"...%s...\", subject)\` — any ANSI escape sequence in the subject string would render against the operator's terminal. Now \`sanitize_subject_for_stderr\` hex-escapes non-printable bytes (dmesg pattern).
- **Production mode precedence**: documented accurately as \`CLI || conf\` (logical OR). Runbook now warns operators that removing \`--production\` from a drop-in is insufficient if conf carries \`production=true\` — both gates must be off for non-prod.

## Follow-ups (out of scope, deferred)

- Remove the conf-side \`production\` key from \`load_config_defaults\` (force CLI-only semantics).
- \`tests/check-packaged-install-readiness.sh\` to also show \`service.env\` alongside \`system.env\`.
- Schema-validating unknown conf keys (currently silently ignored).
- \`openat2(RESOLVE_NO_SYMLINKS|RESOLVE_BENEATH)\` to defend against parent-directory symlink swaps under packaging-helper compromise.

## Out of scope (issue-locked)

- New conf keys
- Hot-reload via SIGHUP
- \`include\` directives
- Env-var substitution inside conf values
- Conf-file signing/checksumming
- Daemon-side GSettings (intentionally rejected per existing \"Why No GSettings\" rationale)