### PR TITLE
[codex] Resolve Meson wrap fallback policy for wirelog

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -64,7 +64,7 @@ else
   duckdb_dep = disabler()
 endif
 
-wirelog_version = '>= 0.44.0'
+wirelog_version = '>= 0.50.0'
 libchronoid_version = '>= 1.0.2'
 force_fallback_for = get_option('force_fallback_for')
 wrap_mode = get_option('wrap_mode')

--- a/meson.build
+++ b/meson.build
@@ -64,31 +64,68 @@ else
   duckdb_dep = disabler()
 endif
 
-wirelog_proj = subproject(
-  'wirelog',
-  default_options : ['tests=false', 'documentation=false'],
-)
-wirelog_consumer_args = []
-if host_machine.system() == 'windows'
-  wirelog_consumer_args += ['-DWIRELOG_BUILDING']
-endif
-wirelog_dep = declare_dependency(
-  link_with : wirelog_proj.get_variable('wirelog_lib'),
-  include_directories : [
-    wirelog_proj.get_variable('wirelog_inc'),
-    wirelog_proj.get_variable('wirelog_src_inc'),
-  ],
-  compile_args : wirelog_consumer_args,
-)
+wirelog_version = '>= 0.44.0'
+libchronoid_version = '>= 1.0.2'
+force_fallback_for = get_option('force_fallback_for')
+wrap_mode = get_option('wrap_mode')
 
-libchronoid_proj = subproject(
-  'libchronoid',
-  default_options : ['tests=false', 'cli=false'],
-)
-libchronoid_dep = declare_dependency(
-  link_with : libchronoid_proj.get_variable('chronoid_lib'),
-  include_directories : libchronoid_proj.get_variable('inc'),
-)
+wirelog_force_fallback = wrap_mode == 'forcefallback' or 'wirelog' in force_fallback_for
+wirelog_dep = disabler()
+if not wirelog_force_fallback
+  wirelog_dep = dependency('wirelog',
+    version : wirelog_version,
+    required : false,
+    allow_fallback : false,
+  )
+endif
+if not wirelog_dep.found()
+  if wrap_mode == 'nofallback'
+    error(('Dependency wirelog @0@ was not found and --wrap-mode=nofallback '
+        + 'disables subproject fallback.').format(wirelog_version))
+  endif
+  wirelog_proj = subproject(
+    'wirelog',
+    version : wirelog_version,
+    default_options : ['tests=false', 'documentation=false'],
+  )
+  wirelog_consumer_args = []
+  if host_machine.system() == 'windows'
+    wirelog_consumer_args += ['-DWIRELOG_BUILDING']
+  endif
+  wirelog_dep = declare_dependency(
+    link_with : wirelog_proj.get_variable('wirelog_lib'),
+    include_directories : [
+      wirelog_proj.get_variable('wirelog_inc'),
+      wirelog_proj.get_variable('wirelog_src_inc'),
+    ],
+    compile_args : wirelog_consumer_args,
+  )
+endif
+
+libchronoid_force_fallback = wrap_mode == 'forcefallback' or 'libchronoid' in force_fallback_for
+libchronoid_dep = disabler()
+if not libchronoid_force_fallback
+  libchronoid_dep = dependency('libchronoid',
+    version : libchronoid_version,
+    required : false,
+    allow_fallback : false,
+  )
+endif
+if not libchronoid_dep.found()
+  if wrap_mode == 'nofallback'
+    error(('Dependency libchronoid @0@ was not found and --wrap-mode=nofallback '
+        + 'disables subproject fallback.').format(libchronoid_version))
+  endif
+  libchronoid_proj = subproject(
+    'libchronoid',
+    version : libchronoid_version,
+    default_options : ['tests=false', 'cli=false'],
+  )
+  libchronoid_dep = declare_dependency(
+    link_with : libchronoid_proj.get_variable('chronoid_lib'),
+    include_directories : libchronoid_proj.get_variable('inc'),
+  )
+endif
 
 subdir('wyrelog')
 subdir('tests')

--- a/subprojects/wirelog.wrap
+++ b/subprojects/wirelog.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 url = https://github.com/semantic-reasoning/wirelog.git
-revision = main
+revision = v0.50.0
 depth = 1

--- a/tools/check-supply-chain-pins.sh
+++ b/tools/check-supply-chain-pins.sh
@@ -6,17 +6,23 @@ set -eu
 ROOT=${1:-.}
 status=0
 
+is_ignored_top_level_redirect_wrap() {
+  wrap=$1
+
+  case "$wrap" in
+    "$ROOT"/subprojects/nanoarrow.wrap|"$ROOT"/subprojects/xxhash.wrap) ;;
+    *) return 1 ;;
+  esac
+
+  name=$(basename "$wrap")
+  expected_target="wirelog/subprojects/$name"
+
+  grep -q '^\[wrap-redirect\]$' "$wrap" \
+    && grep -q "^filename = $expected_target\$" "$wrap"
+}
+
 check_wrap_file() {
   wrap=$1
-  case "$(basename "$wrap")" in
-    nanoarrow.wrap|xxhash.wrap)
-      if ! grep -q '^filename = wirelog/subprojects/' "$wrap"; then
-        echo "$wrap: redirect must point at vendored wirelog subproject wrap" >&2
-        status=1
-      fi
-      return
-      ;;
-  esac
 
   if grep -q '^\[wrap-file\]' "$wrap"; then
     for key in source_url source_filename source_hash directory; do
@@ -52,6 +58,9 @@ check_wrap_file() {
 
 for wrap in "$ROOT"/subprojects/*.wrap; do
   [ -e "$wrap" ] || continue
+  if is_ignored_top_level_redirect_wrap "$wrap"; then
+    continue
+  fi
   check_wrap_file "$wrap"
 done
 
@@ -68,6 +77,10 @@ done
 if [ -d "$ROOT/subprojects/packagecache" ]; then
   missing=0
   for wrap in "$ROOT"/subprojects/*.wrap; do
+    [ -e "$wrap" ] || continue
+    if is_ignored_top_level_redirect_wrap "$wrap"; then
+      continue
+    fi
     filename=$(sed -n 's/^source_filename = //p' "$wrap" | head -n 1)
     if [ -n "$filename" ] && [ ! -f "$ROOT/subprojects/packagecache/$filename" ]; then
       echo "$wrap: packagecache missing $filename" >&2


### PR DESCRIPTION
## Summary

- Prefer system `wirelog >= 0.50.0` and `libchronoid >= 1.0.2` before using Meson wraps.
- Use Meson wraps only as fallback, with explicit handling for `nofallback`, `forcefallback`, and `force_fallback_for` even though the upstream subprojects do not export Meson fallback dependency variables.
- Pin the `wirelog` wrap fallback to `v0.50.0`.
- Treat top-level `nanoarrow` and `xxhash` redirect wraps as untracked Meson leftovers only when they point into `wirelog/subprojects`, since those dependencies are owned by `wirelog`.

Closes #337

## Validation

- `tools/check-supply-chain-pins.sh .`
- `WYL_SUPPLY_CHAIN_REQUIRE_PACKAGECACHE=1 tools/check-supply-chain-pins.sh .` fails as expected on pre-existing missing DuckDB packagecache archives.
- Clean worktree system-first path:
  - `meson setup build-system --wrap-mode=nofallback -Denable_audit=disabled -Denable_fact_store=disabled`
  - `meson compile -C build-system`
  - `meson test -C build-system --print-errorlogs` -> 70 OK, 0 failed, 2 skipped
- Clean worktree fallback path:
  - `meson setup build-fallback --wrap-mode=forcefallback -Denable_audit=disabled -Denable_fact_store=disabled`
  - confirmed `subprojects/wirelog` checked out `v0.50.0`
  - `meson compile -C build-fallback wyrelog/wyctl`
- PR CI on commit `07fd9b2` passed for Ubuntu, macOS, and Windows.
